### PR TITLE
fix: color typing

### DIFF
--- a/gdocs/docs_helpers.py
+++ b/gdocs/docs_helpers.py
@@ -6,12 +6,18 @@ to simplify the implementation of document editing tools.
 """
 
 import logging
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
+ColorComponent = Union[int, float]
+RgbColor = Tuple[ColorComponent, ColorComponent, ColorComponent]
+ColorInput = Union[str, RgbColor]
 
-def _normalize_color(color: Any, param_name: str) -> Optional[Dict[str, float]]:
+
+def _normalize_color(
+    color: Optional[ColorInput], param_name: str
+) -> Optional[Dict[str, float]]:
     """
     Normalize a user-supplied color into Docs API rgbColor format.
 
@@ -65,8 +71,8 @@ def build_text_style(
     underline: bool = None,
     font_size: int = None,
     font_family: str = None,
-    text_color: Any = None,
-    background_color: Any = None,
+    text_color: Optional[ColorInput] = None,
+    background_color: Optional[ColorInput] = None,
 ) -> tuple[Dict[str, Any], list[str]]:
     """
     Build text style object for Google Docs API requests.
@@ -181,8 +187,8 @@ def create_format_text_request(
     underline: bool = None,
     font_size: int = None,
     font_family: str = None,
-    text_color: Any = None,
-    background_color: Any = None,
+    text_color: Optional[ColorInput] = None,
+    background_color: Optional[ColorInput] = None,
 ) -> Optional[Dict[str, Any]]:
     """
     Create an updateTextStyle request for Google Docs API.

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -7,7 +7,7 @@ This module provides MCP tools for interacting with Google Docs API and managing
 import logging
 import asyncio
 import io
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
 
@@ -19,6 +19,7 @@ from core.comments import create_comment_tools
 
 # Import helper functions for document operations
 from gdocs.docs_helpers import (
+    ColorInput,
     create_insert_text_request,
     create_delete_range_request,
     create_format_text_request,
@@ -365,8 +366,8 @@ async def modify_doc_text(
     underline: bool = None,
     font_size: int = None,
     font_family: str = None,
-    text_color: Any = None,
-    background_color: Any = None,
+    text_color: Optional[ColorInput] = None,
+    background_color: Optional[ColorInput] = None,
 ) -> str:
     """
     Modifies text in a Google Doc - can insert/replace text and/or apply formatting in a single operation.


### PR DESCRIPTION
Fixes https://github.com/taylorwilsdon/google_workspace_mcp/issues/307 by avoiding the Any Type in the tool spec