### PR TITLE
fix: always use email from jwt token

### DIFF
--- a/auth/auth_info_middleware.py
+++ b/auth/auth_info_middleware.py
@@ -241,6 +241,18 @@ class AuthInfoMiddleware(Middleware):
         
         try:
             await self._process_request_for_auth(context)
+
+            # if authenticated_user_email exists in fastmcp_context and authenticated_via is jwt_token,
+            # uses authenticated_user_email as the value of the argument "user_google_email"
+            authenticated_user_email = context.fastmcp_context.get_state("authenticated_user_email")
+            authenticated_via = context.fastmcp_context.get_state("authenticated_via")
+
+            if authenticated_user_email and authenticated_via == "jwt_token":
+                # Check if this is a tool call with arguments
+                if hasattr(context, 'message') and hasattr(context.message, "arguments") and "user_google_email" in context.message.arguments:
+                    # Replace user_google_email argument with authenticated email
+                    logger.debug("Replacing user_google_email argument with email from jwt token")
+                    context.message.arguments['user_google_email'] = authenticated_user_email
             
             logger.debug("Passing to next handler")
             result = await call_next(context)


### PR DESCRIPTION
I like the new `auth_info_middleware.py`, this is about using the email from jwt token as value of `user_google_email` for tool calls.

In the multi-user environment, the use case is avoiding requests authenticated with JWT token to perform tool call on-behalf of arbitrary user. E.g., user `foo@example.com` get autenticated over jwt, then it could search emails owned by `bar@example.com` if that user has been authenticated already.