### PR TITLE
Add pagination for search_gmail_messages tool

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -358,7 +358,7 @@ async def search_gmail_messages(
     # Add page token if provided
     if page_token:
         request_params["pageToken"] = page_token
-        logger.info(f"[search_gmail_messages] Using page_token for pagination")
+        logger.info("[search_gmail_messages] Using page_token for pagination")
 
     response = await asyncio.to_thread(
         service.users()
@@ -384,7 +384,7 @@ async def search_gmail_messages(
 
     logger.info(f"[search_gmail_messages] Found {len(messages)} messages")
     if next_page_token:
-        logger.info(f"[search_gmail_messages] More results available (next_page_token present)")
+        logger.info("[search_gmail_messages] More results available (next_page_token present)")
     return formatted_output
 
 


### PR DESCRIPTION
Hi @taylorwilsdon - thanks for an awesome project. In setting it up for my Gmail, this is one of the enhancements I made. It allows pagination for the `search_gmail_messages` tool by passing a `nextPageToken` embedded in the response. In this manner, I can get large amounts of messages incrementally without increasing the page size.

It works on my end. However I haven't done extensive testing or written tests, and I wrote the code with AI. If you think this PR is useful to the project, I'm happy to do any of those things. But I wanted to get your thoughts first. Thanks!