### PR TITLE
feat: get user google email from environment var

### DIFF
--- a/core/server.py
+++ b/core/server.py
@@ -58,6 +58,7 @@ logger = logging.getLogger(__name__)
 
 WORKSPACE_MCP_PORT = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", 8000)))
 WORKSPACE_MCP_BASE_URI = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
+USER_GOOGLE_EMAIL = os.getenv("USER_GOOGLE_EMAIL", None)
 
 # Transport mode detection (will be set by main.py)
 _current_transport_mode = "stdio"  # Default to stdio
@@ -157,8 +158,8 @@ async def oauth2_callback(request: Request) -> HTMLResponse:
 
 @server.tool()
 async def start_google_auth(
-    user_google_email: str,
     service_name: str,
+    user_google_email: str = USER_GOOGLE_EMAIL,
     mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id")
 ) -> str:
     """


### PR DESCRIPTION
This PR implements the ability to set user_google_email using an environment variable. Previously, this value might have been hardcoded or required explicit input. Now, if a relevant environment variable is detected, its value will be used as the default for user_google_email. This provides an optional, more convenient, and centralized way to manage the Google email address. It improves configurability and reduces potential for errors from manual entry especially during execution time in the server checking the authentication.