### PR TITLE
refac: deduplicate scopes config 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **The world's most feature-complete Google Workspace MCP server**
 
-*Connect MCP Clients, AI assistants and developer tools to Google Calendar, Drive, Gmail, Docs, Sheets, and Chat through the Model Context Protocol*
+*Connect MCP Clients, AI assistants and developer tools to Google Calendar, Drive, Gmail, Docs, Sheets, Forms, and Chat through the Model Context Protocol*
 
 </div>
 
@@ -27,12 +27,13 @@ A production-ready MCP server that integrates all major Google Workspace service
 
 ## ✨ Features
 
-- **🔐 Advanced OAuth 2.0**: Secure authentication with automatic token refresh, transport-aware callback handling, session management, and service-specific scope handling
+- **🔐 Advanced OAuth 2.0**: Secure authentication with automatic token refresh, transport-aware callback handling, session management, and centralized scope management
 - **📅 Google Calendar**: Full calendar management with event CRUD operations
 - **📁 Google Drive**: File operations with native Microsoft Office format support (.docx, .xlsx)
 - **📧 Gmail**: Complete email management with search, send, and draft capabilities
 - **📄 Google Docs**: Document operations including content extraction and creation
 - **📊 Google Sheets**: Comprehensive spreadsheet management with flexible cell operations
+- **📝 Google Forms**: Form creation, retrieval, publish settings, and response management
 - **💬 Google Chat**: Space management and messaging capabilities
 - **🔄 Multiple Transports**: HTTP with SSE fallback, OpenAPI compatibility via `mcpo`
 - **⚡ High Performance**: Service caching, thread-safe sessions, FastMCP integration
@@ -60,7 +61,7 @@ uv run main.py
 
 1. **Google Cloud Setup**:
    - Create OAuth 2.0 credentials (web application) in [Google Cloud Console](https://console.cloud.google.com/)
-   - Enable APIs: Calendar, Drive, Gmail, Docs, Sheets, Chat
+   - Enable APIs: Calendar, Drive, Gmail, Docs, Sheets, Forms, Chat
    - Download credentials as `client_secret.json` in project root
    - Add redirect URI: `http://localhost:8000/oauth2callback`
 
@@ -96,7 +97,7 @@ docker build -t google-workspace-mcp .
 docker run -p 8000:8000 -v $(pwd):/app google-workspace-mcp --transport streamable-http
 ```
 
-**Available Tools for `--tools` flag**: `gmail`, `drive`, `calendar`, `docs`, `sheets`, `chat`
+**Available Tools for `--tools` flag**: `gmail`, `drive`, `calendar`, `docs`, `sheets`, `forms`, `chat`
 
 ### Connect to Claude Desktop
 
@@ -210,6 +211,16 @@ When calling a tool:
 | `modify_sheet_values` | Write/update/clear cells |
 | `create_spreadsheet` | Create new spreadsheets |
 | `create_sheet` | Add sheets to existing files |
+
+### 📝 Google Forms ([`forms_tools.py`](gforms/forms_tools.py))
+
+| Tool | Description |
+|------|-------------|
+| `create_form` | Create new forms with title and description |
+| `get_form` | Retrieve form details, questions, and URLs |
+| `set_publish_settings` | Configure form template and authentication settings |
+| `get_form_response` | Get individual form response details |
+| `list_form_responses` | List all responses to a form with pagination |
 
 ### 💬 Google Chat ([`chat_tools.py`](gchat/chat_tools.py))
 

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -13,7 +13,7 @@ from google.auth.transport.requests import Request
 from google.auth.exceptions import RefreshError
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-from config.google_config import OAUTH_STATE_TO_SESSION_ID_MAP, SCOPES
+from auth.scopes import OAUTH_STATE_TO_SESSION_ID_MAP, SCOPES
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -16,7 +16,7 @@ from fastapi import FastAPI, Request
 import uvicorn
 
 from auth.google_auth import handle_auth_callback, CONFIG_CLIENT_SECRETS_PATH
-from config.google_config import OAUTH_STATE_TO_SESSION_ID_MAP, SCOPES
+from auth.scopes import OAUTH_STATE_TO_SESSION_ID_MAP, SCOPES
 from auth.oauth_responses import create_error_response, create_success_response, create_server_error_response
 
 logger = logging.getLogger(__name__)

--- a/auth/scopes.py
+++ b/auth/scopes.py
@@ -1,8 +1,8 @@
 """
-Google Workspace MCP Configuration
+Google Workspace OAuth Scopes
 
-This module centralizes configuration variables for Google Workspace integration,
-including OAuth scopes and the state map for authentication flows.
+This module centralizes OAuth scope definitions for Google Workspace integration.
+Separated from service_decorator.py to avoid circular imports.
 """
 import logging
 from typing import Dict
@@ -28,11 +28,11 @@ DOCS_READONLY_SCOPE = 'https://www.googleapis.com/auth/documents.readonly'
 DOCS_WRITE_SCOPE = 'https://www.googleapis.com/auth/documents'
 
 # Gmail API scopes
-GMAIL_READONLY_SCOPE   = 'https://www.googleapis.com/auth/gmail.readonly'
-GMAIL_SEND_SCOPE       = 'https://www.googleapis.com/auth/gmail.send'
-GMAIL_COMPOSE_SCOPE    = 'https://www.googleapis.com/auth/gmail.compose'
-GMAIL_MODIFY_SCOPE     = 'https://www.googleapis.com/auth/gmail.modify'
-GMAIL_LABELS_SCOPE     = 'https://www.googleapis.com/auth/gmail.labels'
+GMAIL_READONLY_SCOPE = 'https://www.googleapis.com/auth/gmail.readonly'
+GMAIL_SEND_SCOPE = 'https://www.googleapis.com/auth/gmail.send'
+GMAIL_COMPOSE_SCOPE = 'https://www.googleapis.com/auth/gmail.compose'
+GMAIL_MODIFY_SCOPE = 'https://www.googleapis.com/auth/gmail.modify'
+GMAIL_LABELS_SCOPE = 'https://www.googleapis.com/auth/gmail.labels'
 
 # Google Chat API scopes
 CHAT_READONLY_SCOPE = 'https://www.googleapis.com/auth/chat.messages.readonly'
@@ -54,25 +54,22 @@ BASE_SCOPES = [
     OPENID_SCOPE
 ]
 
-# Calendar-specific scopes
+# Service-specific scope groups
 DOCS_SCOPES = [
     DOCS_READONLY_SCOPE,
     DOCS_WRITE_SCOPE
 ]
 
-# Calendar-specific scopes
 CALENDAR_SCOPES = [
     CALENDAR_READONLY_SCOPE,
     CALENDAR_EVENTS_SCOPE
 ]
 
-# Drive-specific scopes
 DRIVE_SCOPES = [
     DRIVE_READONLY_SCOPE,
     DRIVE_FILE_SCOPE
 ]
 
-# Gmail-specific scopes
 GMAIL_SCOPES = [
     GMAIL_READONLY_SCOPE,
     GMAIL_SEND_SCOPE,
@@ -81,20 +78,17 @@ GMAIL_SCOPES = [
     GMAIL_LABELS_SCOPE
 ]
 
-# Chat-specific scopes
 CHAT_SCOPES = [
     CHAT_READONLY_SCOPE,
     CHAT_WRITE_SCOPE,
     CHAT_SPACES_SCOPE
 ]
 
-# Sheets-specific scopes
 SHEETS_SCOPES = [
     SHEETS_READONLY_SCOPE,
     SHEETS_WRITE_SCOPE
 ]
 
-# Forms-specific scopes
 FORMS_SCOPES = [
     FORMS_BODY_SCOPE,
     FORMS_BODY_READONLY_SCOPE,

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -9,6 +9,17 @@ from auth.google_auth import get_authenticated_google_service, GoogleAuthenticat
 
 logger = logging.getLogger(__name__)
 
+# Import scope constants
+from auth.scopes import (
+    GMAIL_READONLY_SCOPE, GMAIL_SEND_SCOPE, GMAIL_COMPOSE_SCOPE, GMAIL_MODIFY_SCOPE, GMAIL_LABELS_SCOPE,
+    DRIVE_READONLY_SCOPE, DRIVE_FILE_SCOPE,
+    DOCS_READONLY_SCOPE, DOCS_WRITE_SCOPE,
+    CALENDAR_READONLY_SCOPE, CALENDAR_EVENTS_SCOPE,
+    SHEETS_READONLY_SCOPE, SHEETS_WRITE_SCOPE,
+    CHAT_READONLY_SCOPE, CHAT_WRITE_SCOPE, CHAT_SPACES_SCOPE,
+    FORMS_BODY_SCOPE, FORMS_BODY_READONLY_SCOPE, FORMS_RESPONSES_READONLY_SCOPE
+)
+
 # Service configuration mapping
 SERVICE_CONFIGS = {
     "gmail": {"service": "gmail", "version": "v1"},
@@ -20,40 +31,41 @@ SERVICE_CONFIGS = {
     "forms": {"service": "forms", "version": "v1"}
 }
 
+
 # Scope group definitions for easy reference
 SCOPE_GROUPS = {
     # Gmail scopes
-    "gmail_read": "https://www.googleapis.com/auth/gmail.readonly",
-    "gmail_send": "https://www.googleapis.com/auth/gmail.send",
-    "gmail_compose": "https://www.googleapis.com/auth/gmail.compose",
-    "gmail_modify": "https://www.googleapis.com/auth/gmail.modify",
-    "gmail_labels": "https://www.googleapis.com/auth/gmail.labels",
+    "gmail_read": GMAIL_READONLY_SCOPE,
+    "gmail_send": GMAIL_SEND_SCOPE,
+    "gmail_compose": GMAIL_COMPOSE_SCOPE,
+    "gmail_modify": GMAIL_MODIFY_SCOPE,
+    "gmail_labels": GMAIL_LABELS_SCOPE,
 
     # Drive scopes
-    "drive_read": "https://www.googleapis.com/auth/drive.readonly",
-    "drive_file": "https://www.googleapis.com/auth/drive.file",
+    "drive_read": DRIVE_READONLY_SCOPE,
+    "drive_file": DRIVE_FILE_SCOPE,
 
     # Docs scopes
-    "docs_read": "https://www.googleapis.com/auth/documents.readonly",
-    "docs_write": "https://www.googleapis.com/auth/documents",
+    "docs_read": DOCS_READONLY_SCOPE,
+    "docs_write": DOCS_WRITE_SCOPE,
 
     # Calendar scopes
-    "calendar_read": "https://www.googleapis.com/auth/calendar.readonly",
-    "calendar_events": "https://www.googleapis.com/auth/calendar.events",
+    "calendar_read": CALENDAR_READONLY_SCOPE,
+    "calendar_events": CALENDAR_EVENTS_SCOPE,
 
     # Sheets scopes
-    "sheets_read": "https://www.googleapis.com/auth/spreadsheets.readonly",
-    "sheets_write": "https://www.googleapis.com/auth/spreadsheets",
+    "sheets_read": SHEETS_READONLY_SCOPE,
+    "sheets_write": SHEETS_WRITE_SCOPE,
 
     # Chat scopes
-    "chat_read": "https://www.googleapis.com/auth/chat.messages.readonly",
-    "chat_write": "https://www.googleapis.com/auth/chat.messages",
-    "chat_spaces": "https://www.googleapis.com/auth/chat.spaces.readonly",
+    "chat_read": CHAT_READONLY_SCOPE,
+    "chat_write": CHAT_WRITE_SCOPE,
+    "chat_spaces": CHAT_SPACES_SCOPE,
 
     # Forms scopes
-    "forms": "https://www.googleapis.com/auth/forms.body",
-    "forms_read": "https://www.googleapis.com/auth/forms.body.readonly",
-    "forms_responses_read": "https://www.googleapis.com/auth/forms.responses.readonly",
+    "forms": FORMS_BODY_SCOPE,
+    "forms_read": FORMS_BODY_READONLY_SCOPE,
+    "forms_responses_read": FORMS_RESPONSES_READONLY_SCOPE,
 }
 
 # Service cache: {cache_key: (service, cached_time, user_email)}

--- a/core/server.py
+++ b/core/server.py
@@ -15,7 +15,7 @@ from auth.oauth_callback_server import get_oauth_redirect_uri, ensure_oauth_call
 from auth.oauth_responses import create_error_response, create_success_response, create_server_error_response
 
 # Import shared configuration
-from config.google_config import (
+from auth.scopes import (
     OAUTH_STATE_TO_SESSION_ID_MAP,
     USERINFO_EMAIL_SCOPE,
     OPENID_SCOPE,


### PR DESCRIPTION
* Created auth/scopes.py with all the scope constants and configuration
* Updated auth/service_decorator.py to import from auth/scopes.py and removed duplicate scope definitions
* Updated all files (core/server.py, auth/google_auth.py, auth/oauth_callback_server.py) to
  import from auth/scopes.py
* Removed the old config/google_config.py file

The structure is now clean with no circular imports:
  - auth/scopes.py: Contains all scope constants and OAUTH_STATE_TO_SESSION_ID_MAP
  - auth/service_decorator.py: Contains the decorator logic and imports scopes from auth/scopes.py
  - All other files import scopes from auth/scopes.py

This eliminates the duplication and consolidates all scope definitions in a single, dedicated module without any circular dependency issues.