### PR TITLE
feat: Enable USER_GOOGLE_EMAIL configuration in manifest.json for DXT users

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,6 +28,7 @@
       "env": {
         "GOOGLE_OAUTH_CLIENT_ID": "${user_config.GOOGLE_OAUTH_CLIENT_ID}",
         "GOOGLE_OAUTH_CLIENT_SECRET": "${user_config.GOOGLE_OAUTH_CLIENT_SECRET}",
+        "USER_GOOGLE_EMAIL": "${user_config.USER_GOOGLE_EMAIL}",
         "GOOGLE_OAUTH_REDIRECT_URI": "${user_config.GOOGLE_OAUTH_REDIRECT_URI}",
         "GOOGLE_CLIENT_SECRET_PATH": "${user_config.GOOGLE_CLIENT_SECRET_PATH}",
         "GOOGLE_CLIENT_SECRETS": "${user_config.GOOGLE_CLIENT_SECRETS}",
@@ -121,6 +122,16 @@
       "sensitive": true,
       "validation": {
         "min_length": 24
+      }
+    },
+    "USER_GOOGLE_EMAIL": {
+      "type": "string",
+      "title": "User Google Email",
+      "description": "Your Google email address for authentication (e.g., your.email@gmail.com)",
+      "required": true,
+      "sensitive": false,
+      "validation": {
+        "pattern": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
       }
     },
     "GOOGLE_OAUTH_REDIRECT_URI": {


### PR DESCRIPTION
Hi Taylor,
First, thank you for creating such a useful project.

While setting up the extension on Claude Desktop using the .dxt file, I noticed that the authentication process couldn't start because it requires the user's email, but there was no field to configure it in the extension settings.

It seems the USER_GOOGLE_EMAIL configuration was missing from manifest.json. Since this is a required variable for the auth flow to identify the user, I've added it to the user_config schema and the mcp_config.env map.

With this change, a field for the user's email now correctly appears in the Claude settings, and the authentication process works as expected. I've tested this by repacking the .dxt with the updated manifest, and it resolves the setup issue.

I thought this might be a helpful fix for others as well. Let me know if you have any feedback.
Thanks!