### PR TITLE
Add attachment details support to calendar events

### DIFF
--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -168,11 +168,6 @@ def _format_attachment_details(attachments: List[Dict[str, Any]], indent: str = 
     """
     Format attachment details including file information.
 
-    Example output format:
-    "  Document.pdf
-    File URL: https://drive.google.com/open?id=abc123
-    File ID: abc123
-    MIME Type: application/pdf"
 
     Args:
         attachments: List of attachment dictionaries from Google Calendar API


### PR DESCRIPTION
## Summary
- Adds `include_attachments` parameter to `get_events()` function to expose event attachment details
- Provides access to file information attached to calendar events (fileId, fileUrl, mimeType, title)
- Follows the same implementation pattern as the attendee details feature (#228)

## Changes
- Added `_format_attachment_details()` helper function following existing code patterns
- Added `include_attachments` parameter to `get_events()` with default value of `False` for backward compatibility
- Updated detailed event output (both single and multiple events) to show attachment information when requested
- Enhanced function docstring with comprehensive documentation for LLM/MCP usage
- Parameter only applies when `detailed=True`, maintaining consistent API design

## Benefits
- Enables users to discover and access files attached to calendar events
- Useful for retrieving meeting documents, presentations, and other shared files
- Maintains full backward compatibility - opt-in feature via parameter
- Well-documented for LLM consumption with clear use cases and examples

## Test Plan
- [x] Python syntax validation passes
- [x] Code follows existing patterns and conventions
- [x] Backward compatible - defaults to False
- [x] Documentation clearly explains parameter behavior and dependencies

Resolves #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)