### PR TITLE
Add color and own attending information to calendar event

### DIFF
--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -77,7 +77,6 @@ def _correct_time_format_for_api(
     logger.info(f"{param_name} '{time_str}' doesn't need formatting, using as is.")
     return time_str
 
-
 @server.tool()
 @require_google_service("calendar", "calendar_read")
 @handle_http_errors("list_calendars")
@@ -110,6 +109,7 @@ async def list_calendars(service, user_google_email: str) -> str:
     )
     logger.info(f"Successfully listed {len(items)} calendars for {user_google_email}.")
     return text_output
+
 
 
 @server.tool()
@@ -531,6 +531,7 @@ async def get_event(
     location = event.get("location", "No Location")
     attendees = event.get("attendees", [])
     attendee_emails = ", ".join([a.get("email", "") for a in attendees]) if attendees else "None"
+    color = event.get("colorId", "No Color")
     event_details = (
         f'Event Details:\n'
         f'- Title: {summary}\n'
@@ -540,7 +541,8 @@ async def get_event(
         f'- Location: {location}\n'
         f'- Attendees: {attendee_emails}\n'
         f'- Event ID: {event_id}\n'
-        f'- Link: {link}'
+        f'- Link: {link}\n'
+        f'- Color: {color}'
     )
     logger.info(f"[get_event] Successfully retrieved event {event_id} for {user_google_email}.")
     return event_details

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -532,6 +532,19 @@ async def get_event(
     attendees = event.get("attendees", [])
     attendee_emails = ", ".join([a.get("email", "") for a in attendees]) if attendees else "None"
     color = event.get("colorId", "No Color")
+
+    response_status = _is_user_attending_event(attendees, event, user_google_email)
+    if response_status == "accepted":
+        attending_str = "Yes"
+    elif response_status == "tentative":
+        attending_str = "Tentative"
+    elif response_status == "needsAction":
+        attending_str = "No response yet"
+    elif response_status == "declined":
+        attending_str = "No"
+    else:
+        attending_str = "Unknown"
+
     event_details = (
         f'Event Details:\n'
         f'- Title: {summary}\n'
@@ -540,9 +553,36 @@ async def get_event(
         f'- Description: {description}\n'
         f'- Location: {location}\n'
         f'- Attendees: {attendee_emails}\n'
+        f'- Attending myself: {attending_str}\n'
         f'- Event ID: {event_id}\n'
         f'- Link: {link}\n'
         f'- Color: {color}'
     )
     logger.info(f"[get_event] Successfully retrieved event {event_id} for {user_google_email}.")
     return event_details
+
+
+def _is_user_attending_event(attendees, event, user_google_email):
+    """
+    Determines if the user is attending the event (not declined).
+    Args:
+        attendees (list): List of attendee dicts.
+        event (dict): The event object.
+        user_google_email (str): The user's Google email address.
+    Returns:
+        bool: True if attending, False otherwise.
+    """
+    """
+    Returns one of: 'accepted', 'tentative', 'needsAction', 'declined', or None if not found.
+    """
+    for attendee in attendees:
+        email = attendee.get("email", "")
+        response_status = attendee.get("responseStatus", "needsAction")
+        if email.lower() == user_google_email.lower():
+            return response_status
+    # If no attendees and creator is myself, treat as accepted
+    if not attendees:
+        creator = event.get("creator", {}).get("email", "")
+        if creator.lower() == user_google_email.lower():
+            return "accepted"
+    return None


### PR DESCRIPTION
Two information I find useful :

- color (for people who use colors as a way to label events)
- attending myself:
   - if multiple invitees, it looks at own response
   - if no invitees, it is "attending" by default

I find that there is a tradeoff between completeness of information and response size, but those two are very useful for my case. Maybe the response should be parametrised to avoid information overload?