### PR TITLE
fix: simplify color in modify_color

### DIFF
--- a/gdocs/docs_helpers.py
+++ b/gdocs/docs_helpers.py
@@ -6,63 +6,36 @@ to simplify the implementation of document editing tools.
 """
 
 import logging
-from typing import Dict, Any, Optional, Tuple, Union
+from typing import Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
 
-ColorComponent = Union[int, float]
-RgbColor = Tuple[ColorComponent, ColorComponent, ColorComponent]
-ColorInput = Union[str, RgbColor]
-
 
 def _normalize_color(
-    color: Optional[ColorInput], param_name: str
+    color: Optional[str], param_name: str
 ) -> Optional[Dict[str, float]]:
     """
     Normalize a user-supplied color into Docs API rgbColor format.
 
-    Supports:
-    - Hex strings: "#RRGGBB" or "RRGGBB"
-    - Tuple/list of 3 ints (0-255) or floats (0-1)
+    Supports only hex strings in the form "#RRGGBB".
     """
     if color is None:
         return None
 
-    def _to_component(value: Any) -> float:
-        if isinstance(value, bool):
-            raise ValueError(f"{param_name} components cannot be boolean values")
-        if isinstance(value, int):
-            if value < 0 or value > 255:
-                raise ValueError(
-                    f"{param_name} components must be 0-255 when using integers"
-                )
-            return value / 255
-        if isinstance(value, float):
-            if value < 0 or value > 1:
-                raise ValueError(
-                    f"{param_name} components must be between 0 and 1 when using floats"
-                )
-            return value
-        raise ValueError(f"{param_name} components must be int (0-255) or float (0-1)")
+    if not isinstance(color, str):
+        raise ValueError(f"{param_name} must be a hex string like '#RRGGBB'")
 
-    if isinstance(color, str):
-        hex_color = color.lstrip("#")
-        if len(hex_color) != 6 or any(
-            c not in "0123456789abcdefABCDEF" for c in hex_color
-        ):
-            raise ValueError(f"{param_name} must be a hex string like '#RRGGBB'")
-        r = int(hex_color[0:2], 16) / 255
-        g = int(hex_color[2:4], 16) / 255
-        b = int(hex_color[4:6], 16) / 255
-        return {"red": r, "green": g, "blue": b}
+    if len(color) != 7 or not color.startswith("#"):
+        raise ValueError(f"{param_name} must be a hex string like '#RRGGBB'")
 
-    if isinstance(color, (list, tuple)) and len(color) == 3:
-        r = _to_component(color[0])
-        g = _to_component(color[1])
-        b = _to_component(color[2])
-        return {"red": r, "green": g, "blue": b}
+    hex_color = color[1:]
+    if any(c not in "0123456789abcdefABCDEF" for c in hex_color):
+        raise ValueError(f"{param_name} must be a hex string like '#RRGGBB'")
 
-    raise ValueError(f"{param_name} must be a hex string or RGB tuple/list")
+    r = int(hex_color[0:2], 16) / 255
+    g = int(hex_color[2:4], 16) / 255
+    b = int(hex_color[4:6], 16) / 255
+    return {"red": r, "green": g, "blue": b}
 
 
 def build_text_style(
@@ -71,8 +44,8 @@ def build_text_style(
     underline: bool = None,
     font_size: int = None,
     font_family: str = None,
-    text_color: Optional[ColorInput] = None,
-    background_color: Optional[ColorInput] = None,
+    text_color: str = None,
+    background_color: str = None,
 ) -> tuple[Dict[str, Any], list[str]]:
     """
     Build text style object for Google Docs API requests.
@@ -83,8 +56,8 @@ def build_text_style(
         underline: Whether text should be underlined
         font_size: Font size in points
         font_family: Font family name
-        text_color: Text color as hex string or RGB tuple/list
-        background_color: Background (highlight) color as hex string or RGB tuple/list
+        text_color: Text color as hex string "#RRGGBB"
+        background_color: Background (highlight) color as hex string "#RRGGBB"
 
     Returns:
         Tuple of (text_style_dict, list_of_field_names)
@@ -187,8 +160,8 @@ def create_format_text_request(
     underline: bool = None,
     font_size: int = None,
     font_family: str = None,
-    text_color: Optional[ColorInput] = None,
-    background_color: Optional[ColorInput] = None,
+    text_color: str = None,
+    background_color: str = None,
 ) -> Optional[Dict[str, Any]]:
     """
     Create an updateTextStyle request for Google Docs API.
@@ -201,8 +174,8 @@ def create_format_text_request(
         underline: Whether text should be underlined
         font_size: Font size in points
         font_family: Font family name
-        text_color: Text color as hex string or RGB tuple/list
-        background_color: Background (highlight) color as hex string or RGB tuple/list
+        text_color: Text color as hex string "#RRGGBB"
+        background_color: Background (highlight) color as hex string "#RRGGBB"
 
     Returns:
         Dictionary representing the updateTextStyle request, or None if no styles provided
@@ -333,7 +306,7 @@ def create_bullet_list_request(
     }
 
 
-def validate_operation(operation: Dict[str, Any]) -> Tuple[bool, str]:
+def validate_operation(operation: Dict[str, Any]) -> tuple[bool, str]:
     """
     Validate a batch operation dictionary.
 

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -7,7 +7,7 @@ This module provides MCP tools for interacting with Google Docs API and managing
 import logging
 import asyncio
 import io
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 
 from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
 
@@ -19,7 +19,6 @@ from core.comments import create_comment_tools
 
 # Import helper functions for document operations
 from gdocs.docs_helpers import (
-    ColorInput,
     create_insert_text_request,
     create_delete_range_request,
     create_format_text_request,
@@ -366,8 +365,8 @@ async def modify_doc_text(
     underline: bool = None,
     font_size: int = None,
     font_family: str = None,
-    text_color: Optional[ColorInput] = None,
-    background_color: Optional[ColorInput] = None,
+    text_color: str = None,
+    background_color: str = None,
 ) -> str:
     """
     Modifies text in a Google Doc - can insert/replace text and/or apply formatting in a single operation.
@@ -383,8 +382,8 @@ async def modify_doc_text(
         underline: Whether to underline text (True/False/None to leave unchanged)
         font_size: Font size in points
         font_family: Font family name (e.g., "Arial", "Times New Roman")
-        text_color: Foreground text color (#RRGGBB or RGB tuple/list)
-        background_color: Background/highlight color (#RRGGBB or RGB tuple/list)
+        text_color: Foreground text color (#RRGGBB)
+        background_color: Background/highlight color (#RRGGBB)
 
     Returns:
         str: Confirmation message with operation details

--- a/gdocs/managers/validation_manager.py
+++ b/gdocs/managers/validation_manager.py
@@ -155,8 +155,8 @@ class ValidationManager:
         underline: Optional[bool] = None,
         font_size: Optional[int] = None,
         font_family: Optional[str] = None,
-        text_color: Optional[Any] = None,
-        background_color: Optional[Any] = None,
+        text_color: Optional[str] = None,
+        background_color: Optional[str] = None,
     ) -> Tuple[bool, str]:
         """
         Validate text formatting parameters.
@@ -167,8 +167,8 @@ class ValidationManager:
             underline: Underline setting
             font_size: Font size in points
             font_family: Font family name
-            text_color: Text color in hex or RGB tuple/list
-            background_color: Background color in hex or RGB tuple/list
+            text_color: Text color in "#RRGGBB" format
+            background_color: Background color in "#RRGGBB" format
 
         Returns:
             Tuple of (is_valid, error_message)
@@ -240,57 +240,24 @@ class ValidationManager:
 
         return True, ""
 
-    def validate_color_param(self, color: Any, param_name: str) -> Tuple[bool, str]:
-        """
-        Validate color parameters (hex string or RGB tuple/list).
-        """
+    def validate_color_param(
+        self, color: Optional[str], param_name: str
+    ) -> Tuple[bool, str]:
+        """Validate color parameters (hex string "#RRGGBB")."""
         if color is None:
             return True, ""
 
-        if isinstance(color, str):
-            hex_color = color.lstrip("#")
-            if len(hex_color) != 6 or any(
-                c not in "0123456789abcdefABCDEF" for c in hex_color
-            ):
-                return (
-                    False,
-                    f"{param_name} must be a hex string like '#RRGGBB' or 'RRGGBB'",
-                )
-            return True, ""
+        if not isinstance(color, str):
+            return False, f"{param_name} must be a hex string like '#RRGGBB'"
 
-        if isinstance(color, (list, tuple)):
-            if len(color) != 3:
-                return False, f"{param_name} tuple/list must have exactly 3 components"
+        if len(color) != 7 or not color.startswith("#"):
+            return False, f"{param_name} must be a hex string like '#RRGGBB'"
 
-            for i, component in enumerate(color):
-                comp_name = f"{param_name}[{i}]"
-                if isinstance(component, bool):
-                    return False, f"{comp_name} cannot be a boolean"
+        hex_color = color[1:]
+        if any(c not in "0123456789abcdefABCDEF" for c in hex_color):
+            return False, f"{param_name} must be a hex string like '#RRGGBB'"
 
-                if isinstance(component, int):
-                    if component < 0 or component > 255:
-                        return (
-                            False,
-                            f"{comp_name} integer values must be between 0 and 255",
-                        )
-                elif isinstance(component, float):
-                    if component < 0 or component > 1:
-                        return (
-                            False,
-                            f"{comp_name} float values must be between 0 and 1",
-                        )
-                else:
-                    return (
-                        False,
-                        f"{comp_name} must be an int (0-255) or float (0-1), got {type(component).__name__}",
-                    )
-
-            return True, ""
-
-        return (
-            False,
-            f"{param_name} must be a hex string or RGB tuple/list like [255, 0, 0] or [1, 0, 0]",
-        )
+        return True, ""
 
     def validate_index(self, index: int, context: str = "Index") -> Tuple[bool, str]:
         """


### PR DESCRIPTION
fixes: https://github.com/taylorwilsdon/google_workspace_mcp/issues/315

Simplify drastically the colors options, only the #RRGGBB format is accepted and the tool prototype does not rely on fancy pydantic stuff, in line with other parameters such as "font_family".
