### PR TITLE
Implement OAuth Credential Injection for Google Workspace MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,28 @@ async def your_new_tool(service, param1: str, param2: int = 10):
 - **Network Exposure**: Consider authentication when using `mcpo` over networks
 - **Scope Minimization**: Tools request only necessary permissions
 
+## 🔐 Advanced OAuth Injection & Environment Variables
+
+The Google Workspace MCP server supports advanced, request-scoped OAuth credential injection and flexible client credential configuration for secure, multi-user, and cloud-native deployments.
+
+### Request-Scoped OAuth Injection
+- **Header-Based:**
+  - Provide an `Authorization: Bearer <token>` header (optionally with `X-User-Email` and `X-User-Id`) on any request.
+  - The token is used for all Google API calls during that request only.
+- **API Endpoints:**
+  - `GET /oauth/status`: Check if credentials are injected for the current request.
+  - `POST /oauth/inject`: Inject credentials for the current request context (JSON body: `access_token`, optional `user_email`, `user_id`).
+  - `POST /oauth/clear`: Clear any injected credentials for the current request context.
+- **Security:** Credentials are only available for the duration of the request and are never persisted to disk or shared between requests.
+
+### Environment Variable-Based Client Credentials
+- You can now provide your Google OAuth client credentials using the environment variables:
+  - `GOOGLE_OAUTH_CLIENT_ID`
+  - `GOOGLE_OAUTH_CLIENT_SECRET`
+  - (optional) `GOOGLE_OAUTH_REDIRECT_URI`
+- If these variables are set, they will be used in preference to any `client_secret.json` file.
+- This makes containerized and cloud deployments easier, more secure, and eliminates the need for file-based secrets management.
+
 ---
 
 ## 🌐 Integration with Open WebUI

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -1,18 +1,18 @@
 # auth/google_auth.py
 
-import os
+import asyncio
 import json
 import logging
-import asyncio
-from typing import List, Optional, Tuple, Dict, Any, Callable
 import os
+from typing import Any, Dict, List, Optional, Tuple
 
-from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import Flow, InstalledAppFlow
-from google.auth.transport.requests import Request
 from google.auth.exceptions import RefreshError
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import Flow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
+
 from auth.scopes import OAUTH_STATE_TO_SESSION_ID_MAP, SCOPES
 
 # Configure logging
@@ -34,12 +34,23 @@ else:
     # Assumes this file is in auth/ and client_secret.json is in the root
     CONFIG_CLIENT_SECRETS_PATH = os.path.join(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-        'client_secret.json'
+        "client_secret.json",
     )
+
+# Importiere die Injection-Getter aus core.server
+try:
+    from core.server import get_injected_oauth_credentials
+except ImportError:
+
+    def get_injected_oauth_credentials():
+        return None
 
 # --- Helper Functions ---
 
-def _find_any_credentials(base_dir: str = DEFAULT_CREDENTIALS_DIR) -> Optional[Credentials]:
+
+def _find_any_credentials(
+    base_dir: str = DEFAULT_CREDENTIALS_DIR,
+) -> Optional[Credentials]:
     """
     Find and load any valid credentials from the credentials directory.
     Used in single-user mode to bypass session-to-OAuth mapping.
@@ -53,128 +64,177 @@ def _find_any_credentials(base_dir: str = DEFAULT_CREDENTIALS_DIR) -> Optional[C
 
     # Scan for any .json credential files
     for filename in os.listdir(base_dir):
-        if filename.endswith('.json'):
+        if filename.endswith(".json"):
             filepath = os.path.join(base_dir, filename)
             try:
-                with open(filepath, 'r') as f:
+                with open(filepath, "r") as f:
                     creds_data = json.load(f)
                 credentials = Credentials(
-                    token=creds_data.get('token'),
-                    refresh_token=creds_data.get('refresh_token'),
-                    token_uri=creds_data.get('token_uri'),
-                    client_id=creds_data.get('client_id'),
-                    client_secret=creds_data.get('client_secret'),
-                    scopes=creds_data.get('scopes')
+                    token=creds_data.get("token"),
+                    refresh_token=creds_data.get("refresh_token"),
+                    token_uri=creds_data.get("token_uri"),
+                    client_id=creds_data.get("client_id"),
+                    client_secret=creds_data.get("client_secret"),
+                    scopes=creds_data.get("scopes"),
                 )
                 logger.info(f"[single-user] Found credentials in {filepath}")
                 return credentials
             except (IOError, json.JSONDecodeError, KeyError) as e:
-                logger.warning(f"[single-user] Error loading credentials from {filepath}: {e}")
+                logger.warning(
+                    f"[single-user] Error loading credentials from {filepath}: {e}"
+                )
                 continue
 
     logger.info(f"[single-user] No valid credentials found in {base_dir}")
     return None
 
-def _get_user_credential_path(user_google_email: str, base_dir: str = DEFAULT_CREDENTIALS_DIR) -> str:
+
+def _get_user_credential_path(
+    user_google_email: str, base_dir: str = DEFAULT_CREDENTIALS_DIR
+) -> str:
     """Constructs the path to a user's credential file."""
     if not os.path.exists(base_dir):
         os.makedirs(base_dir)
         logger.info(f"Created credentials directory: {base_dir}")
     return os.path.join(base_dir, f"{user_google_email}.json")
 
-def save_credentials_to_file(user_google_email: str, credentials: Credentials, base_dir: str = DEFAULT_CREDENTIALS_DIR):
+
+def save_credentials_to_file(
+    user_google_email: str,
+    credentials: Credentials,
+    base_dir: str = DEFAULT_CREDENTIALS_DIR,
+):
     """Saves user credentials to a file."""
     creds_path = _get_user_credential_path(user_google_email, base_dir)
     creds_data = {
-        'token': credentials.token,
-        'refresh_token': credentials.refresh_token,
-        'token_uri': credentials.token_uri,
-        'client_id': credentials.client_id,
-        'client_secret': credentials.client_secret,
-        'scopes': credentials.scopes,
-        'expiry': credentials.expiry.isoformat() if credentials.expiry else None
+        "token": credentials.token,
+        "refresh_token": credentials.refresh_token,
+        "token_uri": credentials.token_uri,
+        "client_id": credentials.client_id,
+        "client_secret": credentials.client_secret,
+        "scopes": credentials.scopes,
+        "expiry": credentials.expiry.isoformat() if credentials.expiry else None,
     }
     try:
-        with open(creds_path, 'w') as f:
+        with open(creds_path, "w") as f:
             json.dump(creds_data, f)
         logger.info(f"Credentials saved for user {user_google_email} to {creds_path}")
     except IOError as e:
-        logger.error(f"Error saving credentials for user {user_google_email} to {creds_path}: {e}")
+        logger.error(
+            f"Error saving credentials for user {user_google_email} to {creds_path}: {e}"
+        )
         raise
+
 
 def save_credentials_to_session(session_id: str, credentials: Credentials):
     """Saves user credentials to the in-memory session cache."""
     _SESSION_CREDENTIALS_CACHE[session_id] = credentials
     logger.debug(f"Credentials saved to session cache for session_id: {session_id}")
 
-def load_credentials_from_file(user_google_email: str, base_dir: str = DEFAULT_CREDENTIALS_DIR) -> Optional[Credentials]:
+
+def load_credentials_from_file(
+    user_google_email: str, base_dir: str = DEFAULT_CREDENTIALS_DIR
+) -> Optional[Credentials]:
     """Loads user credentials from a file."""
     creds_path = _get_user_credential_path(user_google_email, base_dir)
     if not os.path.exists(creds_path):
-        logger.info(f"No credentials file found for user {user_google_email} at {creds_path}")
+        logger.info(
+            f"No credentials file found for user {user_google_email} at {creds_path}"
+        )
         return None
 
     try:
-        with open(creds_path, 'r') as f:
+        with open(creds_path, "r") as f:
             creds_data = json.load(f)
 
         # Parse expiry if present
         expiry = None
-        if creds_data.get('expiry'):
+        if creds_data.get("expiry"):
             try:
                 from datetime import datetime
-                expiry = datetime.fromisoformat(creds_data['expiry'])
+
+                expiry = datetime.fromisoformat(creds_data["expiry"])
             except (ValueError, TypeError) as e:
-                logger.warning(f"Could not parse expiry time for {user_google_email}: {e}")
+                logger.warning(
+                    f"Could not parse expiry time for {user_google_email}: {e}"
+                )
 
         credentials = Credentials(
-            token=creds_data.get('token'),
-            refresh_token=creds_data.get('refresh_token'),
-            token_uri=creds_data.get('token_uri'),
-            client_id=creds_data.get('client_id'),
-            client_secret=creds_data.get('client_secret'),
-            scopes=creds_data.get('scopes'),
-            expiry=expiry
+            token=creds_data.get("token"),
+            refresh_token=creds_data.get("refresh_token"),
+            token_uri=creds_data.get("token_uri"),
+            client_id=creds_data.get("client_id"),
+            client_secret=creds_data.get("client_secret"),
+            scopes=creds_data.get("scopes"),
+            expiry=expiry,
         )
-        logger.debug(f"Credentials loaded for user {user_google_email} from {creds_path}")
+        logger.debug(
+            f"Credentials loaded for user {user_google_email} from {creds_path}"
+        )
         return credentials
     except (IOError, json.JSONDecodeError, KeyError) as e:
-        logger.error(f"Error loading or parsing credentials for user {user_google_email} from {creds_path}: {e}")
+        logger.error(
+            f"Error loading or parsing credentials for user {user_google_email} from {creds_path}: {e}"
+        )
         return None
+
 
 def load_credentials_from_session(session_id: str) -> Optional[Credentials]:
     """Loads user credentials from the in-memory session cache."""
     credentials = _SESSION_CREDENTIALS_CACHE.get(session_id)
     if credentials:
-        logger.debug(f"Credentials loaded from session cache for session_id: {session_id}")
+        logger.debug(
+            f"Credentials loaded from session cache for session_id: {session_id}"
+        )
     else:
-        logger.debug(f"No credentials found in session cache for session_id: {session_id}")
+        logger.debug(
+            f"No credentials found in session cache for session_id: {session_id}"
+        )
     return credentials
 
+
 def load_client_secrets(client_secrets_path: str) -> Dict[str, Any]:
-    """Loads the client secrets file."""
+    """Loads the client secrets from environment variables (if set) or from the client secrets file."""
+    client_id = os.getenv("GOOGLE_OAUTH_CLIENT_ID")
+    client_secret = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET")
+    redirect_uri = os.getenv("GOOGLE_OAUTH_REDIRECT_URI")
+    if client_id and client_secret:
+        config = {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
+        if redirect_uri:
+            config["redirect_uris"] = [redirect_uri]
+        return config
+    # Fallback: load from file
     try:
-        with open(client_secrets_path, 'r') as f:
+        with open(client_secrets_path, "r") as f:
             client_config = json.load(f)
             # The file usually contains a top-level key like "web" or "installed"
             if "web" in client_config:
                 return client_config["web"]
             elif "installed" in client_config:
-                 return client_config["installed"]
+                return client_config["installed"]
             else:
-                 logger.error(f"Client secrets file {client_secrets_path} has unexpected format.")
-                 raise ValueError("Invalid client secrets file format")
+                logger.error(
+                    f"Client secrets file {client_secrets_path} has unexpected format."
+                )
+                raise ValueError("Invalid client secrets file format")
     except (IOError, json.JSONDecodeError) as e:
         logger.error(f"Error loading client secrets file {client_secrets_path}: {e}")
         raise
 
+
 # --- Core OAuth Logic ---
+
 
 async def start_auth_flow(
     mcp_session_id: Optional[str],
     user_google_email: Optional[str],
-    service_name: str, # e.g., "Google Calendar", "Gmail" for user messages
-    redirect_uri: str, # Added redirect_uri as a required parameter
+    service_name: str,  # e.g., "Google Calendar", "Gmail" for user messages
+    redirect_uri: str,  # Added redirect_uri as a required parameter
 ) -> str:
     """
     Initiates the Google OAuth flow and returns an actionable message for the user.
@@ -191,30 +251,48 @@ async def start_auth_flow(
     Raises:
         Exception: If the OAuth flow cannot be initiated.
     """
-    initial_email_provided = bool(user_google_email and user_google_email.strip() and user_google_email.lower() != 'default')
-    user_display_name = f"{service_name} for '{user_google_email}'" if initial_email_provided else service_name
+    initial_email_provided = bool(
+        user_google_email
+        and user_google_email.strip()
+        and user_google_email.lower() != "default"
+    )
+    user_display_name = (
+        f"{service_name} for '{user_google_email}'"
+        if initial_email_provided
+        else service_name
+    )
 
-    logger.info(f"[start_auth_flow] Initiating auth for {user_display_name} (session: {mcp_session_id}) with global SCOPES.")
+    logger.info(
+        f"[start_auth_flow] Initiating auth for {user_display_name} (session: {mcp_session_id}) with global SCOPES."
+    )
 
     try:
-        if 'OAUTHLIB_INSECURE_TRANSPORT' not in os.environ and ("localhost" in redirect_uri or "127.0.0.1" in redirect_uri): # Use passed redirect_uri
-            logger.warning("OAUTHLIB_INSECURE_TRANSPORT not set. Setting it for localhost/local development.")
-            os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
+        if "OAUTHLIB_INSECURE_TRANSPORT" not in os.environ and (
+            "localhost" in redirect_uri or "127.0.0.1" in redirect_uri
+        ):  # Use passed redirect_uri
+            logger.warning(
+                "OAUTHLIB_INSECURE_TRANSPORT not set. Setting it for localhost/local development."
+            )
+            os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
 
         oauth_state = os.urandom(16).hex()
         if mcp_session_id:
             OAUTH_STATE_TO_SESSION_ID_MAP[oauth_state] = mcp_session_id
-            logger.info(f"[start_auth_flow] Stored mcp_session_id '{mcp_session_id}' for oauth_state '{oauth_state}'.")
+            logger.info(
+                f"[start_auth_flow] Stored mcp_session_id '{mcp_session_id}' for oauth_state '{oauth_state}'."
+            )
 
         flow = Flow.from_client_secrets_file(
-            CONFIG_CLIENT_SECRETS_PATH, # Use module constant
-            scopes=SCOPES, # Use global SCOPES
-            redirect_uri=redirect_uri, # Use passed redirect_uri
-            state=oauth_state
+            CONFIG_CLIENT_SECRETS_PATH,  # Use module constant
+            scopes=SCOPES,  # Use global SCOPES
+            redirect_uri=redirect_uri,  # Use passed redirect_uri
+            state=oauth_state,
         )
 
-        auth_url, _ = flow.authorization_url(access_type='offline', prompt='consent')
-        logger.info(f"Auth flow started for {user_display_name}. State: {oauth_state}. Advise user to visit: {auth_url}")
+        auth_url, _ = flow.authorization_url(access_type="offline", prompt="consent")
+        logger.info(
+            f"Auth flow started for {user_display_name}. State: {oauth_state}. Advise user to visit: {auth_url}"
+        )
 
         message_lines = [
             f"**ACTION REQUIRED: Google Authentication Needed for {user_display_name}**\n",
@@ -225,18 +303,28 @@ async def start_auth_flow(
             "**LLM, after presenting the link, instruct the user as follows:**",
             "1. Click the link and complete the authorization in their browser.",
         ]
-        session_info_for_llm = f" (this will link to your current session {mcp_session_id})" if mcp_session_id else ""
+        session_info_for_llm = (
+            f" (this will link to your current session {mcp_session_id})"
+            if mcp_session_id
+            else ""
+        )
 
         if not initial_email_provided:
-            message_lines.extend([
-                f"2. After successful authorization{session_info_for_llm}, the browser page will display the authenticated email address.",
-                "   **LLM: Instruct the user to provide you with this email address.**",
-                "3. Once you have the email, **retry their original command, ensuring you include this `user_google_email`.**"
-            ])
+            message_lines.extend(
+                [
+                    f"2. After successful authorization{session_info_for_llm}, the browser page will display the authenticated email address.",
+                    "   **LLM: Instruct the user to provide you with this email address.**",
+                    "3. Once you have the email, **retry their original command, ensuring you include this `user_google_email`.**",
+                ]
+            )
         else:
-            message_lines.append(f"2. After successful authorization{session_info_for_llm}, **retry their original command**.")
+            message_lines.append(
+                f"2. After successful authorization{session_info_for_llm}, **retry their original command**."
+            )
 
-        message_lines.append(f"\nThe application will use the new credentials. If '{user_google_email}' was provided, it must match the authenticated account.")
+        message_lines.append(
+            f"\nThe application will use the new credentials. If '{user_google_email}' was provided, it must match the authenticated account."
+        )
         return "\n".join(message_lines)
 
     except FileNotFoundError as e:
@@ -245,16 +333,20 @@ async def start_auth_flow(
         raise Exception(error_text)
     except Exception as e:
         error_text = f"Could not initiate authentication for {user_display_name} due to an unexpected error: {str(e)}"
-        logger.error(f"Failed to start the OAuth flow for {user_display_name}: {e}", exc_info=True)
+        logger.error(
+            f"Failed to start the OAuth flow for {user_display_name}: {e}",
+            exc_info=True,
+        )
         raise Exception(error_text)
+
 
 def handle_auth_callback(
     client_secrets_path: str,
     scopes: List[str],
     authorization_response: str,
-    redirect_uri: str, # Made redirect_uri a required parameter
+    redirect_uri: str,  # Made redirect_uri a required parameter
     credentials_base_dir: str = DEFAULT_CREDENTIALS_DIR,
-    session_id: Optional[str] = None
+    session_id: Optional[str] = None,
 ) -> Tuple[str, Credentials]:
     """
     Handles the callback from Google, exchanges the code for credentials,
@@ -279,14 +371,14 @@ def handle_auth_callback(
     """
     try:
         # Allow HTTP for localhost in development
-        if 'OAUTHLIB_INSECURE_TRANSPORT' not in os.environ:
-            logger.warning("OAUTHLIB_INSECURE_TRANSPORT not set. Setting it for localhost development.")
-            os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
+        if "OAUTHLIB_INSECURE_TRANSPORT" not in os.environ:
+            logger.warning(
+                "OAUTHLIB_INSECURE_TRANSPORT not set. Setting it for localhost development."
+            )
+            os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
 
         flow = Flow.from_client_secrets_file(
-            client_secrets_path,
-            scopes=scopes,
-            redirect_uri=redirect_uri
+            client_secrets_path, scopes=scopes, redirect_uri=redirect_uri
         )
 
         # Exchange the authorization code for credentials
@@ -297,11 +389,11 @@ def handle_auth_callback(
 
         # Get user info to determine user_id (using email here)
         user_info = get_user_info(credentials)
-        if not user_info or 'email' not in user_info:
-             logger.error("Could not retrieve user email from Google.")
-             raise ValueError("Failed to get user email for identification.")
+        if not user_info or "email" not in user_info:
+            logger.error("Could not retrieve user email from Google.")
+            raise ValueError("Failed to get user email for identification.")
 
-        user_google_email = user_info['email']
+        user_google_email = user_info["email"]
         logger.info(f"Identified user_google_email: {user_google_email}")
 
         # Save the credentials to file
@@ -313,38 +405,49 @@ def handle_auth_callback(
 
         return user_google_email, credentials
 
-    except Exception as e: # Catch specific exceptions like FlowExchangeError if needed
+    except Exception as e:  # Catch specific exceptions like FlowExchangeError if needed
         logger.error(f"Error handling auth callback: {e}")
-        raise # Re-raise for the caller
+        raise  # Re-raise for the caller
+
 
 def get_credentials(
-    user_google_email: Optional[str], # Can be None if relying on session_id
+    user_google_email: Optional[str],  # Can be None if relying on session_id
     required_scopes: List[str],
     client_secrets_path: Optional[str] = None,
     credentials_base_dir: str = DEFAULT_CREDENTIALS_DIR,
-    session_id: Optional[str] = None
+    session_id: Optional[str] = None,
 ) -> Optional[Credentials]:
     """
-    Retrieves stored credentials, prioritizing session, then file. Refreshes if necessary.
-    If credentials are loaded from file and a session_id is present, they are cached in the session.
-    In single-user mode, bypasses session mapping and uses any available credentials.
-
-    Args:
-        user_google_email: Optional user's Google email.
-        required_scopes: List of scopes the credentials must have.
-        client_secrets_path: Path to client secrets, required for refresh if not in creds.
-        credentials_base_dir: Base directory for credential files.
-        session_id: Optional MCP session ID.
-
-    Returns:
-        Valid Credentials object or None.
+    Retrieves stored credentials, prioritizing injected (request-scoped), then session, then file. Refreshes if necessary.
     """
+    # 1. Check for injected credentials (request-scoped, e.g. via middleware)
+    injected = get_injected_oauth_credentials()
+    if injected and isinstance(injected, dict) and injected.get("access_token"):
+        logger.info(
+            "[get_credentials] Using injected OAuth credentials from request context."
+        )
+        # Build Credentials object from injected token
+        creds = Credentials(
+            token=injected["access_token"],
+            refresh_token=None,  # Not available in injection mode
+            token_uri=None,
+            client_id=None,
+            client_secret=None,
+            scopes=required_scopes,
+        )
+        # Optionally: set email/user_id as custom attributes if needed
+        return creds
+
     # Check for single-user mode
-    if os.getenv('MCP_SINGLE_USER_MODE') == '1':
-        logger.info(f"[get_credentials] Single-user mode: bypassing session mapping, finding any credentials")
+    if os.getenv("MCP_SINGLE_USER_MODE") == "1":
+        logger.info(
+            "[get_credentials] Single-user mode: bypassing session mapping, finding any credentials"
+        )
         credentials = _find_any_credentials(credentials_base_dir)
         if not credentials:
-            logger.info(f"[get_credentials] Single-user mode: No credentials found in {credentials_base_dir}")
+            logger.info(
+                f"[get_credentials] Single-user mode: No credentials found in {credentials_base_dir}"
+            )
             return None
 
         # In single-user mode, if user_google_email wasn't provided, try to get it from user info
@@ -352,11 +455,15 @@ def get_credentials(
         if not user_google_email and credentials.valid:
             try:
                 user_info = get_user_info(credentials)
-                if user_info and 'email' in user_info:
-                    user_google_email = user_info['email']
-                    logger.debug(f"[get_credentials] Single-user mode: extracted user email {user_google_email} from credentials")
+                if user_info and "email" in user_info:
+                    user_google_email = user_info["email"]
+                    logger.debug(
+                        f"[get_credentials] Single-user mode: extracted user email {user_google_email} from credentials"
+                    )
             except Exception as e:
-                logger.debug(f"[get_credentials] Single-user mode: could not extract user email: {e}")
+                logger.debug(
+                    f"[get_credentials] Single-user mode: could not extract user email: {e}"
+                )
     else:
         credentials: Optional[Credentials] = None
 
@@ -364,61 +471,100 @@ def get_credentials(
         if not session_id:
             logger.debug("[get_credentials] No session_id provided")
 
-        logger.debug(f"[get_credentials] Called for user_google_email: '{user_google_email}', session_id: '{session_id}', required_scopes: {required_scopes}")
+        logger.debug(
+            f"[get_credentials] Called for user_google_email: '{user_google_email}', session_id: '{session_id}', required_scopes: {required_scopes}"
+        )
 
         if session_id:
             credentials = load_credentials_from_session(session_id)
             if credentials:
-                logger.debug(f"[get_credentials] Loaded credentials from session for session_id '{session_id}'.")
+                logger.debug(
+                    f"[get_credentials] Loaded credentials from session for session_id '{session_id}'."
+                )
 
         if not credentials and user_google_email:
-            logger.debug(f"[get_credentials] No session credentials, trying file for user_google_email '{user_google_email}'.")
-            credentials = load_credentials_from_file(user_google_email, credentials_base_dir)
+            logger.debug(
+                f"[get_credentials] No session credentials, trying file for user_google_email '{user_google_email}'."
+            )
+            credentials = load_credentials_from_file(
+                user_google_email, credentials_base_dir
+            )
             if credentials and session_id:
-                logger.debug(f"[get_credentials] Loaded from file for user '{user_google_email}', caching to session '{session_id}'.")
-                save_credentials_to_session(session_id, credentials) # Cache for current session
+                logger.debug(
+                    f"[get_credentials] Loaded from file for user '{user_google_email}', caching to session '{session_id}'."
+                )
+                save_credentials_to_session(
+                    session_id, credentials
+                )  # Cache for current session
 
         if not credentials:
-            logger.info(f"[get_credentials] No credentials found for user '{user_google_email}' or session '{session_id}'.")
+            logger.info(
+                f"[get_credentials] No credentials found for user '{user_google_email}' or session '{session_id}'."
+            )
             return None
 
-    logger.debug(f"[get_credentials] Credentials found. Scopes: {credentials.scopes}, Valid: {credentials.valid}, Expired: {credentials.expired}")
+    logger.debug(
+        f"[get_credentials] Credentials found. Scopes: {credentials.scopes}, Valid: {credentials.valid}, Expired: {credentials.expired}"
+    )
 
     if not all(scope in credentials.scopes for scope in required_scopes):
-        logger.warning(f"[get_credentials] Credentials lack required scopes. Need: {required_scopes}, Have: {credentials.scopes}. User: '{user_google_email}', Session: '{session_id}'")
-        return None # Re-authentication needed for scopes
+        logger.warning(
+            f"[get_credentials] Credentials lack required scopes. Need: {required_scopes}, Have: {credentials.scopes}. User: '{user_google_email}', Session: '{session_id}'"
+        )
+        return None  # Re-authentication needed for scopes
 
-    logger.debug(f"[get_credentials] Credentials have sufficient scopes. User: '{user_google_email}', Session: '{session_id}'")
+    logger.debug(
+        f"[get_credentials] Credentials have sufficient scopes. User: '{user_google_email}', Session: '{session_id}'"
+    )
 
     if credentials.valid:
-        logger.debug(f"[get_credentials] Credentials are valid. User: '{user_google_email}', Session: '{session_id}'")
+        logger.debug(
+            f"[get_credentials] Credentials are valid. User: '{user_google_email}', Session: '{session_id}'"
+        )
         return credentials
     elif credentials.expired and credentials.refresh_token:
-        logger.info(f"[get_credentials] Credentials expired. Attempting refresh. User: '{user_google_email}', Session: '{session_id}'")
+        logger.info(
+            f"[get_credentials] Credentials expired. Attempting refresh. User: '{user_google_email}', Session: '{session_id}'"
+        )
         if not client_secrets_path:
-             logger.error("[get_credentials] Client secrets path required for refresh but not provided.")
-             return None
+            logger.error(
+                "[get_credentials] Client secrets path required for refresh but not provided."
+            )
+            return None
         try:
-            logger.debug(f"[get_credentials] Refreshing token using client_secrets_path: {client_secrets_path}")
+            logger.debug(
+                f"[get_credentials] Refreshing token using client_secrets_path: {client_secrets_path}"
+            )
             # client_config = load_client_secrets(client_secrets_path) # Not strictly needed if creds have client_id/secret
             credentials.refresh(Request())
-            logger.info(f"[get_credentials] Credentials refreshed successfully. User: '{user_google_email}', Session: '{session_id}'")
+            logger.info(
+                f"[get_credentials] Credentials refreshed successfully. User: '{user_google_email}', Session: '{session_id}'"
+            )
 
             # Save refreshed credentials
-            if user_google_email: # Always save to file if email is known
-                save_credentials_to_file(user_google_email, credentials, credentials_base_dir)
-            if session_id: # Update session cache if it was the source or is active
+            if user_google_email:  # Always save to file if email is known
+                save_credentials_to_file(
+                    user_google_email, credentials, credentials_base_dir
+                )
+            if session_id:  # Update session cache if it was the source or is active
                 save_credentials_to_session(session_id, credentials)
             return credentials
         except RefreshError as e:
-            logger.warning(f"[get_credentials] RefreshError - token expired/revoked: {e}. User: '{user_google_email}', Session: '{session_id}'")
+            logger.warning(
+                f"[get_credentials] RefreshError - token expired/revoked: {e}. User: '{user_google_email}', Session: '{session_id}'"
+            )
             # For RefreshError, we should return None to trigger reauthentication
             return None
         except Exception as e:
-            logger.error(f"[get_credentials] Error refreshing credentials: {e}. User: '{user_google_email}', Session: '{session_id}'", exc_info=True)
-            return None # Failed to refresh
+            logger.error(
+                f"[get_credentials] Error refreshing credentials: {e}. User: '{user_google_email}', Session: '{session_id}'",
+                exc_info=True,
+            )
+            return None  # Failed to refresh
     else:
-        logger.warning(f"[get_credentials] Credentials invalid/cannot refresh. Valid: {credentials.valid}, Refresh Token: {credentials.refresh_token is not None}. User: '{user_google_email}', Session: '{session_id}'")
+        logger.warning(
+            f"[get_credentials] Credentials invalid/cannot refresh. Valid: {credentials.valid}, Refresh Token: {credentials.refresh_token is not None}. User: '{user_google_email}', Session: '{session_id}'"
+        )
         return None
 
 
@@ -430,7 +576,7 @@ def get_user_info(credentials: Credentials) -> Optional[Dict[str, Any]]:
     try:
         # Using googleapiclient discovery to get user info
         # Requires 'google-api-python-client' library
-        service = build('oauth2', 'v2', credentials=credentials)
+        service = build("oauth2", "v2", credentials=credentials)
         user_info = service.userinfo().get().execute()
         logger.info(f"Successfully fetched user info: {user_info.get('email')}")
         return user_info
@@ -445,18 +591,20 @@ def get_user_info(credentials: Credentials) -> Optional[Dict[str, Any]]:
 
 # --- Centralized Google Service Authentication ---
 
+
 class GoogleAuthenticationError(Exception):
     """Exception raised when Google authentication is required or fails."""
+
     def __init__(self, message: str, auth_url: Optional[str] = None):
         super().__init__(message)
         self.auth_url = auth_url
 
 
 async def get_authenticated_google_service(
-    service_name: str,      # "gmail", "calendar", "drive", "docs"
-    version: str,           # "v1", "v3"
-    tool_name: str,         # For logging/debugging
-    user_google_email: str, # Required - no more Optional
+    service_name: str,  # "gmail", "calendar", "drive", "docs"
+    version: str,  # "v1", "v3"
+    tool_name: str,  # For logging/debugging
+    user_google_email: str,  # Required - no more Optional
     required_scopes: List[str],
 ) -> tuple[Any, str]:
     """
@@ -494,7 +642,6 @@ async def get_authenticated_google_service(
         session_id=None,  # Session ID not available in service layer
     )
 
-
     if not credentials or not credentials.valid:
         logger.warning(
             f"[{tool_name}] No valid credentials. Email: '{user_google_email}'."
@@ -529,8 +676,11 @@ async def get_authenticated_google_service(
         if credentials and credentials.id_token:
             try:
                 import jwt
+
                 # Decode without verification (just to get email for logging)
-                decoded_token = jwt.decode(credentials.id_token, options={"verify_signature": False})
+                decoded_token = jwt.decode(
+                    credentials.id_token, options={"verify_signature": False}
+                )
                 token_email = decoded_token.get("email")
                 if token_email:
                     log_user_email = token_email
@@ -538,12 +688,12 @@ async def get_authenticated_google_service(
             except Exception as e:
                 logger.debug(f"[{tool_name}] Could not decode id_token: {e}")
 
-        logger.info(f"[{tool_name}] Successfully authenticated {service_name} service for user: {log_user_email}")
+        logger.info(
+            f"[{tool_name}] Successfully authenticated {service_name} service for user: {log_user_email}"
+        )
         return service, log_user_email
 
     except Exception as e:
         error_msg = f"[{tool_name}] Failed to build {service_name} service: {str(e)}"
         logger.error(error_msg, exc_info=True)
         raise GoogleAuthenticationError(error_msg)
-
-


### PR DESCRIPTION
# Implement OAuth Credential Injection for Google Workspace MCP

## Overview

This pull request implements dynamic OAuth credential injection for the Google Workspace MCP server and allows to pass GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET as environment variables. This prepares the MCP server to work in a multi user environment that makes its own oauth.

Code written by Claude 4.

### Dynamic OAuth Token Injection
- **HTTP Header Injection**: OAuth tokens passed via `Authorization: Bearer <token>` headers  
- **Automatic Token Refresh**: Fresh tokens fetched on every API call
- **Multi-User Support**: User-specific token injection without credential mixing
- **Fallback Authentication**: Falls back to file-based auth if injection fails

### Architecture Improvements
- **Consistent with Jira Pattern**: Uses same `DynamicMCPToolset` and `create_dynamic_headers_provider` approach
- **Real-time Token Resolution**: No more expired token issues in long-lived connections
- **Secure by Design**: Credentials cleared after each request, no disk persistence

## Google Workspace MCP Server Changes

The Google Workspace MCP server has been enhanced with:

### 1. OAuth Injection Middleware (`core/server.py`)
```python
@server.app.middleware("http")
async def oauth_injection_middleware(request: Request, call_next):
    # Parse OAuth headers (Authorization, X-User-Email, X-User-ID)
    # Inject credentials into global store
    # Clear credentials after request (security)
```

### 2. Enhanced Authentication (`auth/google_auth.py`)
```python
def get_credentials():
    # Check for injected OAuth credentials first
    injected_creds = get_injected_oauth_credentials()
    if injected_creds:
        return create_credentials_from_injection(injected_creds)
    
    # Fallback to file-based authentication
    return load_from_file()
```

### 3. API Endpoints for OAuth Management
- **GET `/oauth/status`** - Check injection status
- **POST `/oauth/inject`** - Inject credentials programmatically  
- **POST `/oauth/clear`** - Clear injected credentials

## 🧪 Testing Strategy

### Manual Testing Scenarios
```bash
# Test OAuth injection via headers
curl -X POST http://localhost:8082/mcp \
  -H "Authorization: Bearer ya29.a0AX9GBdSI..." \
  -H "X-User-Email: user@gmail.com" \
  -H "Content-Type: application/json" \
  -d '{"method": "tools/list"}'

```
