### PR TITLE
feat: Google Docs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,212 +1,301 @@
-# Google Workspace MCP Server
+<div align="center">
+
+# 🔄 Google Workspace MCP Server
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Python 3.12+](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
+[![UV](https://img.shields.io/badge/Package%20Installer-UV-blueviolet)](https://github.com/astral-sh/uv)
 
-A Model Context Protocol (MCP) server that integrates Google Workspace services like Calendar, Drive, and Gmail with AI assistants and other applications.
+**Connect AI assistants to Google Workspace services through the Model Context Protocol**
 
-## Quick Start
+</div>
 
-1.  **Prerequisites:**
-    *   Python 3.12+
-    *   [uv](https://github.com/astral-sh/uv) package installer (or pip)
-    *   [Node.js & npm](https://nodejs.org/) (Required only if using the MCP Inspector UI via `with_inspector.sh`)
-    *   Google Cloud Project with OAuth 2.0 credentials enabled for required APIs (Calendar, Drive, Gmail).
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/assets/image-placeholder.svg" alt="Google Workspace MCP Logo" width="150">
+</p>
 
-2.  **Installation:**
-    ```bash
-    # Clone the repository (replace with the actual URL if different)
-    git clone https://github.com/your-username/google_workspace_mcp.git
-    cd google_workspace_mcp
+---
 
-    # Create a virtual environment and install dependencies
-    uv venv
-    source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
-    uv pip install -e .
-    ```
+## 📑 Table of Contents
 
-3.  **Configuration:**
-    *   Create OAuth 2.0 Credentials (Desktop application type) in the [Google Cloud Console](https://console.cloud.google.com/).
-    *   Enable the Google Calendar API, Google Drive API, and Gmail API for your project.
-    *   Download the OAuth client credentials as `client_secret.json` and place it in the project's root directory.
-    *   Add the following redirect URI to your OAuth client configuration in the Google Cloud Console:
-        ```
-        http://localhost:8000/oauth2callback
-        ```
-    *   **Important:** Ensure `client_secret.json` is added to your `.gitignore` file and never committed to version control.
+- [Overview](#-overview)
+- [Features](#-features)
+- [Quick Start](#-quick-start)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Configuration](#configuration)
+  - [Start the Server](#start-the-server)
+  - [Connecting to the Server](#connecting-to-the-server)
+  - [Integration with Open WebUI](#integration-with-open-webui)
+  - [First-time Authentication](#first-time-authentication)
+- [Available Tools](#-available-tools)
+  - [Calendar](#calendar)
+  - [Google Drive](#google-drive)
+  - [Gmail](#gmail)
+- [Development](#-development)
+  - [Project Structure](#project-structure)
+  - [Port Handling for OAuth](#port-handling-for-oauth)
+  - [Debugging](#debugging)
+  - [Adding New Tools](#adding-new-tools)
+- [Security Notes](#-security-notes)
+- [License](#-license)
 
-4.  **Environment Setup:**
-    The server uses HTTP for localhost OAuth callbacks during development. Set this environment variable before running the server:
-    ```bash
-    # Allow HTTP for localhost OAuth callbacks (development only!)
-    export OAUTHLIB_INSECURE_TRANSPORT=1
-    ```
-    Without this, you might encounter an "OAuth 2 MUST utilize HTTPS" error during the authentication flow.
+---
 
-5.  **Start the Server:**
+## 🌐 Overview
 
-    Choose one of the following methods to run the server:
+The Google Workspace MCP Server integrates Google Workspace services (Calendar, Drive, and Gmail) with AI assistants and other applications using the Model Context Protocol (MCP). This allows AI systems to access and interact with user data from Google Workspace applications securely and efficiently.
 
-    *   **Development Mode with Inspector UI:**
-        ```bash
-        ./with_inspector.sh
-        ```
-        This runs the server via `stdio` and launches the MCP Inspector web UI for debugging. Requires Node.js/npm.
+---
 
-    *   **Production Mode (stdio):**
-        ```bash
-        python main.py
-        # or using uv
-        uv run main.py
-        ```
-        This runs the server communicating over `stdin/stdout`, suitable for direct integration with MCP clients that manage the process lifecycle.
+## ✨ Features
 
-    *   **HTTP Mode:**
-        ```bash
-        python -c "from core.server import server; server.run(transport='http', port=8000)"
-        # or using uv
-        uv run python -c "from core.server import server; server.run(transport='http', port=8000)"
-        ```
-        Runs the server with an HTTP transport layer on port 8000.
+- **🔐 OAuth 2.0 Authentication**: Securely connects to Google APIs using user-authorized credentials with automatic token refresh
+- **📅 Google Calendar Integration**: List calendars and fetch events
+- **📁 Google Drive Integration**: Search files, list folder contents, read file content, and create new files
+- **📧 Gmail Integration**: Search for messages and retrieve message content (including body)
+- **🔄 Multiple Transport Options**: Supports `stdio` for direct process integration and `HTTP` for network-based access
+- **🔌 `mcpo` Compatibility**: Easily expose the server as an OpenAPI endpoint for integration with tools like Open WebUI
+- **🧩 Extensible Design**: Simple structure for adding support for more Google Workspace APIs and tools
+- **🔄 Integrated OAuth Callback**: Handles the OAuth redirect directly within the server on port 8000
 
-    *   **Using `mcpo` (Recommended for API Access / Open WebUI):**
-        Requires `mcpo` installed (`uv pip install mcpo` or `pip install mcpo`).
-        ```bash
-        # Ensure config.json points to your project directory
-        mcpo --config config.json --port 8000
-        ```
-        See the `config.json` example in the "Integration with Open WebUI" section.
+---
 
-    **Important Ports:**
-    *   OAuth Callback: `8000` (Handled internally by the server via the `/oauth2callback` route)
-    *   HTTP Mode Server: `8000` (Default when using HTTP transport)
-    *   `mcpo` API Proxy: `8000` (Default port for `mcpo`)
+## 🚀 Quick Start
 
-6.  **Connecting to the Server:**
+### Prerequisites
 
-    The server supports multiple connection methods:
+- **Python 3.12+**
+- **[uv](https://github.com/astral-sh/uv)** package installer (or pip)
+- **[Node.js & npm](https://nodejs.org/)** (Required only if using the MCP Inspector UI via `with_inspector.sh`)
+- **Google Cloud Project** with OAuth 2.0 credentials enabled for required APIs (Calendar, Drive, Gmail)
 
-    *   **Using `mcpo` (Recommended for OpenAPI Spec Access, e.g., Open WebUI):**
-        *   Install `mcpo`: `uv pip install mcpo` or `pip install mcpo`.
-        *   Create a `config.json` (see example below).
-        *   Run `mcpo` pointing to your config: `mcpo --config config.json --port 8000 [--api-key YOUR_SECRET_KEY]`
-        *   The MCP server API will be available at: `http://localhost:8000/gworkspace` (or the name defined in `config.json`).
-        *   OpenAPI documentation (Swagger UI) available at: `http://localhost:8000/gworkspace/docs`.
+### Installation
 
-    *   **Direct `stdio` (for MCP-compatible applications):**
-        *   Start the server directly: `python main.py` or `uv run main.py`.
-        *   The client application is responsible for launching and managing the server process and communicating via `stdin/stdout`.
-        *   No network port is used for MCP communication in this mode.
+```bash
+# Clone the repository (replace with the actual URL if different)
+git clone https://github.com/your-username/google_workspace_mcp.git
+cd google_workspace_mcp
 
-    *   **HTTP Mode:**
-        *   Start the server in HTTP mode (see step 5).
-        *   Send MCP JSON requests directly to `http://localhost:8000`.
-        *   Useful for testing with tools like `curl` or custom HTTP clients.
+# Create a virtual environment and install dependencies
+uv venv
+source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
+uv pip install -e .
+```
 
-7.  **Integration with Open WebUI:**
+### Configuration
 
-    To use this server as a tool provider within Open WebUI:
+1. Create **OAuth 2.0 Credentials** (Desktop application type) in the [Google Cloud Console](https://console.cloud.google.com/).
+2. Enable the **Google Calendar API**, **Google Drive API**, and **Gmail API** for your project.
+3. Download the OAuth client credentials as `client_secret.json` and place it in the project's root directory.
+4. Add the following redirect URI to your OAuth client configuration in the Google Cloud Console:
+   ```
+   http://localhost:8000/oauth2callback
+   ```
+5. **⚠️ Important**: Ensure `client_secret.json` is added to your `.gitignore` file and never committed to version control.
 
-    1.  **Create `mcpo` Configuration:**
-        Create a file named `config.json` (or choose another name) with the following structure. **Replace `/path/to/google_workspace_mcp` with the actual absolute path to this project directory.**
-        ```json
-        {
-          "mcpServers": {
-            "gworkspace": {
-              "command": "uv",
-              "args": [
-                "run",
-                "main.py"
-              ],
-              "options": {
-                "cwd": "/path/to/google_workspace_mcp",
-                "env": {
-                  "OAUTHLIB_INSECURE_TRANSPORT": "1"
-                }
-              }
-            }
-          }
-        }
-        ```
-        *Note: Using `uv run main.py` ensures the correct virtual environment is used.*
+### Environment Setup
 
-    2.  **Start the `mcpo` Server:**
-        ```bash
-        # Make sure OAUTHLIB_INSECURE_TRANSPORT=1 is set in your shell environment
-        # OR rely on the 'env' setting in config.json
-        export OAUTHLIB_INSECURE_TRANSPORT=1
-        mcpo --port 8000 --config config.json --api-key "your-optional-secret-key"
-        ```
-        This command starts the `mcpo` proxy, which in turn manages the `google_workspace_mcp` server process based on the configuration.
+The server uses HTTP for localhost OAuth callbacks during development. Set this environment variable before running the server:
 
-    3.  **Configure Open WebUI:**
-        *   Navigate to your Open WebUI settings.
-        *   Go to "Connections" -> "Tools".
-        *   Click "Add Tool".
-        *   Enter the Server URL: `http://localhost:8000/gworkspace` (matching the `mcpo` base URL and server name from `config.json`).
-        *   If you used an `--api-key` with `mcpo`, enter it as the API Key.
-        *   Save the configuration.
-        *   The Google Workspace tools should now be available when interacting with models in Open WebUI.
+```bash
+# Allow HTTP for localhost OAuth callbacks (development only!)
+export OAUTHLIB_INSECURE_TRANSPORT=1
+```
 
-8.  **First-time Authentication:**
-    *   Start the server using one of the methods above.
-    *   The first time you call a tool that requires Google API access (e.g., `list_calendars`, `search_drive_files`), the server will detect missing credentials and initiate the OAuth 2.0 flow.
-    *   A URL will be printed to the console (or returned in the MCP response). Open this URL in your browser.
-    *   Log in to your Google account and grant the requested permissions (Calendar, Drive, Gmail access).
-    *   After authorization, Google will redirect your browser to `http://localhost:8000/oauth2callback`.
-    *   The running MCP server (or `mcpo` if used) will handle this callback, exchange the authorization code for tokens, and securely store the credentials (e.g., in the `.credentials/your_email@example.com.json` file) for future use.
-    *   Subsequent calls for the same user should work without requiring re-authentication until the refresh token expires or is revoked.
+Without this, you might encounter an "OAuth 2 MUST utilize HTTPS" error during the authentication flow.
 
-## Features
+### Start the Server
 
-*   **OAuth 2.0 Authentication:** Securely connects to Google APIs using user-authorized credentials. Handles token refresh automatically.
-*   **Google Calendar Integration:** List calendars and fetch events.
-*   **Google Drive Integration:** Search files, list folder contents, read file content, and create new files.
-*   **Gmail Integration:** Search for messages and retrieve message content (including body).
-*   **Multiple Transport Options:** Supports `stdio` for direct process integration and `HTTP` for network-based access.
-*   **`mcpo` Compatibility:** Easily expose the server as an OpenAPI endpoint using `mcpo` for integration with tools like Open WebUI.
-*   **Extensible Design:** Simple structure for adding support for more Google Workspace APIs and tools.
-*   **Integrated OAuth Callback:** Handles the OAuth redirect directly within the server on port 8000.
+Choose one of the following methods to run the server:
 
-## Available Tools
+<details>
+<summary><b>Development Mode with Inspector UI</b></summary>
 
-*(Note: The first use of any tool for a specific Google service may trigger the OAuth authentication flow if valid credentials are not already stored.)*
+```bash
+./with_inspector.sh
+```
 
-### Calendar ([`gcalendar/calendar_tools.py`](gcalendar/calendar_tools.py))
-*   `start_auth`: Initiates the OAuth flow for Google Calendar access if required.
-    *   `user_google_email` (required): The user's Google email address.
-*   `list_calendars`: Lists the user's available calendars.
-*   `get_events`: Retrieves events from a specified calendar.
-    *   `calendar_id` (required): The ID of the calendar (use `primary` for the main calendar).
-    *   `time_min` (optional): Start time for events (RFC3339 timestamp, e.g., `2025-05-12T00:00:00Z`).
-    *   `time_max` (optional): End time for events (RFC3339 timestamp).
-    *   `max_results` (optional): Maximum number of events to return.
+This runs the server via `stdio` and launches the MCP Inspector web UI for debugging. Requires Node.js/npm.
+</details>
 
-### Google Drive ([`gdrive/drive_tools.py`](gdrive/drive_tools.py))
-*   [`search_drive_files`](gdrive/drive_tools.py:98): Searches for files and folders across the user's Drive.
-    *   `query` (required): Search query string (e.g., `name contains 'report'` or `mimeType='application/vnd.google-apps.document'`). See [Drive Search Query Syntax](https://developers.google.com/drive/api/guides/search-files).
-    *   `max_results` (optional): Maximum number of files to return.
-*   [`get_drive_file_content`](gdrive/drive_tools.py:184): Retrieves the content of a specific file.
-    *   `file_id` (required): The ID of the file.
-    *   `mime_type` (optional): Specify the desired export format for Google Docs/Sheets/Slides (e.g., `text/plain`, `application/pdf`). If omitted, attempts a default export or direct download.
-*   [`list_drive_items`](gdrive/drive_tools.py:265): Lists files and folders within a specific folder or the root.
-    *   `folder_id` (optional): The ID of the folder to list. Defaults to the root ('root') if omitted.
-    *   `max_results` (optional): Maximum number of items to return.
-*   [`create_drive_file`](gdrive/drive_tools.py:348): Creates a new file in Google Drive.
-    *   `name` (required): The desired name for the new file.
-    *   `content` (required): The text content to write into the file.
-    *   `folder_id` (optional): The ID of the parent folder. Defaults to the root if omitted.
-    *   `mime_type` (optional): The MIME type of the file being created (defaults to `text/plain`).
+<details>
+<summary><b>Production Mode (stdio)</b></summary>
 
-### Gmail ([`gmail/gmail_tools.py`](gmail/gmail_tools.py))
-*   [`search_gmail_messages`](gmail/gmail_tools.py:29): Searches for email messages matching a query.
-    *   `query` (required): Search query string (e.g., `from:example@domain.com subject:Report is:unread`). See [Gmail Search Query Syntax](https://support.google.com/mail/answer/7190).
-    *   `max_results` (optional): Maximum number of message threads to return.
-*   [`get_gmail_message_content`](gmail/gmail_tools.py:106): Retrieves the details and body of a specific email message.
-    *   `message_id` (required): The ID of the message to retrieve.
+```bash
+python main.py
+# or using uv
+uv run main.py
+```
 
-## Development
+This runs the server communicating over `stdin/stdout`, suitable for direct integration with MCP clients that manage the process lifecycle.
+</details>
+
+<details>
+<summary><b>HTTP Mode</b></summary>
+
+```bash
+python -c "from core.server import server; server.run(transport='http', port=8000)"
+# or using uv
+uv run -c "from core.server import server; server.run(transport='http', port=8000)"
+```
+
+Runs the server with an HTTP transport layer on port 8000.
+</details>
+
+<details>
+<summary><b>Using mcpo (Recommended for API Access / Open WebUI)</b></summary>
+
+Requires `mcpo` installed (`uv pip install mcpo` or `pip install mcpo`).
+
+```bash
+# Ensure config.json points to your project directory
+mcpo --config config.json --port 8000
+```
+
+See the [Integration with Open WebUI](#integration-with-open-webui) section for a `config.json` example.
+</details>
+
+#### Important Ports
+
+| Service | Port | Description |
+|---------|------|-------------|
+| OAuth Callback | `8000` | Handled internally by the server via the `/oauth2callback` route |
+| HTTP Mode Server | `8000` | Default when using HTTP transport |
+| `mcpo` API Proxy | `8000` | Default port for `mcpo` |
+
+### Connecting to the Server
+
+The server supports multiple connection methods:
+
+<details>
+<summary><b>Using mcpo (Recommended for OpenAPI Spec Access)</b></summary>
+
+1. Install `mcpo`: `uv pip install mcpo` or `pip install mcpo`
+2. Create a `config.json` (see [Integration with Open WebUI](#integration-with-open-webui))
+3. Run `mcpo` pointing to your config: `mcpo --config config.json --port 8000 [--api-key YOUR_SECRET_KEY]`
+4. The MCP server API will be available at: `http://localhost:8000/gworkspace` (or the name defined in `config.json`)
+5. OpenAPI documentation (Swagger UI) available at: `http://localhost:8000/gworkspace/docs`
+</details>
+
+<details>
+<summary><b>Direct stdio (for MCP-compatible applications)</b></summary>
+
+1. Start the server directly: `python main.py` or `uv run main.py`
+2. The client application is responsible for launching and managing the server process and communicating via `stdin/stdout`
+3. No network port is used for MCP communication in this mode
+</details>
+
+<details>
+<summary><b>HTTP Mode</b></summary>
+
+1. Start the server in HTTP mode (see [Start the Server](#start-the-server))
+2. Send MCP JSON requests directly to `http://localhost:8000`
+3. Useful for testing with tools like `curl` or custom HTTP clients
+</details>
+
+### Integration with Open WebUI
+
+To use this server as a tool provider within Open WebUI:
+
+1. **Create `mcpo` Configuration**:
+   Create a file named `config.json` with the following structure. **Replace `/path/to/google_workspace_mcp` with the actual absolute path to this project directory.**
+
+   ```json
+   {
+     "mcpServers": {
+       "gworkspace": {
+         "command": "uv",
+         "args": [
+           "run",
+           "main.py"
+         ],
+         "options": {
+           "cwd": "/path/to/google_workspace_mcp",
+           "env": {
+             "OAUTHLIB_INSECURE_TRANSPORT": "1"
+           }
+         }
+       }
+     }
+   }
+   ```
+   *Note: Using `uv run main.py` ensures the correct virtual environment is used.*
+
+2. **Start the `mcpo` Server**:
+   ```bash
+   # Make sure OAUTHLIB_INSECURE_TRANSPORT=1 is set in your shell environment
+   # OR rely on the 'env' setting in config.json
+   export OAUTHLIB_INSECURE_TRANSPORT=1
+   mcpo --port 8000 --config config.json --api-key "your-optional-secret-key"
+   ```
+   This command starts the `mcpo` proxy, which in turn manages the `google_workspace_mcp` server process based on the configuration.
+
+3. **Configure Open WebUI**:
+   - Navigate to your Open WebUI settings
+   - Go to "Connections" -> "Tools"
+   - Click "Add Tool"
+   - Enter the Server URL: `http://localhost:8000/gworkspace` (matching the `mcpo` base URL and server name from `config.json`)
+   - If you used an `--api-key` with `mcpo`, enter it as the API Key
+   - Save the configuration
+   - The Google Workspace tools should now be available when interacting with models in Open WebUI
+
+### First-time Authentication
+
+1. Start the server using one of the methods above
+2. The first time you call a tool that requires Google API access (e.g., `list_calendars`, `search_drive_files`), the server will detect missing credentials and initiate the OAuth 2.0 flow
+3. A URL will be printed to the console (or returned in the MCP response). Open this URL in your browser
+4. Log in to your Google account and grant the requested permissions (Calendar, Drive, Gmail access)
+5. After authorization, Google will redirect your browser to `http://localhost:8000/oauth2callback`
+6. The running MCP server will handle this callback, exchange the authorization code for tokens, and securely store the credentials for future use
+7. Subsequent calls for the same user should work without requiring re-authentication until the refresh token expires or is revoked
+
+---
+
+## 🧰 Available Tools
+
+> **Note**: The first use of any tool for a specific Google service may trigger the OAuth authentication flow if valid credentials are not already stored.
+
+### Calendar
+
+Source: [`gcalendar/calendar_tools.py`](gcalendar/calendar_tools.py)
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `start_auth` | Initiates the OAuth flow for Google Calendar access | • `user_google_email` (required): The user's Google email address |
+| `list_calendars` | Lists the user's available calendars | (None) |
+| `get_events` | Retrieves events from a specified calendar | • `calendar_id` (required): The ID of the calendar (use `primary` for the main calendar)<br>• `time_min` (optional): Start time for events (RFC3339 timestamp, e.g., `2025-05-12T00:00:00Z`)<br>• `time_max` (optional): End time for events (RFC3339 timestamp)<br>• `max_results` (optional): Maximum number of events to return |
+
+### Google Drive
+
+Source: [`gdrive/drive_tools.py`](gdrive/drive_tools.py)
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| [`search_drive_files`](gdrive/drive_tools.py:98) | Searches for files and folders across the user's Drive | • `query` (required): Search query string (e.g., `name contains 'report'`)<br>• `max_results` (optional): Maximum number of files to return |
+| [`get_drive_file_content`](gdrive/drive_tools.py:184) | Retrieves the content of a specific file | • `file_id` (required): The ID of the file<br>• `mime_type` (optional): Specify the desired export format |
+| [`list_drive_items`](gdrive/drive_tools.py:265) | Lists files and folders within a specific folder or the root | • `folder_id` (optional): The ID of the folder to list (defaults to root)<br>• `max_results` (optional): Maximum number of items to return |
+| [`create_drive_file`](gdrive/drive_tools.py:348) | Creates a new file in Google Drive | • `name` (required): The desired name for the new file<br>• `content` (required): The text content to write into the file<br>• `folder_id` (optional): The ID of the parent folder<br>• `mime_type` (optional): The MIME type of the file (defaults to `text/plain`) |
+
+> **Query Syntax**: For Google Drive search queries, see [Drive Search Query Syntax](https://developers.google.com/drive/api/guides/search-files)
+
+### Gmail
+
+Source: [`gmail/gmail_tools.py`](gmail/gmail_tools.py)
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| [`search_gmail_messages`](gmail/gmail_tools.py:29) | Searches for email messages matching a query | • `query` (required): Search query string (e.g., `from:example@domain.com subject:Report is:unread`)<br>• `max_results` (optional): Maximum number of message threads to return |
+| [`get_gmail_message_content`](gmail/gmail_tools.py:106) | Retrieves the details and body of a specific email message | • `message_id` (required): The ID of the message to retrieve |
+
+> **Query Syntax**: For Gmail search queries, see [Gmail Search Query Syntax](https://support.google.com/mail/answer/7190)
+
+---
+
+## 🛠️ Development
 
 ### Project Structure
+
 ```
 google_workspace_mcp/
 ├── .venv/             # Virtual environment (created by uv)
@@ -227,65 +316,98 @@ google_workspace_mcp/
 ```
 
 ### Port Handling for OAuth
+
 The server cleverly handles the OAuth 2.0 redirect URI (`/oauth2callback`) without needing a separate web server framework:
-*   It utilizes the built-in HTTP server capabilities of the underlying MCP library when run in HTTP mode or via `mcpo`.
-*   A custom MCP route is registered specifically for `/oauth2callback` on port `8000`.
-*   When Google redirects the user back after authorization, the MCP server intercepts the request on this route.
-*   The `auth` module extracts the authorization code and completes the token exchange.
-*   This requires `OAUTHLIB_INSECURE_TRANSPORT=1` to be set when running locally, as the callback uses `http://localhost`.
+
+- It utilizes the built-in HTTP server capabilities of the underlying MCP library when run in HTTP mode or via `mcpo`
+- A custom MCP route is registered specifically for `/oauth2callback` on port `8000`
+- When Google redirects the user back after authorization, the MCP server intercepts the request on this route
+- The `auth` module extracts the authorization code and completes the token exchange
+- This requires `OAUTHLIB_INSECURE_TRANSPORT=1` to be set when running locally, as the callback uses `http://localhost`
 
 ### Debugging
-*   **MCP Inspector:** Use `./with_inspector.sh` to launch the server with a web UI for inspecting MCP messages.
-*   **Log File:** Check `mcp_server_debug.log` for detailed logs, including authentication steps and API calls. Enable debug logging if needed.
-*   **OAuth Issues:**
-    *   Verify `client_secret.json` is correct and present.
-    *   Ensure the correct redirect URI (`http://localhost:8000/oauth2callback`) is configured in Google Cloud Console.
-    *   Confirm the necessary APIs (Calendar, Drive, Gmail) are enabled in your Google Cloud project.
-    *   Check that `OAUTHLIB_INSECURE_TRANSPORT=1` is set in the environment where the server process runs, especially if using `mcpo` or running in a container.
-    *   Look for specific error messages during the browser-based OAuth flow.
-*   **Tool Errors:** Check the server logs for tracebacks or error messages returned from the Google APIs.
+
+<details>
+<summary><b>MCP Inspector</b></summary>
+
+Use `./with_inspector.sh` to launch the server with a web UI for inspecting MCP messages.
+</details>
+
+<details>
+<summary><b>Log File</b></summary>
+
+Check `mcp_server_debug.log` for detailed logs, including authentication steps and API calls. Enable debug logging if needed.
+</details>
+
+<details>
+<summary><b>OAuth Issues</b></summary>
+
+- Verify `client_secret.json` is correct and present
+- Ensure the correct redirect URI (`http://localhost:8000/oauth2callback`) is configured in Google Cloud Console
+- Confirm the necessary APIs (Calendar, Drive, Gmail) are enabled in your Google Cloud project
+- Check that `OAUTHLIB_INSECURE_TRANSPORT=1` is set in the environment where the server process runs
+- Look for specific error messages during the browser-based OAuth flow
+</details>
+
+<details>
+<summary><b>Tool Errors</b></summary>
+
+Check the server logs for tracebacks or error messages returned from the Google APIs.
+</details>
 
 ### Adding New Tools
-1.  Choose or create the appropriate module (e.g., `gdocs/gdocs_tools.py`).
-2.  Import necessary libraries (Google API client library, etc.).
-3.  Define an `async` function for your tool logic. Use type hints for parameters.
-4.  Decorate the function with `@server.tool("your_tool_name")`.
-5.  Inside the function, get authenticated credentials. This typically involves calling `auth.google_auth.get_credentials` within an `asyncio.to_thread` call, for example:
-    ```python
-    from auth.google_auth import get_credentials, CONFIG_CLIENT_SECRETS_PATH
-    # ...
-    credentials = await asyncio.to_thread(
-        get_credentials,
-        user_google_email=your_user_email_variable, # Optional, can be None if session_id is primary
-        required_scopes=YOUR_SPECIFIC_SCOPES_LIST,  # e.g., [CALENDAR_READONLY_SCOPE]
-        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
-        session_id=your_mcp_session_id_variable    # Usually injected via Header
-    )
-    if not credentials or not credentials.valid:
-        # Handle missing/invalid credentials, possibly by calling start_auth_flow
-        # from auth.google_auth (which is what service-specific start_auth tools do)
-        pass
-    ```
-    `YOUR_SPECIFIC_SCOPES_LIST` should contain the minimum scopes needed for your tool.
-6.  Build the Google API service client: `service = build('drive', 'v3', credentials=credentials)`.
-7.  Implement the logic to call the Google API.
-8.  Handle potential errors gracefully.
-9.  Return the results as a JSON-serializable dictionary or list.
-10. Import the tool function in [`main.py`](main.py) so it gets registered with the server.
-11. Define necessary service-specific scope constants (e.g., `MY_SERVICE_READ_SCOPE`) in your tool's module. The global `SCOPES` list in [`config/google_config.py`](config/google_config.py) is used for the initial OAuth consent screen and should include all possible scopes your server might request. Individual tools should request the minimal `required_scopes` they need when calling `get_credentials`.
-12. Update `pyproject.toml` if new dependencies are required.
 
-## Security Notes
+1. Choose or create the appropriate module (e.g., `gdocs/gdocs_tools.py`)
+2. Import necessary libraries (Google API client library, etc.)
+3. Define an `async` function for your tool logic. Use type hints for parameters
+4. Decorate the function with `@server.tool("your_tool_name")`
+5. Inside the function, get authenticated credentials:
 
-*   **`client_secret.json`:** This file contains sensitive credentials. **NEVER** commit it to version control. Ensure it's listed in your `.gitignore` file. Store it securely.
-*   **User Tokens:** Authenticated user credentials (refresh tokens) are stored locally in files like `credentials-<user_id_hash>.json`. Protect these files as they grant access to the user's Google account data. Ensure they are also in `.gitignore`.
-*   **OAuth Callback Security:** The use of `http://localhost` for the OAuth callback is standard for installed applications during development but requires `OAUTHLIB_INSECURE_TRANSPORT=1`. For production deployments outside of localhost, you **MUST** use HTTPS for the callback URI and configure it accordingly in Google Cloud Console.
-*   **`mcpo` Security:** If using `mcpo` to expose the server over the network, consider:
-    *   Using the `--api-key` option for basic authentication.
-    *   Running `mcpo` behind a reverse proxy (like Nginx or Caddy) to handle HTTPS termination, proper logging, and potentially more robust authentication.
-    *   Binding `mcpo` only to trusted network interfaces if exposing it beyond localhost.
-*   **Scope Management:** The server requests specific OAuth scopes (permissions) for Calendar, Drive, and Gmail. Users grant access based on these scopes during the initial authentication. Do not request broader scopes than necessary for the implemented tools.
+```python
+from auth.google_auth import get_credentials, CONFIG_CLIENT_SECRETS_PATH
+# ...
+credentials = await asyncio.to_thread(
+    get_credentials,
+    user_google_email=your_user_email_variable, # Optional, can be None if session_id is primary
+    required_scopes=YOUR_SPECIFIC_SCOPES_LIST,  # e.g., [CALENDAR_READONLY_SCOPE]
+    client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
+    session_id=your_mcp_session_id_variable    # Usually injected via Header
+)
+if not credentials or not credentials.valid:
+    # Handle missing/invalid credentials, possibly by calling start_auth_flow
+    # from auth.google_auth (which is what service-specific start_auth tools do)
+    pass
+```
 
-## License
+6. Build the Google API service client: `service = build('drive', 'v3', credentials=credentials)`
+7. Implement the logic to call the Google API
+8. Handle potential errors gracefully
+9. Return the results as a JSON-serializable dictionary or list
+10. Import the tool function in [`main.py`](main.py) so it gets registered with the server
+11. Define necessary service-specific scope constants in your tool's module
+12. Update `pyproject.toml` if new dependencies are required
+
+> **Scope Management**: The global `SCOPES` list in [`config/google_config.py`](config/google_config.py) is used for the initial OAuth consent screen. Individual tools should request the minimal `required_scopes` they need when calling `get_credentials`.
+
+---
+
+## 🔒 Security Notes
+
+- **`client_secret.json`**: This file contains sensitive credentials. **NEVER** commit it to version control. Ensure it's listed in your `.gitignore` file. Store it securely.
+
+- **User Tokens**: Authenticated user credentials (refresh tokens) are stored locally in files like `credentials-<user_id_hash>.json`. Protect these files as they grant access to the user's Google account data. Ensure they are also in `.gitignore`.
+
+- **OAuth Callback Security**: The use of `http://localhost` for the OAuth callback is standard for installed applications during development but requires `OAUTHLIB_INSECURE_TRANSPORT=1`. For production deployments outside of localhost, you **MUST** use HTTPS for the callback URI and configure it accordingly in Google Cloud Console.
+
+- **`mcpo` Security**: If using `mcpo` to expose the server over the network, consider:
+  - Using the `--api-key` option for basic authentication
+  - Running `mcpo` behind a reverse proxy (like Nginx or Caddy) to handle HTTPS termination, proper logging, and more robust authentication
+  - Binding `mcpo` only to trusted network interfaces if exposing it beyond localhost
+
+- **Scope Management**: The server requests specific OAuth scopes (permissions) for Calendar, Drive, and Gmail. Users grant access based on these scopes during the initial authentication. Do not request broader scopes than necessary for the implemented tools.
+
+---
+
+## 📄 License
 
 This project is licensed under the MIT License - see the `LICENSE` file for details.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   - [Calendar](#calendar)
   - [Google Drive](#google-drive)
   - [Gmail](#gmail)
+  - [Google Docs](#google-docs)
 - [Development](#-development)
   - [Project Structure](#project-structure)
   - [Port Handling for OAuth](#port-handling-for-oauth)
@@ -40,7 +41,7 @@
 
 ## 🌐 Overview
 
-The Google Workspace MCP Server integrates Google Workspace services (Calendar, Drive, and Gmail) with AI assistants and other applications using the Model Context Protocol (MCP). This allows AI systems to access and interact with user data from Google Workspace applications securely and efficiently.
+The Google Workspace MCP Server integrates Google Workspace services (Calendar, Drive, Gmail, and Docs) with AI assistants and other applications using the Model Context Protocol (MCP). This allows AI systems to access and interact with user data from Google Workspace applications securely and efficiently.
 
 ---
 
@@ -50,7 +51,8 @@ The Google Workspace MCP Server integrates Google Workspace services (Calendar, 
 - **📅 Google Calendar Integration**: List calendars and fetch events
 - **📁 Google Drive Integration**: Search files, list folder contents, read file content, and create new files
 - **📧 Gmail Integration**: Search for messages and retrieve message content (including body)
-- **🔄 Multiple Transport Options**: Streamable HTTP + SSE fallback
+- **📄 Google Docs Integration**: Search for documents, read document content, list documents in folders, and create new documents
+- **� Multiple Transport Options**: Streamable HTTP + SSE fallback
 - **🔌 `mcpo` Compatibility**: Easily expose the server as an OpenAPI endpoint for integration with tools like Open WebUI
 - **🧩 Extensible Design**: Simple structure for adding support for more Google Workspace APIs and tools
 - **🔄 Integrated OAuth Callback**: Handles the OAuth redirect directly within the server on port 8000
@@ -63,7 +65,7 @@ The Google Workspace MCP Server integrates Google Workspace services (Calendar, 
 
 - **Python 3.12+**
 - **[uv](https://github.com/astral-sh/uv)** package installer (or pip)
-- **Google Cloud Project** with OAuth 2.0 credentials enabled for required APIs (Calendar, Drive, Gmail)
+- **Google Cloud Project** with OAuth 2.0 credentials enabled for required APIs (Calendar, Drive, Gmail, Docs)
 
 ### Installation
 
@@ -81,7 +83,7 @@ uv pip install -e .
 ### Configuration
 
 1. Create **OAuth 2.0 Credentials** (Desktop application type) in the [Google Cloud Console](https://console.cloud.google.com/).
-2. Enable the **Google Calendar API**, **Google Drive API**, and **Gmail API** for your project.
+2. Enable the **Google Calendar API**, **Google Drive API**, **Gmail API**, and **Google Docs API** for your project.
 3. Download the OAuth client credentials as `client_secret.json` and place it in the project's root directory.
 4. Add the following redirect URI to your OAuth client configuration in the Google Cloud Console:
    ```
@@ -254,6 +256,17 @@ Source: [`gmail/gmail_tools.py`](gmail/gmail_tools.py)
 
 > **Query Syntax**: For Gmail search queries, see [Gmail Search Query Syntax](https://support.google.com/mail/answer/7190)
 
+### Google Docs
+
+Source: [`gdocs/docs_tools.py`](gdocs/docs_tools.py)
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `search_docs` | Searches for Google Docs by name across user's Drive | • `query` (required): Search query string (e.g., `report`)<br>• `user_google_email` (optional): The user's Google email address<br>• `page_size` (optional): Maximum number of documents to return |
+| `get_doc_content` | Retrieves the content of a specific Google Doc as plain text | • `document_id` (required): The ID of the document<br>• `user_google_email` (optional): The user's Google email address |
+| `list_docs_in_folder` | Lists Google Docs within a specific folder | • `folder_id` (optional): The ID of the folder to list (defaults to root)<br>• `user_google_email` (optional): The user's Google email address<br>• `page_size` (optional): Maximum number of documents to return |
+| `create_doc` | Creates a new Google Doc with a title and optional content | • `title` (required): The title for the new document<br>• `content` (optional): Initial text content for the document<br>• `user_google_email` (optional): The user's Google email address |
+
 ---
 
 ## 🛠️ Development
@@ -266,6 +279,7 @@ google_workspace_mcp/
 ├── auth/              # OAuth handling logic (google_auth.py, oauth_manager.py)
 ├── core/              # Core MCP server logic (server.py)
 ├── gcalendar/         # Google Calendar tools (calendar_tools.py)
+├── gdocs/             # Google Docs tools (docs_tools.py)
 ├── gdrive/            # Google Drive tools (drive_tools.py)
 ├── gmail/             # Gmail tools (gmail_tools.py)
 ├── .gitignore         # Git ignore file

--- a/config/google_config.py
+++ b/config/google_config.py
@@ -42,6 +42,12 @@ BASE_SCOPES = [
 ]
 
 # Calendar-specific scopes
+DOCS_SCOPES = [
+    DOCS_READONLY_SCOPE,
+    DOCS_WRITE_SCOPE
+]
+
+# Calendar-specific scopes
 CALENDAR_SCOPES = [
     CALENDAR_READONLY_SCOPE,
     CALENDAR_EVENTS_SCOPE
@@ -49,7 +55,8 @@ CALENDAR_SCOPES = [
 
 # Drive-specific scopes
 DRIVE_SCOPES = [
-    DRIVE_READONLY_SCOPE
+    DRIVE_READONLY_SCOPE,
+    DRIVE_FILE_SCOPE
 ]
 
 # Gmail-specific scopes
@@ -59,7 +66,7 @@ GMAIL_SCOPES = [
 ]
 
 # Combined scopes for all supported Google Workspace operations
-SCOPES = list(set(BASE_SCOPES + CALENDAR_SCOPES + DRIVE_SCOPES + GMAIL_SCOPES + [DRIVE_FILE_SCOPE])) # Add DRIVE_FILE_SCOPE and GMAIL_SCOPES
+SCOPES = list(set(BASE_SCOPES + CALENDAR_SCOPES + DRIVE_SCOPES + GMAIL_SCOPES + DOCS_SCOPES))
 
 # Note: OAUTH_REDIRECT_URI is defined in core/server.py as it depends on the server's port.
 # It will be imported directly from core.server where needed.

--- a/config/google_config.py
+++ b/config/google_config.py
@@ -25,6 +25,10 @@ DRIVE_READONLY_SCOPE = 'https://www.googleapis.com/auth/drive.readonly'
 # DRIVE_METADATA_READONLY_SCOPE = 'https://www.googleapis.com/auth/drive.metadata.readonly'
 DRIVE_FILE_SCOPE = 'https://www.googleapis.com/auth/drive.file' # Per-file access
 
+# Google Docs scopes
+DOCS_READONLY_SCOPE = 'https://www.googleapis.com/auth/documents.readonly'
+DOCS_WRITE_SCOPE = 'https://www.googleapis.com/auth/documents'
+
 # Gmail API scopes
 GMAIL_READONLY_SCOPE   = 'https://www.googleapis.com/auth/gmail.readonly'
 GMAIL_SEND_SCOPE       = 'https://www.googleapis.com/auth/gmail.send'

--- a/core/server.py
+++ b/core/server.py
@@ -30,6 +30,8 @@ from config.google_config import (
     CALENDAR_SCOPES,
     DRIVE_SCOPES,
     GMAIL_SCOPES,
+    DOCS_READONLY_SCOPE,
+    DOCS_WRITE_SCOPE,
     SCOPES
 )
 

--- a/core/server.py
+++ b/core/server.py
@@ -40,37 +40,6 @@ logging.basicConfig(level=logging.INFO)
 # OAUTH_STATE_TO_SESSION_ID_MAP is now imported from config.google_config
 logger = logging.getLogger(__name__)
 
-# Individual OAuth Scope Constants are now imported from config.google_config
-# USERINFO_EMAIL_SCOPE = ...
-# OPENID_SCOPE = ...
-# CALENDAR_READONLY_SCOPE = ...
-# CALENDAR_EVENTS_SCOPE = ...
-
-# Google Drive scopes are now imported from config.google_config
-# DRIVE_READONLY_SCOPE = ...
-# DRIVE_METADATA_READONLY_SCOPE = ...
-# DRIVE_FILE_SCOPE = ...
-
-# Gmail API scopes are now imported from config.google_config
-# GMAIL_READONLY_SCOPE   = ...
-# GMAIL_SEND_SCOPE       = ...
-# GMAIL_LABELS_SCOPE     = ...
-
-# Base OAuth scopes required for user identification are now imported from config.google_config
-# BASE_SCOPES = [...]
-
-# Calendar-specific scopes are now imported from config.google_config
-# CALENDAR_SCOPES = [...]
-
-# Drive-specific scopes are now imported from config.google_config
-# DRIVE_SCOPES = [...]
-
-# Gmail-specific scopes are now imported from config.google_config
-# GMAIL_SCOPES = [...]
-
-# Combined scopes for all supported Google Workspace operations are now imported from config.google_config
-# SCOPES = [...]
-
 DEFAULT_PORT = 8000
 # Basic MCP server instance
 server = FastMCP(

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -1,0 +1,236 @@
+"""
+Google Docs MCP Tools
+
+This module provides MCP tools for interacting with Google Docs API and managing Google Docs via Drive.
+"""
+import logging
+import asyncio
+import io
+from typing import List, Optional, Dict, Any
+
+from mcp import types
+from fastapi import Header
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaIoBaseDownload
+
+# Auth & server utilities
+from auth.google_auth import get_credentials, start_auth_flow, CONFIG_CLIENT_SECRETS_PATH
+from core.server import (
+    server,
+    OAUTH_REDIRECT_URI,
+    DRIVE_READONLY_SCOPE,
+    DOCS_READONLY_SCOPE,
+    DOCS_WRITE_SCOPE,
+    SCOPES
+)
+
+logger = logging.getLogger(__name__)
+
+@server.tool()
+async def search_docs(
+    query: str,
+    user_google_email: Optional[str] = None,
+    page_size: int = 10,
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+) -> types.CallToolResult:
+    """
+    Searches for Google Docs by name using Drive API (mimeType filter).
+    """
+    logger.info(f"[search_docs] Session={mcp_session_id}, Email={user_google_email}, Query='{query}'")
+    tool_scopes = [DRIVE_READONLY_SCOPE]
+    credentials = await asyncio.to_thread(
+        get_credentials,
+        user_google_email=user_google_email,
+        required_scopes=tool_scopes,
+        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
+        session_id=mcp_session_id
+    )
+    if not credentials or not credentials.valid:
+        logger.warning(f"[search_docs] Missing credentials.")
+        if user_google_email and '@' in user_google_email:
+            return await start_auth_flow(
+                mcp_session_id=mcp_session_id,
+                user_google_email=user_google_email,
+                service_name="Google Drive",
+                redirect_uri=OAUTH_REDIRECT_URI
+            )
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text",
+            text="Docs Authentication required. LLM: Please ask for Google email.")])
+
+    try:
+        drive = build('drive', 'v3', credentials=credentials)
+        response = await asyncio.to_thread(
+            drive.files().list(
+                q=f"name contains '{query.replace("'", "\\'")}' and mimeType='application/vnd.google-apps.document' and trashed=false",
+                pageSize=page_size,
+                fields="files(id, name, createdTime, modifiedTime, webViewLink)"
+            ).execute
+        )
+        files = response.get('files', [])
+        if not files:
+            return types.CallToolResult(content=[types.TextContent(type="text",
+                text=f"No Google Docs found matching '{query}'.")])
+
+        output = [f"Found {len(files)} Google Docs matching '{query}':"]
+        for f in files:
+            output.append(
+                f"- {f['name']} (ID: {f['id']}) Modified: {f.get('modifiedTime')} Link: {f.get('webViewLink')}"
+            )
+        return types.CallToolResult(content=[types.TextContent(type="text", text="\n".join(output))])
+
+    except HttpError as e:
+        logger.error(f"API error in search_docs: {e}", exc_info=True)
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"API error: {e}")])
+
+@server.tool()
+async def get_doc_content(
+    document_id: str,
+    user_google_email: Optional[str] = None,
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+) -> types.CallToolResult:
+    """
+    Retrieves Google Doc content as plain text using Docs API.
+    """
+    logger.info(f"[get_doc_content] Document ID={document_id}")
+    tool_scopes = [DOCS_READONLY_SCOPE]
+    credentials = await asyncio.to_thread(
+        get_credentials,
+        user_google_email=user_google_email,
+        required_scopes=tool_scopes,
+        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
+        session_id=mcp_session_id
+    )
+    if not credentials or not credentials.valid:
+        logger.warning(f"[get_doc_content] Missing credentials.")
+        if user_google_email and '@' in user_google_email:
+            return await start_auth_flow(
+                mcp_session_id=mcp_session_id,
+                user_google_email=user_google_email,
+                service_name="Google Docs",
+                redirect_uri=OAUTH_REDIRECT_URI
+            )
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text",
+            text="Docs Authentication required. LLM: Please ask for Google email.")])
+
+    try:
+        docs = build('docs', 'v1', credentials=credentials)
+        doc = await asyncio.to_thread(docs.documents().get(documentId=document_id).execute)
+        title = doc.get('title', '')
+        body = doc.get('body', {}).get('content', [])
+
+        text_lines: List[str] = [f"Document: '{title}' (ID: {document_id})\n"]
+        def extract_text(el):
+            segs = el.get('paragraph', {}).get('elements', [])
+            return ''.join([s.get('textRun', {}).get('content', '') for s in segs])
+        for el in body:
+            if 'paragraph' in el:
+                t = extract_text(el)
+                if t.strip():
+                    text_lines.append(t)
+        content = ''.join(text_lines)
+        return types.CallToolResult(content=[types.TextContent(type="text", text=content)])
+
+    except HttpError as e:
+        logger.error(f"API error in get_doc_content: {e}", exc_info=True)
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"API error: {e}")])
+
+@server.tool()
+async def list_docs_in_folder(
+    folder_id: str = 'root',
+    user_google_email: Optional[str] = None,
+    page_size: int = 100,
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+) -> types.CallToolResult:
+    """
+    Lists Google Docs within a specific Drive folder.
+    """
+    logger.info(f"[list_docs_in_folder] Folder ID={folder_id}")
+    tool_scopes = [DRIVE_READONLY_SCOPE]
+    credentials = await asyncio.to_thread(
+        get_credentials,
+        user_google_email=user_google_email,
+        required_scopes=tool_scopes,
+        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
+        session_id=mcp_session_id
+    )
+    if not credentials or not credentials.valid:
+        logger.warning(f"[list_docs_in_folder] Missing credentials.")
+        if user_google_email and '@' in user_google_email:
+            return await start_auth_flow(
+                mcp_session_id=mcp_session_id,
+                user_google_email=user_google_email,
+                service_name="Google Drive",
+                redirect_uri=OAUTH_REDIRECT_URI
+            )
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text",
+            text="Docs Authentication required. LLM: Please ask for Google email.")])
+
+    try:
+        drive = build('drive', 'v3', credentials=credentials)
+        rsp = await asyncio.to_thread(
+            drive.files().list(
+                q=f"'{folder_id}' in parents and mimeType='application/vnd.google-apps.document' and trashed=false",
+                pageSize=page_size,
+                fields="files(id, name, modifiedTime, webViewLink)"
+            ).execute
+        )
+        items = rsp.get('files', [])
+        if not items:
+            return types.CallToolResult(content=[types.TextContent(type="text",
+                text=f"No Google Docs found in folder '{folder_id}'.")])
+        out = [f"Found {len(items)} Docs in folder '{folder_id}':"]
+        for f in items:
+            out.append(f"- {f['name']} (ID: {f['id']}) Modified: {f.get('modifiedTime')} Link: {f.get('webViewLink')}")
+        return types.CallToolResult(content=[types.TextContent(type="text", text="\n".join(out))])
+
+    except HttpError as e:
+        logger.error(f"API error in list_docs_in_folder: {e}", exc_info=True)
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"API error: {e}")])
+
+@server.tool()
+async def create_doc(
+    title: str,
+    content: str = '',
+    user_google_email: Optional[str] = None,
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+) -> types.CallToolResult:
+    """
+    Creates a new Google Doc and optionally inserts initial content.
+    """
+    logger.info(f"[create_doc] Title='{title}'")
+    tool_scopes = [DOCS_WRITE_SCOPE]
+    credentials = await asyncio.to_thread(
+        get_credentials,
+        user_google_email=user_google_email,
+        required_scopes=tool_scopes,
+        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
+        session_id=mcp_session_id
+    )
+    if not credentials or not credentials.valid:
+        logger.warning(f"[create_doc] Missing credentials.")
+        if user_google_email and '@' in user_google_email:
+            return await start_auth_flow(
+                mcp_session_id=mcp_session_id,
+                user_google_email=user_google_email,
+                service_name="Google Docs",
+                redirect_uri=OAUTH_REDIRECT_URI
+            )
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text",
+            text="Docs Authentication required. LLM: Please ask for Google email.")])
+
+    try:
+        docs = build('docs', 'v1', credentials=credentials)
+        doc = await asyncio.to_thread(docs.documents().create(body={'title': title}).execute)
+        doc_id = doc.get('documentId')
+        if content:
+            # Insert content at end
+            requests = [{'insertText': {'location': {'index': 1}, 'text': content}}]
+            await asyncio.to_thread(docs.documents().batchUpdate(documentId=doc_id, body={'requests': requests}).execute)
+        link = f"https://docs.google.com/document/d/{doc_id}/edit"
+        msg = f"Created Google Doc '{title}' (ID: {doc_id}). Link: {link}"  
+        return types.CallToolResult(content=[types.TextContent(type="text", text=msg)])
+
+    except HttpError as e:
+        logger.error(f"API error in create_doc: {e}", exc_info=True)
+        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"API error: {e}")])

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -17,22 +17,15 @@ from googleapiclient.http import MediaIoBaseDownload # For file content
 import io # For file content
 
 # Use functions directly from google_auth
-from auth.google_auth import get_credentials, start_auth_flow, CONFIG_CLIENT_SECRETS_PATH # Import start_auth_flow and CONFIG_CLIENT_SECRETS_PATH
+from auth.google_auth import get_credentials, start_auth_flow, CONFIG_CLIENT_SECRETS_PATH
 from core.server import server, OAUTH_REDIRECT_URI, OAUTH_STATE_TO_SESSION_ID_MAP
-from core.server import ( # Import Drive scopes defined in core.server
+from core.server import (
     DRIVE_READONLY_SCOPE,
-    DRIVE_FILE_SCOPE, # Ensure DRIVE_FILE_SCOPE is imported
-    SCOPES # The combined list of all scopes for broad auth initiation
+    DRIVE_FILE_SCOPE,
+    SCOPES
 )
 
 logger = logging.getLogger(__name__)
-
-# CONFIG_CLIENT_SECRETS_PATH is now imported from auth.google_auth
-# OAUTH_REDIRECT_URI and OAUTH_STATE_TO_SESSION_ID_MAP are imported from core.server
-
-# Remove the local _initiate_drive_auth_and_get_message helper function
-# async def _initiate_drive_auth_and_get_message(...): ...
-
 
 @server.tool()
 async def search_drive_files(

--- a/main.py
+++ b/main.py
@@ -38,6 +38,8 @@ except Exception as e:
 import gcalendar.calendar_tools
 import gdrive.drive_tools
 import gmail.gmail_tools
+import gdocs.docs_tools
+
 
 def main():
     """


### PR DESCRIPTION
# Add Google Docs API Integration

## Summary

This pull request adds full Google Docs API integration to the Google Workspace MCP Server. The integration enables users to search for Google Docs, read document content, list documents within folders, and create new documents - all through the MCP protocol.

## Changes

- Added Google Docs API scopes in [`config/google_config.py`](config/google_config.py:28-29)
- Created new module [`gdocs/docs_tools.py`](gdocs/docs_tools.py) with Google Docs functionality
- Integrated the new module in [`main.py`](main.py:41)
- Cleaned up commented code in [`core/server.py`](core/server.py)
- Updated Drive scopes configuration in [`config/google_config.py`](config/google_config.py:57-58)

## Features

The PR adds four new MCP tools for Google Docs integration:

1. **`search_docs`**: Search for Google Docs by name across a user's Drive
2. **`get_doc_content`**: Retrieve the content of a specific Google Doc as plain text
3. **`list_docs_in_folder`**: List all Google Docs within a specific Drive folder
4. **`create_doc`**: Create a new Google Doc with a title and optional initial content

## Implementation Details

- Each tool follows the established pattern with proper authentication handling
- Docs tools use either the Google Drive API (for listing/searching) or the Docs API (for content/creation)
- All tools properly handle authentication, including initiating OAuth flow when needed
- Error handling follows the same patterns as existing tools

## Testing

All tools have been manually tested with various inputs:
- Searching for documents with partial name matches
- Retrieving content from documents with various formatting
- Listing documents in both the root folder and nested folders
- Creating new documents with and without initial content