### PR TITLE
enh: add more elegant handling for oauth server startup in stdio mode

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -379,6 +379,16 @@ async def start_auth_flow(
         f"[start_auth_flow] Initiating auth for {user_display_name} with global SCOPES."
     )
 
+    # Import here to avoid circular imports
+    from auth.oauth_callback_server import ensure_oauth_callback_available
+    from core.server import _current_transport_mode, WORKSPACE_MCP_PORT, WORKSPACE_MCP_BASE_URI
+
+    # Ensure OAuth callback server is available before generating URLs
+    success, error_msg = ensure_oauth_callback_available(_current_transport_mode, WORKSPACE_MCP_PORT, WORKSPACE_MCP_BASE_URI)
+    if not success:
+        error_detail = f" ({error_msg})" if error_msg else ""
+        raise Exception(f"Cannot initiate OAuth flow - callback server unavailable{error_detail}. Please ensure the OAuth callback server can start before attempting authentication.")
+
     try:
         if "OAUTHLIB_INSECURE_TRANSPORT" not in os.environ and (
             "localhost" in redirect_uri or "127.0.0.1" in redirect_uri

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -36,7 +36,6 @@ class MinimalOAuthServer:
         self.server = None
         self.server_thread = None
         self.is_running = False
-        self._running_lock = threading.Lock()
 
         # Setup the callback route
         self._setup_callback_route()

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -36,6 +36,7 @@ class MinimalOAuthServer:
         self.server = None
         self.server_thread = None
         self.is_running = False
+        self._running_lock = threading.Lock()
 
         # Setup the callback route
         self._setup_callback_route()

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -89,16 +89,16 @@ class MinimalOAuthServer:
                 logger.error(error_message_detail, exc_info=True)
                 return create_server_error_response(str(e))
 
-    def start(self) -> bool:
+    def start(self) -> tuple[bool, str]:
         """
         Start the minimal OAuth server.
 
         Returns:
-            True if started successfully, False otherwise
+            Tuple of (success: bool, error_message: str)
         """
         if self.is_running:
             logger.info("Minimal OAuth server is already running")
-            return True
+            return True, ""
 
         # Check if port is available
         # Extract hostname from base_uri (e.g., "http://localhost" -> "localhost")
@@ -112,8 +112,9 @@ class MinimalOAuthServer:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.bind((hostname, self.port))
         except OSError:
-            logger.error(f"Port {self.port} is already in use on {hostname}. Cannot start minimal OAuth server.")
-            return False
+            error_msg = f"Port {self.port} is already in use on {hostname}. Cannot start minimal OAuth server."
+            logger.error(error_msg)
+            return False, error_msg
 
         def run_server():
             """Run the server in a separate thread."""
@@ -145,13 +146,14 @@ class MinimalOAuthServer:
                     if result == 0:
                         self.is_running = True
                         logger.info(f"Minimal OAuth server started on {hostname}:{self.port}")
-                        return True
+                        return True, ""
             except Exception:
                 pass
             time.sleep(0.1)
 
-        logger.error(f"Failed to start minimal OAuth server on {hostname}:{self.port}")
-        return False
+        error_msg = f"Failed to start minimal OAuth server on {hostname}:{self.port} - server did not respond within {max_wait}s"
+        logger.error(error_msg)
+        return False, error_msg
 
     def stop(self):
         """Stop the minimal OAuth server."""
@@ -202,7 +204,7 @@ def get_oauth_redirect_uri(port: int = 8000, base_uri: str = "http://localhost")
     logger.info(f"Constructed redirect URI: {constructed_uri}")
     return constructed_uri
 
-def ensure_oauth_callback_available(transport_mode: str = "stdio", port: int = 8000, base_uri: str = "http://localhost") -> bool:
+def ensure_oauth_callback_available(transport_mode: str = "stdio", port: int = 8000, base_uri: str = "http://localhost") -> tuple[bool, str]:
     """
     Ensure OAuth callback endpoint is available for the given transport mode.
 
@@ -215,14 +217,14 @@ def ensure_oauth_callback_available(transport_mode: str = "stdio", port: int = 8
         base_uri: Base URI (default "http://localhost")
 
     Returns:
-        True if callback endpoint is available, False otherwise
+        Tuple of (success: bool, error_message: str)
     """
     global _minimal_oauth_server
 
     if transport_mode == "streamable-http":
         # In streamable-http mode, the main FastAPI server should handle callbacks
         logger.debug("Using existing FastAPI server for OAuth callbacks (streamable-http mode)")
-        return True
+        return True, ""
 
     elif transport_mode == "stdio":
         # In stdio mode, start minimal server if not already running
@@ -232,19 +234,21 @@ def ensure_oauth_callback_available(transport_mode: str = "stdio", port: int = 8
 
         if not _minimal_oauth_server.is_running:
             logger.info("Starting minimal OAuth server for stdio mode")
-            result = _minimal_oauth_server.start()
-            if result:
+            success, error_msg = _minimal_oauth_server.start()
+            if success:
                 logger.info(f"Minimal OAuth server successfully started on {base_uri}:{port}")
+                return True, ""
             else:
-                logger.error(f"Failed to start minimal OAuth server on {base_uri}:{port}")
-            return result
+                logger.error(f"Failed to start minimal OAuth server on {base_uri}:{port}: {error_msg}")
+                return False, error_msg
         else:
             logger.info("Minimal OAuth server is already running")
-            return True
+            return True, ""
 
     else:
-        logger.error(f"Unknown transport mode: {transport_mode}")
-        return False
+        error_msg = f"Unknown transport mode: {transport_mode}"
+        logger.error(error_msg)
+        return False, error_msg
 
 def cleanup_oauth_callback_server():
     """Clean up the minimal OAuth server if it was started."""

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -131,6 +131,7 @@ class MinimalOAuthServer:
 
             except Exception as e:
                 logger.error(f"Minimal OAuth server error: {e}", exc_info=True)
+                self.is_running = False
 
         # Start server in background thread
         self.server_thread = threading.Thread(target=run_server, daemon=True)

--- a/core/server.py
+++ b/core/server.py
@@ -193,8 +193,12 @@ async def start_google_auth(
 
     # Ensure OAuth callback is available for current transport mode
     redirect_uri = get_oauth_redirect_uri_for_current_mode()
-    if not ensure_oauth_callback_available(_current_transport_mode, WORKSPACE_MCP_PORT, WORKSPACE_MCP_BASE_URI):
-        raise Exception("Failed to start OAuth callback server. Please try again.")
+    success, error_msg = ensure_oauth_callback_available(_current_transport_mode, WORKSPACE_MCP_PORT, WORKSPACE_MCP_BASE_URI)
+    if not success:
+        if error_msg:
+            raise Exception(f"Failed to start OAuth callback server: {error_msg}")
+        else:
+            raise Exception("Failed to start OAuth callback server. Please try again.")
 
     auth_result = await start_auth_flow(
         user_google_email=user_google_email,

--- a/main.py
+++ b/main.py
@@ -153,10 +153,10 @@ def main():
             if success:
                 safe_print(f"   OAuth callback server started on {base_uri}:{port}/oauth2callback")
             else:
+                warning_msg = f"   ⚠️  Warning: Failed to start OAuth callback server"
                 if error_msg:
-                    safe_print(f"   ⚠️  Warning: Failed to start OAuth callback server: {error_msg}")
-                else:
-                    safe_print("   ⚠️  Warning: Failed to start OAuth callback server")
+                    warning_msg += f": {error_msg}"
+                safe_print(warning_msg)
 
         safe_print("   Ready for MCP connections!")
         safe_print("")

--- a/main.py
+++ b/main.py
@@ -149,10 +149,14 @@ def main():
             safe_print("🚀 Starting server in stdio mode")
             # Start minimal OAuth callback server for stdio mode
             from auth.oauth_callback_server import ensure_oauth_callback_available
-            if ensure_oauth_callback_available('stdio', port, base_uri):
+            success, error_msg = ensure_oauth_callback_available('stdio', port, base_uri)
+            if success:
                 safe_print(f"   OAuth callback server started on {base_uri}:{port}/oauth2callback")
             else:
-                safe_print("   ⚠️  Warning: Failed to start OAuth callback server")
+                if error_msg:
+                    safe_print(f"   ⚠️  Warning: Failed to start OAuth callback server: {error_msg}")
+                else:
+                    safe_print("   ⚠️  Warning: Failed to start OAuth callback server")
 
         safe_print("   Ready for MCP connections!")
         safe_print("")

--- a/uv.lock
+++ b/uv.lock
@@ -921,7 +921,7 @@ wheels = [
 
 [[package]]
 name = "workspace-mcp"
-version = "1.1.10"
+version = "1.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Noticed you don't get specific info (port unavailable etc) if the stdio built in minimal oauth callback server fails to start up, this fixes that. 