### PR TITLE
Added saving to disk support

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -24,6 +24,7 @@ drive:
     - create_drive_file
   extended:
     - list_drive_items
+    - save_drive_file_to_disk
   complete:
     - get_drive_file_permissions
     - check_drive_file_public_access


### PR DESCRIPTION
## Add save_drive_file_to_disk tool for downloading files directly to filesystem

Closes #254

### Problem

The existing `get_drive_file_content` tool downloads Google Drive files to memory (io.BytesIO) and attempts to return content as text. This approach has several limitations:

- **Memory constraints**: Large files consume excessive memory by loading entire contents into RAM
- **Binary file handling**: Binary files cannot be properly handled or saved locally
- **Context window pollution**: AI context gets filled with file content that may not be analyzable
- **No local file access**: No way to save files directly to disk for subsequent processing by other tools

### Solution

This PR adds a new `save_drive_file_to_disk` MCP tool that downloads Google Drive files directly to the local filesystem without streaming content through the AI context.

### Features

✅ **Direct disk download**: Uses `MediaIoBaseDownload` with file handles to write directly to disk
✅ **Smart path handling**: Converts relative paths to workspace root automatically
✅ **Native file support**: Handles both Google native files (with export) and regular files
✅ **Automatic directory creation**: Creates necessary parent directories as needed
✅ **Shared drive support**: Full support for shared drives with `supportsAllDrives=True`
✅ **Detailed feedback**: Returns comprehensive success message with file metadata and location
✅ **Export format mapping**: Automatically exports Google Docs/Sheets/Slides to Office formats

### Technical Implementation

**New function**: `save_drive_file_to_disk()`
- **Location**: `gdrive/drive_tools.py` (lines 412-509)
- **Parameters**:
  - `user_google_email`: User's Google email (required)
  - `file_id`: Google Drive file ID (required)
  - `local_file_path`: Local destination path (required)
- **Tool tier**: Added to extended tier in `core/tool_tiers.yaml`

**Export format mappings**:
- Google Docs → `.docx` (Word)
- Google Sheets → `.xlsx` (Excel)  
- Google Slides → `.pptx` (PowerPoint)

### Use Cases

This feature is particularly useful for:
- 📦 Downloading large datasets or media files for local processing
- 🖼️ Saving binary files (images, PDFs, archives) that cannot be text-analyzed
- 🤖 Building automation workflows that need files on disk
- ⚙️ Batch processing operations on multiple Drive files
- 💾 Archiving or backup operations

### Code Changes

**Files modified**:
- `gdrive/drive_tools.py`: +97 lines (new function)
- `core/tool_tiers.yaml`: +1 line (tool tier registration)

**No conflicts**: This PR adds new functionality without modifying existing tools. It complements recent upload improvements from PR #239.

### Testing

Tested with:
- ✅ Large files (>100MB)
- ✅ Binary files (images, PDFs)
- ✅ Google native files (Docs, Sheets, Slides)
- ✅ Shared drive files
- ✅ Relative and absolute paths
- ✅ Directory auto-creation

### Example Usage

```python
# Download a large image file
save_drive_file_to_disk(
    user_google_email="user@example.com",
    file_id="1ABC123xyz",
    local_file_path="downloads/image.jpg"
)

# Export Google Doc to Word
save_drive_file_to_disk(
    user_google_email="user@example.com", 
    file_id="1DEF456xyz",
    local_file_path="docs/report.docx"
)
```

### Checklist

- [x] Code follows project style guidelines
- [x] Function properly decorated with MCP server registration
- [x] Error handling implemented with `@handle_http_errors`
- [x] Authentication handled via `@require_google_service`
- [x] Logging added for debugging
- [x] No conflicts with existing functionality
- [x] Tool tier configuration updated
- [x] Rebased on latest main branch

### Related

- Issue #254 - Feature request for save-to-disk functionality
- PR #239 - Recent upload improvements (no conflicts)
