### PR TITLE
feat: enhance Gmail search with XML structure and web interface links

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -63,6 +63,21 @@ def _extract_message_body(payload):
     return body_data
 
 
+def _generate_gmail_web_url(item_id: str, account_index: int = 0) -> str:
+    """
+    Generate Gmail web interface URL for a message or thread ID.
+    Uses #all to access messages from any Gmail folder/label (not just inbox).
+
+    Args:
+        item_id: Gmail message ID or thread ID
+        account_index: Google account index (default 0 for primary account)
+
+    Returns:
+        Gmail web interface URL that opens the message/thread in Gmail web interface
+    """
+    return f"https://mail.google.com/mail/u/{account_index}/#all/{item_id}"
+
+
 @server.tool()
 async def search_gmail_messages(
     query: str,
@@ -71,7 +86,7 @@ async def search_gmail_messages(
 ) -> types.CallToolResult:
     """
     Searches messages in a user's Gmail account based on a query.
-    Returns both Message IDs and Thread IDs for each found message.
+    Returns both Message IDs and Thread IDs for each found message, along with Gmail web interface links for manual verification.
 
     Args:
         query (str): The search query. Supports standard Gmail search operators.
@@ -79,7 +94,7 @@ async def search_gmail_messages(
         page_size (int): The maximum number of messages to return. Defaults to 10.
 
     Returns:
-        types.CallToolResult: Contains a list of found messages with both Message IDs (for get_gmail_message_content) and Thread IDs (for get_gmail_thread_content), or an error/auth guidance message.
+        types.CallToolResult: Contains XML-structured results with Message IDs, Thread IDs, and clickable Gmail web interface URLs for each found message, or an error/auth guidance message.
     """
     tool_name = "search_gmail_messages"
     logger.info(
@@ -115,22 +130,32 @@ async def search_gmail_messages(
                 ]
             )
 
-        # Build enhanced output showing both message ID and thread ID
+        # Build enhanced output with XML structure and Gmail web links
         lines = [
             f"Found {len(messages)} messages:",
             "",
             "Note: Use Message ID with get_gmail_message_content, Thread ID with get_gmail_thread_content",
+            "Click the Gmail links below to view messages/threads directly in your browser:",
             "",
+            f'<gmail_results count="{len(messages)}">',
         ]
 
         for i, msg in enumerate(messages, 1):
+            message_url = _generate_gmail_web_url(msg["id"])
+            thread_url = _generate_gmail_web_url(msg["threadId"])
+
             lines.extend(
                 [
-                    f"{i}. Message ID: {msg['id']}",
-                    f"   Thread ID:  {msg['threadId']}",
-                    "",
+                    f'    <message index="{i}">',
+                    f'        <message_id>{msg["id"]}</message_id>',
+                    f"        <message_url>{message_url}</message_url>",
+                    f'        <thread_id>{msg["threadId"]}</thread_id>',
+                    f"        <thread_url>{thread_url}</thread_url>",
+                    f"    </message>",
                 ]
             )
+
+        lines.append("</gmail_results>")
 
         return types.CallToolResult(
             content=[types.TextContent(type="text", text="\n".join(lines))]


### PR DESCRIPTION
- Add _generate_gmail_web_url() helper function using #all for universal Gmail access
- Update search_gmail_messages to return XML-structured output with index attributes
- Include clickable Gmail web interface URLs for both messages and threads
- Maintain backward compatibility with existing Message/Thread ID usage
- Improve manual verification capabilities for users when multiple threads have same subject