### PR TITLE
fix(gmail): accept List[str] for label arrays; emit clean array schema (single + batch)

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -1007,8 +1007,8 @@ async def modify_gmail_message_labels(
     service,
     user_google_email: str,
     message_id: str,
-    add_label_ids: Optional[List[str]] = None,
-    remove_label_ids: Optional[List[str]] = None,
+    add_label_ids: List[str] = Body(default=[], description="Label IDs to add to the message."),
+    remove_label_ids: List[str] = Body(default=[], description="Label IDs to remove from the message."),
 ) -> str:
     """
     Adds or removes labels from a Gmail message.
@@ -1059,8 +1059,8 @@ async def batch_modify_gmail_message_labels(
     service,
     user_google_email: str,
     message_ids: List[str],
-    add_label_ids: Optional[List[str]] = None,
-    remove_label_ids: Optional[List[str]] = None,
+    add_label_ids: List[str] = Body(default=[], description="Label IDs to add to messages."),
+    remove_label_ids: List[str] = Body(default=[], description="Label IDs to remove from messages."),
 ) -> str:
     """
     Adds or removes labels from multiple Gmail messages in a single batch request.


### PR DESCRIPTION
Summary
Fix input validation for Gmail label modification tools by changing Optional[List[str]] parameters to List[str] with empty defaults. This yields a plain “type: array” schema and resolves validation failures before the Gmail API call.

Problem (Issue #167)
Label modification tools failed pre-validation for array inputs (e.g., ["Label_X"]) due to anyOf([array,null]) schemas on optional list parameters.

Solution
Update add_label_ids and remove_label_ids to:
List[str] = Body(default=[], description="…")
Retain runtime guard requiring at least one non-empty list.
No behavioral changes beyond schema.

Schema Impact
  - Before: anyOf([{"type": "array"}, {"type": "null"}]) → Validation failure
  - After: {"type": "array"} → Clean array schema, validation success

Behavior Preservation
  - Existing runtime guard maintained: if not add_label_ids and not remove_label_ids: raise Exception(...)
  - No breaking changes to existing code
  - Same Gmail API calls and error handling

Testing
Verified both single and batch label modifications accept arrays and execute successfully (user labels and system labels).
Confirmed operations return success strings and reflect in the UI.

Compatibility
  - No breaking changes: Existing code continues to work
  - No new dependencies: Only parameter type changes
  - Backward compatible: Empty array defaults maintain existing behavior
  - API unchanged: Same Gmail REST API calls and responses
  - Scope limited to gmail/gmail_tools.py.

Fixes #167