### PR TITLE
Add draft_gmail_message MCP tool

### DIFF
--- a/config/google_config.py
+++ b/config/google_config.py
@@ -32,6 +32,7 @@ DOCS_WRITE_SCOPE = 'https://www.googleapis.com/auth/documents'
 # Gmail API scopes
 GMAIL_READONLY_SCOPE   = 'https://www.googleapis.com/auth/gmail.readonly'
 GMAIL_SEND_SCOPE       = 'https://www.googleapis.com/auth/gmail.send'
+GMAIL_COMPOSE_SCOPE    = 'https://www.googleapis.com/auth/gmail.compose'
 # Optional, if you later need label management:
 # GMAIL_LABELS_SCOPE     = 'https://www.googleapis.com/auth/gmail.labels'
 
@@ -63,6 +64,7 @@ DRIVE_SCOPES = [
 GMAIL_SCOPES = [
     GMAIL_READONLY_SCOPE,
     GMAIL_SEND_SCOPE,
+    GMAIL_COMPOSE_SCOPE
 ]
 
 # Combined scopes for all supported Google Workspace operations

--- a/core/server.py
+++ b/core/server.py
@@ -25,6 +25,7 @@ from config.google_config import (
     DRIVE_FILE_SCOPE,
     GMAIL_READONLY_SCOPE,
     GMAIL_SEND_SCOPE,
+    GMAIL_COMPOSE_SCOPE,
     BASE_SCOPES,
     CALENDAR_SCOPES,
     DRIVE_SCOPES,

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -3,6 +3,7 @@ Google Gmail MCP Tools
 
 This module provides MCP tools for interacting with the Gmail API.
 """
+
 import logging
 import asyncio
 import base64
@@ -12,11 +13,15 @@ from email.mime.text import MIMEText
 
 
 from mcp import types
-from fastapi import Header, Body 
+from fastapi import Header, Body
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
-from auth.google_auth import get_credentials, start_auth_flow, CONFIG_CLIENT_SECRETS_PATH
+from auth.google_auth import (
+    get_credentials,
+    start_auth_flow,
+    CONFIG_CLIENT_SECRETS_PATH,
+)
 
 from core.server import (
     GMAIL_READONLY_SCOPE,
@@ -24,17 +29,18 @@ from core.server import (
     GMAIL_COMPOSE_SCOPE,
     OAUTH_REDIRECT_URI,
     SCOPES,
-    server
+    server,
 )
 
 logger = logging.getLogger(__name__)
+
 
 @server.tool()
 async def search_gmail_messages(
     query: str,
     user_google_email: Optional[str] = None,
     page_size: int = 10,
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
 ) -> types.CallToolResult:
     """
     Searches messages in a user's Gmail account based on a query.
@@ -50,7 +56,9 @@ async def search_gmail_messages(
         types.CallToolResult: Contains a list of found message IDs or an error/auth guidance message.
     """
     tool_name = "search_gmail_messages"
-    logger.info(f"[{tool_name}] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}', Query: '{query}'")
+    logger.info(
+        f"[{tool_name}] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}', Query: '{query}'"
+    )
 
     # Use get_credentials to fetch credentials
     credentials = await asyncio.to_thread(
@@ -58,57 +66,89 @@ async def search_gmail_messages(
         user_google_email=user_google_email,
         required_scopes=[GMAIL_READONLY_SCOPE],
         client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
-        session_id=mcp_session_id
+        session_id=mcp_session_id,
     )
 
     # Check if credentials are valid, initiate auth flow if not
     if not credentials or not credentials.valid:
-        logger.warning(f"[{tool_name}] No valid credentials. Session: '{mcp_session_id}', Email: '{user_google_email}'.")
-        if user_google_email and '@' in user_google_email:
-            logger.info(f"[{tool_name}] Valid email '{user_google_email}' provided, initiating auth flow for this email (requests all SCOPES).")
+        logger.warning(
+            f"[{tool_name}] No valid credentials. Session: '{mcp_session_id}', Email: '{user_google_email}'."
+        )
+        if user_google_email and "@" in user_google_email:
+            logger.info(
+                f"[{tool_name}] Valid email '{user_google_email}' provided, initiating auth flow for this email (requests all SCOPES)."
+            )
             # Use the centralized start_auth_flow
-            return await start_auth_flow(mcp_session_id=mcp_session_id, user_google_email=user_google_email, service_name="Gmail", redirect_uri=OAUTH_REDIRECT_URI)
+            return await start_auth_flow(
+                mcp_session_id=mcp_session_id,
+                user_google_email=user_google_email,
+                service_name="Gmail",
+                redirect_uri=OAUTH_REDIRECT_URI,
+            )
         else:
             error_msg = "Gmail Authentication required. No active authenticated session, and no valid 'user_google_email' provided. LLM: Please ask the user for their Google email address and retry, or use the 'start_auth' tool with their email."
             logger.info(f"[{tool_name}] {error_msg}")
-            return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_msg)])
+            return types.CallToolResult(
+                isError=True, content=[types.TextContent(type="text", text=error_msg)]
+            )
 
     try:
         # Build the service object directly
-        service = build('gmail', 'v1', credentials=credentials)
-        user_email_from_creds = credentials.id_token.get('email') if credentials.id_token else 'Unknown (Gmail)'
+        service = build("gmail", "v1", credentials=credentials)
+        user_email_from_creds = (
+            credentials.id_token.get("email")
+            if credentials.id_token
+            else "Unknown (Gmail)"
+        )
         logger.info(f"[{tool_name}] Using service for: {user_email_from_creds}")
 
         response = await asyncio.to_thread(
-            service.users().messages().list(
-                userId='me',
-                q=query,
-                maxResults=page_size
-            ).execute
+            service.users()
+            .messages()
+            .list(userId="me", q=query, maxResults=page_size)
+            .execute
         )
-        messages = response.get('messages', [])
+        messages = response.get("messages", [])
         if not messages:
-            return types.CallToolResult(content=[types.TextContent(type="text", text=f"No messages found for '{query}'.")])
+            return types.CallToolResult(
+                content=[
+                    types.TextContent(
+                        type="text", text=f"No messages found for '{query}'."
+                    )
+                ]
+            )
 
         lines = [f"Found {len(messages)} messages:"]
         for msg in messages:
-             lines.append(f"- ID: {msg['id']}") # list doesn't return snippet by default
+            lines.append(f"- ID: {msg['id']}")  # list doesn't return snippet by default
 
-        return types.CallToolResult(content=[types.TextContent(type="text", text="\n".join(lines))])
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text="\n".join(lines))]
+        )
 
     except HttpError as e:
-        logger.error(f"[{tool_name}] Gmail API error searching messages: {e}", exc_info=True)
-        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Gmail API error: {e}")])
+        logger.error(
+            f"[{tool_name}] Gmail API error searching messages: {e}", exc_info=True
+        )
+        return types.CallToolResult(
+            isError=True,
+            content=[types.TextContent(type="text", text=f"Gmail API error: {e}")],
+        )
     except Exception as e:
-        logger.exception(f"[{tool_name}] Unexpected error searching Gmail messages: {e}")
-        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Unexpected error: {e}")])
+        logger.exception(
+            f"[{tool_name}] Unexpected error searching Gmail messages: {e}"
+        )
+        return types.CallToolResult(
+            isError=True,
+            content=[types.TextContent(type="text", text=f"Unexpected error: {e}")],
+        )
 
 
 @server.tool()
 async def get_gmail_message_content(
     message_id: str,
     user_google_email: Optional[str] = None,
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
 ) -> types.CallToolResult:
     """
     Retrieves the full content (subject, sender, plain text body) of a specific Gmail message.
@@ -123,7 +163,9 @@ async def get_gmail_message_content(
         types.CallToolResult: Contains the message details or an error/auth guidance message.
     """
     tool_name = "get_gmail_message_content"
-    logger.info(f"[{tool_name}] Invoked. Message ID: '{message_id}', Session: '{mcp_session_id}', Email: '{user_google_email}'")
+    logger.info(
+        f"[{tool_name}] Invoked. Message ID: '{message_id}', Session: '{mcp_session_id}', Email: '{user_google_email}'"
+    )
 
     # Use get_credentials to fetch credentials
     credentials = await asyncio.to_thread(
@@ -131,84 +173,128 @@ async def get_gmail_message_content(
         user_google_email=user_google_email,
         required_scopes=[GMAIL_READONLY_SCOPE],
         client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
-        session_id=mcp_session_id
+        session_id=mcp_session_id,
     )
 
     # Check if credentials are valid, initiate auth flow if not
     if not credentials or not credentials.valid:
-        logger.warning(f"[{tool_name}] No valid credentials. Session: '{mcp_session_id}', Email: '{user_google_email}'.")
-        if user_google_email and '@' in user_google_email:
-            logger.info(f"[{tool_name}] Valid email '{user_google_email}' provided, initiating auth flow for this email (requests all SCOPES).")
+        logger.warning(
+            f"[{tool_name}] No valid credentials. Session: '{mcp_session_id}', Email: '{user_google_email}'."
+        )
+        if user_google_email and "@" in user_google_email:
+            logger.info(
+                f"[{tool_name}] Valid email '{user_google_email}' provided, initiating auth flow for this email (requests all SCOPES)."
+            )
             # Use the centralized start_auth_flow
-            return await start_auth_flow(mcp_session_id=mcp_session_id, user_google_email=user_google_email, service_name="Gmail", redirect_uri=OAUTH_REDIRECT_URI)
+            return await start_auth_flow(
+                mcp_session_id=mcp_session_id,
+                user_google_email=user_google_email,
+                service_name="Gmail",
+                redirect_uri=OAUTH_REDIRECT_URI,
+            )
         else:
             error_msg = "Gmail Authentication required. No active authenticated session, and no valid 'user_google_email' provided. LLM: Please ask the user for their Google email address and retry, or use the 'start_auth' tool with their email."
             logger.info(f"[{tool_name}] {error_msg}")
-            return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_msg)])
+            return types.CallToolResult(
+                isError=True, content=[types.TextContent(type="text", text=error_msg)]
+            )
 
     try:
         # Build the service object directly
-        service = build('gmail', 'v1', credentials=credentials)
-        user_email_from_creds = credentials.id_token.get('email') if credentials.id_token else 'Unknown (Gmail)'
+        service = build("gmail", "v1", credentials=credentials)
+        user_email_from_creds = (
+            credentials.id_token.get("email")
+            if credentials.id_token
+            else "Unknown (Gmail)"
+        )
         logger.info(f"[{tool_name}] Using service for: {user_email_from_creds}")
 
         # Fetch message metadata first to get headers
         message_metadata = await asyncio.to_thread(
-            service.users().messages().get(
-                userId='me',
+            service.users()
+            .messages()
+            .get(
+                userId="me",
                 id=message_id,
-                format='metadata',
-                metadataHeaders=['Subject', 'From']
-            ).execute
+                format="metadata",
+                metadataHeaders=["Subject", "From"],
+            )
+            .execute
         )
 
-        headers = {h['name']: h['value'] for h in message_metadata.get('payload', {}).get('headers', [])}
-        subject = headers.get('Subject', '(no subject)')
-        sender = headers.get('From', '(unknown sender)')
+        headers = {
+            h["name"]: h["value"]
+            for h in message_metadata.get("payload", {}).get("headers", [])
+        }
+        subject = headers.get("Subject", "(no subject)")
+        sender = headers.get("From", "(unknown sender)")
 
         # Now fetch the full message to get the body parts
         message_full = await asyncio.to_thread(
-             service.users().messages().get(
-                userId='me',
+            service.users()
+            .messages()
+            .get(
+                userId="me",
                 id=message_id,
-                format='full' # Request full payload for body
-            ).execute
+                format="full",  # Request full payload for body
+            )
+            .execute
         )
 
         # Find the plain text part (more robustly)
         body_data = ""
-        payload = message_full.get('payload', {})
-        parts = [payload] if 'parts' not in payload else payload.get('parts', [])
+        payload = message_full.get("payload", {})
+        parts = [payload] if "parts" not in payload else payload.get("parts", [])
 
-        part_queue = list(parts) # Use a queue for BFS traversal of parts
+        part_queue = list(parts)  # Use a queue for BFS traversal of parts
         while part_queue:
             part = part_queue.pop(0)
-            if part.get('mimeType') == 'text/plain' and part.get('body', {}).get('data'):
-                data = base64.urlsafe_b64decode(part['body']['data'])
-                body_data = data.decode('utf-8', errors='ignore')
-                break # Found plain text body
-            elif part.get('mimeType', '').startswith('multipart/') and 'parts' in part:
-                part_queue.extend(part.get('parts', [])) # Add sub-parts to the queue
+            if part.get("mimeType") == "text/plain" and part.get("body", {}).get(
+                "data"
+            ):
+                data = base64.urlsafe_b64decode(part["body"]["data"])
+                body_data = data.decode("utf-8", errors="ignore")
+                break  # Found plain text body
+            elif part.get("mimeType", "").startswith("multipart/") and "parts" in part:
+                part_queue.extend(part.get("parts", []))  # Add sub-parts to the queue
 
         # If no plain text found, check the main payload body if it exists
-        if not body_data and payload.get('mimeType') == 'text/plain' and payload.get('body', {}).get('data'):
-             data = base64.urlsafe_b64decode(payload['body']['data'])
-             body_data = data.decode('utf-8', errors='ignore')
+        if (
+            not body_data
+            and payload.get("mimeType") == "text/plain"
+            and payload.get("body", {}).get("data")
+        ):
+            data = base64.urlsafe_b64decode(payload["body"]["data"])
+            body_data = data.decode("utf-8", errors="ignore")
 
-
-        content_text = "\n".join([
-            f"Subject: {subject}",
-            f"From:    {sender}",
-            f"\n--- BODY ---\n{body_data or '[No text/plain body found]'}"
-        ])
-        return types.CallToolResult(content=[types.TextContent(type="text", text=content_text)])
+        content_text = "\n".join(
+            [
+                f"Subject: {subject}",
+                f"From:    {sender}",
+                f"\n--- BODY ---\n{body_data or '[No text/plain body found]'}",
+            ]
+        )
+        return types.CallToolResult(
+            content=[types.TextContent(type="text", text=content_text)]
+        )
 
     except HttpError as e:
-        logger.error(f"[{tool_name}] Gmail API error getting message content: {e}", exc_info=True)
-        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Gmail API error: {e}")])
+        logger.error(
+            f"[{tool_name}] Gmail API error getting message content: {e}", exc_info=True
+        )
+        return types.CallToolResult(
+            isError=True,
+            content=[types.TextContent(type="text", text=f"Gmail API error: {e}")],
+        )
     except Exception as e:
-        logger.exception(f"[{tool_name}] Unexpected error getting Gmail message content: {e}")
-        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Unexpected error: {e}")])
+        logger.exception(
+            f"[{tool_name}] Unexpected error getting Gmail message content: {e}"
+        )
+        return types.CallToolResult(
+            isError=True,
+            content=[types.TextContent(type="text", text=f"Unexpected error: {e}")],
+        )
+
 
 @server.tool()
 async def send_gmail_message(
@@ -216,7 +302,7 @@ async def send_gmail_message(
     subject: str = Body(..., description="Email subject."),
     body: str = Body(..., description="Email body (plain text)."),
     user_google_email: Optional[str] = None,
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
 ) -> types.CallToolResult:
     """
     Sends an email using the user's Gmail account.
@@ -240,23 +326,33 @@ async def send_gmail_message(
             user_google_email=user_google_email,
             required_scopes=[GMAIL_SEND_SCOPE],
             client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
-            session_id=mcp_session_id
+            session_id=mcp_session_id,
         )
-         # Check if credentials are valid, initiate auth flow if not
+        # Check if credentials are valid, initiate auth flow if not
         if not credentials or not credentials.valid:
-            logger.warning(f"[{tool_name}] No valid credentials. Session: '{mcp_session_id}', Email: '{user_google_email}'.")
-            if user_google_email and '@' in user_google_email:
-                logger.info(f"[{tool_name}] Valid email '{user_google_email}' provided, initiating auth flow for this email (requests all SCOPES).")
+            logger.warning(
+                f"[{tool_name}] No valid credentials. Session: '{mcp_session_id}', Email: '{user_google_email}'."
+            )
+            if user_google_email and "@" in user_google_email:
+                logger.info(
+                    f"[{tool_name}] Valid email '{user_google_email}' provided, initiating auth flow for this email (requests all SCOPES)."
+                )
                 # Use the centralized start_auth_flow
-                return await start_auth_flow(mcp_session_id=mcp_session_id, user_google_email=user_google_email, service_name="Gmail", redirect_uri=OAUTH_REDIRECT_URI)
+                return await start_auth_flow(
+                    mcp_session_id=mcp_session_id,
+                    user_google_email=user_google_email,
+                    service_name="Gmail",
+                    redirect_uri=OAUTH_REDIRECT_URI,
+                )
             else:
                 error_msg = "Gmail Authentication required. No active authenticated session, and no valid 'user_google_email' provided. LLM: Please ask the user for their Google email address and retry, or use the 'start_auth' tool with their email."
                 logger.info(f"[{tool_name}] {error_msg}")
-                return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_msg)])
+                return types.CallToolResult(
+                    isError=True,
+                    content=[types.TextContent(type="text", text=error_msg)],
+                )
 
-        service = await asyncio.to_thread(
-            build, "gmail", "v1", credentials=credentials
-        )
+        service = await asyncio.to_thread(build, "gmail", "v1", credentials=credentials)
 
         # Prepare the email
         message = MIMEText(body)
@@ -270,14 +366,29 @@ async def send_gmail_message(
             service.users().messages().send(userId="me", body=send_body).execute
         )
         message_id = sent_message.get("id")
-        return types.CallToolResult(content=[types.TextContent(type="text", text=f"Email sent! Message ID: {message_id}")])
+        return types.CallToolResult(
+            content=[
+                types.TextContent(
+                    type="text", text=f"Email sent! Message ID: {message_id}"
+                )
+            ]
+        )
 
     except HttpError as e:
-        logger.error(f"[{tool_name}] Gmail API error sending message: {e}", exc_info=True)
-        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Gmail API error: {e}")])
+        logger.error(
+            f"[{tool_name}] Gmail API error sending message: {e}", exc_info=True
+        )
+        return types.CallToolResult(
+            isError=True,
+            content=[types.TextContent(type="text", text=f"Gmail API error: {e}")],
+        )
     except Exception as e:
         logger.exception(f"[{tool_name}] Unexpected error sending Gmail message: {e}")
-        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Unexpected error: {e}")])
+        return types.CallToolResult(
+            isError=True,
+            content=[types.TextContent(type="text", text=f"Unexpected error: {e}")],
+        )
+
 
 @server.tool()
 async def draft_gmail_message(
@@ -285,7 +396,7 @@ async def draft_gmail_message(
     body: str = Body(..., description="Email body (plain text)."),
     to: Optional[str] = Body(None, description="Optional recipient email address."),
     user_google_email: Optional[str] = None,
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
 ) -> types.CallToolResult:
     """
     Creates a draft email in the user's Gmail account.
@@ -302,62 +413,91 @@ async def draft_gmail_message(
         types.CallToolResult: Contains the draft ID of the created email, or an error/auth guidance message.
     """
     tool_name = "draft_gmail_message"
-    logger.info(f"[{tool_name}] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}'")
-    
-    try:
-        # Use get_credentials to fetch credentials
-        credentials = await asyncio.to_thread(
-            get_credentials,
-            user_google_email=user_google_email,
-            required_scopes=[GMAIL_COMPOSE_SCOPE],
-            client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
-            session_id=mcp_session_id
-        )
-         # Check if credentials are valid, initiate auth flow if not
-        if not credentials or not credentials.valid:
-            logger.warning(f"[{tool_name}] No valid credentials. Session: '{mcp_session_id}', Email: '{user_google_email}'.")
-            if user_google_email and '@' in user_google_email:
-                logger.info(f"[{tool_name}] Valid email '{user_google_email}' provided, initiating auth flow for this email (requests all SCOPES).")
-                # Use the centralized start_auth_flow
-                return await start_auth_flow(mcp_session_id=mcp_session_id, user_google_email=user_google_email, service_name="Gmail", redirect_uri=OAUTH_REDIRECT_URI)
-            else:
-                error_msg = "Gmail Authentication required. No active authenticated session, and no valid 'user_google_email' provided. LLM: Please ask the user for their Google email address and retry, or use the 'start_auth' tool with their email."
-                logger.info(f"[{tool_name}] {error_msg}")
-                return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_msg)])
+    logger.info(
+        f"[{tool_name}] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}', Subject: '{subject}'"
+    )
 
-        service = await asyncio.to_thread(
-            build, "gmail", "v1", credentials=credentials
+    # Use get_credentials to fetch credentials
+    credentials = await asyncio.to_thread(
+        get_credentials,
+        user_google_email=user_google_email,
+        required_scopes=[GMAIL_COMPOSE_SCOPE],
+        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
+        session_id=mcp_session_id,
+    )
+
+    # Check if credentials are valid, initiate auth flow if not
+    if not credentials or not credentials.valid:
+        logger.warning(
+            f"[{tool_name}] No valid credentials. Session: '{mcp_session_id}', Email: '{user_google_email}'."
         )
-        user_email_from_creds = credentials.id_token.get('email') if credentials.id_token else 'Unknown (Gmail)'
+        if user_google_email and "@" in user_google_email:
+            logger.info(
+                f"[{tool_name}] Valid email '{user_google_email}' provided, initiating auth flow for this email (requests all SCOPES)."
+            )
+            # Use the centralized start_auth_flow
+            return await start_auth_flow(
+                mcp_session_id=mcp_session_id,
+                user_google_email=user_google_email,
+                service_name="Gmail",
+                redirect_uri=OAUTH_REDIRECT_URI,
+            )
+        else:
+            error_msg = "Gmail Authentication required. No active authenticated session, and no valid 'user_google_email' provided. LLM: Please ask the user for their Google email address and retry, or use the 'start_auth' tool with their email."
+            logger.info(f"[{tool_name}] {error_msg}")
+            return types.CallToolResult(
+                isError=True, content=[types.TextContent(type="text", text=error_msg)]
+            )
+
+    try:
+        # Build the service object directly
+        service = build("gmail", "v1", credentials=credentials)
+        user_email_from_creds = (
+            credentials.id_token.get("email")
+            if credentials.id_token
+            else "Unknown (Gmail)"
+        )
         logger.info(f"[{tool_name}] Using service for: {user_email_from_creds}")
 
         # Prepare the email
         message = MIMEText(body)
         message["subject"] = subject
-        
+
         # Add recipient if provided
         if to:
             message["to"] = to
-            
+
         raw_message = base64.urlsafe_b64encode(message.as_bytes()).decode()
-        
+
         # Create a draft instead of sending
-        draft_body = {
-            "message": {
-                "raw": raw_message
-            }
-        }
+        draft_body = {"message": {"raw": raw_message}}
 
         # Create the draft
         created_draft = await asyncio.to_thread(
             service.users().drafts().create(userId="me", body=draft_body).execute
         )
         draft_id = created_draft.get("id")
-        return types.CallToolResult(content=[types.TextContent(type="text", text=f"Draft created! Draft ID: {draft_id}")])
+        return types.CallToolResult(
+            content=[
+                types.TextContent(
+                    type="text", text=f"Draft created! Draft ID: {draft_id}"
+                )
+            ]
+        )
 
     except HttpError as e:
-        logger.error(f"[{tool_name}] Gmail API error creating draft: {e}", exc_info=True)
-        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Gmail API error: {e}")])
+        logger.error(
+            f"[{tool_name}] Gmail API error creating draft: {e}", exc_info=True
+        )
+        return types.CallToolResult(
+            isError=True,
+            content=[types.TextContent(type="text", text=f"Gmail API error: {e}")],
+        )
     except Exception as e:
-        logger.exception(f"[{tool_name}] Unexpected error creating Gmail draft: {e}")
-        return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"Unexpected error: {e}")])
+        logger.exception(
+            f"[{tool_name}] Unexpected error creating Gmail draft: {e}"
+        )
+        return types.CallToolResult(
+            isError=True,
+            content=[types.TextContent(type="text", text=f"Unexpected error: {e}")],
+        )


### PR DESCRIPTION
Add new tool to create Gmail draft messages with optional recipients. This allows users to save email drafts at any stage of composition without requiring all fields to be completed.

- Implements Gmail draft API integration
- Makes "to" field optional for flexibility
- Uses GMAIL_COMPOSE_SCOPE for authentication
- Maintains existing project patterns for error handling and logging