### PR TITLE
Explain GOOGLE_CLIENT_SECRETS in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ uv run main.py
 1. **Google Cloud Setup**:
    - Create OAuth 2.0 credentials (web application) in [Google Cloud Console](https://console.cloud.google.com/)
    - Enable APIs: Calendar, Drive, Gmail, Docs, Sheets, Slides, Forms, Chat
-   - Download credentials as `client_secret.json` in project root (or a secure location and then setting `GOOGLE_CLIENT_SECRETS` environment variable to the right path).
+   - Download credentials as `client_secret.json` in project root
+     - To use a different location for `client_secret.json`, you can set the `GOOGLE_CLIENT_SECRETS` environment variable with that path
    - Add redirect URI: `http://localhost:8000/oauth2callback`
 
 2. **Environment**:

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ uv run main.py
 1. **Google Cloud Setup**:
    - Create OAuth 2.0 credentials (web application) in [Google Cloud Console](https://console.cloud.google.com/)
    - Enable APIs: Calendar, Drive, Gmail, Docs, Sheets, Slides, Forms, Chat
-   - Download credentials as `client_secret.json` in project root
+   - Download credentials as `client_secret.json` in project root (or a secure location and then setting `GOOGLE_CLIENT_SECRETS` environment variable to the right path).
    - Add redirect URI: `http://localhost:8000/oauth2callback`
 
 2. **Environment**:


### PR DESCRIPTION
Currently the only way to find out about configuring the secrets location is by reading the code at https://github.com/taylorwilsdon/google_workspace_mcp/blob/ec480a2aee3eaa76497d9bb75e9269e0594db428/auth/google_auth.py#L30-L39

So, just add a quick note in the relevant part of the README.md