### PR TITLE
feat: Google Meet support for create and edit event, fix move attributes

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -921,7 +921,7 @@ wheels = [
 
 [[package]]
 name = "workspace-mcp"
-version = "1.1.13"
+version = "1.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Closes:
https://github.com/taylorwilsdon/google_workspace_mcp/issues/129
https://github.com/taylorwilsdon/google_workspace_mcp/issues/130

<img width="630" height="651" alt="image" src="https://github.com/user-attachments/assets/5f7e90ee-4ec2-4f4b-8c3e-98b94655c62d" />


  For create_event function:
  - Added add_google_meet: bool = False parameter
  - When True, creates a Google Meet conference using the conferenceData
  field with hangoutsMeet type
  - Generates a unique request ID using UUID for conference creation
  - Sets conferenceDataVersion=1 in the API call when Google Meet is
  requested
  - Enhanced confirmation message to include Google Meet link when available

  For modify_event function:
  - Added add_google_meet: Optional[bool] = None parameter
  - When True, adds Google Meet conference to existing event
  - When False, removes existing Google Meet conference
  - When None, preserves existing conference data
  - Always sets conferenceDataVersion=1 for proper conference data handling
  - Enhanced confirmation message to show Google Meet link when added or
  removal status

  Key Features:
  - Uses Google Calendar API's conferenceData with hangoutsMeet type for
  Google Meet integration
  - Generates unique request IDs for conference creation requests
  - Preserves existing event data (including conference data) when not
  explicitly modified
  - Provides clear feedback in confirmation messages about Google Meet status
  - Includes proper logging for debugging conference-related operations

  The implementation follows Google Calendar API best practices and maintains
   backward compatibility - existing code will continue to work without
  Google Meet, and the new parameter is optional.
