### PR TITLE
feat: Make get_presentation tool to also extract text in slides

### DIFF
--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -93,33 +93,43 @@ async def get_presentation(
 
         # Collect text from the slide whose JSON structure is very complicated
         # https://googleapis.github.io/google-api-python-client/docs/dyn/slides_v1.presentations.html#get
-        slide_texts = []
+        slide_text = ""
         try:
+            texts_from_elements = []
             for page_element in slide.get('pageElements', []):
                 shape = page_element.get('shape', None)
-                if shape and shape.get('shapeType', None) == 'TEXT_BOX':
+                if shape and shape.get('text', None):
                     text = shape.get('text', None)
                     if text:
+                        text_elements_in_shape = []
                         for text_element in text.get('textElements', []):
                             text_run = text_element.get('textRun', None)
-                            start_index = text_element.get('startIndex', 0)
                             if text_run:
                                 content = text_run.get('content', None)
                                 if content:
-                                    slide_texts.append([start_index, content])
+                                    start_index = text_element.get('startIndex', 0)
+                                    text_elements_in_shape.append((start_index, content))
 
-            # Sort and cleanup text we collected
-            slide_texts.sort(key=lambda idx_and_cont: idx_and_cont[0])
-            slide_text = "".join([i[1] for i in slide_texts])
+                        if text_elements_in_shape:
+                            # Sort text elements within a single shape
+                            text_elements_in_shape.sort(key=lambda item: item[0])
+                            full_text_from_shape = "".join([item[1] for item in text_elements_in_shape])
+                            texts_from_elements.append(full_text_from_shape)
+
+            # cleanup text we collected
+            slide_text = "\n".join(texts_from_elements)
             slide_text_rows = slide_text.split("\n")
-            slide_text_rows = [row for row in slide_text_rows if len(row.replace(" ", "")) > 0]
-            slide_text_rows = ["    > " + row for row in slide_text_rows]
-            slide_text = "\n" + "\n".join(slide_text_rows)
+            slide_text_rows = [row for row in slide_text_rows if len(row.strip()) > 0]
+            if slide_text_rows:
+                slide_text_rows = ["    > " + row for row in slide_text_rows]
+                slide_text = "\n" + "\n".join(slide_text_rows)
+            else:
+                slide_text = ""
         except Exception as e:
             logger.warning(f"Failed to extract text from the slide {slide_id}: {e}")
             slide_text = f"<failed to extract text: {type(e)}, {e}>"
 
-        slides_info.append(f"  Slide {i}: ID {slide_id}, {len(page_elements)} element(s), text: {slide_text if len(slide_text) > 0 else 'empty'}")
+        slides_info.append(f"  Slide {i}: ID {slide_id}, {len(page_elements)} element(s), text: {slide_text if slide_text else 'empty'}")
 
     confirmation_message = f"""Presentation Details for {user_google_email}:
 - Title: {title}


### PR DESCRIPTION
Thank you for this MCP server!

Besides other things I wanted to use it recently to get a presentation so AI agent can summarize the presentation, but found out it is returning just metadata (e.g. document name or number of slides), not the text that is there in the slides.

Turns out Google Slides API response when getting a presentation is very complex, so I came up with attached code that tries to extract basic unformatted text in right order.

Some useful docs were:
* https://developers.google.com/workspace/slides/api/concepts/text
* https://googleapis.github.io/google-api-python-client/docs/dyn/slides_v1.presentations.html#get