### PR TITLE
fix: SSL Connection Pool Exhaustion in Gmail Batch API

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -7,8 +7,8 @@ This module provides MCP tools for interacting with the Gmail API.
 import logging
 import asyncio
 import base64
-from typing import Optional, List, Dict, Literal
 import ssl
+from typing import Optional, List, Dict, Literal
 
 from email.mime.text import MIMEText
 

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -7,8 +7,8 @@ This module provides MCP tools for interacting with the Gmail API.
 import logging
 import asyncio
 import base64
-import ssl
 from typing import Optional, List, Dict, Literal
+import ssl
 
 from email.mime.text import MIMEText
 


### PR DESCRIPTION
Closes https://github.com/taylorwilsdon/google_workspace_mcp/issues/115#issuecomment-3109333693

This PR addresses critical SSL connection pool exhaustion issues in the Gmail batch API implementation that were causing frequent failures with errors like `[SSL] record layer failure`, `[SSL: UNEXPECTED_RECORD]`, and `IncompleteRead` exceptions.

The root cause was identified as:
- Connection pool exhaustion from creating too many concurrent SSL connections
- Missing proper connection management and reuse
- Aggressive parallel processing in fallback scenarios that worsened the problem

## Changes Made

### **Core Fixes**

- **Reduced Batch Sizes**: Decreased from 100 to 25 items per batch to limit concurrent SSL connections
- **Sequential Fallback Processing**: Replaced `asyncio.gather` with sequential processing to prevent SSL connection storms
- **Exponential Backoff Retry**: Added dedicated retry logic with 1s, 2s, 4s delays for SSL errors
- **Connection Cleanup Delays**: Added 0.1s delays between requests to allow proper connection cleanup

### **Files Modified**

- `gmail/gmail_tools.py`: Updated `get_gmail_messages_content_batch` and `get_gmail_threads_content_batch` functions

### **Specific Changes**

1. **Batch Size Reduction** (`gmail/gmail_tools.py:268`, `606`)
   ```python
   # Before: chunks of 100 (Gmail batch limit)
   for chunk_start in range(0, len(message_ids), 100):

   # After: smaller chunks to prevent SSL exhaustion
   BATCH_SIZE = 25
   for chunk_start in range(0, len(message_ids), BATCH_SIZE):
   ```

2. **Sequential Fallback Processing** (`gmail/gmail_tools.py:303-342`, `621-646`)
   ```python
   # Before: Parallel processing with asyncio.gather
   fetch_results = await asyncio.gather(
       *[fetch_message(mid) for mid in chunk_ids], return_exceptions=False
   )

   # After: Sequential processing with delays
   for mid in chunk_ids:
       mid_result, msg_data, error = await fetch_message_with_retry(mid)
       results[mid_result] = {"data": msg_data, "error": error}
       await asyncio.sleep(0.1)  # Connection cleanup delay
   ```

3. **SSL Error Retry Logic** (`gmail/gmail_tools.py:309-332`)
   ```python
   async def fetch_message_with_retry(mid: str, max_retries: int = 3):
       for attempt in range(max_retries):
           try:
               # ... existing message fetch logic ...
               return mid, msg, None
           except ssl.SSLError as ssl_error:
               if attempt < max_retries - 1:
                   delay = 2 ** attempt  # Exponential backoff
                   await asyncio.sleep(delay)
               else:
                   return mid, None, ssl_error
   ```

## Problem Solved

### **Before (Problematic Behavior)**
- Batch API created 100+ concurrent SSL connections
- `asyncio.gather` fallback created even more parallel connections
- No retry logic for transient SSL errors
- SSL connection pool exhaustion led to:
  - `[SSL] record layer failure`
  - `[SSL: UNEXPECTED_RECORD]`
  - `[SSL: LENGTH_MISMATCH]`
  - `IncompleteRead` exceptions

### **After (Fixed Behavior)**
- Limited to 25 concurrent connections per batch
- Sequential fallback processing prevents connection storms
- Exponential backoff retry handles transient SSL errors gracefully
- Connection cleanup delays allow proper resource management
- Maintains full functionality while preventing SSL exhaustion
## Impact

- **Reliability**: Eliminates SSL connection pool exhaustion failures
- **Performance**: Reduces connection overhead while maintaining throughput
- **Scalability**: Better resource management for high-volume operations
- **User Experience**: Consistent batch API functionality without intermittent SSL failures

## Backwards Compatibility
- ⚠️ Slightly reduced throughput (25 vs 100 per batch) for improved reliability
