### PR TITLE
explain that when show_completed is set, show_hidden should also be set

### DIFF
--- a/gtasks/tasks_tools.py
+++ b/gtasks/tasks_tools.py
@@ -289,7 +289,7 @@ async def list_tasks(
         task_list_id (str): The ID of the task list to retrieve tasks from.
         max_results (Optional[int]): Maximum number of tasks to return. (default: 20, max: 10000).
         page_token (Optional[str]): Token for pagination.
-        show_completed (bool): Whether to include completed tasks (default: True).
+        show_completed (bool): Whether to include completed tasks (default: True). Note that show_hidden must also be true to show tasks completed in first party clients, such as the web UI and Google's mobile apps.
         show_deleted (bool): Whether to include deleted tasks (default: False).
         show_hidden (bool): Whether to include hidden tasks (default: False).
         show_assigned (bool): Whether to include assigned tasks (default: False).


### PR DESCRIPTION
fixes #139

add comment from https://developers.google.com/workspace/tasks/reference/rest/v1/tasks/list about the parameter show_completed

This doc comment is provided to the LLM in tool information, helping it know how to show completed tasks.