### PR TITLE
fix: oauth 2.1 broken

### DIFF
--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -57,11 +57,17 @@ def _get_auth_context(
     Returns:
         Tuple of (authenticated_user, auth_method, mcp_session_id)
     """
+    ctx = None
+    authenticated_user: Optional[str] = None
+    auth_method: Optional[str] = None
+    mcp_session_id: Optional[str] = None
+
     try:
         ctx = get_context()
-        if not ctx:
-            return None, None, None
+    except Exception as e:
+        logger.debug(f"[{tool_name}] Could not get FastMCP context: {e}")
 
+    if ctx:
         authenticated_user = ctx.get_state("authenticated_user_email")
         auth_method = ctx.get_state("authenticated_via")
         mcp_session_id = ctx.session_id if hasattr(ctx, "session_id") else None
@@ -69,14 +75,32 @@ def _get_auth_context(
         if mcp_session_id:
             set_fastmcp_session_id(mcp_session_id)
 
-        logger.debug(
-            f"[{tool_name}] Auth from middleware: {authenticated_user} via {auth_method}"
-        )
-        return authenticated_user, auth_method, mcp_session_id
+    # Fallback: derive the authenticated user directly from the validated access token.
+    # FastMCP's GoogleProvider (OAuth proxy) may issue FastMCP JWTs to clients and
+    # only expose the upstream Google identity via `get_access_token().claims`.
+    if not authenticated_user:
+        try:
+            access_token = get_access_token()
+            token_email = None
+            if access_token and getattr(access_token, "claims", None):
+                token_email = access_token.claims.get("email")
 
-    except Exception as e:
-        logger.debug(f"[{tool_name}] Could not get FastMCP context: {e}")
-        return None, None, None
+            if token_email:
+                authenticated_user = token_email
+                auth_method = auth_method or "fastmcp_access_token"
+
+                if ctx and hasattr(ctx, "set_state"):
+                    ctx.set_state("authenticated_user_email", authenticated_user)
+                    ctx.set_state("authenticated_via", auth_method)
+        except Exception as e:
+            logger.debug(
+                f"[{tool_name}] Could not derive authenticated user from access token: {e}"
+            )
+
+    logger.debug(
+        f"[{tool_name}] Auth context: {authenticated_user or 'none'} via {auth_method or 'none'}"
+    )
+    return authenticated_user, auth_method, mcp_session_id
 
 
 def _detect_oauth_version(
@@ -97,6 +121,19 @@ def _detect_oauth_version(
             f"[{tool_name}] OAuth 2.1 mode: Using OAuth 2.1 for authenticated user '{authenticated_user}'"
         )
         return True
+
+    # If FastMCP protocol-level auth is enabled, a validated access token should
+    # be available even if middleware state wasn't populated.
+    try:
+        if get_access_token() is not None:
+            logger.info(
+                f"[{tool_name}] OAuth 2.1 mode: Using OAuth 2.1 based on validated access token"
+            )
+            return True
+    except Exception as e:
+        logger.debug(
+            f"[{tool_name}] Could not inspect access token for OAuth mode: {e}"
+        )
 
     # Only use version detection for unauthenticated requests
     config = get_oauth_config()
@@ -308,8 +345,17 @@ def _extract_oauth21_user_email(
         Exception: If no authenticated user found in OAuth 2.1 mode
     """
     if not authenticated_user:
+        try:
+            access_token = get_access_token()
+            if access_token and getattr(access_token, "claims", None):
+                token_email = access_token.claims.get("email")
+                if token_email:
+                    return token_email
+        except Exception:
+            pass
+
         raise Exception(
-            f"OAuth 2.1 mode requires an authenticated user for {func_name}, but none was found."
+            f"OAuth 2.1 mode requires an authenticated user email for {func_name}, but none was found in context or token claims."
         )
     return authenticated_user
 
@@ -709,9 +755,8 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
                 resolved_scopes = _resolve_scopes(scopes)
 
                 try:
-                    # Detect OAuth version (simplified for multiple services)
-                    use_oauth21 = (
-                        is_oauth21_enabled() and authenticated_user is not None
+                    use_oauth21 = _detect_oauth_version(
+                        authenticated_user, mcp_session_id, tool_name
                     )
 
                     # In OAuth 2.0 mode, we may need to override user_google_email


### PR DESCRIPTION
Integration with Librechat's OAUTH 2.1  does not work anymore after the recent fastmcp upgrades

Here is the analysis and the fix done  by codex:
The patch seems quite convoluted but it has the merit to solve the broken, it was no more possible to use oauth with the MCP server without it

Issue:

The regression happens after the fastmcp upgrade (it’s unpinned: pyproject.toml (line 14), and now resolves to fastmcp 2.14.0 / mcp 1.24.0: uv.lock (line 415), uv.lock (line 817)). With the newer MCP SDK, the built-in /token handler is stricter about how token requests are encoded / where client_id is provided, so LibreChat’s token_exchange_method: default_post flow reaches the Google callback but then fails on POST /token (401), which leaves subsequent POST /mcp calls as 401 invalid_token.

Fix:

Added a compatibility auth provider that only swaps the /token route to accept both JSON and x-www-form-urlencoded token requests, and to backfill client_id/client_secret from Authorization: Basic … when missing, while still enforcing client validation, redirect_uri matching, and PKCE (auth/compat_google_provider.py (line 47), auth/compat_google_provider.py (line 100), auth/compat_google_provider.py (line 239), auth/compat_google_provider.py (line 352)).
Wired this provider in standard OAuth 2.1 mode (core/server.py (line 131)) so external-provider mode is unchanged.
Hardened the service decorators to derive the authenticated email from the validated access-token claims (and to treat “validated access token present” as OAuth 2.1) instead of relying on middleware state that isn’t consistently populated on newer FastMCP (auth/service_decorator.py (line 78), auth/service_decorator.py (line 106), auth/service_decorator.py (line 329)).