### PR TITLE
Refactor base URL handling and add Docker Compose for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,11 @@ RUN uv sync --frozen --no-dev
 # Create non-root user for security
 RUN useradd --create-home --shell /bin/bash app \
     && chown -R app:app /app
-USER app
 
 # Give read access to the store_creds volume
 RUN chmod -R 755 /app/store_creds
+
+USER app
 
 # Expose port (use default of 8000 if PORT not set)
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN useradd --create-home --shell /bin/bash app \
     && chown -R app:app /app
 USER app
 
+# Give read access to the store_creds volume
+RUN chmod -R 755 /app/store_creds
+
 # Expose port (use default of 8000 if PORT not set)
 EXPOSE 8000
 # Expose additional port if PORT environment variable is set to a different value

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,10 @@ RUN uv sync --frozen --no-dev
 RUN useradd --create-home --shell /bin/bash app \
     && chown -R app:app /app
 
-# Give read access to the store_creds volume
-RUN chmod -R 755 /app/store_creds
+# Give read and write access to the store_creds volume
+RUN mkdir -p /app/store_creds \
+    && chown -R app:app /app/store_creds \
+    && chmod 755 /app/store_creds
 
 USER app
 

--- a/auth/fastmcp_google_auth.py
+++ b/auth/fastmcp_google_auth.py
@@ -12,7 +12,6 @@ Key features:
 - Session bridging to Google credentials for API access
 """
 
-import os
 import logging
 from typing import Dict, Any, Optional, List
 

--- a/auth/fastmcp_google_auth.py
+++ b/auth/fastmcp_google_auth.py
@@ -39,11 +39,14 @@ class GoogleWorkspaceAuthProvider(AuthProvider):
         """Initialize the Google Workspace auth provider."""
         super().__init__()
         
-        # Get configuration from environment
-        self.client_id = os.getenv("GOOGLE_OAUTH_CLIENT_ID")
-        self.client_secret = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET")
-        self.base_url = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
-        self.port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", 8000)))
+        # Get configuration from OAuth config
+        from auth.oauth_config import get_oauth_config
+        config = get_oauth_config()
+        
+        self.client_id = config.client_id
+        self.client_secret = config.client_secret
+        self.base_url = config.get_oauth_base_url()
+        self.port = config.port
         
         if not self.client_id:
             logger.warning("GOOGLE_OAUTH_CLIENT_ID not set - OAuth 2.1 authentication will not work")

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -17,9 +17,8 @@ from googleapiclient.errors import HttpError
 from auth.scopes import SCOPES
 from auth.oauth21_session_store import get_oauth21_session_store
 from auth.credential_store import get_credential_store
+from auth.oauth_config import get_oauth_config
 from core.config import (
-    WORKSPACE_MCP_PORT,
-    WORKSPACE_MCP_BASE_URI,
     get_transport_mode,
     get_oauth_redirect_uri,
 )
@@ -818,8 +817,9 @@ async def get_authenticated_google_service(
         from auth.oauth_callback_server import ensure_oauth_callback_available
 
         redirect_uri = get_oauth_redirect_uri()
+        config = get_oauth_config()
         success, error_msg = ensure_oauth_callback_available(
-            get_transport_mode(), WORKSPACE_MCP_PORT, WORKSPACE_MCP_BASE_URI
+            get_transport_mode(), config.port, config.base_uri
         )
         if not success:
             error_detail = f" ({error_msg})" if error_msg else ""

--- a/auth/google_remote_auth_provider.py
+++ b/auth/google_remote_auth_provider.py
@@ -60,11 +60,14 @@ class GoogleRemoteAuthProvider(RemoteAuthProvider):
         if not REMOTEAUTHPROVIDER_AVAILABLE:
             raise ImportError("FastMCP v2.11.1+ required for RemoteAuthProvider")
 
-        # Get configuration from environment
-        self.client_id = os.getenv("GOOGLE_OAUTH_CLIENT_ID")
-        self.client_secret = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET")
-        self.base_url = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
-        self.port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", 8000)))
+        # Get configuration from OAuth config
+        from auth.oauth_config import get_oauth_config
+        config = get_oauth_config()
+        
+        self.client_id = config.client_id
+        self.client_secret = config.client_secret
+        self.base_url = config.get_oauth_base_url()
+        self.port = config.port
 
         if not self.client_id:
             logger.error(
@@ -86,13 +89,12 @@ class GoogleRemoteAuthProvider(RemoteAuthProvider):
         # The /mcp/ resource URL is handled in the protected resource metadata endpoint
         super().__init__(
             token_verifier=token_verifier,
-            authorization_servers=[AnyHttpUrl(f"{self.base_url}")],
-            resource_server_url=f"{self.base_url}",
+            authorization_servers=[AnyHttpUrl(self.base_url)],
+            resource_server_url=self.base_url,
         )
-        
 
         logger.debug(
-            f"Initialized GoogleRemoteAuthProvider with base_url={self.base_url}, port={self.port}"
+            f"Initialized GoogleRemoteAuthProvider with base_url={self.base_url}"
         )
 
     def get_routes(self) -> List[Route]:

--- a/auth/google_remote_auth_provider.py
+++ b/auth/google_remote_auth_provider.py
@@ -86,8 +86,8 @@ class GoogleRemoteAuthProvider(RemoteAuthProvider):
         # The /mcp/ resource URL is handled in the protected resource metadata endpoint
         super().__init__(
             token_verifier=token_verifier,
-            authorization_servers=[AnyHttpUrl(f"{self.base_url}:{self.port}")],
-            resource_server_url=f"{self.base_url}:{self.port}",
+            authorization_servers=[AnyHttpUrl(f"{self.base_url}")],
+            resource_server_url=f"{self.base_url}",
         )
 
         logger.debug("GoogleRemoteAuthProvider")

--- a/auth/google_remote_auth_provider.py
+++ b/auth/google_remote_auth_provider.py
@@ -13,7 +13,6 @@ This provider is used only in streamable-http transport mode with FastMCP v2.11.
 For earlier versions or other transport modes, the legacy GoogleWorkspaceAuthProvider is used.
 """
 
-import os
 import logging
 import aiohttp
 from typing import Optional, List

--- a/auth/google_remote_auth_provider.py
+++ b/auth/google_remote_auth_provider.py
@@ -89,6 +89,7 @@ class GoogleRemoteAuthProvider(RemoteAuthProvider):
             authorization_servers=[AnyHttpUrl(f"{self.base_url}")],
             resource_server_url=f"{self.base_url}",
         )
+        
 
         logger.debug("GoogleRemoteAuthProvider")
 

--- a/auth/google_remote_auth_provider.py
+++ b/auth/google_remote_auth_provider.py
@@ -91,7 +91,9 @@ class GoogleRemoteAuthProvider(RemoteAuthProvider):
         )
         
 
-        logger.debug("GoogleRemoteAuthProvider")
+        logger.debug(
+            f"Initialized GoogleRemoteAuthProvider with base_url={self.base_url}, port={self.port}"
+        )
 
     def get_routes(self) -> List[Route]:
         """

--- a/auth/oauth_common_handlers.py
+++ b/auth/oauth_common_handlers.py
@@ -241,7 +241,8 @@ async def handle_oauth_protected_resource(request: Request):
 
     # For streamable-http transport, the MCP server runs at /mcp
     # This is the actual resource being protected
-    resource_url = f"{base_url}/mcp/"
+    # As of August, /mcp is now the proper base - prior was /mcp/
+    resource_url = f"{base_url}/mcp"
 
     # Build metadata response per RFC 9449
     metadata = {

--- a/auth/oauth_common_handlers.py
+++ b/auth/oauth_common_handlers.py
@@ -241,7 +241,7 @@ async def handle_oauth_protected_resource(request: Request):
 
     # For streamable-http transport, the MCP server runs at /mcp
     # This is the actual resource being protected
-    resource_url = f"{base_url}/mcp"
+    resource_url = f"{base_url}/mcp/"
 
     # Build metadata response per RFC 9449
     metadata = {

--- a/auth/oauth_common_handlers.py
+++ b/auth/oauth_common_handlers.py
@@ -254,7 +254,6 @@ async def handle_oauth_protected_resource(request: Request):
         "client_registration_required": True,
         "client_configuration_endpoint": f"{base_url}/.well-known/oauth-client",
     }
-
     # Log the response for debugging
     logger.debug(f"Returning protected resource metadata: {metadata}")
 

--- a/auth/oauth_config.py
+++ b/auth/oauth_config.py
@@ -25,7 +25,7 @@ class OAuthConfig:
         # Base server configuration
         self.base_uri = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
         self.port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", "8000")))
-        self.base_url = f"{self.base_uri}:{self.port}"
+        self.base_url = f"{self.base_uri}"
 
         # OAuth client configuration
         self.client_id = os.getenv("GOOGLE_OAUTH_CLIENT_ID")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - GOOGLE_MCP_CREDENTIALS_DIR=/store_creds
+      - GOOGLE_MCP_CREDENTIALS_DIR=/app/store_creds
     volumes:
       - ./client_secret.json:/app/client_secret.json:ro
       - store_creds:/app/store_creds:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,13 @@ services:
     container_name: gws_mcp
     ports:
       - "8000:8000"
+    environment:
+      - GOOGLE_MCP_CREDENTIALS_DIR=/store_creds
     volumes:
       - ./client_secret.json:/app/client_secret.json:ro
+      - store_creds:/store_creds
     env_file:
       - .env
+
+volumes:
+  store_creds:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  gws_mcp:
+    build: .
+    container_name: gws_mcp
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./client_secret.json:/app/client_secret.json:ro
+    env_file:
+      - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - GOOGLE_MCP_CREDENTIALS_DIR=/store_creds
     volumes:
       - ./client_secret.json:/app/client_secret.json:ro
-      - store_creds:/store_creds
+      - store_creds:/app/store_creds:rw
     env_file:
       - .env
 

--- a/helm-chart/workspace-mcp/templates/NOTES.txt
+++ b/helm-chart/workspace-mcp/templates/NOTES.txt
@@ -49,7 +49,7 @@
 4. Important Notes:
    - Make sure you have configured your Google OAuth credentials in the secret
    - The application requires internet access to reach Google APIs
-   - OAuth callback URL: {{ default "http://localhost" .Values.env.WORKSPACE_MCP_BASE_URI }}:{{ .Values.env.WORKSPACE_MCP_PORT }}/oauth2callback
+   - OAuth callback URL: {{ if .Values.env.WORKSPACE_EXTERNAL_URL }}{{ .Values.env.WORKSPACE_EXTERNAL_URL }}{{ else }}{{ default "http://localhost" .Values.env.WORKSPACE_MCP_BASE_URI }}:{{ .Values.env.WORKSPACE_MCP_PORT }}{{ end }}/oauth2callback
 
 For more information about the Google Workspace MCP Server, visit:
 https://github.com/taylorwilsdon/google_workspace_mcp

--- a/helm-chart/workspace-mcp/values.yaml
+++ b/helm-chart/workspace-mcp/values.yaml
@@ -80,6 +80,10 @@ env:
   # For external access: "https://your-domain.com" or "http://your-ingress-host"
   WORKSPACE_MCP_BASE_URI: ""
   
+  # External URL for reverse proxy setups (e.g., "https://your-domain.com")
+  # If set, this overrides the base_uri:port combination for OAuth endpoints
+  WORKSPACE_EXTERNAL_URL: ""
+  
   # OAuth 2.1 support
   MCP_ENABLE_OAUTH21: "false"
   

--- a/main.py
+++ b/main.py
@@ -102,6 +102,8 @@ def main():
     # Set port and base URI once for reuse throughout the function
     port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", 8000)))
     base_uri = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
+    external_url = os.getenv("WORKSPACE_EXTERNAL_URL")
+    display_url = external_url if external_url else f"{base_uri}:{port}"
 
     safe_print("🔧 Google Workspace MCP Server")
     safe_print("=" * 35)
@@ -113,8 +115,8 @@ def main():
     safe_print(f"   📦 Version: {version}")
     safe_print(f"   🌐 Transport: {args.transport}")
     if args.transport == 'streamable-http':
-        safe_print(f"   🔗 URL: {base_uri}:{port}")
-        safe_print(f"   🔐 OAuth Callback: {base_uri}:{port}/oauth2callback")
+        safe_print(f"   🔗 URL: {display_url}")
+        safe_print(f"   🔐 OAuth Callback: {display_url}/oauth2callback")
     safe_print(f"   👤 Mode: {'Single-user' if args.single_user else 'Multi-user'}")
     safe_print(f"   🐍 Python: {sys.version.split()[0]}")
     safe_print("")
@@ -248,6 +250,8 @@ def main():
             configure_server_for_http()
             safe_print("")
             safe_print(f"🚀 Starting HTTP server on {base_uri}:{port}")
+            if external_url:
+                safe_print(f"   External URL: {external_url}")
         else:
             safe_print("")
             safe_print("🚀 Starting STDIO server")
@@ -255,7 +259,7 @@ def main():
             from auth.oauth_callback_server import ensure_oauth_callback_available
             success, error_msg = ensure_oauth_callback_available('stdio', port, base_uri)
             if success:
-                safe_print(f"   OAuth callback server started on {base_uri}:{port}/oauth2callback")
+                safe_print(f"   OAuth callback server started on {display_url}/oauth2callback")
             else:
                 warning_msg = "   ⚠️  Warning: Failed to start OAuth callback server"
                 if error_msg:

--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,7 @@
         "GOOGLE_CLIENT_SECRETS": "${user_config.GOOGLE_CLIENT_SECRETS}",
         "WORKSPACE_MCP_BASE_URI": "${user_config.WORKSPACE_MCP_BASE_URI}",
         "WORKSPACE_MCP_PORT": "${user_config.WORKSPACE_MCP_PORT}",
+        "WORKSPACE_EXTERNAL_URL": "${user_config.WORKSPACE_EXTERNAL_URL}",
         "OAUTHLIB_INSECURE_TRANSPORT": "${user_config.OAUTHLIB_INSECURE_TRANSPORT}",
         "GOOGLE_PSE_API_KEY": "${user_config.GOOGLE_PSE_API_KEY}",
         "GOOGLE_PSE_ENGINE_ID": "${user_config.GOOGLE_PSE_ENGINE_ID}"
@@ -184,6 +185,16 @@
       "validation": {
         "min": 1024,
         "max": 65535
+      }
+    },
+    "WORKSPACE_EXTERNAL_URL": {
+      "type": "string",
+      "title": "External URL",
+      "description": "External URL for reverse proxy setups (e.g., https://your-domain.com). Overrides base_uri:port for OAuth endpoints",
+      "required": false,
+      "sensitive": false,
+      "validation": {
+        "pattern": "^https?://[a-zA-Z0-9.-]+(:[0-9]+)?$"
       }
     },
     "OAUTHLIB_INSECURE_TRANSPORT": {

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -85,6 +85,7 @@ startCommand:
           WORKSPACE_MCP_BASE_URI: config.workspaceMcpBaseUri,
           WORKSPACE_MCP_PORT: String(config.workspaceMcpPort),
           PORT: String(config.workspaceMcpPort),
+          ...(config.workspaceExternalUrl && { WORKSPACE_EXTERNAL_URL: config.workspaceExternalUrl }),
           ...(config.mcpSingleUserMode && { MCP_SINGLE_USER_MODE: '1' }),
           ...(config.mcpEnableOauth21 && { MCP_ENABLE_OAUTH21: 'true' }),
           ...(config.oauthlibInsecureTransport && { OAUTHLIB_INSECURE_TRANSPORT: '1' }),


### PR DESCRIPTION
This pull request primarily updates how the application's base URL and port are handled throughout the authentication and configuration code, and adds a Docker Compose configuration for local development. The most significant changes involve removing the port from the `base_url` variable, which simplifies URL management and ensures consistency. Additionally, a new `docker-compose.yml` file is introduced to streamline running the service locally.

Configuration and URL handling improvements:

* Removed the port from the `base_url` in `auth/oauth_config.py` and updated its usage in `auth/google_remote_auth_provider.py` to ensure URLs are consistently constructed without appending the port. [[1]](diffhunk://#diff-13f6b130be79ba2fa7350c792f996a8135e9c5538d37dc3e92e02b9119f82902L28-R28) [[2]](diffhunk://#diff-66082450489b1dd7fb3a4cc897721c79ec2ce9248175e0078cfa35770bf12fb8L89-R93)
* Updated the protected resource URL in `auth/oauth_common_handlers.py` to include a trailing slash, aligning with standard URL conventions.

Development environment setup:

* Added a new `docker-compose.yml` file to define a `gws_mcp` service for easier local development and deployment, including port mapping, environment variables, and volume mounting for secrets.