### PR TITLE
Fix pyproject.toml for uvx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,5 +45,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 
+[project.scripts]
+google-workspace-mcp = "main:main"
+
 [tool.setuptools]
-packages = ["auth", "gcalendar", "core", "gdocs", "gdrive", "gmail", "config", "gchat", "gsheets"]
+packages = ["auth", "gcalendar", "core", "gdocs", "gdrive", "gmail", "gchat", "gsheets", "gforms"]
+py-modules = ["main"]


### PR DESCRIPTION
I wanted to be able to run this whole thing straight from github with `uvx --from git+https://github.com/taylorwilsdon/google_workspace_mcp google-workspace-mcp` but had no luck because of some wonky stuff in `pyproject.toml`. This un-wonks it by removing the missing `config` package, adding the missing `gforms` package, and teaching setuptools that there's a `main` module in the root of the project.

The better fix is probably to move main.py into a subdirectory and then letting setuptools auto-discover all the packages, but that was more yak-shaving than I felt like doing at 8am on a Tuesday 😉 