### PR TITLE
feat: Add Support for Google Drive and Gmail Operations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Taylor Wilsdon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,190 +2,277 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A Model Context Protocol (MCP) server that integrates Google Workspace services with AI assistants and other applications.
+A Model Context Protocol (MCP) server that integrates Google Workspace services like Calendar, Drive, and Gmail with AI assistants and other applications.
 
 ## Quick Start
 
-1. **Prerequisites:**
-   - Python 3.12+
-   - [uv](https://github.com/astral-sh/uv) package installer
-   - [Node.js & npm](https://nodejs.org/) (for MCP Inspector)
-   - Google Cloud Project with OAuth 2.0 credentials
+1.  **Prerequisites:**
+    *   Python 3.12+
+    *   [uv](https://github.com/astral-sh/uv) package installer (or pip)
+    *   [Node.js & npm](https://nodejs.org/) (Required only if using the MCP Inspector UI via `with_inspector.sh`)
+    *   Google Cloud Project with OAuth 2.0 credentials enabled for required APIs (Calendar, Drive, Gmail).
 
-2. **Installation:**
-   ```bash
-   git clone https://github.com/your-username/google_workspace_mcp.git
-   cd google_workspace_mcp
-   uv pip install -e .
-   ```
+2.  **Installation:**
+    ```bash
+    # Clone the repository (replace with the actual URL if different)
+    git clone https://github.com/your-username/google_workspace_mcp.git
+    cd google_workspace_mcp
 
-3. **Configuration:**
-   - Create OAuth 2.0 credentials in [Google Cloud Console](https://console.cloud.google.com/)
-   - Download credentials as `client_secret.json` to project root
-   - Add the following redirect URI to your OAuth client in Google Cloud Console:
-     ```
-     http://localhost:8000/oauth2callback
-     ```
+    # Create a virtual environment and install dependencies
+    uv venv
+    source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
+    uv pip install -e .
+    ```
 
-4. **Environment Setup:**
-   The server uses HTTP for localhost OAuth callbacks in development. Set this environment variable:
-   ```bash
-   # Allow HTTP for localhost OAuth callbacks (development only)
-   export OAUTHLIB_INSECURE_TRANSPORT=1
-   ```
-   Without this, you'll get an "OAuth 2 MUST utilize HTTPS" error.
+3.  **Configuration:**
+    *   Create OAuth 2.0 Credentials (Desktop application type) in the [Google Cloud Console](https://console.cloud.google.com/).
+    *   Enable the Google Calendar API, Google Drive API, and Gmail API for your project.
+    *   Download the OAuth client credentials as `client_secret.json` and place it in the project's root directory.
+    *   Add the following redirect URI to your OAuth client configuration in the Google Cloud Console:
+        ```
+        http://localhost:8000/oauth2callback
+        ```
+    *   **Important:** Ensure `client_secret.json` is added to your `.gitignore` file and never committed to version control.
 
-5. **Start the Server:**
+4.  **Environment Setup:**
+    The server uses HTTP for localhost OAuth callbacks during development. Set this environment variable before running the server:
+    ```bash
+    # Allow HTTP for localhost OAuth callbacks (development only!)
+    export OAUTHLIB_INSECURE_TRANSPORT=1
+    ```
+    Without this, you might encounter an "OAuth 2 MUST utilize HTTPS" error during the authentication flow.
 
-   Choose one of these methods to run the server:
+5.  **Start the Server:**
 
-   ```bash
-   # Development mode with Inspector UI
-   ./with_inspector.sh
+    Choose one of the following methods to run the server:
 
-   # OR Production mode (stdin/stdout)
-   python main.py
+    *   **Development Mode with Inspector UI:**
+        ```bash
+        ./with_inspector.sh
+        ```
+        This runs the server via `stdio` and launches the MCP Inspector web UI for debugging. Requires Node.js/npm.
 
-   # OR HTTP mode
-   python -c "from core.server import server; server.run(transport='http', port=8000)"
+    *   **Production Mode (stdio):**
+        ```bash
+        python main.py
+        # or using uv
+        uv run main.py
+        ```
+        This runs the server communicating over `stdin/stdout`, suitable for direct integration with MCP clients that manage the process lifecycle.
 
-   # OR Using mcpo (recommended for API access)
-   mcpo --config config.json
-   ```
+    *   **HTTP Mode:**
+        ```bash
+        python -c "from core.server import server; server.run(transport='http', port=8000)"
+        # or using uv
+        uv run python -c "from core.server import server; server.run(transport='http', port=8000)"
+        ```
+        Runs the server with an HTTP transport layer on port 8000.
 
-   **Important Ports:**
-   - OAuth Callback: `8000` (handled by MCP custom route)
-   - HTTP Mode: `8000` (when running in HTTP mode)
-   - mcpo API: `8000` (default when using mcpo)
+    *   **Using `mcpo` (Recommended for API Access / Open WebUI):**
+        Requires `mcpo` installed (`uv pip install mcpo` or `pip install mcpo`).
+        ```bash
+        # Ensure config.json points to your project directory
+        mcpo --config config.json --port 8000
+        ```
+        See the `config.json` example in the "Integration with Open WebUI" section.
 
-6. **Connecting to the Server:**
+    **Important Ports:**
+    *   OAuth Callback: `8000` (Handled internally by the server via the `/oauth2callback` route)
+    *   HTTP Mode Server: `8000` (Default when using HTTP transport)
+    *   `mcpo` API Proxy: `8000` (Default port for `mcpo`)
 
-   The server supports multiple connection methods:
+6.  **Connecting to the Server:**
 
-   - **Using mcpo (Recommended for OpenAPI Spec Access ie Open WebUI usage)**:
-     - Install mcpo: `pip install mcpo` or `uvx mcpo`
-     - Run with provided config: `mcpo --config config.json`
-     - Access API at: `http://localhost:8000/gworkspace`
-     - OpenAPI docs at: `http://localhost:8000/gworkspace/docs`
+    The server supports multiple connection methods:
 
-   - **Direct stdio (for MCP-compatible applications)**:
-     - Start server with `python main.py`
-     - Application manages server process and communicates via stdin/stdout
-     - No network port needed - uses process I/O streams
+    *   **Using `mcpo` (Recommended for OpenAPI Spec Access, e.g., Open WebUI):**
+        *   Install `mcpo`: `uv pip install mcpo` or `pip install mcpo`.
+        *   Create a `config.json` (see example below).
+        *   Run `mcpo` pointing to your config: `mcpo --config config.json --port 8000 [--api-key YOUR_SECRET_KEY]`
+        *   The MCP server API will be available at: `http://localhost:8000/gworkspace` (or the name defined in `config.json`).
+        *   OpenAPI documentation (Swagger UI) available at: `http://localhost:8000/gworkspace/docs`.
 
-   - **HTTP Mode**:
-     - Start server in HTTP mode
-     - Send requests to `http://localhost:8000`
-     - Useful for direct HTTP client access
+    *   **Direct `stdio` (for MCP-compatible applications):**
+        *   Start the server directly: `python main.py` or `uv run main.py`.
+        *   The client application is responsible for launching and managing the server process and communicating via `stdin/stdout`.
+        *   No network port is used for MCP communication in this mode.
 
-7. **Integration with Open WebUI:**
+    *   **HTTP Mode:**
+        *   Start the server in HTTP mode (see step 5).
+        *   Send MCP JSON requests directly to `http://localhost:8000`.
+        *   Useful for testing with tools like `curl` or custom HTTP clients.
 
-   To use this server with Open WebUI:
+7.  **Integration with Open WebUI:**
 
-   1. **Create mcpo Configuration:**
-      ```json
-      {
-        "mcpServers": {
-          "gworkspace": {
-            "command": "uv",
-            "args": [
-              "--directory",
-              "/path/to/google_workspace_mcp",
-              "run",
-              "main.py"
-            ]
+    To use this server as a tool provider within Open WebUI:
+
+    1.  **Create `mcpo` Configuration:**
+        Create a file named `config.json` (or choose another name) with the following structure. **Replace `/path/to/google_workspace_mcp` with the actual absolute path to this project directory.**
+        ```json
+        {
+          "mcpServers": {
+            "gworkspace": {
+              "command": "uv",
+              "args": [
+                "run",
+                "main.py"
+              ],
+              "options": {
+                "cwd": "/path/to/google_workspace_mcp",
+                "env": {
+                  "OAUTHLIB_INSECURE_TRANSPORT": "1"
+                }
+              }
+            }
           }
         }
-      }
-      ```
-      Save this as `config.json` in your project directory.
+        ```
+        *Note: Using `uv run main.py` ensures the correct virtual environment is used.*
 
-   2. **Start the mcpo Server:**
-      ```bash
-      mcpo --port 8000 --api-key "your-secret-key" --config config.json
-      ```
-      This exposes your MCP server as an OpenAPI-compatible endpoint.
+    2.  **Start the `mcpo` Server:**
+        ```bash
+        # Make sure OAUTHLIB_INSECURE_TRANSPORT=1 is set in your shell environment
+        # OR rely on the 'env' setting in config.json
+        export OAUTHLIB_INSECURE_TRANSPORT=1
+        mcpo --port 8000 --config config.json --api-key "your-optional-secret-key"
+        ```
+        This command starts the `mcpo` proxy, which in turn manages the `google_workspace_mcp` server process based on the configuration.
 
-   3. **Configure Open WebUI:**
-      - Go to Open WebUI settings
-      - Add a new API endpoint
-      - Use URL: `http://localhost:8000/gworkspace`
-      - Add your API key if configured
-      - The Google Workspace tools will now be available in Open WebUI
+    3.  **Configure Open WebUI:**
+        *   Navigate to your Open WebUI settings.
+        *   Go to "Connections" -> "Tools".
+        *   Click "Add Tool".
+        *   Enter the Server URL: `http://localhost:8000/gworkspace` (matching the `mcpo` base URL and server name from `config.json`).
+        *   If you used an `--api-key` with `mcpo`, enter it as the API Key.
+        *   Save the configuration.
+        *   The Google Workspace tools should now be available when interacting with models in Open WebUI.
 
-8. **First-time Setup:**
-   - Start the server using one of the methods above
-   - First API call will trigger OAuth flow
-   - Browser will open to Google login
-   - OAuth callback is handled by the MCP server on port 8000
-   - After authorization, server stores credentials for future use
+8.  **First-time Authentication:**
+    *   Start the server using one of the methods above.
+    *   The first time you call a tool that requires Google API access (e.g., `list_calendars`, `search_drive_files`), the server will detect missing credentials and initiate the OAuth 2.0 flow.
+    *   A URL will be printed to the console (or returned in the MCP response). Open this URL in your browser.
+    *   Log in to your Google account and grant the requested permissions (Calendar, Drive, Gmail access).
+    *   After authorization, Google will redirect your browser to `http://localhost:8000/oauth2callback`.
+    *   The running MCP server (or `mcpo` if used) will handle this callback, exchange the authorization code for tokens, and securely store the credentials (e.g., `credentials-<user_id_hash>.json`) in the project directory for future use.
+    *   Subsequent calls for the same user should work without requiring re-authentication until the refresh token expires or is revoked.
 
 ## Features
 
-- OAuth 2.0 authentication with Google APIs
-- Google Calendar integration (list calendars, fetch events)
-- Both stdio and HTTP transport support
-- Extensible design for adding more Google Workspace APIs
-- Dynamic port selection for OAuth callback
+*   **OAuth 2.0 Authentication:** Securely connects to Google APIs using user-authorized credentials. Handles token refresh automatically.
+*   **Google Calendar Integration:** List calendars and fetch events.
+*   **Google Drive Integration:** Search files, list folder contents, read file content, and create new files.
+*   **Gmail Integration:** Search for messages and retrieve message content (including body).
+*   **Multiple Transport Options:** Supports `stdio` for direct process integration and `HTTP` for network-based access.
+*   **`mcpo` Compatibility:** Easily expose the server as an OpenAPI endpoint using `mcpo` for integration with tools like Open WebUI.
+*   **Extensible Design:** Simple structure for adding support for more Google Workspace APIs and tools.
+*   **Integrated OAuth Callback:** Handles the OAuth redirect directly within the server on port 8000.
 
 ## Available Tools
 
-### Calendar
-- `list_calendars`: Lists user's calendars
-- `get_events`: Gets calendar events (requires `calendar_id`, optional `time_min`, `time_max`, `max_results`)
+*(Note: The first use of any tool for a specific Google service may trigger the OAuth authentication flow if valid credentials are not already stored.)*
 
 ### Authentication
-- `start_auth`: Starts OAuth flow (requires `user_id`)
-- `auth_status`: Checks auth status (requires `user_id`)
-- `complete_auth`: Manual code entry (requires `user_id`, `authorization_code`)
+*   [`start_auth`](auth/auth_flow.py:138): Manually initiates the OAuth flow for a user (usually handled automatically). Requires `user_id`.
+*   [`auth_status`](auth/auth_flow.py:139): Checks the current authentication status for a user. Requires `user_id`.
+*   [`complete_auth`](auth/auth_flow.py:140): Allows manual entry of an authorization code (alternative flow). Requires `user_id`, `authorization_code`.
+
+### Calendar ([`gcalendar/calendar_tools.py`](gcalendar/calendar_tools.py))
+*   `list_calendars`: Lists the user's available calendars.
+*   `get_events`: Retrieves events from a specified calendar.
+    *   `calendar_id` (required): The ID of the calendar (use `primary` for the main calendar).
+    *   `time_min` (optional): Start time for events (RFC3339 timestamp, e.g., `2025-05-12T00:00:00Z`).
+    *   `time_max` (optional): End time for events (RFC3339 timestamp).
+    *   `max_results` (optional): Maximum number of events to return.
+
+### Google Drive ([`gdrive/drive_tools.py`](gdrive/drive_tools.py))
+*   [`search_drive_files`](gdrive/drive_tools.py:98): Searches for files and folders across the user's Drive.
+    *   `query` (required): Search query string (e.g., `name contains 'report'` or `mimeType='application/vnd.google-apps.document'`). See [Drive Search Query Syntax](https://developers.google.com/drive/api/guides/search-files).
+    *   `max_results` (optional): Maximum number of files to return.
+*   [`get_drive_file_content`](gdrive/drive_tools.py:184): Retrieves the content of a specific file.
+    *   `file_id` (required): The ID of the file.
+    *   `mime_type` (optional): Specify the desired export format for Google Docs/Sheets/Slides (e.g., `text/plain`, `application/pdf`). If omitted, attempts a default export or direct download.
+*   [`list_drive_items`](gdrive/drive_tools.py:265): Lists files and folders within a specific folder or the root.
+    *   `folder_id` (optional): The ID of the folder to list. Defaults to the root ('root') if omitted.
+    *   `max_results` (optional): Maximum number of items to return.
+*   [`create_drive_file`](gdrive/drive_tools.py:348): Creates a new file in Google Drive.
+    *   `name` (required): The desired name for the new file.
+    *   `content` (required): The text content to write into the file.
+    *   `folder_id` (optional): The ID of the parent folder. Defaults to the root if omitted.
+    *   `mime_type` (optional): The MIME type of the file being created (defaults to `text/plain`).
+
+### Gmail ([`gmail/gmail_tools.py`](gmail/gmail_tools.py))
+*   [`search_gmail_messages`](gmail/gmail_tools.py:29): Searches for email messages matching a query.
+    *   `query` (required): Search query string (e.g., `from:example@domain.com subject:Report is:unread`). See [Gmail Search Query Syntax](https://support.google.com/mail/answer/7190).
+    *   `max_results` (optional): Maximum number of message threads to return.
+*   [`get_gmail_message_content`](gmail/gmail_tools.py:106): Retrieves the details and body of a specific email message.
+    *   `message_id` (required): The ID of the message to retrieve.
 
 ## Development
 
 ### Project Structure
 ```
 google_workspace_mcp/
-├── core/           # Core MCP server logic
-├── auth/           # OAuth handling
-├── gcalendar/      # Calendar tools
-├── main.py         # Entry point
-├── config.json     # mcpo configuration
-├── pyproject.toml  # Dependencies
-└── with_inspector.sh
+├── .venv/             # Virtual environment (created by uv)
+├── auth/              # OAuth handling logic (auth_flow.py, google_auth.py, etc.)
+├── core/              # Core MCP server logic (server.py)
+├── gcalendar/         # Google Calendar tools (calendar_tools.py)
+├── gdrive/            # Google Drive tools (drive_tools.py)
+├── gmail/             # Gmail tools (gmail_tools.py)
+├── .gitignore         # Git ignore file
+├── client_secret.json # Google OAuth Credentials (DO NOT COMMIT)
+├── config.json        # Example mcpo configuration
+├── main.py            # Main server entry point (imports tools)
+├── mcp_server_debug.log # Log file for debugging
+├── pyproject.toml     # Project metadata and dependencies (for uv/pip)
+├── README.md          # This file
+├── uv.lock            # uv lock file
+└── with_inspector.sh  # Script to run with MCP Inspector
 ```
 
-### Port Handling
-The server handles OAuth callbacks through a custom MCP route:
-- Uses port 8000 for all OAuth callbacks
-- Callback endpoint at /oauth2callback
-- Integrated with MCP server's HTTP transport
-- Handles credential exchange and storage
-- Requires OAUTHLIB_INSECURE_TRANSPORT=1 for HTTP callbacks
+### Port Handling for OAuth
+The server cleverly handles the OAuth 2.0 redirect URI (`/oauth2callback`) without needing a separate web server framework:
+*   It utilizes the built-in HTTP server capabilities of the underlying MCP library when run in HTTP mode or via `mcpo`.
+*   A custom MCP route is registered specifically for `/oauth2callback` on port `8000`.
+*   When Google redirects the user back after authorization, the MCP server intercepts the request on this route.
+*   The `auth` module extracts the authorization code and completes the token exchange.
+*   This requires `OAUTHLIB_INSECURE_TRANSPORT=1` to be set when running locally, as the callback uses `http://localhost`.
 
 ### Debugging
-- Use MCP Inspector UI (`./with_inspector.sh`)
-- Check `mcp_server_debug.log` for detailed logs
-- Monitor port assignment in logs when OAuth flow starts
-- Verify OAuth setup in Google Cloud Console
-- Ensure APIs are enabled in Google Cloud project
-- Check OAUTHLIB_INSECURE_TRANSPORT is set if you get HTTPS errors
+*   **MCP Inspector:** Use `./with_inspector.sh` to launch the server with a web UI for inspecting MCP messages.
+*   **Log File:** Check `mcp_server_debug.log` for detailed logs, including authentication steps and API calls. Enable debug logging if needed.
+*   **OAuth Issues:**
+    *   Verify `client_secret.json` is correct and present.
+    *   Ensure the correct redirect URI (`http://localhost:8000/oauth2callback`) is configured in Google Cloud Console.
+    *   Confirm the necessary APIs (Calendar, Drive, Gmail) are enabled in your Google Cloud project.
+    *   Check that `OAUTHLIB_INSECURE_TRANSPORT=1` is set in the environment where the server process runs, especially if using `mcpo` or running in a container.
+    *   Look for specific error messages during the browser-based OAuth flow.
+*   **Tool Errors:** Check the server logs for tracebacks or error messages returned from the Google APIs.
 
 ### Adding New Tools
-1. Create tool function in appropriate module
-2. Decorate with `@server.tool("tool_name")`
-3. Define parameters using type hints
-4. Implement logic
-5. Import in `main.py`
-6. Return results as dictionary
+1.  Choose or create the appropriate module (e.g., `gdocs/gdocs_tools.py`).
+2.  Import necessary libraries (Google API client library, etc.).
+3.  Define an `async` function for your tool logic. Use type hints for parameters.
+4.  Decorate the function with `@server.tool("your_tool_name")`.
+5.  Inside the function, get authenticated credentials using `await get_credentials(user_id, SCOPES)` where `SCOPES` is a list of required Google API scopes for your tool.
+6.  Build the Google API service client: `service = build('drive', 'v3', credentials=credentials)`.
+7.  Implement the logic to call the Google API.
+8.  Handle potential errors gracefully.
+9.  Return the results as a JSON-serializable dictionary or list.
+10. Import the tool function in [`main.py`](main.py) so it gets registered with the server.
+11. Define the necessary `SCOPES` constant in [`core/server.py`](core/server.py) and add it to the relevant tool imports.
+12. Update `pyproject.toml` if new dependencies are required.
 
 ## Security Notes
 
-- Store `client_secret.json` securely (never commit to VCS)
-- User tokens stored as `credentials-<user_id_hash>.json`
-- Add both files to `.gitignore`
-- OAuth callback uses HTTP on localhost only (requires OAUTHLIB_INSECURE_TRANSPORT=1)
-- Production deployments should use HTTPS
-- When using mcpo, secure your API key and use HTTPS in production
+*   **`client_secret.json`:** This file contains sensitive credentials. **NEVER** commit it to version control. Ensure it's listed in your `.gitignore` file. Store it securely.
+*   **User Tokens:** Authenticated user credentials (refresh tokens) are stored locally in files like `credentials-<user_id_hash>.json`. Protect these files as they grant access to the user's Google account data. Ensure they are also in `.gitignore`.
+*   **OAuth Callback Security:** The use of `http://localhost` for the OAuth callback is standard for installed applications during development but requires `OAUTHLIB_INSECURE_TRANSPORT=1`. For production deployments outside of localhost, you **MUST** use HTTPS for the callback URI and configure it accordingly in Google Cloud Console.
+*   **`mcpo` Security:** If using `mcpo` to expose the server over the network, consider:
+    *   Using the `--api-key` option for basic authentication.
+    *   Running `mcpo` behind a reverse proxy (like Nginx or Caddy) to handle HTTPS termination, proper logging, and potentially more robust authentication.
+    *   Binding `mcpo` only to trusted network interfaces if exposing it beyond localhost.
+*   **Scope Management:** The server requests specific OAuth scopes (permissions) for Calendar, Drive, and Gmail. Users grant access based on these scopes during the initial authentication. Do not request broader scopes than necessary for the implemented tools.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file
+This project is licensed under the MIT License - see the `LICENSE` file for details.

--- a/core/server.py
+++ b/core/server.py
@@ -34,6 +34,12 @@ DRIVE_READONLY_SCOPE = 'https://www.googleapis.com/auth/drive.readonly'
 # DRIVE_METADATA_READONLY_SCOPE = 'https://www.googleapis.com/auth/drive.metadata.readonly'
 DRIVE_FILE_SCOPE = 'https://www.googleapis.com/auth/drive.file' # Per-file access
 
+# Gmail API scopes
+GMAIL_READONLY_SCOPE   = 'https://www.googleapis.com/auth/gmail.readonly'
+GMAIL_SEND_SCOPE       = 'https://www.googleapis.com/auth/gmail.send'
+# Optional, if you later need label management:
+# GMAIL_LABELS_SCOPE     = 'https://www.googleapis.com/auth/gmail.labels'
+
 # Base OAuth scopes required for user identification
 BASE_SCOPES = [
     USERINFO_EMAIL_SCOPE,
@@ -51,8 +57,14 @@ DRIVE_SCOPES = [
     DRIVE_READONLY_SCOPE
 ]
 
+# Gmail-specific scopes
+GMAIL_SCOPES = [
+    GMAIL_READONLY_SCOPE,
+    GMAIL_SEND_SCOPE,
+]
+
 # Combined scopes for all supported Google Workspace operations
-SCOPES = list(set(BASE_SCOPES + CALENDAR_SCOPES + DRIVE_SCOPES + [DRIVE_FILE_SCOPE])) # Add DRIVE_FILE_SCOPE
+SCOPES = list(set(BASE_SCOPES + CALENDAR_SCOPES + DRIVE_SCOPES + GMAIL_SCOPES + [DRIVE_FILE_SCOPE])) # Add DRIVE_FILE_SCOPE and GMAIL_SCOPES
 
 DEFAULT_PORT = 8000
 # Basic MCP server instance

--- a/core/server.py
+++ b/core/server.py
@@ -28,6 +28,12 @@ OPENID_SCOPE = 'openid'
 CALENDAR_READONLY_SCOPE = 'https://www.googleapis.com/auth/calendar.readonly'
 CALENDAR_EVENTS_SCOPE = 'https://www.googleapis.com/auth/calendar.events'
 
+# Google Drive scopes
+DRIVE_READONLY_SCOPE = 'https://www.googleapis.com/auth/drive.readonly'
+# Add other Drive scopes here if needed in the future, e.g.:
+# DRIVE_METADATA_READONLY_SCOPE = 'https://www.googleapis.com/auth/drive.metadata.readonly'
+DRIVE_FILE_SCOPE = 'https://www.googleapis.com/auth/drive.file' # Per-file access
+
 # Base OAuth scopes required for user identification
 BASE_SCOPES = [
     USERINFO_EMAIL_SCOPE,
@@ -40,8 +46,13 @@ CALENDAR_SCOPES = [
     CALENDAR_EVENTS_SCOPE
 ]
 
-# Combined scopes for calendar operations
-SCOPES = BASE_SCOPES + CALENDAR_SCOPES
+# Drive-specific scopes
+DRIVE_SCOPES = [
+    DRIVE_READONLY_SCOPE
+]
+
+# Combined scopes for all supported Google Workspace operations
+SCOPES = list(set(BASE_SCOPES + CALENDAR_SCOPES + DRIVE_SCOPES + [DRIVE_FILE_SCOPE])) # Add DRIVE_FILE_SCOPE
 
 DEFAULT_PORT = 8000
 # Basic MCP server instance

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -1,0 +1,356 @@
+"""
+Google Drive MCP Tools
+
+This module provides MCP tools for interacting with Google Drive API.
+"""
+import logging
+import asyncio
+import os
+from typing import List, Optional, Dict, Any
+
+from mcp import types
+from fastapi import Header
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaIoBaseDownload # For file content
+import io # For file content
+
+from auth.google_auth import get_credentials
+from core.server import server, OAUTH_REDIRECT_URI, OAUTH_STATE_TO_SESSION_ID_MAP
+from core.server import ( # Import Drive scopes defined in core.server
+    DRIVE_READONLY_SCOPE,
+    SCOPES # The combined list of all scopes for broad auth initiation
+)
+
+logger = logging.getLogger(__name__)
+
+# Path to client secrets, similar to calendar_tools.py
+_client_secrets_env = os.getenv("GOOGLE_CLIENT_SECRETS")
+if _client_secrets_env:
+    CONFIG_CLIENT_SECRETS_PATH = _client_secrets_env
+else:
+    # Adjusted path relative to gdrive/ assuming main.py is in parent dir of gdrive/
+    CONFIG_CLIENT_SECRETS_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'client_secret.json')
+
+
+async def _initiate_drive_auth_and_get_message(
+    mcp_session_id: Optional[str],
+    required_scopes: List[str],
+    user_google_email: Optional[str] = None
+) -> types.CallToolResult:
+    from google_auth_oauthlib.flow import Flow # Local import
+    
+    initial_email_provided = bool(user_google_email and user_google_email.strip() and user_google_email.lower() != 'default')
+    user_display_name = f"Google Drive for '{user_google_email}'" if initial_email_provided else "Google Drive"
+
+    logger.info(f"[_initiate_drive_auth_and_get_message] Initiating auth for {user_display_name} (session: {mcp_session_id}) with scopes: {required_scopes}")
+    try:
+        if 'OAUTHLIB_INSECURE_TRANSPORT' not in os.environ and "localhost" in OAUTH_REDIRECT_URI:
+            os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
+        
+        oauth_state = os.urandom(16).hex()
+        if mcp_session_id:
+            OAUTH_STATE_TO_SESSION_ID_MAP[oauth_state] = mcp_session_id
+        
+        flow = Flow.from_client_secrets_file(
+            CONFIG_CLIENT_SECRETS_PATH,
+            scopes=required_scopes,
+            redirect_uri=OAUTH_REDIRECT_URI,
+            state=oauth_state
+        )
+        auth_url, _ = flow.authorization_url(access_type='offline', prompt='consent')
+        
+        message_lines = [
+            f"**ACTION REQUIRED: Google Authentication Needed for {user_display_name}**\n",
+            "To proceed, the user must authorize this application for Google Drive access.",
+            "**LLM, please present this exact authorization URL to the user as a clickable hyperlink:**",
+            f"Authorization URL: {auth_url}",
+            f"Markdown for hyperlink: [Click here to authorize Google Drive access]({auth_url})\n",
+            "**LLM, after presenting the link, instruct the user as follows:**",
+            "1. Click the link and complete the authorization in their browser.",
+        ]
+        session_info_for_llm = f" (this will link to your current session {mcp_session_id})" if mcp_session_id else ""
+
+        if not initial_email_provided:
+            message_lines.extend([
+                f"2. After successful authorization{session_info_for_llm}, the browser page will display the authenticated email address.",
+                "   **LLM: Instruct the user to provide you with this email address.**",
+                "3. Once you have the email, **retry their original command, ensuring you include this `user_google_email`.**"
+            ])
+        else:
+            message_lines.append(f"2. After successful authorization{session_info_for_llm}, **retry their original command**.")
+        
+        message_lines.append(f"\nThe application will use the new credentials. If '{user_google_email}' was provided, it must match the authenticated account.")
+        message = "\n".join(message_lines)
+        
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=message)])
+    except FileNotFoundError as e:
+        error_text = f"OAuth client secrets file not found: {e}. Please ensure '{CONFIG_CLIENT_SECRETS_PATH}' is correctly configured."
+        logger.error(error_text, exc_info=True)
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_text)])
+    except Exception as e:
+        error_text = f"Could not initiate authentication for {user_display_name} due to an unexpected error: {str(e)}"
+        logger.error(f"Failed to start the OAuth flow for {user_display_name}: {e}", exc_info=True)
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_text)])
+
+@server.tool()
+async def search_drive_files(
+    query: str,
+    user_google_email: Optional[str] = None,
+    page_size: int = 10,
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+) -> types.CallToolResult:
+    """
+    Searches for files in Google Drive based on a query string.
+    """
+    logger.info(f"[search_drive_files] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}', Query: '{query}'")
+    tool_specific_scopes = [DRIVE_READONLY_SCOPE]
+    credentials = await asyncio.to_thread(
+        get_credentials,
+        user_google_email=user_google_email,
+        required_scopes=tool_specific_scopes,
+        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
+        session_id=mcp_session_id
+    )
+
+    if not credentials or not credentials.valid:
+        logger.warning(f"[search_drive_files] No valid credentials for Drive. Session: '{mcp_session_id}', Email: '{user_google_email}'.")
+        if user_google_email and '@' in user_google_email:
+            return await _initiate_drive_auth_and_get_message(mcp_session_id, scopes=tool_specific_scopes, user_google_email=user_google_email)
+        else:
+            error_msg = "Drive Authentication required. LLM: Please ask for Google email."
+            return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_msg)])
+    
+    try:
+        service = build('drive', 'v3', credentials=credentials)
+        user_email_from_creds = credentials.id_token.get('email') if credentials.id_token else 'Unknown (Drive)'
+        results = await asyncio.to_thread(
+            service.files().list(
+                q=query,
+                pageSize=page_size,
+                fields="nextPageToken, files(id, name, mimeType, webViewLink, iconLink, modifiedTime, size)"
+            ).execute
+        )
+        files = results.get('files', [])
+        if not files:
+            return types.CallToolResult(content=[types.TextContent(type="text", text=f"No files found for '{query}'.")])
+
+        formatted_files_text_parts = [f"Found {len(files)} files for {user_email_from_creds} matching '{query}':"]
+        for item in files:
+            size_str = f", Size: {item.get('size', 'N/A')}" if 'size' in item else ""
+            formatted_files_text_parts.append(
+                f"- Name: \"{item['name']}\" (ID: {item['id']}, Type: {item['mimeType']}{size_str}, Modified: {item.get('modifiedTime', 'N/A')}) Link: {item.get('webViewLink', '#')}"
+            )
+        text_output = "\n".join(formatted_files_text_parts)
+        return types.CallToolResult(content=[types.TextContent(type="text", text=text_output)])
+    except HttpError as error:
+        logger.error(f"API error searching Drive files: {error}", exc_info=True)
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"API error: {error}")])
+    except Exception as e:
+        logger.exception(f"Unexpected error searching Drive files: {e}")
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Unexpected error: {e}")])
+
+@server.tool()
+async def get_drive_file_content(
+    file_id: str,
+    user_google_email: Optional[str] = None,
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+) -> types.CallToolResult:
+    """
+    Gets the content of a specific file from Google Drive.
+    """
+    logger.info(f"[get_drive_file_content] Invoked. File ID: '{file_id}'")
+    tool_specific_scopes = [DRIVE_READONLY_SCOPE]
+    credentials = await asyncio.to_thread(
+        get_credentials,
+        user_google_email=user_google_email,
+        required_scopes=tool_specific_scopes,
+        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
+        session_id=mcp_session_id
+    )
+
+    if not credentials or not credentials.valid:
+        logger.warning(f"[get_drive_file_content] No valid credentials for Drive. Session: '{mcp_session_id}', Email: '{user_google_email}'.")
+        if user_google_email and '@' in user_google_email:
+             return await _initiate_drive_auth_and_get_message(mcp_session_id, scopes=tool_specific_scopes, user_google_email=user_google_email)
+        else:
+            error_msg = "Drive Authentication required. LLM: Please ask for Google email."
+            return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_msg)])
+
+    try:
+        service = build('drive', 'v3', credentials=credentials)
+        file_metadata = await asyncio.to_thread(
+            service.files().get(fileId=file_id, fields="id, name, mimeType, webViewLink").execute
+        )
+        mime_type = file_metadata.get('mimeType', '')
+        file_name = file_metadata.get('name', 'Unknown File')
+        content_text = f"File: \"{file_name}\" (ID: {file_id}, Type: {mime_type})\nLink: {file_metadata.get('webViewLink', '#')}\n\n--- CONTENT ---\n"
+        
+        export_mime_type = None
+        if mime_type == 'application/vnd.google-apps.document': export_mime_type = 'text/plain'
+        elif mime_type == 'application/vnd.google-apps.spreadsheet': export_mime_type = 'text/csv'
+        elif mime_type == 'application/vnd.google-apps.presentation': export_mime_type = 'text/plain'
+        
+        request_obj = service.files().export_media(fileId=file_id, mimeType=export_mime_type) if export_mime_type \
+            else service.files().get_media(fileId=file_id)
+
+        fh = io.BytesIO()
+        downloader = MediaIoBaseDownload(fh, request_obj)
+        done = False
+        loop = asyncio.get_event_loop()
+        while not done:
+            status, done = await loop.run_in_executor(None, downloader.next_chunk)
+        
+        file_content_bytes = fh.getvalue()
+        try:
+            file_content_str = file_content_bytes.decode('utf-8')
+        except UnicodeDecodeError:
+            file_content_str = f"[Content is binary or uses an unsupported text encoding. Length: {len(file_content_bytes)} bytes]"
+        content_text += file_content_str
+        logger.info(f"Successfully retrieved content for Drive file ID: {file_id}")
+        return types.CallToolResult(content=[types.TextContent(type="text", text=content_text)])
+    except HttpError as error:
+        logger.error(f"API error getting Drive file content for {file_id}: {error}", exc_info=True)
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"API error: {error}")])
+    except Exception as e:
+        logger.exception(f"Unexpected error getting Drive file content for {file_id}: {e}")
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Unexpected error: {e}")])
+
+@server.tool()
+async def list_drive_items(
+    folder_id: str = 'root', # Default to root folder
+    user_google_email: Optional[str] = None,
+    page_size: int = 100, # Default page size for listing
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+) -> types.CallToolResult:
+    """
+    Lists files and folders within a specified Google Drive folder.
+    Defaults to listing items in the root folder if no folder_id is provided.
+    """
+    logger.info(f"[list_drive_items] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}', Folder ID: '{folder_id}'")
+    tool_specific_scopes = [DRIVE_READONLY_SCOPE]
+    credentials = await asyncio.to_thread(
+        get_credentials,
+        user_google_email=user_google_email,
+        required_scopes=tool_specific_scopes,
+        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
+        session_id=mcp_session_id
+    )
+
+    if not credentials or not credentials.valid:
+        logger.warning(f"[list_drive_items] No valid credentials for Drive. Session: '{mcp_session_id}', Email: '{user_google_email}'.")
+        if user_google_email and '@' in user_google_email:
+             return await _initiate_drive_auth_and_get_message(mcp_session_id, scopes=tool_specific_scopes, user_google_email=user_google_email)
+        else:
+            error_msg = "Drive Authentication required. LLM: Please ask for Google email."
+            return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_msg)])
+
+    try:
+        service = build('drive', 'v3', credentials=credentials)
+        user_email_from_creds = credentials.id_token.get('email') if credentials.id_token else 'Unknown (Drive)'
+        logger.info(f"Successfully built Drive service for list_drive_items. User: {user_email_from_creds}")
+
+        # Build the query to list items in the specified folder, excluding trashed items
+        query = f"'{folder_id}' in parents and trashed = false"
+
+        results = await asyncio.to_thread(
+            service.files().list(
+                q=query,
+                pageSize=page_size,
+                fields="nextPageToken, files(id, name, mimeType, webViewLink, iconLink, modifiedTime, size)"
+            ).execute
+        )
+
+        items = results.get('files', [])
+        if not items:
+            return types.CallToolResult(content=[types.TextContent(type="text", text=f"No items found in folder '{folder_id}' for {user_email_from_creds}.")])
+
+        formatted_items_text_parts = [f"Items in folder '{folder_id}' for {user_email_from_creds}:"]
+        for item in items:
+            item_type = "Folder" if item.get('mimeType') == 'application/vnd.google-apps.folder' else "File"
+            size_str = f", Size: {item.get('size', 'N/A')}" if 'size' in item else ""
+            formatted_items_text_parts.append(
+                f"- {item_type}: \"{item['name']}\" (ID: {item['id']}, Type: {item['mimeType']}{size_str}, Modified: {item.get('modifiedTime', 'N/A')}) Link: {item.get('webViewLink', '#')}"
+            )
+
+        text_output = "\n".join(formatted_items_text_parts)
+        logger.info(f"Successfully listed {len(items)} items in folder: '{folder_id}'.")
+        return types.CallToolResult(content=[types.TextContent(type="text", text=text_output)])
+
+    except HttpError as error:
+        logger.error(f"API error listing Drive items in folder {folder_id}: {error}", exc_info=True)
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"API error: {error}")])
+    except Exception as e:
+        logger.exception(f"Unexpected error listing Drive items in folder {folder_id}: {e}")
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Unexpected error: {e}")])
+
+@server.tool()
+async def create_drive_file(
+    file_name: str,
+    content: str,
+    folder_id: str = 'root', # Default to root folder
+    user_google_email: Optional[str] = None,
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+) -> types.CallToolResult:
+    """
+    Creates a new file with specified content in a Google Drive folder.
+    Defaults to creating the file in the root folder if no folder_id is provided.
+    Requires the drive.file scope.
+    """
+    logger.info(f"[create_drive_file] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}', File Name: '{file_name}', Folder ID: '{folder_id}'")
+    
+    # This tool requires the DRIVE_FILE_SCOPE for writing
+    tool_specific_scopes = ['https://www.googleapis.com/auth/drive.file'] # Explicitly use the scope string
+
+    credentials = await asyncio.to_thread(
+        get_credentials,
+        user_google_email=user_google_email,
+        required_scopes=tool_specific_scopes,
+        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
+        session_id=mcp_session_id
+    )
+
+    if not credentials or not credentials.valid:
+        logger.warning(f"[create_drive_file] No valid credentials for Drive write access. Session: '{mcp_session_id}', Email: '{user_google_email}'.")
+        if user_google_email and '@' in user_google_email:
+             # Initiate auth asking for the specific scopes needed by this tool
+             return await _initiate_drive_auth_and_get_message(mcp_session_id, required_scopes=tool_specific_scopes, user_google_email=user_google_email)
+        else:
+            error_msg = "Drive Authentication with write permissions required. LLM: Please ask for Google email."
+            return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_msg)])
+
+    try:
+        service = build('drive', 'v3', credentials=credentials)
+        user_email_from_creds = credentials.id_token.get('email') if credentials.id_token else 'Unknown (Drive)'
+        logger.info(f"Successfully built Drive service for create_drive_file. User: {user_email_from_creds}")
+
+        file_metadata = {
+            'name': file_name,
+            'parents': [folder_id] # Specify the parent folder
+        }
+        media = io.BytesIO(content.encode('utf-8')) # Encode content to bytes
+        media_body = MediaIoBaseUpload(media, mimetype='text/plain', resumable=True) # Assume text/plain for now
+
+        # Use asyncio.to_thread for the blocking API call
+        created_file = await asyncio.to_thread(
+            service.files().create(
+                body=file_metadata,
+                media_body=media_body,
+                fields='id, name, webViewLink'
+            ).execute
+        )
+
+        file_id = created_file.get('id')
+        file_name = created_file.get('name')
+        web_view_link = created_file.get('webViewLink')
+
+        success_message = f"Successfully created file \"{file_name}\" (ID: {file_id}) in folder '{folder_id}' for {user_email_from_creds}. Link: {web_view_link}"
+        logger.info(success_message)
+        return types.CallToolResult(content=[types.TextContent(type="text", text=success_message)])
+
+    except HttpError as error:
+        logger.error(f"API error creating Drive file '{file_name}' in folder {folder_id}: {error}", exc_info=True)
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"API error creating file: {error}")])
+    except Exception as e:
+        logger.exception(f"Unexpected error creating Drive file '{file_name}' in folder {folder_id}: {e}")
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Unexpected error creating file: {e}")])

--- a/gmail/__init__.py
+++ b/gmail/__init__.py
@@ -1,0 +1,1 @@
+# This file marks the 'gmail' directory as a Python package.

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -1,0 +1,214 @@
+"""
+Google Gmail MCP Tools
+
+This module provides MCP tools for interacting with the Gmail API.
+"""
+import logging
+import asyncio
+import os
+import base64
+import email
+from typing import List, Optional, Any # Keep Any
+
+from mcp import types
+from fastapi import Header
+# Remove unused Resource import
+# from googleapiclient.discovery import Resource as GoogleApiServiceResource
+from googleapiclient.errors import HttpError
+
+# Import the decorator, config path, AND the context variable
+from auth.auth_flow import require_google_auth, CONFIG_CLIENT_SECRETS_PATH, current_google_service
+from core.server import server
+from core.server import (
+    GMAIL_READONLY_SCOPE,
+    GMAIL_SEND_SCOPE,
+)
+
+logger = logging.getLogger(__name__)
+
+@server.tool()
+@require_google_auth(
+    required_scopes=[GMAIL_READONLY_SCOPE],
+    service_name="Gmail",
+    api_name="gmail",
+    api_version="v1"
+)
+async def search_gmail_messages( # Signature cleaned - no google_service param
+    query: str,
+    user_google_email: Optional[str] = None,
+    page_size: int = 10,
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+) -> types.CallToolResult:
+    """
+    Searches messages in a user's Gmail account based on a query.
+    Authentication and service object are handled by the @require_google_auth decorator using context variables.
+
+    Args:
+        query (str): The search query. Supports standard Gmail search operators.
+        user_google_email (Optional[str]): The user's Google email address (used for context/logging).
+        page_size (int): The maximum number of messages to return. Defaults to 10.
+        mcp_session_id (Optional[str]): The active MCP session ID (used for context/logging).
+
+    Returns:
+        types.CallToolResult: Contains a list of found message IDs or an error/auth guidance message.
+    """
+    # *** Add logging and check here ***
+    tool_name = "search_gmail_messages"
+    logger.debug(f"[{tool_name}] Entered function. Attempting to get service from context var...")
+    google_service = current_google_service.get()
+    logger.debug(f"[{tool_name}] Service retrieved from context var. Type: {type(google_service)}, id: {id(google_service)}")
+
+    if not google_service:
+         logger.error(f"[{tool_name}] Google service retrieved from context is None!")
+         return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text="Internal error: Google service unavailable in tool context.")])
+
+    logger.info(f"[{tool_name}] Session: '{mcp_session_id}', Email: '{user_google_email}', Query: '{query}'")
+    try:
+        # More robust way to extract email from credentials
+        id_token = getattr(google_service._http.credentials, 'id_token', None)
+        if isinstance(id_token, dict) and 'email' in id_token:
+            user_email_from_creds = id_token.get('email')
+        else:
+            # Fallback to user_google_email parameter or default
+            user_email_from_creds = user_google_email or "Unknown (Gmail)"
+        logger.info(f"[{tool_name}] Using service for: {user_email_from_creds}")
+    except AttributeError as e:
+         logger.error(f"[{tool_name}] Error accessing credentials/email from google_service: {e}", exc_info=True)
+         user_email_from_creds = user_google_email or "Unknown (Gmail - Error)"
+
+
+    try:
+        response = await asyncio.to_thread(
+            google_service.users().messages().list(
+                userId='me',
+                q=query,
+                maxResults=page_size
+            ).execute
+        )
+        messages = response.get('messages', [])
+        if not messages:
+            return types.CallToolResult(content=[types.TextContent(type="text", text=f"No messages found for '{query}'.")])
+
+        lines = [f"Found {len(messages)} messages:"]
+        for msg in messages:
+             lines.append(f"- ID: {msg['id']}") # list doesn't return snippet by default
+
+        return types.CallToolResult(content=[types.TextContent(type="text", text="\n".join(lines))])
+
+    except HttpError as e:
+        logger.error(f"Gmail API error searching messages: {e}", exc_info=True)
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Gmail API error: {e}")])
+    except Exception as e:
+        logger.exception(f"Unexpected error searching Gmail messages: {e}")
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Unexpected error: {e}")])
+
+
+@server.tool()
+@require_google_auth(
+    required_scopes=[GMAIL_READONLY_SCOPE],
+    service_name="Gmail",
+    api_name="gmail",
+    api_version="v1"
+)
+async def get_gmail_message_content( # Signature cleaned - no google_service param
+    message_id: str,
+    user_google_email: Optional[str] = None,
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+) -> types.CallToolResult:
+    """
+    Retrieves the full content (subject, sender, plain text body) of a specific Gmail message.
+    Authentication and service object are handled by the @require_google_auth decorator using context variables.
+
+    Args:
+        message_id (str): The unique ID of the Gmail message to retrieve.
+        user_google_email (Optional[str]): The user's Google email address (used for context/logging).
+        mcp_session_id (Optional[str]): The active MCP session ID (used for context/logging).
+
+    Returns:
+        types.CallToolResult: Contains the message details or an error/auth guidance message.
+    """
+    # *** Add logging and check here ***
+    tool_name = "get_gmail_message_content"
+    logger.debug(f"[{tool_name}] Entered function. Attempting to get service from context var...")
+    google_service = current_google_service.get()
+    logger.debug(f"[{tool_name}] Service retrieved from context var. Type: {type(google_service)}, id: {id(google_service)}")
+
+    if not google_service:
+         logger.error(f"[{tool_name}] Google service retrieved from context is None!")
+         return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text="Internal error: Google service unavailable in tool context.")])
+
+    logger.info(f"[{tool_name}] Message ID: '{message_id}', Session: '{mcp_session_id}', Email: '{user_google_email}'")
+    try:
+        # More robust way to extract email from credentials
+        id_token = getattr(google_service._http.credentials, 'id_token', None)
+        if isinstance(id_token, dict) and 'email' in id_token:
+            user_email_from_creds = id_token.get('email')
+        else:
+            # Fallback to user_google_email parameter or default
+            user_email_from_creds = user_google_email or "Unknown (Gmail)"
+        logger.info(f"[{tool_name}] Using service for: {user_email_from_creds}")
+    except AttributeError as e:
+         logger.error(f"[{tool_name}] Error accessing credentials/email from google_service: {e}", exc_info=True)
+         user_email_from_creds = user_google_email or "Unknown (Gmail - Error)"
+
+
+    try:
+        # Fetch message metadata first to get headers
+        message_metadata = await asyncio.to_thread(
+            google_service.users().messages().get(
+                userId='me',
+                id=message_id,
+                format='metadata',
+                metadataHeaders=['Subject', 'From']
+            ).execute
+        )
+
+        headers = {h['name']: h['value'] for h in message_metadata.get('payload', {}).get('headers', [])}
+        subject = headers.get('Subject', '(no subject)')
+        sender = headers.get('From', '(unknown sender)')
+
+        # Now fetch the full message to get the body parts
+        message_full = await asyncio.to_thread(
+             google_service.users().messages().get(
+                userId='me',
+                id=message_id,
+                format='full' # Request full payload for body
+            ).execute
+        )
+
+        # Find the plain text part (more robustly)
+        body_data = ""
+        payload = message_full.get('payload', {})
+        parts = [payload] if 'parts' not in payload else payload.get('parts', [])
+
+        part_queue = list(parts) # Use a queue for BFS traversal of parts
+        while part_queue:
+            part = part_queue.pop(0)
+            if part.get('mimeType') == 'text/plain' and part.get('body', {}).get('data'):
+                data = base64.urlsafe_b64decode(part['body']['data'])
+                body_data = data.decode('utf-8', errors='ignore')
+                break # Found plain text body
+            elif part.get('mimeType', '').startswith('multipart/') and 'parts' in part:
+                part_queue.extend(part.get('parts', [])) # Add sub-parts to the queue
+
+        # If no plain text found, check the main payload body if it exists
+        if not body_data and payload.get('mimeType') == 'text/plain' and payload.get('body', {}).get('data'):
+             data = base64.urlsafe_b64decode(payload['body']['data'])
+             body_data = data.decode('utf-8', errors='ignore')
+
+
+        content_text = "\n".join([
+            f"Subject: {subject}",
+            f"From:    {sender}",
+            f"\n--- BODY ---\n{body_data or '[No text/plain body found]'}"
+        ])
+        return types.CallToolResult(content=[types.TextContent(type="text", text=content_text)])
+
+    except HttpError as e:
+        logger.error(f"Gmail API error getting message content: {e}", exc_info=True)
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Gmail API error: {e}")])
+    except Exception as e:
+        logger.exception(f"Unexpected error getting Gmail message content: {e}")
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Unexpected error: {e}")])
+
+# Note: send_gmail_message tool would need GMAIL_SEND_SCOPE and similar refactoring if added.

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ except Exception as e:
 # Import calendar tools to register them with the MCP server via decorators
 # Tools are registered when this module is imported
 import gcalendar.calendar_tools
+import gdrive.drive_tools # Import Drive tools to register them
 
 def main():
     """

--- a/main.py
+++ b/main.py
@@ -36,7 +36,8 @@ except Exception as e:
 # Import calendar tools to register them with the MCP server via decorators
 # Tools are registered when this module is imported
 import gcalendar.calendar_tools
-import gdrive.drive_tools # Import Drive tools to register them
+import gdrive.drive_tools
+import gmail.gmail_tools
 
 def main():
     """


### PR DESCRIPTION
# feat: add Google Drive & Gmail support to MCP server

## Description
This pull request introduces comprehensive Google Drive and Gmail integration into the MCP server. It:

- Defines new OAuth scopes for Drive and Gmail in `core/server.py`.
- Updates the combined `SCOPES` list to include Drive (readonly + per-file) and Gmail (readonly + send).
- Enhances existing calendar tools with clearer LLM guidance, parameter docs, and return types.
- Adds a new `gdrive` package with tools for searching, listing, reading, and creating Drive files.
- Adds a new `gmail` package with tools for searching messages and retrieving message content.
- Registers the new tools by importing `gdrive.drive_tools` and `gmail.gmail_tools` in `main.py`.

## Changes
- **core/server.py**
  - Added constants:
    - `DRIVE_READONLY_SCOPE`, `DRIVE_FILE_SCOPE`
    - `GMAIL_READONLY_SCOPE`, `GMAIL_SEND_SCOPE`
  - Introduced `DRIVE_SCOPES`, `GMAIL_SCOPES`
  - Updated `SCOPES = list(set(BASE_SCOPES + CALENDAR_SCOPES + DRIVE_SCOPES + GMAIL_SCOPES + [DRIVE_FILE_SCOPE]))`
- **gcalendar/calendar_tools.py**
  - Expanded docstrings for `start_auth`, `list_calendars`, `get_events` with:
    - LLM guidance bullets
    - Detailed `Args:` and `Returns:` types
- **gdrive/drive_tools.py** (new)
  - Helper: `_initiate_drive_auth_and_get_message`
  - Tools:
    - `search_drive_files(query, …)`
    - `get_drive_file_content(file_id, …)`
    - `list_drive_items(folder_id, …)`
    - `create_drive_file(file_name, content, folder_id, …)`
- **gmail/gmail_tools.py** (new)
  - Decorator-based auth via `@require_google_auth`
  - Tools:
    - `search_gmail_messages(query, …)`
    - `get_gmail_message_content(message_id, …)`
- **main.py**
  - Added imports:
    ```python
    import gdrive.drive_tools
    import gmail.gmail_tools
    ```

## How to Test
1. Place your OAuth client secrets file (`client_secret.json`) in the project root (or set `GOOGLE_CLIENT_SECRETS` env var).
2. Install and run the MCP server:
   ```bash
   uv pip install -e .
   python main.py
