### PR TITLE
feat(auth): add persistent OAuth state storage for Claude Desktop account switching

### DIFF
--- a/auth/oauth_state_store.py
+++ b/auth/oauth_state_store.py
@@ -1,0 +1,228 @@
+"""
+Persistent OAuth State Store
+
+This module provides persistent storage for OAuth state parameters to survive
+process restarts during the OAuth flow. This is especially important for
+Claude Desktop where the MCP server runs as a subprocess.
+"""
+
+import os
+import json
+import logging
+from typing import Dict, Any, Optional
+from datetime import datetime, timedelta, timezone
+from threading import RLock
+
+logger = logging.getLogger(__name__)
+
+
+class PersistentOAuthStateStore:
+    """
+    File-based OAuth state storage that persists across process restarts.
+
+    Stores OAuth state parameters in a JSON file to ensure they survive
+    MCP server restarts during the OAuth flow.
+    """
+
+    def __init__(self, state_file_path: Optional[str] = None):
+        """
+        Initialize the persistent OAuth state store.
+
+        Args:
+            state_file_path: Path to the state storage file. If None, uses
+                           credentials directory with oauth_states.json filename.
+        """
+        if state_file_path is None:
+            # Use same directory as credentials
+            base_dir = os.getenv("GOOGLE_MCP_CREDENTIALS_DIR")
+            if not base_dir:
+                home_dir = os.path.expanduser("~")
+                if home_dir and home_dir != "~":
+                    base_dir = os.path.join(home_dir, ".google_workspace_mcp", "credentials")
+                else:
+                    base_dir = os.path.join(os.getcwd(), ".credentials")
+
+            # Ensure directory exists
+            if not os.path.exists(base_dir):
+                os.makedirs(base_dir)
+                logger.info(f"Created OAuth state directory: {base_dir}")
+
+            state_file_path = os.path.join(base_dir, "oauth_states.json")
+
+        self.state_file_path = state_file_path
+        self._lock = RLock()
+        logger.info(f"PersistentOAuthStateStore initialized with file: {state_file_path}")
+
+    def _load_states(self) -> Dict[str, Dict[str, Any]]:
+        """Load states from disk. Caller must hold lock."""
+        if not os.path.exists(self.state_file_path):
+            return {}
+
+        try:
+            with open(self.state_file_path, "r") as f:
+                data = json.load(f)
+
+            # Convert ISO strings back to datetime objects
+            for state_data in data.values():
+                if "expires_at" in state_data and state_data["expires_at"]:
+                    state_data["expires_at"] = datetime.fromisoformat(state_data["expires_at"])
+                if "created_at" in state_data and state_data["created_at"]:
+                    state_data["created_at"] = datetime.fromisoformat(state_data["created_at"])
+
+            logger.debug(f"Loaded {len(data)} OAuth states from disk")
+            return data
+
+        except (IOError, json.JSONDecodeError) as e:
+            logger.error(f"Error loading OAuth states from {self.state_file_path}: {e}")
+            return {}
+
+    def _save_states(self, states: Dict[str, Dict[str, Any]]):
+        """Save states to disk. Caller must hold lock."""
+        try:
+            # Convert datetime objects to ISO strings for JSON serialization
+            serializable_states = {}
+            for state, state_data in states.items():
+                serializable_data = state_data.copy()
+                if "expires_at" in serializable_data and serializable_data["expires_at"]:
+                    serializable_data["expires_at"] = serializable_data["expires_at"].isoformat()
+                if "created_at" in serializable_data and serializable_data["created_at"]:
+                    serializable_data["created_at"] = serializable_data["created_at"].isoformat()
+                serializable_states[state] = serializable_data
+
+            with open(self.state_file_path, "w") as f:
+                json.dump(serializable_states, f, indent=2)
+
+            logger.debug(f"Saved {len(states)} OAuth states to disk")
+
+        except IOError as e:
+            logger.error(f"Error saving OAuth states to {self.state_file_path}: {e}")
+
+    def _cleanup_expired_states(self, states: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+        """Remove expired states. Caller must hold lock."""
+        now = datetime.now(timezone.utc)
+        cleaned_states = {}
+        expired_count = 0
+
+        for state, state_data in states.items():
+            expires_at = state_data.get("expires_at")
+            if expires_at and expires_at <= now:
+                expired_count += 1
+                logger.debug(f"Removing expired OAuth state: {state[:8]}...")
+            else:
+                cleaned_states[state] = state_data
+
+        if expired_count > 0:
+            logger.info(f"Cleaned up {expired_count} expired OAuth states")
+
+        return cleaned_states
+
+    def store_oauth_state(
+        self,
+        state: str,
+        session_id: Optional[str] = None,
+        expires_in_seconds: int = 600,
+    ) -> None:
+        """
+        Persist an OAuth state value for later validation.
+
+        Args:
+            state: The OAuth state parameter
+            session_id: Optional session identifier
+            expires_in_seconds: How long the state is valid (default: 10 minutes)
+
+        Raises:
+            ValueError: If state is empty or expires_in_seconds is negative
+        """
+        if not state:
+            raise ValueError("OAuth state must be provided")
+        if expires_in_seconds < 0:
+            raise ValueError("expires_in_seconds must be non-negative")
+
+        with self._lock:
+            # Load existing states
+            states = self._load_states()
+
+            # Clean up expired states
+            states = self._cleanup_expired_states(states)
+
+            # Add new state
+            now = datetime.now(timezone.utc)
+            expiry = now + timedelta(seconds=expires_in_seconds)
+
+            states[state] = {
+                "session_id": session_id,
+                "expires_at": expiry,
+                "created_at": now,
+            }
+
+            # Save to disk
+            self._save_states(states)
+
+            logger.debug(
+                f"Stored OAuth state {state[:8]}... (expires at {expiry.isoformat()})"
+            )
+
+    def validate_and_consume_oauth_state(
+        self,
+        state: str,
+        session_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Validate that a state value exists and consume it.
+
+        Args:
+            state: The OAuth state returned by Google
+            session_id: Optional session identifier that initiated the flow
+
+        Returns:
+            Metadata associated with the state
+
+        Raises:
+            ValueError: If the state is missing, expired, or does not match the session
+        """
+        if not state:
+            raise ValueError("Missing OAuth state parameter")
+
+        with self._lock:
+            # Load and clean up states
+            states = self._load_states()
+            states = self._cleanup_expired_states(states)
+
+            # Check if state exists
+            state_info = states.get(state)
+
+            if not state_info:
+                logger.error("SECURITY: OAuth callback received unknown or expired state")
+                raise ValueError("Invalid or expired OAuth state parameter")
+
+            # Validate session binding if present
+            bound_session = state_info.get("session_id")
+            if bound_session and session_id and bound_session != session_id:
+                # Consume the state to prevent replay attempts
+                del states[state]
+                self._save_states(states)
+                logger.error(
+                    f"SECURITY: OAuth state session mismatch (expected {bound_session}, got {session_id})"
+                )
+                raise ValueError("OAuth state does not match the initiating session")
+
+            # State is valid – consume it to prevent reuse
+            del states[state]
+            self._save_states(states)
+
+            logger.debug(f"Validated and consumed OAuth state {state[:8]}...")
+            return state_info
+
+
+# Global instance
+_global_state_store: Optional[PersistentOAuthStateStore] = None
+
+
+def get_persistent_oauth_state_store() -> PersistentOAuthStateStore:
+    """Get the global persistent OAuth state store."""
+    global _global_state_store
+
+    if _global_state_store is None:
+        _global_state_store = PersistentOAuthStateStore()
+
+    return _global_state_store


### PR DESCRIPTION
## Problem

When using this MCP server in Claude Desktop and switching between accounts (e.g., from a Pro account to a Teams account, or Teams to Enterprise), users encounter a critical authentication error:

```
Invalid or expired OAuth state parameter
```

### Root Cause

Claude Desktop restarts the MCP server process when switching between accounts. The OAuth authentication flow works as follows:

1. User initiates authentication → MCP server generates a state parameter and stores it in-memory
2. User clicks auth link → redirects to Google for authentication
3. **Claude Desktop switches accounts → MCP server process restarts → in-memory state is lost**
4. Google redirects back with the authorization code and state parameter
5. MCP server tries to validate state → **fails because the state was lost during restart**

This makes it impossible to complete authentication when switching between Claude Desktop accounts.

## Solution

This PR implements **persistent file-based OAuth state storage** that survives process restarts.

### Changes

1. **New file: `auth/oauth_state_store.py`**
   - Implements `PersistentOAuthStateStore` class
   - Stores OAuth states in `~/.google_workspace_mcp/credentials/oauth_states.json`
   - Thread-safe operations using `RLock`
   - Automatic cleanup of expired states
   - Handles datetime serialization/deserialization for JSON storage

2. **Modified: `auth/oauth21_session_store.py`**
   - Integrates persistent storage into existing OAuth session management
   - Falls back to in-memory storage if persistent storage fails
   - Comprehensive logging with `[OAUTH21]` and `[PERSISTENT STORE]` prefixes

### Key Features

- ✅ **Process restart resilient**: State survives MCP server restarts
- ✅ **Thread-safe**: Uses RLock for concurrent access
- ✅ **Auto-cleanup**: Expired states are automatically removed
- ✅ **Backward compatible**: Falls back to in-memory storage if persistent storage unavailable
- ✅ **Security**: States are consumed (one-time use) to prevent replay attacks
- ✅ **Configurable expiry**: States expire after 10 minutes by default

## Testing

Tested and verified working:
1. ✅ Start authentication in Claude Desktop Pro account
2. ✅ Click auth link while MCP server is running
3. ✅ Switch to Claude Desktop Teams account (triggers MCP restart)
4. ✅ Complete Google authentication
5. ✅ Successfully returns to Claude Desktop with valid credentials

The persistent state storage successfully validated the state parameter after the restart.

## Use Case Impact

This fix is critical for Claude Desktop users who:
- Use multiple Claude account types (Pro, Teams, Enterprise)
- Switch between accounts during the same session
- Need reliable authentication across account switches

Without this fix, users must:
- Avoid switching accounts during OAuth flows
- Manually restart Claude Desktop to clear state
- Experience authentication failures frequently

## Additional Notes

- State storage location: `~/.google_workspace_mcp/credentials/oauth_states.json`
- Respects `GOOGLE_MCP_CREDENTIALS_DIR` environment variable
- Comprehensive logging for debugging OAuth flows
- No breaking changes to existing functionality