### PR TITLE
feat: Single User Mode -> trusted environment to bypass session requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,26 @@ Runs the server with an HTTP transport layer on port 8000.
 </details>
 
 <details>
+<summary><b>Single-User Mode</b></summary>
+
+For simplified single-user environments, you can run the server in single-user mode, which bypasses session-to-OAuth mapping and uses any available credentials from the `.credentials` directory:
+
+```bash
+python main.py --single-user
+# or using uv
+uv run main.py --single-user
+```
+
+In single-user mode:
+- The server automatically finds and uses any valid credentials in the `.credentials` directory
+- No session mapping is required - the server uses the first valid credential file found
+- Useful for development, testing, or single-user deployments
+- Still requires initial OAuth authentication to create credential files
+
+This mode is particularly helpful when you don't need multi-user session management and want simplified credential handling.
+</details>
+
+<details>
 <summary><b>Using mcpo (Recommended for Open WebUI and other OpenAPI spec compatible clients)</b></summary>
 
 Requires `mcpo` installed (`uv pip install mcpo` or `pip install mcpo`).
@@ -330,7 +350,7 @@ Source: [`gmail/gmail_tools.py`](gmail/gmail_tools.py)
 
 > **Query Syntax**: For Gmail search queries, see [Gmail Search Query Syntax](https://support.google.com/mail/answer/7190)
 
-### 📝 Google Docs 
+### 📝 Google Docs
 
 Source: [`gdocs/docs_tools.py`](gdocs/docs_tools.py)
 

--- a/core/streamable_http.py
+++ b/core/streamable_http.py
@@ -1,0 +1,262 @@
+import contextlib
+import logging
+import os
+from collections.abc import AsyncIterator
+from typing import Optional, Dict, Any, Callable
+
+import anyio
+from mcp.server.lowlevel import Server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.routing import Mount
+from starlette.types import Receive, Scope, Send, ASGIApp
+
+# Global variable to store the current session ID for the current request
+# This will be used to pass the session ID to the FastMCP tools
+CURRENT_SESSION_ID = None
+
+logger = logging.getLogger(__name__)
+
+class SessionAwareStreamableHTTPManager:
+    """
+    A wrapper around StreamableHTTPSessionManager that provides access to session information.
+    This class enables retrieving active session data which can be useful for tools that need 
+    to know about current sessions.
+    """
+    
+    def __init__(self, app: Server, stateless: bool = False, event_store: Optional[Any] = None):
+        """
+        Initialize the session manager wrapper.
+        
+        Args:
+            app: The MCP Server instance
+            stateless: Whether to use stateless mode (default: False)
+            event_store: Optional event store for storing session events
+        """
+        self.session_manager = StreamableHTTPSessionManager(
+            app=app,
+            event_store=event_store,
+            stateless=stateless
+        )
+        self._sessions = {}
+        
+    async def handle_request(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """
+        Handle an incoming request by delegating to the underlying session manager.
+        
+        Args:
+            scope: The ASGI scope
+            receive: The ASGI receive function
+            send: The ASGI send function
+        """
+        global CURRENT_SESSION_ID
+        
+        # Check for session ID in headers
+        headers = dict(scope.get("headers", []))
+        session_id = None
+        for key, value in headers.items():
+            if key.lower() == b'mcp-session-id':
+                session_id = value.decode('utf-8')
+                break
+        
+        # Extract session ID from StreamableHTTP if not in headers
+        if not session_id and hasattr(self.session_manager, '_get_session_id_from_scope'):
+            try:
+                # Try to get session ID directly from StreamableHTTP manager
+                session_id = self.session_manager._get_session_id_from_scope(scope)
+            except Exception:
+                pass
+        
+        # Set the global session ID for this request
+        if session_id:
+            CURRENT_SESSION_ID = session_id
+            
+            # Inject the session ID into the request headers
+            # This allows FastMCP to access it via the Header mechanism
+            new_headers = []
+            has_session_header = False
+            
+            for k, v in scope.get("headers", []):
+                if k.lower() == b'mcp-session-id':
+                    new_headers.append((k, session_id.encode('utf-8')))
+                    has_session_header = True
+                else:
+                    new_headers.append((k, v))
+            
+            # Add the header if it doesn't exist
+            if not has_session_header:
+                new_headers.append((b'mcp-session-id', session_id.encode('utf-8')))
+            
+            # Replace headers in scope
+            scope["headers"] = new_headers
+        else:
+            CURRENT_SESSION_ID = None
+        
+        # Create a wrapper for the send function to capture the session ID
+        # from the response if it's not in the request
+        original_send = send
+        
+        async def wrapped_send(message):
+            nonlocal session_id
+            global CURRENT_SESSION_ID
+            
+            # If this is a response, check for session ID in headers
+            if message.get("type") == "http.response.start" and not session_id:
+                headers = message.get("headers", [])
+                for k, v in headers:
+                    if k.lower() == b'mcp-session-id':
+                        new_session_id = v.decode('utf-8')
+                        CURRENT_SESSION_ID = new_session_id
+                        break
+            
+            await original_send(message)
+        
+        # Process the request with the wrapped send function
+        await self.session_manager.handle_request(scope, receive, wrapped_send)
+        
+        # Clear the global session ID after the request is done
+        CURRENT_SESSION_ID = None
+    
+    @contextlib.asynccontextmanager
+    async def run(self) -> AsyncIterator[None]:
+        """
+        Context manager for running the session manager.
+        
+        Yields:
+            None
+        """
+        async with self.session_manager.run():
+            logger.debug("SessionAwareStreamableHTTPManager started")
+            try:
+                yield
+            finally:
+                logger.debug("SessionAwareStreamableHTTPManager shutting down")
+    
+    def get_active_sessions(self) -> Dict[str, Any]:
+        """
+        Get information about all active sessions.
+        
+        Returns:
+            A dictionary mapping session IDs to session information
+        """
+        # Access the internal sessions dictionary from the session manager
+        if hasattr(self.session_manager, '_sessions'):
+            return {
+                session_id: {
+                    "created_at": session.created_at,
+                    "last_active": session.last_active,
+                    "client_id": session.client_id if hasattr(session, 'client_id') else None,
+                }
+                for session_id, session in self.session_manager._sessions.items()
+            }
+        return {}
+    
+    def get_session(self, session_id: str) -> Optional[Any]:
+        """
+        Get information about a specific session.
+        
+        Args:
+            session_id: The ID of the session to retrieve
+            
+        Returns:
+            Session information if found, None otherwise
+        """
+        if hasattr(self.session_manager, '_sessions') and session_id in self.session_manager._sessions:
+            session = self.session_manager._sessions[session_id]
+            return {
+                "created_at": session.created_at,
+                "last_active": session.last_active,
+                "client_id": session.client_id if hasattr(session, 'client_id') else None,
+            }
+        return None
+
+def create_starlette_app(mcp_server: Server, base_path: str = "/mcp") -> Starlette:
+    """
+    Create a Starlette application with a mounted StreamableHTTPSessionManager.
+    
+    Args:
+        mcp_server: The MCP Server instance
+        base_path: The base path to mount the session manager at
+        
+    Returns:
+        A Starlette application
+    """
+    session_manager = SessionAwareStreamableHTTPManager(
+        app=mcp_server,
+        stateless=False,  # Use stateful sessions by default
+    )
+    
+    async def handle_streamable_http(scope: Scope, receive: Receive, send: Send) -> None:
+        # Log information about the incoming request
+        path = scope.get("path", "unknown path")
+        method = scope.get("method", "unknown method")
+        logger.info(f"Incoming request: {method} {path}")
+        
+        # Process the request
+        await session_manager.handle_request(scope, receive, send)
+    
+    @contextlib.asynccontextmanager
+    async def lifespan(app: Starlette) -> AsyncIterator[None]:
+        """Context manager for session manager."""
+        async with session_manager.run():
+            logger.info(f"Application started with StreamableHTTP session manager at {base_path}")
+            try:
+                yield
+            finally:
+                logger.info("Application shutting down...")
+    
+    app = Starlette(
+        debug=True,
+        routes=[
+            Mount(base_path, app=handle_streamable_http),
+        ],
+        lifespan=lifespan,
+    )
+    
+    # Create a middleware to set the FastMCP session ID header
+    class SessionHeaderMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request: Request, call_next):
+            # If we have a current session ID, add it to the request's headers
+            # This makes it available to FastMCP via the Header injection
+            if CURRENT_SESSION_ID:
+                # Save the session ID in an environment variable that FastMCP can access
+                os.environ["MCP_CURRENT_SESSION_ID"] = CURRENT_SESSION_ID
+                
+                # Since we can't modify request.headers directly,
+                # we'll handle this in our SessionAwareStreamableHTTPManager
+                logger.debug(f"SessionHeaderMiddleware: Set environment session ID to {CURRENT_SESSION_ID}")
+            
+            # Call the next middleware or endpoint
+            response = await call_next(request)
+            
+            # Remove the environment variable after the request
+            if "MCP_CURRENT_SESSION_ID" in os.environ:
+                del os.environ["MCP_CURRENT_SESSION_ID"]
+            
+            return response
+    
+    # Add the middleware to the app
+    app.add_middleware(SessionHeaderMiddleware)
+    
+    # Attach the session manager to the app for access elsewhere
+    app.state.session_manager = session_manager
+    
+    return app, session_manager
+
+# Function to get the current session ID (used by tools)
+def get_current_session_id() -> Optional[str]:
+    """
+    Get the session ID for the current request context.
+    
+    Returns:
+        The session ID if available, None otherwise
+    """
+    # First check the global variable (set during request handling)
+    if CURRENT_SESSION_ID:
+        return CURRENT_SESSION_ID
+    
+    # Then check environment variable (set by middleware)
+    return os.environ.get("MCP_CURRENT_SESSION_ID")

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -73,7 +73,9 @@ async def search_drive_files(
 
     try:
         service = build('drive', 'v3', credentials=credentials)
-        user_email_from_creds = credentials.id_token.get('email') if credentials.id_token else 'Unknown (Drive)'
+        user_email_from_creds = 'Unknown (Drive)'
+        if credentials.id_token and isinstance(credentials.id_token, dict):
+            user_email_from_creds = credentials.id_token.get('email', 'Unknown (Drive)')
 
         # Check if the query looks like a structured Drive query or free text
         # Basic check for operators or common keywords used in structured queries
@@ -243,7 +245,9 @@ async def list_drive_items(
 
     try:
         service = build('drive', 'v3', credentials=credentials)
-        user_email_from_creds = credentials.id_token.get('email') if credentials.id_token else 'Unknown (Drive)'
+        user_email_from_creds = 'Unknown (Drive)'
+        if credentials.id_token and isinstance(credentials.id_token, dict):
+            user_email_from_creds = credentials.id_token.get('email', 'Unknown (Drive)')
 
         results = await asyncio.to_thread(
             service.files().list(
@@ -317,7 +321,9 @@ async def create_drive_file(
 
     try:
         service = build('drive', 'v3', credentials=credentials)
-        user_email_from_creds = credentials.id_token.get('email') if credentials.id_token else 'Unknown (Drive)'
+        user_email_from_creds = 'Unknown (Drive)'
+        if credentials.id_token and isinstance(credentials.id_token, dict):
+            user_email_from_creds = credentials.id_token.get('email', 'Unknown (Drive)')
 
         file_metadata = {
             'name': file_name,

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -202,11 +202,9 @@ async def get_gmail_message_content(
     try:
         # Build the service object directly
         service = build("gmail", "v1", credentials=credentials)
-        user_email_from_creds = (
-            credentials.id_token.get("email")
-            if credentials.id_token
-            else "Unknown (Gmail)"
-        )
+        user_email_from_creds = "Unknown (Gmail)"
+        if credentials.id_token and isinstance(credentials.id_token, dict):
+            user_email_from_creds = credentials.id_token.get("email", "Unknown (Gmail)")
         logger.info(f"[{tool_name}] Using service for: {user_email_from_creds}")
 
         # Fetch message metadata first to get headers
@@ -452,11 +450,9 @@ async def draft_gmail_message(
     try:
         # Build the service object directly
         service = build("gmail", "v1", credentials=credentials)
-        user_email_from_creds = (
-            credentials.id_token.get("email")
-            if credentials.id_token
-            else "Unknown (Gmail)"
-        )
+        user_email_from_creds = "Unknown (Gmail)"
+        if credentials.id_token and isinstance(credentials.id_token, dict):
+            user_email_from_creds = credentials.id_token.get("email", "Unknown (Gmail)")
         logger.info(f"[{tool_name}] Using service for: {user_email_from_creds}")
 
         # Prepare the email

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 import logging
 import os
 import sys
@@ -35,7 +36,6 @@ except Exception as e:
     sys.stderr.write(f"CRITICAL: Failed to set up file logging to '{log_file_path}': {e}\n")
 
 # Import calendar tools to register them with the MCP server via decorators
-# Tools are registered when this module is imported
 import gcalendar.calendar_tools
 import gdrive.drive_tools
 import gmail.gmail_tools
@@ -47,6 +47,17 @@ def main():
     Main entry point for the Google Workspace MCP server.
     Uses streamable-http transport via a Starlette application with SessionAwareStreamableHTTPManager.
     """
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description='Google Workspace MCP Server')
+    parser.add_argument('--single-user', action='store_true',
+                        help='Run in single-user mode - bypass session mapping and use any credentials from ./credentials directory')
+    args = parser.parse_args()
+
+    # Set global single-user mode flag
+    if args.single_user:
+        os.environ['MCP_SINGLE_USER_MODE'] = '1'
+        logger.info("Starting in single-user mode - bypassing session-to-OAuth mapping")
+
     try:
         logger.info("Google Workspace MCP server starting...")
 


### PR DESCRIPTION
# Introduce Single-User Mode and Improve Credential Handling

This pull request introduces a `--single-user` command-line flag to the MCP server, allowing it to operate without session-to-OAuth mapping and use any available credentials found in the `.credentials` directory. Additionally, it improves the robustness of extracting user email for logging from credentials across Google Calendar, Drive, and Gmail tools.

**Key Changes:**

-   **Single-User Mode:**
    -   Added `--single-user` flag to [`main.py`](main.py) using `argparse`.
    -   Introduced `MCP_SINGLE_USER_MODE` environment variable to signal single-user mode activation.
    -   Implemented [`_find_any_credentials()`](auth/google_auth.py:41) in [`auth/google_auth.py`](auth/google_auth.py) to locate and load any credential file for single-user use.
    -   Updated [`get_credentials()`](auth/google_auth.py:287) logic in [`auth/google_auth.py`](auth/google_auth.py) to bypass session mapping when in single-user mode.
-   **Improved Credential Logging:**
    -   Modified credential handling in [`gcalendar/calendar_tools.py`](gcalendar/calendar_tools.py), [`gdrive/drive_tools.py`](gdrive/drive_tools.py), and [`gmail/gmail_tools.py`](gmail/gmail_tools.py) to safely extract user email from `credentials.id_token` by checking if it is a dictionary before accessing the 'email' key.
-   **Code Cleanup:**
    -   Removed duplicate `os` import and unused `InsecureTransportError` import from [`auth/google_auth.py`](auth/google_auth.py).
    -   Updated comment regarding the session credentials cache in [`auth/google_auth.py`](auth/google_auth.py).

These changes facilitate easier testing and development in single-user environments while making the logging of user information more resilient to variations in credential object structure.