### PR TITLE
enh: Refactor authentication to deduplicate redundant logic 

### DIFF
--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -12,23 +12,12 @@ import sys
 from typing import List, Optional, Dict, Any
 
 from mcp import types
-from fastapi import Header
-
-from google.oauth2.credentials import Credentials
-from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
-from auth.google_auth import (
-    get_credentials,
-    start_auth_flow,
-    CONFIG_CLIENT_SECRETS_PATH,
-)
+from auth.google_auth import get_authenticated_google_service
 
-# Import the server directly (will be initialized before this module is imported)
-# Also import the OAUTH_STATE_TO_SESSION_ID_MAP for linking OAuth state to MCP session
 from core.server import (
     server,
-    OAUTH_REDIRECT_URI,
     CALENDAR_READONLY_SCOPE,
     CALENDAR_EVENTS_SCOPE,
 )
@@ -97,111 +86,38 @@ def _correct_time_format_for_api(
 # --- Helper for Authentication and Service Initialization ---
 
 
-async def _get_authenticated_calendar_service(
-    tool_name: str,
-    user_google_email: Optional[str],
-    mcp_session_id: Optional[str],
-    required_scopes: List[str],
-) -> tuple[Any, str] | types.CallToolResult:
-    """
-    Handles common authentication and Google Calendar service initialization logic.
-    Returns a tuple of (service, log_user_email) on success, or CallToolResult on auth failure.
-    """
-    logger.info(
-        f"[{tool_name}] Attempting to get authenticated calendar service. Email: '{user_google_email}', Session: '{mcp_session_id}', Session Type: {type(mcp_session_id)}"
-    )
-
-    credentials = await asyncio.to_thread(
-        get_credentials,
-        user_google_email=user_google_email,
-        required_scopes=required_scopes,
-        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH,
-        session_id=mcp_session_id,
-    )
-
-    if not credentials or not credentials.valid:
-        logger.warning(
-            f"[{tool_name}] No valid credentials. Session: '{mcp_session_id}', Email: '{user_google_email}'."
-        )
-        if user_google_email and "@" in user_google_email:
-            logger.info(
-                f"[{tool_name}] Valid email '{user_google_email}' provided, initiating auth flow."
-            )
-            # This call will return a CallToolResult which should be propagated
-            return await start_auth_flow(
-                mcp_session_id=mcp_session_id,
-                user_google_email=user_google_email,
-                service_name="Google Calendar",
-                redirect_uri=OAUTH_REDIRECT_URI,
-            )
-        else:
-            error_msg = f"Authentication required for {tool_name}. No active authenticated session, and no valid 'user_google_email' provided. LLM: Please ask the user for their Google email address and retry, or use the 'start_google_auth' tool with their email and service_name='Google Calendar'."
-            logger.info(f"[{tool_name}] {error_msg}")
-            return types.CallToolResult(
-                isError=True, content=[types.TextContent(type="text", text=error_msg)]
-            )
-
-    try:
-        service = build("calendar", "v3", credentials=credentials)
-        log_user_email = user_google_email or "Unknown"
-
-        # Try to get email from id_token if it's a dict, otherwise use user_google_email or "Unknown"
-        if not user_google_email and credentials and credentials.id_token:
-            try:
-                if isinstance(credentials.id_token, dict):
-                    log_user_email = credentials.id_token.get("email", "Unknown")
-                # If id_token is a string (JWT), we'd need to decode it, but for logging purposes "Unknown" is fine
-            except Exception:
-                pass  # Keep log_user_email as "Unknown"
-
-        logger.info(
-            f"[{tool_name}] Successfully built calendar service. User associated with creds: {log_user_email}"
-        )
-        return service, log_user_email
-    except Exception as e:
-        message = f"[{tool_name}] Unexpected error building calendar service: {e}."
-        logger.exception(message)
-        return types.CallToolResult(
-            isError=True, content=[types.TextContent(type="text", text=message)]
-        )
-
-
 # --- Tool Implementations ---
 
 @server.tool()
 async def list_calendars(
-    user_google_email: Optional[str] = None,
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
+    user_google_email: str,
 ) -> types.CallToolResult:
     """
     Retrieves a list of calendars accessible to the authenticated user.
-    Prioritizes authentication via the active MCP session (`mcp_session_id`).
-    If the session isn't authenticated for Calendar, it falls back to using `user_google_email`.
-    If neither provides valid credentials, it returns a message guiding the LLM to request the user's email
-    or initiate the authentication flow via the `start_google_auth` tool (provide service_name='Google Calendar').
 
     Args:
-        user_google_email (Optional[str]): The user's Google email address. Required if the MCP session is not already authenticated for Calendar access.
-        mcp_session_id (Optional[str]): The active MCP session ID (automatically injected by FastMCP from the Mcp-Session-Id header). Used for session-based authentication.
+        user_google_email (str): The user's Google email address. Required.
 
     Returns:
         types.CallToolResult: Contains a list of the user's calendars (summary, ID, primary status),
                                an error message if the API call fails,
                                or an authentication guidance message if credentials are required.
     """
-
+    tool_name = "list_calendars"
     logger.info(
-        f"[list_calendars] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}'"
+        f"[{tool_name}] Invoked. Email: '{user_google_email}'"
     )
-    auth_result = await _get_authenticated_calendar_service(
-        tool_name="list_calendars",
+
+    auth_result = await get_authenticated_google_service(
+        service_name="calendar",
+        version="v3",
+        tool_name=tool_name,
         user_google_email=user_google_email,
-        mcp_session_id=mcp_session_id,
         required_scopes=[CALENDAR_READONLY_SCOPE],
     )
     if isinstance(auth_result, types.CallToolResult):
-        return auth_result  # Propagate auth error or auth initiation message
-    service, log_user_email = auth_result
+        return auth_result  # Auth error
+    service, user_email = auth_result
 
     try:
         calendar_list_response = await asyncio.to_thread(
@@ -212,7 +128,7 @@ async def list_calendars(
             return types.CallToolResult(
                 content=[
                     types.TextContent(
-                        type="text", text=f"No calendars found for {log_user_email}."
+                        type="text", text=f"No calendars found for {user_email}."
                     )
                 ]
             )
@@ -222,10 +138,10 @@ async def list_calendars(
             for cal in items
         ]
         text_output = (
-            f"Successfully listed {len(items)} calendars for {log_user_email}:\n"
+            f"Successfully listed {len(items)} calendars for {user_email}:\n"
             + "\n".join(calendars_summary_list)
         )
-        logger.info(f"Successfully listed {len(items)} calendars for {log_user_email}.")
+        logger.info(f"Successfully listed {len(items)} calendars for {user_email}.")
         return types.CallToolResult(
             content=[types.TextContent(type="text", text=text_output)]
         )
@@ -245,42 +161,35 @@ async def list_calendars(
 
 @server.tool()
 async def get_events(
-    user_google_email: Optional[str] = None,
+    user_google_email: str,
     calendar_id: str = "primary",
     time_min: Optional[str] = None,
     time_max: Optional[str] = None,
     max_results: int = 25,
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
 ) -> types.CallToolResult:
     """
     Retrieves a list of events from a specified Google Calendar within a given time range.
-    Prioritizes authentication via the active MCP session (`mcp_session_id`).
-    If the session isn't authenticated for Calendar, it falls back to using `user_google_email`.
-    If neither provides valid credentials, it returns a message guiding the LLM to request the user's email
-    or initiate the authentication flow via the `start_google_auth` tool (provide service_name='Google Calendar').
 
     Args:
-        user_google_email (Optional[str]): The user's Google email address. Required if the MCP session is not already authenticated for Calendar access.
+        user_google_email (str): The user's Google email address. Required.
         calendar_id (str): The ID of the calendar to query. Use 'primary' for the user's primary calendar. Defaults to 'primary'. Calendar IDs can be obtained using `list_calendars`.
         time_min (Optional[str]): The start of the time range (inclusive) in RFC3339 format (e.g., '2024-05-12T10:00:00Z' or '2024-05-12'). If omitted, defaults to the current time.
         time_max (Optional[str]): The end of the time range (exclusive) in RFC3339 format. If omitted, events starting from `time_min` onwards are considered (up to `max_results`).
         max_results (int): The maximum number of events to return. Defaults to 25.
-        mcp_session_id (Optional[str]): The active MCP session ID (automatically injected by FastMCP from the Mcp-Session-Id header). Used for session-based authentication.
 
     Returns:
         types.CallToolResult: Contains a list of events (summary, start time, link) within the specified range,
                                an error message if the API call fails,
                                or an authentication guidance message if credentials are required.
     """
-    auth_result = await _get_authenticated_calendar_service(
-        tool_name="get_events",
-        user_google_email=user_google_email,
-        mcp_session_id=mcp_session_id,
+    tool_name = "get_events"
+
+    auth_result = await get_authenticated_google_service(
         required_scopes=[CALENDAR_READONLY_SCOPE],
     )
     if isinstance(auth_result, types.CallToolResult):
-        return auth_result
-    service, log_user_email = auth_result
+        return auth_result  # Auth error
+    service, user_email = auth_result
 
     try:
         logger.info(
@@ -330,7 +239,7 @@ async def get_events(
                 content=[
                     types.TextContent(
                         type="text",
-                        text=f"No events found in calendar '{calendar_id}' for {log_user_email} for the specified time range.",
+                        text=f"No events found in calendar '{calendar_id}' for {user_email} for the specified time range.",
                     )
                 ]
             )
@@ -347,10 +256,10 @@ async def get_events(
             )
 
         text_output = (
-            f"Successfully retrieved {len(items)} events from calendar '{calendar_id}' for {log_user_email}:\n"
+            f"Successfully retrieved {len(items)} events from calendar '{calendar_id}' for {user_email}:\n"
             + "\n".join(event_details_list)
         )
-        logger.info(f"Successfully retrieved {len(items)} events for {log_user_email}.")
+        logger.info(f"Successfully retrieved {len(items)} events for {user_email}.")
         return types.CallToolResult(
             content=[types.TextContent(type="text", text=text_output)]
         )
@@ -370,48 +279,48 @@ async def get_events(
 
 @server.tool()
 async def create_event(
+    user_google_email: str,
     summary: str,
     start_time: str,
     end_time: str,
-    user_google_email: Optional[str] = None,
     calendar_id: str = "primary",
     description: Optional[str] = None,
     location: Optional[str] = None,
     attendees: Optional[List[str]] = None,
     timezone: Optional[str] = None,
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
 ) -> types.CallToolResult:
     """
-    Creates a new event. Prioritizes authenticated MCP session, then `user_google_email`.
-    If no valid authentication is found, guides the LLM to obtain user's email or use `start_google_auth` (provide service_name='Google Calendar').
+    Creates a new event.
 
     Args:
+        user_google_email (str): The user's Google email address. Required.
         summary (str): Event title.
         start_time (str): Start time (RFC3339, e.g., "2023-10-27T10:00:00-07:00" or "2023-10-27" for all-day).
         end_time (str): End time (RFC3339, e.g., "2023-10-27T11:00:00-07:00" or "2023-10-28" for all-day).
-        user_google_email (Optional[str]): User's Google email. Used if session isn't authenticated.
         calendar_id (str): Calendar ID (default: 'primary').
         description (Optional[str]): Event description.
         location (Optional[str]): Event location.
         attendees (Optional[List[str]]): Attendee email addresses.
         timezone (Optional[str]): Timezone (e.g., "America/New_York").
-        mcp_session_id (Optional[str]): Active MCP session ID (injected by FastMCP from Mcp-Session-Id header).
 
     Returns:
         A CallToolResult confirming creation or an error/auth guidance message.
     """
+    tool_name = "create_event"
     logger.info(
-        f"[create_event] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}', Summary: {summary}"
+        f"[{tool_name}] Invoked. Email: '{user_google_email}', Summary: {summary}"
     )
-    auth_result = await _get_authenticated_calendar_service(
-        tool_name="create_event",
+
+    auth_result = await get_authenticated_google_service(
+        service_name="calendar",
+        version="v3",
+        tool_name=tool_name,
         user_google_email=user_google_email,
-        mcp_session_id=mcp_session_id,
         required_scopes=[CALENDAR_EVENTS_SCOPE],
     )
     if isinstance(auth_result, types.CallToolResult):
-        return auth_result
-    service, log_user_email = auth_result
+        return auth_result  # Auth error
+    service, user_email = auth_result
 
     try:
 
@@ -443,19 +352,19 @@ async def create_event(
         )
 
         link = created_event.get("htmlLink", "No link available")
-        # Corrected confirmation_message to use log_user_email
-        confirmation_message = f"Successfully created event '{created_event.get('summary', summary)}' for {log_user_email}. Link: {link}"
-        # Corrected logger to use log_user_email and include event ID
+        # Corrected confirmation_message to use user_email
+        confirmation_message = f"Successfully created event '{created_event.get('summary', summary)}' for {user_email}. Link: {link}"
+        # Corrected logger to use user_email and include event ID
         logger.info(
-            f"Event created successfully for {log_user_email}. ID: {created_event.get('id')}, Link: {link}"
+            f"Event created successfully for {user_email}. ID: {created_event.get('id')}, Link: {link}"
         )
         return types.CallToolResult(
             content=[types.TextContent(type="text", text=confirmation_message)]
         )
     except HttpError as error:
-        # Corrected error message to use log_user_email and provide better guidance
-        # log_user_email_for_error is now log_user_email from the helper or the original user_google_email
-        message = f"API error creating event: {error}. You might need to re-authenticate. LLM: Try 'start_google_auth' with the user's email ({log_user_email if log_user_email != 'Unknown' else 'target Google account'}) and service_name='Google Calendar'."
+        # Corrected error message to use user_email and provide better guidance
+        # user_email_for_error is now user_email from the helper or the original user_google_email
+        message = f"API error creating event: {error}. You might need to re-authenticate. LLM: Try 'start_google_auth' with the user's email ({user_email if user_email != 'Unknown' else 'target Google account'}) and service_name='Google Calendar'."
         logger.error(message, exc_info=True)
         return types.CallToolResult(
             isError=True, content=[types.TextContent(type="text", text=message)]
@@ -470,8 +379,8 @@ async def create_event(
 
 @server.tool()
 async def modify_event(
+    user_google_email: str,
     event_id: str,
-    user_google_email: Optional[str] = None,
     calendar_id: str = "primary",
     summary: Optional[str] = None,
     start_time: Optional[str] = None,
@@ -480,15 +389,13 @@ async def modify_event(
     location: Optional[str] = None,
     attendees: Optional[List[str]] = None,
     timezone: Optional[str] = None,
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
 ) -> types.CallToolResult:
     """
-    Modifies an existing event. Prioritizes authenticated MCP session, then `user_google_email`.
-    If no valid authentication is found, guides the LLM to obtain user's email or use `start_google_auth` (provide service_name='Google Calendar').
+    Modifies an existing event.
 
     Args:
+        user_google_email (str): The user's Google email address. Required.
         event_id (str): The ID of the event to modify.
-        user_google_email (Optional[str]): User's Google email. Used if session isn't authenticated.
         calendar_id (str): Calendar ID (default: 'primary').
         summary (Optional[str]): New event title.
         start_time (Optional[str]): New start time (RFC3339, e.g., "2023-10-27T10:00:00-07:00" or "2023-10-27" for all-day).
@@ -497,23 +404,24 @@ async def modify_event(
         location (Optional[str]): New event location.
         attendees (Optional[List[str]]): New attendee email addresses.
         timezone (Optional[str]): New timezone (e.g., "America/New_York").
-        mcp_session_id (Optional[str]): Active MCP session ID (injected by FastMCP from Mcp-Session-Id header).
 
     Returns:
         A CallToolResult confirming modification or an error/auth guidance message.
     """
     logger.info(
-        f"[modify_event] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}', Event ID: {event_id}"
+        f"[{tool_name}] Invoked. Email: '{user_google_email}', Event ID: {event_id}"
     )
-    auth_result = await _get_authenticated_calendar_service(
-        tool_name="modify_event",
+
+    auth_result = await get_authenticated_google_service(
+        service_name="calendar",
+        version="v3",
+        tool_name=tool_name,
         user_google_email=user_google_email,
-        mcp_session_id=mcp_session_id,
         required_scopes=[CALENDAR_EVENTS_SCOPE],
     )
     if isinstance(auth_result, types.CallToolResult):
-        return auth_result
-    service, log_user_email = auth_result
+        return auth_result  # Auth error
+    service, user_email = auth_result
 
     try:
 
@@ -596,9 +504,9 @@ async def modify_event(
         )
 
         link = updated_event.get("htmlLink", "No link available")
-        confirmation_message = f"Successfully modified event '{updated_event.get('summary', summary)}' (ID: {event_id}) for {log_user_email}. Link: {link}"
+        confirmation_message = f"Successfully modified event '{updated_event.get('summary', summary)}' (ID: {event_id}) for {user_email}. Link: {link}"
         logger.info(
-            f"Event modified successfully for {log_user_email}. ID: {updated_event.get('id')}, Link: {link}"
+            f"Event modified successfully for {user_email}. ID: {updated_event.get('id')}, Link: {link}"
         )
         return types.CallToolResult(
             content=[types.TextContent(type="text", text=confirmation_message)]
@@ -609,7 +517,7 @@ async def modify_event(
             message = f"Event not found. The event with ID '{event_id}' could not be found in calendar '{calendar_id}'. LLM: The event may have been deleted, or the event ID might be incorrect. Verify the event exists using 'get_events' before attempting to modify it."
             logger.error(f"[modify_event] {message}")
         else:
-            message = f"API error modifying event (ID: {event_id}): {error}. You might need to re-authenticate. LLM: Try 'start_google_auth' with the user's email ({log_user_email if log_user_email != 'Unknown' else 'target Google account'}) and service_name='Google Calendar'."
+            message = f"API error modifying event (ID: {event_id}): {error}. You might need to re-authenticate. LLM: Try 'start_google_auth' with the user's email ({user_email if user_email != 'Unknown' else 'target Google account'}) and service_name='Google Calendar'."
             logger.error(message, exc_info=True)
         return types.CallToolResult(
             isError=True, content=[types.TextContent(type="text", text=message)]
@@ -624,36 +532,36 @@ async def modify_event(
 
 @server.tool()
 async def delete_event(
+    user_google_email: str,
     event_id: str,
-    user_google_email: Optional[str] = None,
     calendar_id: str = "primary",
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
 ) -> types.CallToolResult:
     """
-    Deletes an existing event. Prioritizes authenticated MCP session, then `user_google_email`.
-    If no valid authentication is found, guides the LLM to obtain user's email or use `start_google_auth` (provide service_name='Google Calendar').
+    Deletes an existing event.
 
     Args:
+        user_google_email (str): The user's Google email address. Required.
         event_id (str): The ID of the event to delete.
-        user_google_email (Optional[str]): User's Google email. Used if session isn't authenticated.
         calendar_id (str): Calendar ID (default: 'primary').
-        mcp_session_id (Optional[str]): Active MCP session ID (injected by FastMCP from Mcp-Session-Id header).
 
     Returns:
         A CallToolResult confirming deletion or an error/auth guidance message.
     """
+    tool_name = "delete_event"
     logger.info(
-        f"[delete_event] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}', Event ID: {event_id}"
+        f"[{tool_name}] Invoked. Email: '{user_google_email}', Event ID: {event_id}"
     )
-    auth_result = await _get_authenticated_calendar_service(
-        tool_name="delete_event",
+
+    auth_result = await get_authenticated_google_service(
+        service_name="calendar",
+        version="v3",
+        tool_name=tool_name,
         user_google_email=user_google_email,
-        mcp_session_id=mcp_session_id,
         required_scopes=[CALENDAR_EVENTS_SCOPE],
     )
     if isinstance(auth_result, types.CallToolResult):
-        return auth_result
-    service, log_user_email = auth_result
+        return auth_result  # Auth error
+    service, user_email = auth_result
 
     try:
 
@@ -689,8 +597,8 @@ async def delete_event(
             service.events().delete(calendarId=calendar_id, eventId=event_id).execute
         )
 
-        confirmation_message = f"Successfully deleted event (ID: {event_id}) from calendar '{calendar_id}' for {log_user_email}."
-        logger.info(f"Event deleted successfully for {log_user_email}. ID: {event_id}")
+        confirmation_message = f"Successfully deleted event (ID: {event_id}) from calendar '{calendar_id}' for {user_email}."
+        logger.info(f"Event deleted successfully for {user_email}. ID: {event_id}")
         return types.CallToolResult(
             content=[types.TextContent(type="text", text=confirmation_message)]
         )
@@ -700,7 +608,7 @@ async def delete_event(
             message = f"Event not found. The event with ID '{event_id}' could not be found in calendar '{calendar_id}'. LLM: The event may have been deleted already, or the event ID might be incorrect."
             logger.error(f"[delete_event] {message}")
         else:
-            message = f"API error deleting event (ID: {event_id}): {error}. You might need to re-authenticate. LLM: Try 'start_google_auth' with the user's email ({log_user_email if log_user_email != 'Unknown' else 'target Google account'}) and service_name='Google Calendar'."
+            message = f"API error deleting event (ID: {event_id}): {error}. You might need to re-authenticate. LLM: Try 'start_google_auth' with the user's email ({user_email if user_email != 'Unknown' else 'target Google account'}) and service_name='Google Calendar'."
             logger.error(message, exc_info=True)
         return types.CallToolResult(
             isError=True, content=[types.TextContent(type="text", text=message)]

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -185,8 +185,13 @@ async def get_events(
     tool_name = "get_events"
 
     auth_result = await get_authenticated_google_service(
+        service_name="calendar",
+        version="v3",
+        tool_name=tool_name,
+        user_google_email=user_google_email,
         required_scopes=[CALENDAR_READONLY_SCOPE],
     )
+
     if isinstance(auth_result, types.CallToolResult):
         return auth_result  # Auth error
     service, user_email = auth_result
@@ -408,6 +413,7 @@ async def modify_event(
     Returns:
         A CallToolResult confirming modification or an error/auth guidance message.
     """
+    tool_name = "modify_event"
     logger.info(
         f"[{tool_name}] Invoked. Email: '{user_google_email}', Event ID: {event_id}"
     )

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -16,66 +16,49 @@ from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseDownload # For file content
 import io # For file content
 
-# Use functions directly from google_auth
-from auth.google_auth import get_credentials, start_auth_flow, CONFIG_CLIENT_SECRETS_PATH
-from core.server import server, OAUTH_REDIRECT_URI, OAUTH_STATE_TO_SESSION_ID_MAP
+from auth.google_auth import get_authenticated_google_service
+from core.server import server
 from core.server import (
     DRIVE_READONLY_SCOPE,
     DRIVE_FILE_SCOPE,
-    SCOPES
 )
 
 logger = logging.getLogger(__name__)
 
 @server.tool()
 async def search_drive_files(
+    user_google_email: str,
     query: str,
-    user_google_email: Optional[str] = None,
     page_size: int = 10,
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
 ) -> types.CallToolResult:
     """
     Searches for files and folders within a user's Google Drive based on a query string.
-    Prioritizes authentication via the active MCP session (`mcp_session_id`).
-    If the session isn't authenticated for Drive, it falls back to using `user_google_email`.
-    If neither provides valid credentials, it returns a message guiding the LLM to request the user's email
-    or initiate the authentication flow via the centralized start_auth_flow.
 
     Args:
+        user_google_email (str): The user's Google email address. Required.
         query (str): The search query string. Supports Google Drive search operators (e.g., 'name contains "report"', 'mimeType="application/vnd.google-apps.document"', 'parents in "folderId"').
-        user_google_email (Optional[str]): The user's Google email address. Required if the MCP session is not already authenticated for Drive access.
         page_size (int): The maximum number of files to return. Defaults to 10.
-        mcp_session_id (Optional[str]): The active MCP session ID (automatically injected by FastMCP from the Mcp-Session-Id header). Used for session-based authentication.
 
     Returns:
         types.CallToolResult: Contains a list of found files/folders with their details (ID, name, type, size, modified time, link),
                                an error message if the API call fails,
                                or an authentication guidance message if credentials are required.
     """
-    logger.info(f"[search_drive_files] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}', Query: '{query}'")
-    tool_specific_scopes = [DRIVE_READONLY_SCOPE]
-    credentials = await asyncio.to_thread(
-        get_credentials,
-        user_google_email=user_google_email,
-        required_scopes=tool_specific_scopes,
-        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH, # Use imported constant
-        session_id=mcp_session_id
-    )
+    tool_name = "search_drive_files"
+    logger.info(f"[{tool_name}] Invoked. Email: '{user_google_email}', Query: '{query}'")
 
-    if not credentials or not credentials.valid:
-        logger.warning(f"[search_drive_files] No valid credentials for Drive. Session: '{mcp_session_id}', Email: '{user_google_email}'.")
-        if user_google_email and '@' in user_google_email:
-            # Use the centralized start_auth_flow
-            return await start_auth_flow(mcp_session_id=mcp_session_id, user_google_email=user_google_email, service_name="Google Drive", redirect_uri=OAUTH_REDIRECT_URI)
-        else:
-            error_msg = "Drive Authentication required. LLM: Please ask for Google email."
-            return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_msg)])
+    auth_result = await get_authenticated_google_service(
+        service_name="drive",
+        version="v3",
+        tool_name=tool_name,
+        user_google_email=user_google_email,
+        required_scopes=[DRIVE_READONLY_SCOPE],
+    )
+    if isinstance(auth_result, types.CallToolResult):
+        return auth_result  # Auth error
+    service, user_email = auth_result
 
     try:
-        service = build('drive', 'v3', credentials=credentials)
-        user_email_from_creds = 'Unknown (Drive)'
-        if credentials.id_token and isinstance(credentials.id_token, dict):
-            user_email_from_creds = credentials.id_token.get('email', 'Unknown (Drive)')
 
         # Check if the query looks like a structured Drive query or free text
         # Basic check for operators or common keywords used in structured queries
@@ -118,49 +101,37 @@ async def search_drive_files(
 
 @server.tool()
 async def get_drive_file_content(
+    user_google_email: str,
     file_id: str,
-    user_google_email: Optional[str] = None,
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
 ) -> types.CallToolResult:
     """
     Retrieves the content of a specific file from Google Drive by its ID.
     Handles both native Google Docs/Sheets/Slides (exporting them to plain text or CSV) and other file types (downloading directly).
-    Prioritizes authentication via the active MCP session (`mcp_session_id`).
-    If the session isn't authenticated for Drive, it falls back to using `user_google_email`.
-    If neither provides valid credentials, it returns a message guiding the LLM to request the user's email
-    or initiate the authentication flow via the centralized start_auth_flow.
 
     Args:
+        user_google_email (str): The user's Google email address. Required.
         file_id (str): The unique ID of the Google Drive file to retrieve content from. This ID is typically obtained from `search_drive_files` or `list_drive_items`.
-        user_google_email (Optional[str]): The user's Google email address. Required if the MCP session is not already authenticated for Drive access.
-        mcp_session_id (Optional[str]): The active MCP session ID (automatically injected by FastMCP from the Mcp-Session-Id header). Used for session-based authentication.
 
     Returns:
         types.CallToolResult: Contains the file metadata (name, ID, type, link) and its content (decoded as UTF-8 if possible, otherwise indicates binary content),
                                an error message if the API call fails or the file is not accessible/found,
                                or an authentication guidance message if credentials are required.
     """
-    logger.info(f"[get_drive_file_content] Invoked. File ID: '{file_id}'")
-    tool_specific_scopes = [DRIVE_READONLY_SCOPE]
-    credentials = await asyncio.to_thread(
-        get_credentials,
-        user_google_email=user_google_email,
-        required_scopes=tool_specific_scopes,
-        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH, # Use imported constant
-        session_id=mcp_session_id
-    )
+    tool_name = "get_drive_file_content"
+    logger.info(f"[{tool_name}] Invoked. File ID: '{file_id}'")
 
-    if not credentials or not credentials.valid:
-        logger.warning(f"[get_drive_file_content] No valid credentials for Drive. Session: '{mcp_session_id}', Email: '{user_google_email}'.")
-        if user_google_email and '@' in user_google_email:
-             # Use the centralized start_auth_flow
-             return await start_auth_flow(mcp_session_id=mcp_session_id, user_google_email=user_google_email, service_name="Google Drive", redirect_uri=OAUTH_REDIRECT_URI)
-        else:
-            error_msg = "Drive Authentication required. LLM: Please ask for Google email."
-            return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_msg)])
+    auth_result = await get_authenticated_google_service(
+        service_name="drive",
+        version="v3",
+        tool_name=tool_name,
+        user_google_email=user_google_email,
+        required_scopes=[DRIVE_READONLY_SCOPE],
+    )
+    if isinstance(auth_result, types.CallToolResult):
+        return auth_result  # Auth error
+    service, user_email = auth_result
 
     try:
-        service = build('drive', 'v3', credentials=credentials)
         file_metadata = await asyncio.to_thread(
             service.files().get(fileId=file_id, fields="id, name, mimeType, webViewLink").execute
         )
@@ -200,55 +171,39 @@ async def get_drive_file_content(
 
 @server.tool()
 async def list_drive_items(
+    user_google_email: str,
     folder_id: str = 'root', # Default to root folder
-    user_google_email: Optional[str] = None,
     page_size: int = 100, # Default page size for listing
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
 ) -> types.CallToolResult:
     """
     Lists files and folders directly within a specified Google Drive folder.
     Defaults to the root folder if `folder_id` is not provided. Does not recurse into subfolders.
-    Prioritizes authentication via the active MCP session (`mcp_session_id`).
-    If the session isn't authenticated for Drive, it falls back to using `user_google_email`.
-    If neither provides valid credentials, it returns a message guiding the LLM to request the user's email
-    or initiate the authentication flow via the centralized start_auth_flow.
 
     Args:
+        user_google_email (str): The user's Google email address. Required.
         folder_id (str): The ID of the Google Drive folder to list items from. Defaults to 'root'.
-        user_google_email (Optional[str]): The user's Google email address. Required if the MCP session is not already authenticated for Drive access.
         page_size (int): The maximum number of items to return per page. Defaults to 100.
-        mcp_session_id (Optional[str]): The active MCP session ID (automatically injected by FastMCP from the Mcp-Session-Id header). Used for session-based authentication.
 
     Returns:
         types.CallToolResult: Contains a list of files/folders within the specified folder, including their details (ID, name, type, size, modified time, link),
                                an error message if the API call fails or the folder is not accessible/found,
                                or an authentication guidance message if credentials are required.
     """
-    logger.info(f"[list_drive_items] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}', Folder ID: '{folder_id}'")
-    tool_specific_scopes = [DRIVE_READONLY_SCOPE]
-    credentials = await asyncio.to_thread(
-        get_credentials,
-        user_google_email=user_google_email,
-        required_scopes=tool_specific_scopes,
-        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH, # Use imported constant
-        session_id=mcp_session_id
-    )
+    tool_name = "list_drive_items"
+    logger.info(f"[{tool_name}] Invoked. Email: '{user_google_email}', Folder ID: '{folder_id}'")
 
-    if not credentials or not credentials.valid:
-        logger.warning(f"[list_drive_items] No valid credentials for Drive. Session: '{mcp_session_id}', Email: '{user_google_email}'.")
-        if user_google_email and '@' in user_google_email:
-            # Use the centralized start_auth_flow
-            return await start_auth_flow(mcp_session_id=mcp_session_id, user_google_email=user_google_email, service_name="Google Drive", redirect_uri=OAUTH_REDIRECT_URI)
-        else:
-            error_msg = "Drive Authentication required. LLM: Please ask for Google email."
-            return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_msg)])
+    auth_result = await get_authenticated_google_service(
+        service_name="drive",
+        version="v3",
+        tool_name=tool_name,
+        user_google_email=user_google_email,
+        required_scopes=[DRIVE_READONLY_SCOPE],
+    )
+    if isinstance(auth_result, types.CallToolResult):
+        return auth_result  # Auth error
+    service, user_email = auth_result
 
     try:
-        service = build('drive', 'v3', credentials=credentials)
-        user_email_from_creds = 'Unknown (Drive)'
-        if credentials.id_token and isinstance(credentials.id_token, dict):
-            user_email_from_creds = credentials.id_token.get('email', 'Unknown (Drive)')
-
         results = await asyncio.to_thread(
             service.files().list(
                 q=f"'{folder_id}' in parents and trashed=false", # List items directly in the folder
@@ -277,54 +232,40 @@ async def list_drive_items(
 
 @server.tool()
 async def create_drive_file(
+    user_google_email: str,
     file_name: str,
     content: str,
     folder_id: str = 'root', # Default to root folder
-    user_google_email: Optional[str] = None,
     mime_type: str = 'text/plain', # Default to plain text
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
 ) -> types.CallToolResult:
     """
     Creates a new file in Google Drive with the specified name, content, and optional parent folder.
-    Prioritizes authenticated MCP session, then `user_google_email`.
-    If no valid authentication is found, guides the LLM to obtain user's email or use `start_auth`.
 
     Args:
+        user_google_email (str): The user's Google email address. Required.
         file_name (str): The name for the new file.
         content (str): The content to write to the file.
         folder_id (str): The ID of the parent folder. Defaults to 'root'.
-        user_google_email (Optional[str]): User's Google email. Used if session isn't authenticated.
         mime_type (str): The MIME type of the file. Defaults to 'text/plain'.
-        mcp_session_id (Optional[str]): Active MCP session ID (injected by FastMCP from Mcp-Session-Id header).
 
     Returns:
         A CallToolResult confirming creation or an error/auth guidance message.
     """
-    logger.info(f"[create_drive_file] Invoked. Session: '{mcp_session_id}', Email: '{user_google_email}', File Name: {file_name}, Folder ID: {folder_id}")
-    tool_specific_scopes = [DRIVE_FILE_SCOPE] # Use DRIVE_FILE_SCOPE for creating files
-    credentials = await asyncio.to_thread(
-        get_credentials,
-        user_google_email=user_google_email,
-        required_scopes=tool_specific_scopes,
-        client_secrets_path=CONFIG_CLIENT_SECRETS_PATH, # Use imported constant
-        session_id=mcp_session_id
-    )
+    tool_name = "create_drive_file"
+    logger.info(f"[{tool_name}] Invoked. Email: '{user_google_email}', File Name: {file_name}, Folder ID: {folder_id}")
 
-    if not credentials or not credentials.valid:
-        logger.warning(f"[create_drive_file] No valid credentials. Session: '{mcp_session_id}', Email: '{user_google_email}'.")
-        if user_google_email and '@' in user_google_email:
-            # Use the centralized start_auth_flow
-            return await start_auth_flow(mcp_session_id=mcp_session_id, user_google_email=user_google_email, service_name="Google Drive", redirect_uri=OAUTH_REDIRECT_URI)
-        else:
-            error_msg = "Authentication required to create file. LLM: Please ask for Google email."
-            return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=error_msg)])
+    auth_result = await get_authenticated_google_service(
+        service_name="drive",
+        version="v3",
+        tool_name=tool_name,
+        user_google_email=user_google_email,
+        required_scopes=[DRIVE_FILE_SCOPE],
+    )
+    if isinstance(auth_result, types.CallToolResult):
+        return auth_result  # Auth error
+    service, user_email = auth_result
 
     try:
-        service = build('drive', 'v3', credentials=credentials)
-        user_email_from_creds = 'Unknown (Drive)'
-        if credentials.id_token and isinstance(credentials.id_token, dict):
-            user_email_from_creds = credentials.id_token.get('email', 'Unknown (Drive)')
-
         file_metadata = {
             'name': file_name,
             'parents': [folder_id],
@@ -341,9 +282,10 @@ async def create_drive_file(
         )
 
         link = created_file.get('webViewLink', 'No link available')
-        confirmation_message = f"Successfully created file '{created_file.get('name', file_name)}' (ID: {created_file.get('id', 'N/A')}) in folder '{folder_id}' for {user_email_from_creds}. Link: {link}"
+        confirmation_message = f"Successfully created file '{created_file.get('name', file_name)}' (ID: {created_file.get('id', 'N/A')}) in folder '{folder_id}' for {user_email}. Link: {link}"
         logger.info(f"Successfully created file. Link: {link}")
         return types.CallToolResult(content=[types.TextContent(type="text", text=confirmation_message)])
+
     except HttpError as error:
         logger.error(f"API error creating Drive file '{file_name}': {error}", exc_info=True)
         return types.CallToolResult(isError=True, content=[types.TextContent(type="text", text=f"API error: {error}")])

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -84,7 +84,7 @@ async def search_drive_files(
         if not files:
             return types.CallToolResult(content=[types.TextContent(type="text", text=f"No files found for '{query}'.")])
 
-        formatted_files_text_parts = [f"Found {len(files)} files for {user_email_from_creds} matching '{query}':"]
+        formatted_files_text_parts = [f"Found {len(files)} files for {user_google_email} matching '{query}':"]
         for item in files:
             size_str = f", Size: {item.get('size', 'N/A')}" if 'size' in item else ""
             formatted_files_text_parts.append(
@@ -215,7 +215,7 @@ async def list_drive_items(
         if not files:
             return types.CallToolResult(content=[types.TextContent(type="text", text=f"No items found in folder '{folder_id}'.")])
 
-        formatted_items_text_parts = [f"Found {len(files)} items in folder '{folder_id}' for {user_email_from_creds}:"]
+        formatted_items_text_parts = [f"Found {len(files)} items in folder '{folder_id}' for {user_google_email}:"]
         for item in files:
             size_str = f", Size: {item.get('size', 'N/A')}" if 'size' in item else ""
             formatted_items_text_parts.append(


### PR DESCRIPTION
feat: Centralize Google Workspace Authentication

This pull request implements a centralized authentication helper for Google Workspace MCP tools, significantly reducing code duplication and improving maintainability.

**Key Changes:**

- **Centralized Authentication Helper**: A new asynchronous function, [`get_authenticated_google_service()`](auth/google_auth.py:442), has been added to [`auth/google_auth.py`](auth/google_auth.py:1). This function handles the common logic for obtaining authenticated Google service clients (Gmail, Calendar, Drive, Docs) based on a required `user_google_email` and necessary scopes.
- **Removed Session Dependency**: The brittle in-memory session cache (`_SESSION_CREDENTIALS_CACHE`) and the `mcp_session_id` parameter have been removed from the authentication flow and tool function signatures. Authentication now relies solely on the user's Google email address and stored credentials.
- **Required User Email**: All Google Workspace tool functions now require the `user_google_email` parameter, making the authentication requirement explicit.
- **Refactored Tool Modules**:
    - **Gmail Tools** ([`gmail/gmail_tools.py`](gmail/gmail_tools.py:1)): Refactored [`search_gmail_messages()`](gmail/gmail_tools.py:73), [`get_gmail_message_content()`](gmail/gmail_tools.py:160), [`send_gmail_message()`](gmail/gmail_tools.py:259), [`draft_gmail_message()`](gmail/gmail_tools.py:329), and [`get_gmail_thread_content()`](gmail/gmail_tools.py:408) to use the new centralized helper. Removed duplicated authentication logic and `mcp_session_id` parameters.
    - **Calendar Tools** ([`gcalendar/calendar_tools.py`](gcalendar/calendar_tools.py:1)): Replaced the internal [`_get_authenticated_calendar_service()`](gcalendar/calendar_tools.py:100) helper with the new centralized [`get_authenticated_google_service()`](auth/google_auth.py:442) function. Updated [`list_calendars()`](gcalendar/calendar_tools.py:98), [`get_events()`](gcalendar/calendar_tools.py:169), [`create_event()`](gcalendar/calendar_tools.py:287), [`modify_event()`](gcalendar/calendar_tools.py:387), and [`delete_event()`](gcalendar/calendar_tools.py:540) to use the centralized flow and require `user_google_email`.
    - **Drive Tools** ([`gdrive/drive_tools.py`](gdrive/drive_tools.py:1)): Refactored [`search_drive_files()`](gdrive/drive_tools.py:28), [`get_drive_file_content()`](gdrive/drive_tools.py:102), [`list_drive_items()`](gdrive/drive_tools.py:172), and [`create_drive_file()`](gdrive/drive_tools.py:233) to utilize the centralized authentication helper and require `user_google_email`.
    - **Docs Tools** ([`gdocs/docs_tools.py`](gdocs/docs_tools.py:1)): Updated [`search_docs()`](gdocs/docs_tools.py:27), [`get_doc_content()`](gdocs/docs_tools.py:77), [`list_docs_in_folder()`](gdocs/docs_tools.py:107), and [`create_doc()`](gdocs/docs_tools.py:157) to use the centralized authentication and require `user_google_email`.

**Benefits:**

- **Massive Code Reduction**: Eliminates over 700 lines of duplicated authentication code across the tool modules.
- **Single Source of Truth**: Authentication logic is now managed in one place, simplifying maintenance, testing, and debugging.
- **Consistent Behavior**: Ensures uniform authentication handling across all Google Workspace tools.
- **Improved Maintainability**: Changes to authentication logic only need to be made in a single function.
- **Cleaner Tool Signatures**: Removes the `mcp_session_id` parameter from tool functions.
- **Enhanced Reliability**: Eliminates the brittleness associated with the in-memory session cache.

This refactoring aligns the Google Workspace tools with best practices for code organization and maintainability, making it easier to add new tools and services in the future.