### PR TITLE
Fix Google Slides getThumbnail API parameter names

### DIFF
--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -253,7 +253,8 @@ async def get_page_thumbnail(
         service.presentations().pages().getThumbnail(
             presentationId=presentation_id,
             pageObjectId=page_object_id,
-            thumbnailPropertiesImageSize=thumbnail_size
+            thumbnailProperties_thumbnailSize=thumbnail_size,
+            thumbnailProperties_mimeType='PNG'
         ).execute
     )
 


### PR DESCRIPTION
The getThumbnail API call was using incorrect parameter name `thumbnailPropertiesImageSize` instead of the flattened parameter names required by the Google API Python client:
- `thumbnailProperties_thumbnailSize`
- `thumbnailProperties_mimeType`
