### PR TITLE
refac: service decorator & httperror handler

### DIFF
--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -243,7 +243,7 @@ def require_google_service(
                 cached_result = _get_cached_service(cache_key)
                 if cached_result:
                     service, actual_user_email = cached_result
-            
+
             if service is None:
                 try:
                     tool_name = func.__name__

--- a/gchat/chat_tools.py
+++ b/gchat/chat_tools.py
@@ -13,11 +13,13 @@ from googleapiclient.errors import HttpError
 # Auth & server utilities
 from auth.service_decorator import require_google_service
 from core.server import server
+from core.utils import handle_http_errors
 
 logger = logging.getLogger(__name__)
 
 @server.tool()
 @require_google_service("chat", "chat_read")
+@handle_http_errors("list_spaces")
 async def list_spaces(
     service,
     user_google_email: str,
@@ -32,44 +34,37 @@ async def list_spaces(
     """
     logger.info(f"[list_spaces] Email={user_google_email}, Type={space_type}")
 
-    try:
-        # Build filter based on space_type
-        filter_param = None
-        if space_type == "room":
-            filter_param = "spaceType = SPACE"
-        elif space_type == "dm":
-            filter_param = "spaceType = DIRECT_MESSAGE"
+    # Build filter based on space_type
+    filter_param = None
+    if space_type == "room":
+        filter_param = "spaceType = SPACE"
+    elif space_type == "dm":
+        filter_param = "spaceType = DIRECT_MESSAGE"
 
-        request_params = {"pageSize": page_size}
-        if filter_param:
-            request_params["filter"] = filter_param
+    request_params = {"pageSize": page_size}
+    if filter_param:
+        request_params["filter"] = filter_param
 
-        response = await asyncio.to_thread(
-            service.spaces().list(**request_params).execute
-        )
+    response = await asyncio.to_thread(
+        service.spaces().list(**request_params).execute
+    )
 
-        spaces = response.get('spaces', [])
-        if not spaces:
-            return f"No Chat spaces found for type '{space_type}'."
+    spaces = response.get('spaces', [])
+    if not spaces:
+        return f"No Chat spaces found for type '{space_type}'."
 
-        output = [f"Found {len(spaces)} Chat spaces (type: {space_type}):"]
-        for space in spaces:
-            space_name = space.get('displayName', 'Unnamed Space')
-            space_id = space.get('name', '')
-            space_type_actual = space.get('spaceType', 'UNKNOWN')
-            output.append(f"- {space_name} (ID: {space_id}, Type: {space_type_actual})")
+    output = [f"Found {len(spaces)} Chat spaces (type: {space_type}):"]
+    for space in spaces:
+        space_name = space.get('displayName', 'Unnamed Space')
+        space_id = space.get('name', '')
+        space_type_actual = space.get('spaceType', 'UNKNOWN')
+        output.append(f"- {space_name} (ID: {space_id}, Type: {space_type_actual})")
 
-        return "\n".join(output)
-
-    except HttpError as e:
-        logger.error(f"API error in list_spaces: {e}", exc_info=True)
-        raise Exception(f"API error: {e}")
-    except Exception as e:
-        logger.exception(f"Unexpected error in list_spaces: {e}")
-        raise Exception(f"Unexpected error: {e}")
+    return "\n".join(output)
 
 @server.tool()
 @require_google_service("chat", "chat_read")
+@handle_http_errors("get_messages")
 async def get_messages(
     service,
     user_google_email: str,
@@ -85,48 +80,41 @@ async def get_messages(
     """
     logger.info(f"[get_messages] Space ID: '{space_id}' for user '{user_google_email}'")
 
-    try:
-        # Get space info first
-        space_info = await asyncio.to_thread(
-            service.spaces().get(name=space_id).execute
-        )
-        space_name = space_info.get('displayName', 'Unknown Space')
+    # Get space info first
+    space_info = await asyncio.to_thread(
+        service.spaces().get(name=space_id).execute
+    )
+    space_name = space_info.get('displayName', 'Unknown Space')
 
-        # Get messages
-        response = await asyncio.to_thread(
-            service.spaces().messages().list(
-                parent=space_id,
-                pageSize=page_size,
-                orderBy=order_by
-            ).execute
-        )
+    # Get messages
+    response = await asyncio.to_thread(
+        service.spaces().messages().list(
+            parent=space_id,
+            pageSize=page_size,
+            orderBy=order_by
+        ).execute
+    )
 
-        messages = response.get('messages', [])
-        if not messages:
-            return f"No messages found in space '{space_name}' (ID: {space_id})."
+    messages = response.get('messages', [])
+    if not messages:
+        return f"No messages found in space '{space_name}' (ID: {space_id})."
 
-        output = [f"Messages from '{space_name}' (ID: {space_id}):\n"]
-        for msg in messages:
-            sender = msg.get('sender', {}).get('displayName', 'Unknown Sender')
-            create_time = msg.get('createTime', 'Unknown Time')
-            text_content = msg.get('text', 'No text content')
-            msg_name = msg.get('name', '')
+    output = [f"Messages from '{space_name}' (ID: {space_id}):\n"]
+    for msg in messages:
+        sender = msg.get('sender', {}).get('displayName', 'Unknown Sender')
+        create_time = msg.get('createTime', 'Unknown Time')
+        text_content = msg.get('text', 'No text content')
+        msg_name = msg.get('name', '')
 
-            output.append(f"[{create_time}] {sender}:")
-            output.append(f"  {text_content}")
-            output.append(f"  (Message ID: {msg_name})\n")
+        output.append(f"[{create_time}] {sender}:")
+        output.append(f"  {text_content}")
+        output.append(f"  (Message ID: {msg_name})\n")
 
-        return "\n".join(output)
-
-    except HttpError as error:
-        logger.error(f"[get_messages] API error for space {space_id}: {error}", exc_info=True)
-        raise Exception(f"API error accessing space {space_id}: {error}")
-    except Exception as e:
-        logger.exception(f"[get_messages] Unexpected error for space {space_id}: {e}")
-        raise Exception(f"Unexpected error accessing space {space_id}: {e}")
+    return "\n".join(output)
 
 @server.tool()
 @require_google_service("chat", "chat_write")
+@handle_http_errors("send_message")
 async def send_message(
     service,
     user_google_email: str,
@@ -142,39 +130,32 @@ async def send_message(
     """
     logger.info(f"[send_message] Email: '{user_google_email}', Space: '{space_id}'")
 
-    try:
-        message_body = {
-            'text': message_text
-        }
+    message_body = {
+        'text': message_text
+    }
 
-        # Add thread key if provided (for threaded replies)
-        request_params = {
-            'parent': space_id,
-            'body': message_body
-        }
-        if thread_key:
-            request_params['threadKey'] = thread_key
+    # Add thread key if provided (for threaded replies)
+    request_params = {
+        'parent': space_id,
+        'body': message_body
+    }
+    if thread_key:
+        request_params['threadKey'] = thread_key
 
-        message = await asyncio.to_thread(
-            service.spaces().messages().create(**request_params).execute
-        )
+    message = await asyncio.to_thread(
+        service.spaces().messages().create(**request_params).execute
+    )
 
-        message_name = message.get('name', '')
-        create_time = message.get('createTime', '')
+    message_name = message.get('name', '')
+    create_time = message.get('createTime', '')
 
-        msg = f"Message sent to space '{space_id}' by {user_google_email}. Message ID: {message_name}, Time: {create_time}"
-        logger.info(f"Successfully sent message to space '{space_id}' by {user_google_email}")
-        return msg
-
-    except HttpError as e:
-        logger.error(f"API error in send_message: {e}", exc_info=True)
-        raise Exception(f"API error: {e}")
-    except Exception as e:
-        logger.exception(f"Unexpected error in send_message: {e}")
-        raise Exception(f"Unexpected error: {e}")
+    msg = f"Message sent to space '{space_id}' by {user_google_email}. Message ID: {message_name}, Time: {create_time}"
+    logger.info(f"Successfully sent message to space '{space_id}' by {user_google_email}")
+    return msg
 
 @server.tool()
 @require_google_service("chat", "chat_read")
+@handle_http_errors("search_messages")
 async def search_messages(
     service,
     user_google_email: str,
@@ -190,65 +171,57 @@ async def search_messages(
     """
     logger.info(f"[search_messages] Email={user_google_email}, Query='{query}'")
 
-    try:
-        # If specific space provided, search within that space
-        if space_id:
-            response = await asyncio.to_thread(
-                service.spaces().messages().list(
-                    parent=space_id,
-                    pageSize=page_size,
-                    filter=f'text:"{query}"'
-                ).execute
-            )
-            messages = response.get('messages', [])
-            context = f"space '{space_id}'"
-        else:
-            # Search across all accessible spaces (this may require iterating through spaces)
-            # For simplicity, we'll search the user's spaces first
-            spaces_response = await asyncio.to_thread(
-                service.spaces().list(pageSize=100).execute
-            )
-            spaces = spaces_response.get('spaces', [])
+    # If specific space provided, search within that space
+    if space_id:
+        response = await asyncio.to_thread(
+            service.spaces().messages().list(
+                parent=space_id,
+                pageSize=page_size,
+                filter=f'text:"{query}"'
+            ).execute
+        )
+        messages = response.get('messages', [])
+        context = f"space '{space_id}'"
+    else:
+        # Search across all accessible spaces (this may require iterating through spaces)
+        # For simplicity, we'll search the user's spaces first
+        spaces_response = await asyncio.to_thread(
+            service.spaces().list(pageSize=100).execute
+        )
+        spaces = spaces_response.get('spaces', [])
 
-            messages = []
-            for space in spaces[:10]:  # Limit to first 10 spaces to avoid timeout
-                try:
-                    space_messages = await asyncio.to_thread(
-                        service.spaces().messages().list(
-                            parent=space.get('name'),
-                            pageSize=5,
-                            filter=f'text:"{query}"'
-                        ).execute
-                    )
-                    space_msgs = space_messages.get('messages', [])
-                    for msg in space_msgs:
-                        msg['_space_name'] = space.get('displayName', 'Unknown')
-                    messages.extend(space_msgs)
-                except HttpError:
-                    continue  # Skip spaces we can't access
-            context = "all accessible spaces"
+        messages = []
+        for space in spaces[:10]:  # Limit to first 10 spaces to avoid timeout
+            try:
+                space_messages = await asyncio.to_thread(
+                    service.spaces().messages().list(
+                        parent=space.get('name'),
+                        pageSize=5,
+                        filter=f'text:"{query}"'
+                    ).execute
+                )
+                space_msgs = space_messages.get('messages', [])
+                for msg in space_msgs:
+                    msg['_space_name'] = space.get('displayName', 'Unknown')
+                messages.extend(space_msgs)
+            except HttpError:
+                continue  # Skip spaces we can't access
+        context = "all accessible spaces"
 
-        if not messages:
-            return f"No messages found matching '{query}' in {context}."
+    if not messages:
+        return f"No messages found matching '{query}' in {context}."
 
-        output = [f"Found {len(messages)} messages matching '{query}' in {context}:"]
-        for msg in messages:
-            sender = msg.get('sender', {}).get('displayName', 'Unknown Sender')
-            create_time = msg.get('createTime', 'Unknown Time')
-            text_content = msg.get('text', 'No text content')
-            space_name = msg.get('_space_name', 'Unknown Space')
+    output = [f"Found {len(messages)} messages matching '{query}' in {context}:"]
+    for msg in messages:
+        sender = msg.get('sender', {}).get('displayName', 'Unknown Sender')
+        create_time = msg.get('createTime', 'Unknown Time')
+        text_content = msg.get('text', 'No text content')
+        space_name = msg.get('_space_name', 'Unknown Space')
 
-            # Truncate long messages
-            if len(text_content) > 100:
-                text_content = text_content[:100] + "..."
+        # Truncate long messages
+        if len(text_content) > 100:
+            text_content = text_content[:100] + "..."
 
-            output.append(f"- [{create_time}] {sender} in '{space_name}': {text_content}")
+        output.append(f"- [{create_time}] {sender} in '{space_name}': {text_content}")
 
-        return "\n".join(output)
-
-    except HttpError as e:
-        logger.error(f"API error in search_messages: {e}", exc_info=True)
-        raise Exception(f"API error: {e}")
-    except Exception as e:
-        logger.exception(f"Unexpected error in search_messages: {e}")
-        raise Exception(f"Unexpected error: {e}")
+    return "\n".join(output)

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -14,13 +14,14 @@ from googleapiclient.http import MediaIoBaseDownload
 
 # Auth & server utilities
 from auth.service_decorator import require_google_service, require_multiple_services
-from core.utils import extract_office_xml_text
+from core.utils import extract_office_xml_text, handle_http_errors
 from core.server import server
 
 logger = logging.getLogger(__name__)
 
 @server.tool()
 @require_google_service("drive", "drive_read")
+@handle_http_errors("search_docs")
 async def search_docs(
     service,
     user_google_email: str,
@@ -35,36 +36,32 @@ async def search_docs(
     """
     logger.info(f"[search_docs] Email={user_google_email}, Query='{query}'")
 
-    try:
-        escaped_query = query.replace("'", "\\'")
+    escaped_query = query.replace("'", "\\'")
 
-        response = await asyncio.to_thread(
-            service.files().list(
-                q=f"name contains '{escaped_query}' and mimeType='application/vnd.google-apps.document' and trashed=false",
-                pageSize=page_size,
-                fields="files(id, name, createdTime, modifiedTime, webViewLink)"
-            ).execute
+    response = await asyncio.to_thread(
+        service.files().list(
+            q=f"name contains '{escaped_query}' and mimeType='application/vnd.google-apps.document' and trashed=false",
+            pageSize=page_size,
+            fields="files(id, name, createdTime, modifiedTime, webViewLink)"
+        ).execute
+    )
+    files = response.get('files', [])
+    if not files:
+        return f"No Google Docs found matching '{query}'."
+
+    output = [f"Found {len(files)} Google Docs matching '{query}':"]
+    for f in files:
+        output.append(
+            f"- {f['name']} (ID: {f['id']}) Modified: {f.get('modifiedTime')} Link: {f.get('webViewLink')}"
         )
-        files = response.get('files', [])
-        if not files:
-            return f"No Google Docs found matching '{query}'."
-
-        output = [f"Found {len(files)} Google Docs matching '{query}':"]
-        for f in files:
-            output.append(
-                f"- {f['name']} (ID: {f['id']}) Modified: {f.get('modifiedTime')} Link: {f.get('webViewLink')}"
-            )
-        return "\n".join(output)
-
-    except HttpError as e:
-        logger.error(f"API error in search_docs: {e}", exc_info=True)
-        raise Exception(f"API error: {e}")
+    return "\n".join(output)
 
 @server.tool()
 @require_multiple_services([
     {"service_type": "drive", "scopes": "drive_read", "param_name": "drive_service"},
     {"service_type": "docs", "scopes": "docs_read", "param_name": "docs_service"}
 ])
+@handle_http_errors("get_doc_content")
 async def get_doc_content(
     drive_service,
     docs_service,
@@ -81,97 +78,87 @@ async def get_doc_content(
     """
     logger.info(f"[get_doc_content] Invoked. Document/File ID: '{document_id}' for user '{user_google_email}'")
 
-    try:
-        # Step 2: Get file metadata from Drive
-        file_metadata = await asyncio.to_thread(
-            drive_service.files().get(
-                fileId=document_id, fields="id, name, mimeType, webViewLink"
-            ).execute
+    # Step 2: Get file metadata from Drive
+    file_metadata = await asyncio.to_thread(
+        drive_service.files().get(
+            fileId=document_id, fields="id, name, mimeType, webViewLink"
+        ).execute
+    )
+    mime_type = file_metadata.get("mimeType", "")
+    file_name = file_metadata.get("name", "Unknown File")
+    web_view_link = file_metadata.get("webViewLink", "#")
+
+    logger.info(f"[get_doc_content] File '{file_name}' (ID: {document_id}) has mimeType: '{mime_type}'")
+
+    body_text = "" # Initialize body_text
+
+    # Step 3: Process based on mimeType
+    if mime_type == "application/vnd.google-apps.document":
+        logger.info(f"[get_doc_content] Processing as native Google Doc.")
+        doc_data = await asyncio.to_thread(
+            docs_service.documents().get(documentId=document_id).execute
         )
-        mime_type = file_metadata.get("mimeType", "")
-        file_name = file_metadata.get("name", "Unknown File")
-        web_view_link = file_metadata.get("webViewLink", "#")
+        body_elements = doc_data.get('body', {}).get('content', [])
 
-        logger.info(f"[get_doc_content] File '{file_name}' (ID: {document_id}) has mimeType: '{mime_type}'")
+        processed_text_lines: List[str] = []
+        for element in body_elements:
+            if 'paragraph' in element:
+                paragraph = element.get('paragraph', {})
+                para_elements = paragraph.get('elements', [])
+                current_line_text = ""
+                for pe in para_elements:
+                    text_run = pe.get('textRun', {})
+                    if text_run and 'content' in text_run:
+                        current_line_text += text_run['content']
+                if current_line_text.strip():
+                        processed_text_lines.append(current_line_text)
+        body_text = "".join(processed_text_lines)
+    else:
+        logger.info(f"[get_doc_content] Processing as Drive file (e.g., .docx, other). MimeType: {mime_type}")
 
-        body_text = "" # Initialize body_text
+        export_mime_type_map = {
+                # Example: "application/vnd.google-apps.spreadsheet"z: "text/csv",
+                # Native GSuite types that are not Docs would go here if this function
+                # was intended to export them. For .docx, direct download is used.
+        }
+        effective_export_mime = export_mime_type_map.get(mime_type)
 
-        # Step 3: Process based on mimeType
-        if mime_type == "application/vnd.google-apps.document":
-            logger.info(f"[get_doc_content] Processing as native Google Doc.")
-            doc_data = await asyncio.to_thread(
-                docs_service.documents().get(documentId=document_id).execute
-            )
-            body_elements = doc_data.get('body', {}).get('content', [])
+        request_obj = (
+            drive_service.files().export_media(fileId=document_id, mimeType=effective_export_mime)
+            if effective_export_mime
+            else drive_service.files().get_media(fileId=document_id)
+        )
 
-            processed_text_lines: List[str] = []
-            for element in body_elements:
-                if 'paragraph' in element:
-                    paragraph = element.get('paragraph', {})
-                    para_elements = paragraph.get('elements', [])
-                    current_line_text = ""
-                    for pe in para_elements:
-                        text_run = pe.get('textRun', {})
-                        if text_run and 'content' in text_run:
-                            current_line_text += text_run['content']
-                    if current_line_text.strip():
-                         processed_text_lines.append(current_line_text)
-            body_text = "".join(processed_text_lines)
+        fh = io.BytesIO()
+        downloader = MediaIoBaseDownload(fh, request_obj)
+        loop = asyncio.get_event_loop()
+        done = False
+        while not done:
+            status, done = await loop.run_in_executor(None, downloader.next_chunk)
+
+        file_content_bytes = fh.getvalue()
+
+        office_text = extract_office_xml_text(file_content_bytes, mime_type)
+        if office_text:
+            body_text = office_text
         else:
-            logger.info(f"[get_doc_content] Processing as Drive file (e.g., .docx, other). MimeType: {mime_type}")
+            try:
+                body_text = file_content_bytes.decode("utf-8")
+            except UnicodeDecodeError:
+                body_text = (
+                    f"[Binary or unsupported text encoding for mimeType '{mime_type}' - "
+                    f"{len(file_content_bytes)} bytes]"
+                )
 
-            export_mime_type_map = {
-                 # Example: "application/vnd.google-apps.spreadsheet"z: "text/csv",
-                 # Native GSuite types that are not Docs would go here if this function
-                 # was intended to export them. For .docx, direct download is used.
-            }
-            effective_export_mime = export_mime_type_map.get(mime_type)
-
-            request_obj = (
-                drive_service.files().export_media(fileId=document_id, mimeType=effective_export_mime)
-                if effective_export_mime
-                else drive_service.files().get_media(fileId=document_id)
-            )
-
-            fh = io.BytesIO()
-            downloader = MediaIoBaseDownload(fh, request_obj)
-            loop = asyncio.get_event_loop()
-            done = False
-            while not done:
-                status, done = await loop.run_in_executor(None, downloader.next_chunk)
-
-            file_content_bytes = fh.getvalue()
-
-            office_text = extract_office_xml_text(file_content_bytes, mime_type)
-            if office_text:
-                body_text = office_text
-            else:
-                try:
-                    body_text = file_content_bytes.decode("utf-8")
-                except UnicodeDecodeError:
-                    body_text = (
-                        f"[Binary or unsupported text encoding for mimeType '{mime_type}' - "
-                        f"{len(file_content_bytes)} bytes]"
-                    )
-
-        header = (
-            f'File: "{file_name}" (ID: {document_id}, Type: {mime_type})\n'
-            f'Link: {web_view_link}\n\n--- CONTENT ---\n'
-        )
-        return header + body_text
-
-    except HttpError as error:
-        logger.error(
-            f"[get_doc_content] API error for ID {document_id}: {error}",
-            exc_info=True,
-        )
-        raise Exception(f"API error processing document/file ID {document_id}: {error}")
-    except Exception as e:
-        logger.exception(f"[get_doc_content] Unexpected error for ID {document_id}: {e}")
-        raise Exception(f"Unexpected error processing document/file ID {document_id}: {e}")
+    header = (
+        f'File: "{file_name}" (ID: {document_id}, Type: {mime_type})\n'
+        f'Link: {web_view_link}\n\n--- CONTENT ---\n'
+    )
+    return header + body_text
 
 @server.tool()
 @require_google_service("drive", "drive_read")
+@handle_http_errors("list_docs_in_folder")
 async def list_docs_in_folder(
     service,
     user_google_email: str,
@@ -186,34 +173,27 @@ async def list_docs_in_folder(
     """
     logger.info(f"[list_docs_in_folder] Invoked. Email: '{user_google_email}', Folder ID: '{folder_id}'")
 
-    try:
-        rsp = await asyncio.to_thread(
-            service.files().list(
-                q=f"'{folder_id}' in parents and mimeType='application/vnd.google-apps.document' and trashed=false",
-                pageSize=page_size,
-                fields="files(id, name, modifiedTime, webViewLink)"
-            ).execute
-        )
-        items = rsp.get('files', [])
-        if not items:
-            return f"No Google Docs found in folder '{folder_id}'."
-        out = [f"Found {len(items)} Docs in folder '{folder_id}':"]
-        for f in items:
-            out.append(f"- {f['name']} (ID: {f['id']}) Modified: {f.get('modifiedTime')} Link: {f.get('webViewLink')}")
-        return "\n".join(out)
-
-    except HttpError as e:
-        logger.error(f"API error in list_docs_in_folder: {e}", exc_info=True)
-        raise Exception(f"API error: {e}")
-    except Exception as e:
-        logger.exception(f"Unexpected error in list_docs_in_folder: {e}")
-        raise Exception(f"Unexpected error: {e}")
+    rsp = await asyncio.to_thread(
+        service.files().list(
+            q=f"'{folder_id}' in parents and mimeType='application/vnd.google-apps.document' and trashed=false",
+            pageSize=page_size,
+            fields="files(id, name, modifiedTime, webViewLink)"
+        ).execute
+    )
+    items = rsp.get('files', [])
+    if not items:
+        return f"No Google Docs found in folder '{folder_id}'."
+    out = [f"Found {len(items)} Docs in folder '{folder_id}':"]
+    for f in items:
+        out.append(f"- {f['name']} (ID: {f['id']}) Modified: {f.get('modifiedTime')} Link: {f.get('webViewLink')}")
+    return "\n".join(out)
 
 @server.tool()
 @require_google_service("docs", "docs_write")
+@handle_http_errors("create_doc")
 async def create_doc(
     service,
-    user_google_email: str, # Made user_google_email required
+    user_google_email: str,
     title: str,
     content: str = '',
 ) -> str:
@@ -225,20 +205,12 @@ async def create_doc(
     """
     logger.info(f"[create_doc] Invoked. Email: '{user_google_email}', Title='{title}'")
 
-    try:
-        doc = await asyncio.to_thread(service.documents().create(body={'title': title}).execute)
-        doc_id = doc.get('documentId')
-        if content:
-            requests = [{'insertText': {'location': {'index': 1}, 'text': content}}]
-            await asyncio.to_thread(service.documents().batchUpdate(documentId=doc_id, body={'requests': requests}).execute)
-        link = f"https://docs.google.com/document/d/{doc_id}/edit"
-        msg = f"Created Google Doc '{title}' (ID: {doc_id}) for {user_google_email}. Link: {link}"
-        logger.info(f"Successfully created Google Doc '{title}' (ID: {doc_id}) for {user_google_email}. Link: {link}")
-        return msg
-
-    except HttpError as e:
-        logger.error(f"API error in create_doc: {e}", exc_info=True)
-        raise Exception(f"API error: {e}")
-    except Exception as e:
-        logger.exception(f"Unexpected error in create_doc: {e}")
-        raise Exception(f"Unexpected error: {e}")
+    doc = await asyncio.to_thread(service.documents().create(body={'title': title}).execute)
+    doc_id = doc.get('documentId')
+    if content:
+        requests = [{'insertText': {'location': {'index': 1}, 'text': content}}]
+        await asyncio.to_thread(service.documents().batchUpdate(documentId=doc_id, body={'requests': requests}).execute)
+    link = f"https://docs.google.com/document/d/{doc_id}/edit"
+    msg = f"Created Google Doc '{title}' (ID: {doc_id}) for {user_google_email}. Link: {link}"
+    logger.info(f"Successfully created Google Doc '{title}' (ID: {doc_id}) for {user_google_email}. Link: {link}")
+    return msg

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -14,7 +14,7 @@ from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
 import io
 
 from auth.service_decorator import require_google_service
-from core.utils import extract_office_xml_text
+from core.utils import extract_office_xml_text, handle_http_errors
 from core.server import server
 
 logger = logging.getLogger(__name__)
@@ -76,6 +76,7 @@ def _build_drive_list_params(
 
 @server.tool()
 @require_google_service("drive", "drive_read")
+@handle_http_errors("search_drive_files")
 async def search_drive_files(
     service,
     user_google_email: str,
@@ -103,52 +104,46 @@ async def search_drive_files(
     """
     logger.info(f"[search_drive_files] Invoked. Email: '{user_google_email}', Query: '{query}'")
 
-    try:
-        # Check if the query looks like a structured Drive query or free text
-        # Look for Drive API operators and structured query patterns
-        is_structured_query = any(pattern.search(query) for pattern in DRIVE_QUERY_PATTERNS)
+    # Check if the query looks like a structured Drive query or free text
+    # Look for Drive API operators and structured query patterns
+    is_structured_query = any(pattern.search(query) for pattern in DRIVE_QUERY_PATTERNS)
 
-        if is_structured_query:
-            final_query = query
-            logger.info(f"[search_drive_files] Using structured query as-is: '{final_query}'")
-        else:
-            # For free text queries, wrap in fullText contains
-            escaped_query = query.replace("'", "\\'")
-            final_query = f"fullText contains '{escaped_query}'"
-            logger.info(f"[search_drive_files] Reformatting free text query '{query}' to '{final_query}'")
+    if is_structured_query:
+        final_query = query
+        logger.info(f"[search_drive_files] Using structured query as-is: '{final_query}'")
+    else:
+        # For free text queries, wrap in fullText contains
+        escaped_query = query.replace("'", "\\'")
+        final_query = f"fullText contains '{escaped_query}'"
+        logger.info(f"[search_drive_files] Reformatting free text query '{query}' to '{final_query}'")
 
-        list_params = _build_drive_list_params(
-            query=final_query,
-            page_size=page_size,
-            drive_id=drive_id,
-            include_items_from_all_drives=include_items_from_all_drives,
-            corpora=corpora,
+    list_params = _build_drive_list_params(
+        query=final_query,
+        page_size=page_size,
+        drive_id=drive_id,
+        include_items_from_all_drives=include_items_from_all_drives,
+        corpora=corpora,
+    )
+
+    results = await asyncio.to_thread(
+        service.files().list(**list_params).execute
+    )
+    files = results.get('files', [])
+    if not files:
+        return f"No files found for '{query}'."
+
+    formatted_files_text_parts = [f"Found {len(files)} files for {user_google_email} matching '{query}':"]
+    for item in files:
+        size_str = f", Size: {item.get('size', 'N/A')}" if 'size' in item else ""
+        formatted_files_text_parts.append(
+            f"- Name: \"{item['name']}\" (ID: {item['id']}, Type: {item['mimeType']}{size_str}, Modified: {item.get('modifiedTime', 'N/A')}) Link: {item.get('webViewLink', '#')}"
         )
-
-        results = await asyncio.to_thread(
-            service.files().list(**list_params).execute
-        )
-        files = results.get('files', [])
-        if not files:
-            return f"No files found for '{query}'."
-
-        formatted_files_text_parts = [f"Found {len(files)} files for {user_google_email} matching '{query}':"]
-        for item in files:
-            size_str = f", Size: {item.get('size', 'N/A')}" if 'size' in item else ""
-            formatted_files_text_parts.append(
-                f"- Name: \"{item['name']}\" (ID: {item['id']}, Type: {item['mimeType']}{size_str}, Modified: {item.get('modifiedTime', 'N/A')}) Link: {item.get('webViewLink', '#')}"
-            )
-        text_output = "\n".join(formatted_files_text_parts)
-        return text_output
-    except HttpError as error:
-        logger.error(f"API error searching Drive files: {error}", exc_info=True)
-        raise Exception(f"API error: {error}")
-    except Exception as e:
-        logger.exception(f"Unexpected error searching Drive files: {e}")
-        raise Exception(f"Unexpected error: {e}")
+    text_output = "\n".join(formatted_files_text_parts)
+    return text_output
 
 @server.tool()
 @require_google_service("drive", "drive_read")
+@handle_http_errors("get_drive_file_content")
 async def get_drive_file_content(
     service,
     user_google_email: str,
@@ -171,56 +166,46 @@ async def get_drive_file_content(
     """
     logger.info(f"[get_drive_file_content] Invoked. File ID: '{file_id}'")
 
-    try:
-        file_metadata = await asyncio.to_thread(
-            service.files().get(
-                fileId=file_id, fields="id, name, mimeType, webViewLink", supportsAllDrives=True
-            ).execute
-        )
-        mime_type = file_metadata.get("mimeType", "")
-        file_name = file_metadata.get("name", "Unknown File")
-        export_mime_type = {
-            "application/vnd.google-apps.document": "text/plain",
-            "application/vnd.google-apps.spreadsheet": "text/csv",
-            "application/vnd.google-apps.presentation": "text/plain",
-        }.get(mime_type)
+    file_metadata = await asyncio.to_thread(
+        service.files().get(
+            fileId=file_id, fields="id, name, mimeType, webViewLink", supportsAllDrives=True
+        ).execute
+    )
+    mime_type = file_metadata.get("mimeType", "")
+    file_name = file_metadata.get("name", "Unknown File")
+    export_mime_type = {
+        "application/vnd.google-apps.document": "text/plain",
+        "application/vnd.google-apps.spreadsheet": "text/csv",
+        "application/vnd.google-apps.presentation": "text/plain",
+    }.get(mime_type)
 
-        request_obj = (
-            service.files().export_media(fileId=file_id, mimeType=export_mime_type)
-            if export_mime_type
-            else service.files().get_media(fileId=file_id)
-        )
-        fh = io.BytesIO()
-        downloader = MediaIoBaseDownload(fh, request_obj)
-        loop = asyncio.get_event_loop()
-        done = False
-        while not done:
-            status, done = await loop.run_in_executor(None, downloader.next_chunk)
+    request_obj = (
+        service.files().export_media(fileId=file_id, mimeType=export_mime_type)
+        if export_mime_type
+        else service.files().get_media(fileId=file_id)
+    )
+    fh = io.BytesIO()
+    downloader = MediaIoBaseDownload(fh, request_obj)
+    loop = asyncio.get_event_loop()
+    done = False
+    while not done:
+        status, done = await loop.run_in_executor(None, downloader.next_chunk)
 
-        file_content_bytes = fh.getvalue()
+    file_content_bytes = fh.getvalue()
 
-        # Attempt Office XML extraction only for actual Office XML files
-        office_mime_types = {
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            "application/vnd.openxmlformats-officedocument.presentationml.presentation", 
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        }
-        
-        if mime_type in office_mime_types:
-            office_text = extract_office_xml_text(file_content_bytes, mime_type)
-            if office_text:
-                body_text = office_text
-            else:
-                # Fallback: try UTF-8; otherwise flag binary
-                try:
-                    body_text = file_content_bytes.decode("utf-8")
-                except UnicodeDecodeError:
-                    body_text = (
-                        f"[Binary or unsupported text encoding for mimeType '{mime_type}' - "
-                        f"{len(file_content_bytes)} bytes]"
-                    )
+    # Attempt Office XML extraction only for actual Office XML files
+    office_mime_types = {
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    }
+    
+    if mime_type in office_mime_types:
+        office_text = extract_office_xml_text(file_content_bytes, mime_type)
+        if office_text:
+            body_text = office_text
         else:
-            # For non-Office files (including Google native files), try UTF-8 decode directly
+            # Fallback: try UTF-8; otherwise flag binary
             try:
                 body_text = file_content_bytes.decode("utf-8")
             except UnicodeDecodeError:
@@ -228,26 +213,27 @@ async def get_drive_file_content(
                     f"[Binary or unsupported text encoding for mimeType '{mime_type}' - "
                     f"{len(file_content_bytes)} bytes]"
                 )
+    else:
+        # For non-Office files (including Google native files), try UTF-8 decode directly
+        try:
+            body_text = file_content_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            body_text = (
+                f"[Binary or unsupported text encoding for mimeType '{mime_type}' - "
+                f"{len(file_content_bytes)} bytes]"
+            )
 
-        # Assemble response
-        header = (
-            f'File: "{file_name}" (ID: {file_id}, Type: {mime_type})\n'
-            f'Link: {file_metadata.get("webViewLink", "#")}\n\n--- CONTENT ---\n'
-        )
-        return header + body_text
-
-    except HttpError as error:
-        logger.error(
-            f"API error getting Drive file content for {file_id}: {error}",
-            exc_info=True,
-        )
-        raise Exception(f"API error: {error}")
-    except Exception as e:
-        logger.exception(f"Unexpected error getting Drive file content for {file_id}: {e}")
-        raise Exception(f"Unexpected error: {e}")
+    # Assemble response
+    header = (
+        f'File: "{file_name}" (ID: {file_id}, Type: {mime_type})\n'
+        f'Link: {file_metadata.get("webViewLink", "#")}\n\n--- CONTENT ---\n'
+    )
+    return header + body_text
 
 
+@server.tool()
 @require_google_service("drive", "drive_read")
+@handle_http_errors("list_drive_items")
 async def list_drive_items(
     service,
     user_google_email: str,
@@ -275,40 +261,35 @@ async def list_drive_items(
     """
     logger.info(f"[list_drive_items] Invoked. Email: '{user_google_email}', Folder ID: '{folder_id}'")
 
-    try:
-        final_query = f"'{folder_id}' in parents and trashed=false"
+    final_query = f"'{folder_id}' in parents and trashed=false"
 
-        list_params = _build_drive_list_params(
-            query=final_query,
-            page_size=page_size,
-            drive_id=drive_id,
-            include_items_from_all_drives=include_items_from_all_drives,
-            corpora=corpora,
+    list_params = _build_drive_list_params(
+        query=final_query,
+        page_size=page_size,
+        drive_id=drive_id,
+        include_items_from_all_drives=include_items_from_all_drives,
+        corpora=corpora,
+    )
+
+    results = await asyncio.to_thread(
+        service.files().list(**list_params).execute
+    )
+    files = results.get('files', [])
+    if not files:
+        return f"No items found in folder '{folder_id}'."
+
+    formatted_items_text_parts = [f"Found {len(files)} items in folder '{folder_id}' for {user_google_email}:"]
+    for item in files:
+        size_str = f", Size: {item.get('size', 'N/A')}" if 'size' in item else ""
+        formatted_items_text_parts.append(
+            f"- Name: \"{item['name']}\" (ID: {item['id']}, Type: {item['mimeType']}{size_str}, Modified: {item.get('modifiedTime', 'N/A')}) Link: {item.get('webViewLink', '#')}"
         )
+    text_output = "\n".join(formatted_items_text_parts)
+    return text_output
 
-        results = await asyncio.to_thread(
-            service.files().list(**list_params).execute
-        )
-        files = results.get('files', [])
-        if not files:
-            return f"No items found in folder '{folder_id}'."
-
-        formatted_items_text_parts = [f"Found {len(files)} items in folder '{folder_id}' for {user_google_email}:"]
-        for item in files:
-            size_str = f", Size: {item.get('size', 'N/A')}" if 'size' in item else ""
-            formatted_items_text_parts.append(
-                f"- Name: \"{item['name']}\" (ID: {item['id']}, Type: {item['mimeType']}{size_str}, Modified: {item.get('modifiedTime', 'N/A')}) Link: {item.get('webViewLink', '#')}"
-            )
-        text_output = "\n".join(formatted_items_text_parts)
-        return text_output
-    except HttpError as error:
-        logger.error(f"API error listing Drive items in folder {folder_id}: {error}", exc_info=True)
-        raise Exception(f"API error: {error}")
-    except Exception as e:
-        logger.exception(f"Unexpected error listing Drive items in folder {folder_id}: {e}")
-        raise Exception(f"Unexpected error: {e}")
-
+@server.tool()
 @require_google_service("drive", "drive_file")
+@handle_http_errors("create_drive_file")
 async def create_drive_file(
     service,
     user_google_email: str,
@@ -332,31 +313,23 @@ async def create_drive_file(
     """
     logger.info(f"[create_drive_file] Invoked. Email: '{user_google_email}', File Name: {file_name}, Folder ID: {folder_id}")
 
-    try:
-        file_metadata = {
-            'name': file_name,
-            'parents': [folder_id],
-            'mimeType': mime_type
-        }
-        media = io.BytesIO(content.encode('utf-8'))
+    file_metadata = {
+        'name': file_name,
+        'parents': [folder_id],
+        'mimeType': mime_type
+    }
+    media = io.BytesIO(content.encode('utf-8'))
 
-        created_file = await asyncio.to_thread(
-            service.files().create(
-                body=file_metadata,
-                media_body=MediaIoBaseUpload(media, mimetype=mime_type, resumable=True),
-                fields='id, name, webViewLink',
-                supportsAllDrives=True
-            ).execute
-        )
+    created_file = await asyncio.to_thread(
+        service.files().create(
+            body=file_metadata,
+            media_body=MediaIoBaseUpload(media, mimetype=mime_type, resumable=True),
+            fields='id, name, webViewLink',
+            supportsAllDrives=True
+        ).execute
+    )
 
-        link = created_file.get('webViewLink', 'No link available')
-        confirmation_message = f"Successfully created file '{created_file.get('name', file_name)}' (ID: {created_file.get('id', 'N/A')}) in folder '{folder_id}' for {user_google_email}. Link: {link}"
-        logger.info(f"Successfully created file. Link: {link}")
-        return confirmation_message
-
-    except HttpError as error:
-        logger.error(f"API error creating Drive file '{file_name}': {error}", exc_info=True)
-        raise Exception(f"API error: {error}")
-    except Exception as e:
-        logger.exception(f"Unexpected error creating Drive file '{file_name}': {e}")
-        raise Exception(f"Unexpected error: {e}")
+    link = created_file.get('webViewLink', 'No link available')
+    confirmation_message = f"Successfully created file '{created_file.get('name', file_name)}' (ID: {created_file.get('id', 'N/A')}) in folder '{folder_id}' for {user_google_email}. Link: {link}"
+    logger.info(f"Successfully created file. Link: {link}")
+    return confirmation_message

--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -13,12 +13,14 @@ from googleapiclient.errors import HttpError
 
 from auth.service_decorator import require_google_service
 from core.server import server
+from core.utils import handle_http_errors
 
 logger = logging.getLogger(__name__)
 
 
 @server.tool()
 @require_google_service("slides", "slides")
+@handle_http_errors("create_presentation")
 async def create_presentation(
     service,
     user_google_email: str,
@@ -36,39 +38,30 @@ async def create_presentation(
     """
     logger.info(f"[create_presentation] Invoked. Email: '{user_google_email}', Title: '{title}'")
 
-    try:
-        body = {
-            'title': title
-        }
-        
-        result = await asyncio.to_thread(
-            service.presentations().create(body=body).execute
-        )
-        
-        presentation_id = result.get('presentationId')
-        presentation_url = f"https://docs.google.com/presentation/d/{presentation_id}/edit"
-        
-        confirmation_message = f"""Presentation Created Successfully for {user_google_email}:
+    body = {
+        'title': title
+    }
+    
+    result = await asyncio.to_thread(
+        service.presentations().create(body=body).execute
+    )
+    
+    presentation_id = result.get('presentationId')
+    presentation_url = f"https://docs.google.com/presentation/d/{presentation_id}/edit"
+    
+    confirmation_message = f"""Presentation Created Successfully for {user_google_email}:
 - Title: {title}
 - Presentation ID: {presentation_id}
 - URL: {presentation_url}
 - Slides: {len(result.get('slides', []))} slide(s) created"""
-        
-        logger.info(f"Presentation created successfully for {user_google_email}")
-        return confirmation_message
-        
-    except HttpError as error:
-        message = f"API error: {error}. You might need to re-authenticate. LLM: Try 'start_google_auth' with the user's email ({user_google_email}) and service_name='Google Slides'."
-        logger.error(message, exc_info=True)
-        raise Exception(message)
-    except Exception as e:
-        message = f"Unexpected error: {e}."
-        logger.exception(message)
-        raise Exception(message)
+    
+    logger.info(f"Presentation created successfully for {user_google_email}")
+    return confirmation_message
 
 
 @server.tool()
 @require_google_service("slides", "slides_read")
+@handle_http_errors("get_presentation")
 async def get_presentation(
     service,
     user_google_email: str,
@@ -86,22 +79,21 @@ async def get_presentation(
     """
     logger.info(f"[get_presentation] Invoked. Email: '{user_google_email}', ID: '{presentation_id}'")
 
-    try:
-        result = await asyncio.to_thread(
-            service.presentations().get(presentationId=presentation_id).execute
-        )
-        
-        title = result.get('title', 'Untitled')
-        slides = result.get('slides', [])
-        page_size = result.get('pageSize', {})
-        
-        slides_info = []
-        for i, slide in enumerate(slides, 1):
-            slide_id = slide.get('objectId', 'Unknown')
-            page_elements = slide.get('pageElements', [])
-            slides_info.append(f"  Slide {i}: ID {slide_id}, {len(page_elements)} element(s)")
-        
-        confirmation_message = f"""Presentation Details for {user_google_email}:
+    result = await asyncio.to_thread(
+        service.presentations().get(presentationId=presentation_id).execute
+    )
+    
+    title = result.get('title', 'Untitled')
+    slides = result.get('slides', [])
+    page_size = result.get('pageSize', {})
+    
+    slides_info = []
+    for i, slide in enumerate(slides, 1):
+        slide_id = slide.get('objectId', 'Unknown')
+        page_elements = slide.get('pageElements', [])
+        slides_info.append(f"  Slide {i}: ID {slide_id}, {len(page_elements)} element(s)")
+    
+    confirmation_message = f"""Presentation Details for {user_google_email}:
 - Title: {title}
 - Presentation ID: {presentation_id}
 - URL: https://docs.google.com/presentation/d/{presentation_id}/edit
@@ -110,22 +102,14 @@ async def get_presentation(
 
 Slides Breakdown:
 {chr(10).join(slides_info) if slides_info else '  No slides found'}"""
-        
-        logger.info(f"Presentation retrieved successfully for {user_google_email}")
-        return confirmation_message
-        
-    except HttpError as error:
-        message = f"API error: {error}. You might need to re-authenticate. LLM: Try 'start_google_auth' with the user's email ({user_google_email}) and service_name='Google Slides'."
-        logger.error(message, exc_info=True)
-        raise Exception(message)
-    except Exception as e:
-        message = f"Unexpected error: {e}."
-        logger.exception(message)
-        raise Exception(message)
+    
+    logger.info(f"Presentation retrieved successfully for {user_google_email}")
+    return confirmation_message
 
 
 @server.tool()
 @require_google_service("slides", "slides")
+@handle_http_errors("batch_update_presentation")
 async def batch_update_presentation(
     service,
     user_google_email: str,
@@ -145,53 +129,44 @@ async def batch_update_presentation(
     """
     logger.info(f"[batch_update_presentation] Invoked. Email: '{user_google_email}', ID: '{presentation_id}', Requests: {len(requests)}")
 
-    try:
-        body = {
-            'requests': requests
-        }
-        
-        result = await asyncio.to_thread(
-            service.presentations().batchUpdate(
-                presentationId=presentation_id,
-                body=body
-            ).execute
-        )
-        
-        replies = result.get('replies', [])
-        
-        confirmation_message = f"""Batch Update Completed for {user_google_email}:
+    body = {
+        'requests': requests
+    }
+    
+    result = await asyncio.to_thread(
+        service.presentations().batchUpdate(
+            presentationId=presentation_id,
+            body=body
+        ).execute
+    )
+    
+    replies = result.get('replies', [])
+    
+    confirmation_message = f"""Batch Update Completed for {user_google_email}:
 - Presentation ID: {presentation_id}
 - URL: https://docs.google.com/presentation/d/{presentation_id}/edit
 - Requests Applied: {len(requests)}
 - Replies Received: {len(replies)}"""
-        
-        if replies:
-            confirmation_message += "\n\nUpdate Results:"
-            for i, reply in enumerate(replies, 1):
-                if 'createSlide' in reply:
-                    slide_id = reply['createSlide'].get('objectId', 'Unknown')
-                    confirmation_message += f"\n  Request {i}: Created slide with ID {slide_id}"
-                elif 'createShape' in reply:
-                    shape_id = reply['createShape'].get('objectId', 'Unknown')
-                    confirmation_message += f"\n  Request {i}: Created shape with ID {shape_id}"
-                else:
-                    confirmation_message += f"\n  Request {i}: Operation completed"
-        
-        logger.info(f"Batch update completed successfully for {user_google_email}")
-        return confirmation_message
-        
-    except HttpError as error:
-        message = f"API error: {error}. You might need to re-authenticate. LLM: Try 'start_google_auth' with the user's email ({user_google_email}) and service_name='Google Slides'."
-        logger.error(message, exc_info=True)
-        raise Exception(message)
-    except Exception as e:
-        message = f"Unexpected error: {e}."
-        logger.exception(message)
-        raise Exception(message)
+    
+    if replies:
+        confirmation_message += "\n\nUpdate Results:"
+        for i, reply in enumerate(replies, 1):
+            if 'createSlide' in reply:
+                slide_id = reply['createSlide'].get('objectId', 'Unknown')
+                confirmation_message += f"\n  Request {i}: Created slide with ID {slide_id}"
+            elif 'createShape' in reply:
+                shape_id = reply['createShape'].get('objectId', 'Unknown')
+                confirmation_message += f"\n  Request {i}: Created shape with ID {shape_id}"
+            else:
+                confirmation_message += f"\n  Request {i}: Operation completed"
+    
+    logger.info(f"Batch update completed successfully for {user_google_email}")
+    return confirmation_message
 
 
 @server.tool()
 @require_google_service("slides", "slides_read")
+@handle_http_errors("get_page")
 async def get_page(
     service,
     user_google_email: str,
@@ -211,35 +186,34 @@ async def get_page(
     """
     logger.info(f"[get_page] Invoked. Email: '{user_google_email}', Presentation: '{presentation_id}', Page: '{page_object_id}'")
 
-    try:
-        result = await asyncio.to_thread(
-            service.presentations().pages().get(
-                presentationId=presentation_id,
-                pageObjectId=page_object_id
-            ).execute
-        )
-        
-        page_type = result.get('pageType', 'Unknown')
-        page_elements = result.get('pageElements', [])
-        
-        elements_info = []
-        for element in page_elements:
-            element_id = element.get('objectId', 'Unknown')
-            if 'shape' in element:
-                shape_type = element['shape'].get('shapeType', 'Unknown')
-                elements_info.append(f"  Shape: ID {element_id}, Type: {shape_type}")
-            elif 'table' in element:
-                table = element['table']
-                rows = table.get('rows', 0)
-                cols = table.get('columns', 0)
-                elements_info.append(f"  Table: ID {element_id}, Size: {rows}x{cols}")
-            elif 'line' in element:
-                line_type = element['line'].get('lineType', 'Unknown')
-                elements_info.append(f"  Line: ID {element_id}, Type: {line_type}")
-            else:
-                elements_info.append(f"  Element: ID {element_id}, Type: Unknown")
-        
-        confirmation_message = f"""Page Details for {user_google_email}:
+    result = await asyncio.to_thread(
+        service.presentations().pages().get(
+            presentationId=presentation_id,
+            pageObjectId=page_object_id
+        ).execute
+    )
+    
+    page_type = result.get('pageType', 'Unknown')
+    page_elements = result.get('pageElements', [])
+    
+    elements_info = []
+    for element in page_elements:
+        element_id = element.get('objectId', 'Unknown')
+        if 'shape' in element:
+            shape_type = element['shape'].get('shapeType', 'Unknown')
+            elements_info.append(f"  Shape: ID {element_id}, Type: {shape_type}")
+        elif 'table' in element:
+            table = element['table']
+            rows = table.get('rows', 0)
+            cols = table.get('columns', 0)
+            elements_info.append(f"  Table: ID {element_id}, Size: {rows}x{cols}")
+        elif 'line' in element:
+            line_type = element['line'].get('lineType', 'Unknown')
+            elements_info.append(f"  Line: ID {element_id}, Type: {line_type}")
+        else:
+            elements_info.append(f"  Element: ID {element_id}, Type: Unknown")
+    
+    confirmation_message = f"""Page Details for {user_google_email}:
 - Presentation ID: {presentation_id}
 - Page ID: {page_object_id}
 - Page Type: {page_type}
@@ -247,22 +221,14 @@ async def get_page(
 
 Page Elements:
 {chr(10).join(elements_info) if elements_info else '  No elements found'}"""
-        
-        logger.info(f"Page retrieved successfully for {user_google_email}")
-        return confirmation_message
-        
-    except HttpError as error:
-        message = f"API error: {error}. You might need to re-authenticate. LLM: Try 'start_google_auth' with the user's email ({user_google_email}) and service_name='Google Slides'."
-        logger.error(message, exc_info=True)
-        raise Exception(message)
-    except Exception as e:
-        message = f"Unexpected error: {e}."
-        logger.exception(message)
-        raise Exception(message)
+    
+    logger.info(f"Page retrieved successfully for {user_google_email}")
+    return confirmation_message
 
 
 @server.tool()
 @require_google_service("slides", "slides_read")
+@handle_http_errors("get_page_thumbnail")
 async def get_page_thumbnail(
     service,
     user_google_email: str,
@@ -284,33 +250,23 @@ async def get_page_thumbnail(
     """
     logger.info(f"[get_page_thumbnail] Invoked. Email: '{user_google_email}', Presentation: '{presentation_id}', Page: '{page_object_id}', Size: '{thumbnail_size}'")
 
-    try:
-        result = await asyncio.to_thread(
-            service.presentations().pages().getThumbnail(
-                presentationId=presentation_id,
-                pageObjectId=page_object_id,
-                thumbnailPropertiesImageSize=thumbnail_size
-            ).execute
-        )
-        
-        thumbnail_url = result.get('contentUrl', '')
-        
-        confirmation_message = f"""Thumbnail Generated for {user_google_email}:
+    result = await asyncio.to_thread(
+        service.presentations().pages().getThumbnail(
+            presentationId=presentation_id,
+            pageObjectId=page_object_id,
+            thumbnailPropertiesImageSize=thumbnail_size
+        ).execute
+    )
+    
+    thumbnail_url = result.get('contentUrl', '')
+    
+    confirmation_message = f"""Thumbnail Generated for {user_google_email}:
 - Presentation ID: {presentation_id}
 - Page ID: {page_object_id}
 - Thumbnail Size: {thumbnail_size}
 - Thumbnail URL: {thumbnail_url}
 
 You can view or download the thumbnail using the provided URL."""
-        
-        logger.info(f"Thumbnail generated successfully for {user_google_email}")
-        return confirmation_message
-        
-    except HttpError as error:
-        message = f"API error: {error}. You might need to re-authenticate. LLM: Try 'start_google_auth' with the user's email ({user_google_email}) and service_name='Google Slides'."
-        logger.error(message, exc_info=True)
-        raise Exception(message)
-    except Exception as e:
-        message = f"Unexpected error: {e}."
-        logger.exception(message)
-        raise Exception(message)
+    
+    logger.info(f"Thumbnail generated successfully for {user_google_email}")
+    return confirmation_message


### PR DESCRIPTION
# Refactor: Centralized Error Handling & Elegant Service Injection

This pull request introduces two major refactoring improvements to enhance the robustness, maintainability, and developer experience of the Google Workspace MCP server.

## 1. Elegant Service Injection (`@require_google_service`)

### The Problem
Previously, any tool using the `@require_google_service` decorator (e.g., `create_event`) required the calling LLM to redundantly include a `service` parameter in its request. This was because the `FastMCP` server inspected the function's raw signature, saw the `service` parameter meant for internal injection, and incorrectly exposed it as a required field in the public API schema. This led to unnecessary `422 Unprocessable Entity` errors and brittle tool definitions.

### The Solution
The `@require_google_service` decorator in `auth/service_decorator.py` has been refactored to solve this problem elegantly. It now:
1.  Inspects the decorated function's original signature.
2.  Programmatically creates and exposes a **new signature** to the `FastMCP` server that **omits the `service` parameter**.
3.  Internally, it proceeds to fetch the required Google service object and injects it into the original function call.

This change completely resolves the issue at its source, isolating the logic within the decorator and requiring no changes to the individual tool functions. LLM tool calls are now cleaner and no longer fail for this reason.

## 2. Centralized `HttpError` Handling

### The Problem
Across all tool modules (`gcalendar`, `gdrive`, etc.), Google API `HttpError` exceptions were handled with repetitive `try...except` blocks. This boilerplate code was duplicated in nearly every tool function, making the codebase verbose and difficult to maintain.

### The Solution
A new, centralized error handling decorator, `@handle_http_errors`, has been created in `core/utils.py`. This decorator wraps the tool function and provides a single, consistent place for `HttpError` and other exception handling.

The refactoring involved:
1.  **Creating the `@handle_http_errors` decorator:** This decorator logs the error and raises a standardized `Exception` with a user-friendly message, including a hint to re-authenticate.
2.  **Applying the decorator:** The new decorator has been applied to all relevant tool functions across all service modules.
3.  **Removing Redundant Code:** All of the now-unnecessary `try...except HttpError` blocks have been removed from the tool functions, resulting in significantly cleaner and more concise code.

## Summary of Changes
- **Modified `auth/service_decorator.py`**: Implemented the elegant service injection logic.
- **Added `core/utils.py`**: Introduced the new `@handle_http_errors` decorator.
- **Refactored All Tool Modules**:
    - `gcalendar/calendar_tools.py`
    - `gchat/chat_tools.py`
    - `gdocs/docs_tools.py`
    - `gdrive/drive_tools.py`
    - `gforms/forms_tools.py`
    - `gsheets/sheets_tools.py`
    - `gslides/slides_tools.py`
- Removed dozens of redundant `try...except` blocks, improving code clarity and maintainability.

These changes make the server more robust, the code easier to read, and the development of new tools much simpler.