### PR TITLE
Add Gmail attachment support with ephemeral ID handling

### DIFF
--- a/auth/mcp_session_middleware.py
+++ b/auth/mcp_session_middleware.py
@@ -48,7 +48,6 @@ class MCPSessionMiddleware(BaseHTTPMiddleware):
             auth_context = None
             user_email = None
             mcp_session_id = None
-            
             # Check for FastMCP auth context
             if hasattr(request.state, "auth"):
                 auth_context = request.state.auth

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -8,7 +8,7 @@ import logging
 import asyncio
 import base64
 import ssl
-from typing import Optional, List, Dict, Literal
+from typing import Optional, List, Dict, Literal, Any
 
 from email.mime.text import MIMEText
 
@@ -121,7 +121,7 @@ def _format_body_content(text_body: str, html_body: str) -> str:
         return "[No readable content found]"
 
 
-def _extract_attachments(payload: dict) -> List[Dict[str, any]]:
+def _extract_attachments(payload: dict) -> List[Dict[str, Any]]:
     """
     Extract attachment metadata from a Gmail message payload.
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive Gmail attachment functionality to the MCP server, enabling users to list and download email attachments.

## Changes

1. **New helper function `_extract_attachments()`**
   - Recursively extracts attachment metadata from Gmail message payloads
   - Returns filename, mimeType, size, and attachmentId for each attachment

2. **Enhanced `get_gmail_message_content()`**
   - Now displays attachment information when messages contain attachments
   - Shows attachment metadata and download instructions

3. **New tool `get_gmail_attachment_content()`**
   - Downloads email attachments via Gmail API
   - Returns base64-encoded attachment data for further processing
   - Properly handles Gmail's ephemeral attachment ID behavior

## Key Technical Insight

Gmail attachment IDs are **ephemeral** and change between API calls for the same message. This PR addresses this by:

- Using the attachment ID provided by the caller directly without refetching the message
- Documenting that filename/mime type should be obtained from the initial message fetch
- Including clear error messages when attachment IDs become stale

If we refetch the message to get metadata, the new attachment IDs won't match the original ID parameter, causing downloads to fail. The attachment download endpoint returns size information directly, making message refetch unnecessary.

## Testing

Tested with real Gmail messages containing various attachment types (PDFs, images, etc.). The implementation successfully:
- Detects attachments in messages
- Provides accurate metadata
- Downloads attachment content without ID mismatch errors

## Related Issues

Fixes attachment download functionality that was previously failing with "Could not find attachment metadata" errors.