### PR TITLE
feat: Add MCP tool annotations (47 tools)

### DIFF
--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -18,6 +18,8 @@ from googleapiclient.discovery import build
 from auth.service_decorator import require_google_service
 from core.utils import handle_http_errors
 
+from mcp.types import ToolAnnotations
+
 from core.server import server
 
 
@@ -301,7 +303,12 @@ def _correct_time_format_for_api(
     return time_str
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="List Calendars",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("list_calendars", is_read_only=True, service_type="calendar")
 @require_google_service("calendar", "calendar_read")
 async def list_calendars(service, user_google_email: str) -> str:

--- a/gchat/chat_tools.py
+++ b/gchat/chat_tools.py
@@ -12,6 +12,8 @@ from googleapiclient.errors import HttpError
 
 # Auth & server utilities
 from auth.service_decorator import require_google_service
+from mcp.types import ToolAnnotations
+
 from core.server import server
 from core.utils import handle_http_errors
 

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -375,7 +375,7 @@ async def create_doc(
 @server.tool(
     annotations=ToolAnnotations(
         title="Modify Doc Text",
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @handle_http_errors("modify_doc_text", service_type="docs")
@@ -589,7 +589,7 @@ async def modify_doc_text(
 @server.tool(
     annotations=ToolAnnotations(
         title="Find and Replace in Doc",
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @handle_http_errors("find_and_replace_doc", service_type="docs")
@@ -641,7 +641,7 @@ async def find_and_replace_doc(
 @server.tool(
     annotations=ToolAnnotations(
         title="Insert Doc Elements",
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @handle_http_errors("insert_doc_elements", service_type="docs")
@@ -728,7 +728,7 @@ async def insert_doc_elements(
 @server.tool(
     annotations=ToolAnnotations(
         title="Insert Doc Image",
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @handle_http_errors("insert_doc_image", service_type="docs")
@@ -825,7 +825,7 @@ async def insert_doc_image(
 @server.tool(
     annotations=ToolAnnotations(
         title="Update Doc Headers/Footers",
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @handle_http_errors("update_doc_headers_footers", service_type="docs")
@@ -887,7 +887,7 @@ async def update_doc_headers_footers(
 @server.tool(
     annotations=ToolAnnotations(
         title="Batch Update Doc",
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @handle_http_errors("batch_update_doc", service_type="docs")

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -11,6 +11,8 @@ from typing import List, Dict, Any
 
 from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
 
+from mcp.types import ToolAnnotations
+
 # Auth & server utilities
 from auth.service_decorator import require_google_service, require_multiple_services
 from core.utils import extract_office_xml_text, handle_http_errors
@@ -49,7 +51,12 @@ import json
 logger = logging.getLogger(__name__)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Search Docs",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("search_docs", is_read_only=True, service_type="docs")
 @require_google_service("drive", "drive_read")
 async def search_docs(
@@ -91,7 +98,12 @@ async def search_docs(
     return "\n".join(output)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Get Doc Content",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("get_doc_content", is_read_only=True, service_type="docs")
 @require_multiple_services(
     [
@@ -276,7 +288,12 @@ async def get_doc_content(
     return header + body_text
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="List Docs in Folder",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("list_docs_in_folder", is_read_only=True, service_type="docs")
 @require_google_service("drive", "drive_read")
 async def list_docs_in_folder(
@@ -314,7 +331,12 @@ async def list_docs_in_folder(
     return "\n".join(out)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Create Doc",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("create_doc", service_type="docs")
 @require_google_service("docs", "docs_write")
 async def create_doc(
@@ -350,7 +372,12 @@ async def create_doc(
     return msg
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Modify Doc Text",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("modify_doc_text", service_type="docs")
 @require_google_service("docs", "docs_write")
 async def modify_doc_text(
@@ -559,7 +586,12 @@ async def modify_doc_text(
     return f"{operation_summary} in document {document_id}.{text_info} Link: {link}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Find and Replace in Doc",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("find_and_replace_doc", service_type="docs")
 @require_google_service("docs", "docs_write")
 async def find_and_replace_doc(
@@ -606,7 +638,12 @@ async def find_and_replace_doc(
     return f"Replaced {replacements} occurrence(s) of '{find_text}' with '{replace_text}' in document {document_id}. Link: {link}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Insert Doc Elements",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("insert_doc_elements", service_type="docs")
 @require_google_service("docs", "docs_write")
 async def insert_doc_elements(
@@ -688,7 +725,12 @@ async def insert_doc_elements(
     return f"Inserted {description} at index {index} in document {document_id}. Link: {link}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Insert Doc Image",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("insert_doc_image", service_type="docs")
 @require_multiple_services(
     [
@@ -780,7 +822,12 @@ async def insert_doc_image(
     return f"Inserted {source_description}{size_info} at index {index} in document {document_id}. Link: {link}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Update Doc Headers/Footers",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("update_doc_headers_footers", service_type="docs")
 @require_google_service("docs", "docs_write")
 async def update_doc_headers_footers(
@@ -837,7 +884,12 @@ async def update_doc_headers_footers(
         return f"Error: {message}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Batch Update Doc",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("batch_update_doc", service_type="docs")
 @require_google_service("docs", "docs_write")
 async def batch_update_doc(
@@ -894,7 +946,12 @@ async def batch_update_doc(
         return f"Error: {message}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Inspect Doc Structure",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("inspect_doc_structure", is_read_only=True, service_type="docs")
 @require_google_service("docs", "docs_read")
 async def inspect_doc_structure(
@@ -1022,7 +1079,12 @@ async def inspect_doc_structure(
     return f"Document structure analysis for {document_id}:\n\n{json.dumps(result, indent=2)}\n\nLink: {link}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Create Table with Data",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("create_table_with_data", service_type="docs")
 @require_google_service("docs", "docs_write")
 async def create_table_with_data(
@@ -1120,7 +1182,12 @@ async def create_table_with_data(
         return f"ERROR: {message}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Debug Table Structure",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("debug_table_structure", is_read_only=True, service_type="docs")
 @require_google_service("docs", "docs_read")
 async def debug_table_structure(
@@ -1207,7 +1274,12 @@ async def debug_table_structure(
     return f"Table structure debug for table {table_index}:\n\n{json.dumps(debug_info, indent=2)}\n\nLink: {link}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Export Doc to PDF",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("export_doc_to_pdf", service_type="drive")
 @require_google_service("drive", "drive_file")
 async def export_doc_to_pdf(

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -334,7 +334,7 @@ async def list_docs_in_folder(
 @server.tool(
     annotations=ToolAnnotations(
         title="Create Doc",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("create_doc", service_type="docs")
@@ -375,7 +375,7 @@ async def create_doc(
 @server.tool(
     annotations=ToolAnnotations(
         title="Modify Doc Text",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("modify_doc_text", service_type="docs")
@@ -589,7 +589,7 @@ async def modify_doc_text(
 @server.tool(
     annotations=ToolAnnotations(
         title="Find and Replace in Doc",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("find_and_replace_doc", service_type="docs")
@@ -641,7 +641,7 @@ async def find_and_replace_doc(
 @server.tool(
     annotations=ToolAnnotations(
         title="Insert Doc Elements",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("insert_doc_elements", service_type="docs")
@@ -728,7 +728,7 @@ async def insert_doc_elements(
 @server.tool(
     annotations=ToolAnnotations(
         title="Insert Doc Image",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("insert_doc_image", service_type="docs")
@@ -825,7 +825,7 @@ async def insert_doc_image(
 @server.tool(
     annotations=ToolAnnotations(
         title="Update Doc Headers/Footers",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("update_doc_headers_footers", service_type="docs")
@@ -887,7 +887,7 @@ async def update_doc_headers_footers(
 @server.tool(
     annotations=ToolAnnotations(
         title="Batch Update Doc",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("batch_update_doc", service_type="docs")
@@ -1082,7 +1082,7 @@ async def inspect_doc_structure(
 @server.tool(
     annotations=ToolAnnotations(
         title="Create Table with Data",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("create_table_with_data", service_type="docs")
@@ -1277,7 +1277,7 @@ async def debug_table_structure(
 @server.tool(
     annotations=ToolAnnotations(
         title="Export Doc to PDF",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("export_doc_to_pdf", service_type="drive")

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
 
+from mcp.types import ToolAnnotations
+
 from auth.service_decorator import require_google_service
 from auth.oauth_config import is_stateless_mode
 from core.attachment_storage import get_attachment_storage, get_attachment_url
@@ -44,7 +46,12 @@ DOWNLOAD_CHUNK_SIZE_BYTES = 256 * 1024  # 256 KB
 UPLOAD_CHUNK_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB (Google recommended minimum)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Search Drive Files",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("search_drive_files", is_read_only=True, service_type="drive")
 @require_google_service("drive", "drive_read")
 async def search_drive_files(
@@ -118,7 +125,12 @@ async def search_drive_files(
     return text_output
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Get Drive File Content",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("get_drive_file_content", is_read_only=True, service_type="drive")
 @require_google_service("drive", "drive_read")
 async def get_drive_file_content(
@@ -209,7 +221,12 @@ async def get_drive_file_content(
     return header + body_text
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Get Drive File Download URL",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors(
     "get_drive_file_download_url", is_read_only=True, service_type="drive"
 )
@@ -385,7 +402,12 @@ async def get_drive_file_download_url(
         )
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="List Drive Items",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("list_drive_items", is_read_only=True, service_type="drive")
 @require_google_service("drive", "drive_read")
 async def list_drive_items(
@@ -445,7 +467,12 @@ async def list_drive_items(
     return text_output
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Create Drive File",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("create_drive_file", service_type="drive")
 @require_google_service("drive", "drive_file")
 async def create_drive_file(
@@ -680,7 +707,12 @@ async def create_drive_file(
     return confirmation_message
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Get Drive File Permissions",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors(
     "get_drive_file_permissions", is_read_only=True, service_type="drive"
 )
@@ -789,7 +821,12 @@ async def get_drive_file_permissions(
         return f"Error getting file permissions: {e}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Check Drive File Public Access",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors(
     "check_drive_file_public_access", is_read_only=True, service_type="drive"
 )
@@ -886,7 +923,12 @@ async def check_drive_file_public_access(
     return "\n".join(output_parts)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Update Drive File",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("update_drive_file", is_read_only=False, service_type="drive")
 @require_google_service("drive", "drive_file")
 async def update_drive_file(
@@ -1063,7 +1105,12 @@ async def update_drive_file(
     return "\n".join(output_parts)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Get Drive Shareable Link",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("get_drive_shareable_link", is_read_only=True, service_type="drive")
 @require_google_service("drive", "drive_read")
 async def get_drive_shareable_link(
@@ -1123,7 +1170,12 @@ async def get_drive_shareable_link(
     return "\n".join(output_parts)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Share Drive File",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("share_drive_file", is_read_only=False, service_type="drive")
 @require_google_service("drive", "drive_file")
 async def share_drive_file(
@@ -1219,7 +1271,12 @@ async def share_drive_file(
     return "\n".join(output_parts)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Batch Share Drive File",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("batch_share_drive_file", is_read_only=False, service_type="drive")
 @require_google_service("drive", "drive_file")
 async def batch_share_drive_file(
@@ -1362,7 +1419,12 @@ async def batch_share_drive_file(
     return "\n".join(output_parts)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Update Drive Permission",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("update_drive_permission", is_read_only=False, service_type="drive")
 @require_google_service("drive", "drive_file")
 async def update_drive_permission(
@@ -1443,7 +1505,12 @@ async def update_drive_permission(
     return "\n".join(output_parts)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Remove Drive Permission",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("remove_drive_permission", is_read_only=False, service_type="drive")
 @require_google_service("drive", "drive_file")
 async def remove_drive_permission(
@@ -1487,7 +1554,12 @@ async def remove_drive_permission(
     return "\n".join(output_parts)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Transfer Drive Ownership",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors(
     "transfer_drive_ownership", is_read_only=False, service_type="drive"
 )

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -470,7 +470,7 @@ async def list_drive_items(
 @server.tool(
     annotations=ToolAnnotations(
         title="Create Drive File",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("create_drive_file", service_type="drive")
@@ -926,7 +926,7 @@ async def check_drive_file_public_access(
 @server.tool(
     annotations=ToolAnnotations(
         title="Update Drive File",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("update_drive_file", is_read_only=False, service_type="drive")
@@ -1173,7 +1173,7 @@ async def get_drive_shareable_link(
 @server.tool(
     annotations=ToolAnnotations(
         title="Share Drive File",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("share_drive_file", is_read_only=False, service_type="drive")
@@ -1274,7 +1274,7 @@ async def share_drive_file(
 @server.tool(
     annotations=ToolAnnotations(
         title="Batch Share Drive File",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("batch_share_drive_file", is_read_only=False, service_type="drive")
@@ -1422,7 +1422,7 @@ async def batch_share_drive_file(
 @server.tool(
     annotations=ToolAnnotations(
         title="Update Drive Permission",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("update_drive_permission", is_read_only=False, service_type="drive")
@@ -1557,7 +1557,7 @@ async def remove_drive_permission(
 @server.tool(
     annotations=ToolAnnotations(
         title="Transfer Drive Ownership",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors(

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -926,7 +926,7 @@ async def check_drive_file_public_access(
 @server.tool(
     annotations=ToolAnnotations(
         title="Update Drive File",
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @handle_http_errors("update_drive_file", is_read_only=False, service_type="drive")
@@ -1422,7 +1422,7 @@ async def batch_share_drive_file(
 @server.tool(
     annotations=ToolAnnotations(
         title="Update Drive Permission",
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @handle_http_errors("update_drive_permission", is_read_only=False, service_type="drive")
@@ -1557,7 +1557,7 @@ async def remove_drive_permission(
 @server.tool(
     annotations=ToolAnnotations(
         title="Transfer Drive Ownership",
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @handle_http_errors(

--- a/gforms/forms_tools.py
+++ b/gforms/forms_tools.py
@@ -10,6 +10,8 @@ from typing import Optional, Dict, Any
 
 
 from auth.service_decorator import require_google_service
+from mcp.types import ToolAnnotations
+
 from core.server import server
 from core.utils import handle_http_errors
 

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -1680,7 +1680,7 @@ async def delete_gmail_filter(
 @server.tool(
     annotations=ToolAnnotations(
         title="Modify Gmail Message Labels",
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @handle_http_errors("modify_gmail_message_labels", service_type="gmail")
@@ -1741,7 +1741,7 @@ async def modify_gmail_message_labels(
 @server.tool(
     annotations=ToolAnnotations(
         title="Batch Modify Gmail Labels",
-        destructiveHint=False,
+        destructiveHint=True,
     ),
 )
 @handle_http_errors("batch_modify_gmail_message_labels", service_type="gmail")

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -16,6 +16,8 @@ from email.mime.text import MIMEText
 from fastapi import Body
 from pydantic import Field
 
+from mcp.types import ToolAnnotations
+
 from auth.service_decorator import require_google_service
 from core.utils import handle_http_errors
 from core.server import server
@@ -381,7 +383,12 @@ def _format_gmail_results_plain(
     return "\n".join(lines)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Search Gmail Messages",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("search_gmail_messages", is_read_only=True, service_type="gmail")
 @require_google_service("gmail", "gmail_read")
 async def search_gmail_messages(
@@ -445,7 +452,12 @@ async def search_gmail_messages(
     return formatted_output
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Get Gmail Message Content",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors(
     "get_gmail_message_content", is_read_only=True, service_type="gmail"
 )
@@ -544,7 +556,12 @@ async def get_gmail_message_content(
     return "\n".join(content_lines)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Get Gmail Messages Batch",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors(
     "get_gmail_messages_content_batch", is_read_only=True, service_type="gmail"
 )
@@ -741,7 +758,12 @@ async def get_gmail_messages_content_batch(
     return final_output
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Get Gmail Attachment",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors(
     "get_gmail_attachment_content", is_read_only=True, service_type="gmail"
 )
@@ -888,7 +910,12 @@ async def get_gmail_attachment_content(
         return "\n".join(result_lines)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Send Gmail Message",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("send_gmail_message", service_type="gmail")
 @require_google_service("gmail", GMAIL_SEND_SCOPE)
 async def send_gmail_message(
@@ -994,7 +1021,12 @@ async def send_gmail_message(
     return f"Email sent! Message ID: {message_id}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Draft Gmail Message",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("draft_gmail_message", service_type="gmail")
 @require_google_service("gmail", GMAIL_COMPOSE_SCOPE)
 async def draft_gmail_message(
@@ -1189,7 +1221,12 @@ def _format_thread_content(thread_data: dict, thread_id: str) -> str:
     return "\n".join(content_lines)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Get Gmail Thread Content",
+        readOnlyHint=True,
+    ),
+)
 @require_google_service("gmail", "gmail_read")
 @handle_http_errors("get_gmail_thread_content", is_read_only=True, service_type="gmail")
 async def get_gmail_thread_content(
@@ -1217,7 +1254,12 @@ async def get_gmail_thread_content(
     return _format_thread_content(thread_response, thread_id)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Get Gmail Threads Batch",
+        readOnlyHint=True,
+    ),
+)
 @require_google_service("gmail", "gmail_read")
 @handle_http_errors(
     "get_gmail_threads_content_batch", is_read_only=True, service_type="gmail"
@@ -1326,7 +1368,12 @@ async def get_gmail_threads_content_batch(
     return header + "\n\n" + "\n---\n\n".join(output_threads)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="List Gmail Labels",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("list_gmail_labels", is_read_only=True, service_type="gmail")
 @require_google_service("gmail", "gmail_read")
 async def list_gmail_labels(service, user_google_email: str) -> str:
@@ -1374,7 +1421,12 @@ async def list_gmail_labels(service, user_google_email: str) -> str:
     return "\n".join(lines)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Manage Gmail Label",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("manage_gmail_label", service_type="gmail")
 @require_google_service("gmail", GMAIL_LABELS_SCOPE)
 async def manage_gmail_label(
@@ -1453,7 +1505,12 @@ async def manage_gmail_label(
         return f"Label '{label_name}' (ID: {label_id}) deleted successfully!"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="List Gmail Filters",
+        readOnlyHint=True,
+    ),
+)
 @handle_http_errors("list_gmail_filters", is_read_only=True, service_type="gmail")
 @require_google_service("gmail", "gmail_settings_basic")
 async def list_gmail_filters(service, user_google_email: str) -> str:
@@ -1531,7 +1588,12 @@ async def list_gmail_filters(service, user_google_email: str) -> str:
     return "\n".join(lines).rstrip()
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Create Gmail Filter",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("create_gmail_filter", service_type="gmail")
 @require_google_service("gmail", "gmail_settings_basic")
 async def create_gmail_filter(
@@ -1571,7 +1633,12 @@ async def create_gmail_filter(
     return f"Filter created successfully!\nFilter ID: {filter_id}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Delete Gmail Filter",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("delete_gmail_filter", service_type="gmail")
 @require_google_service("gmail", "gmail_settings_basic")
 async def delete_gmail_filter(
@@ -1610,7 +1677,12 @@ async def delete_gmail_filter(
     )
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Modify Gmail Message Labels",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("modify_gmail_message_labels", service_type="gmail")
 @require_google_service("gmail", GMAIL_MODIFY_SCOPE)
 async def modify_gmail_message_labels(
@@ -1666,7 +1738,12 @@ async def modify_gmail_message_labels(
     return f"Message labels updated successfully!\nMessage ID: {message_id}\n{'; '.join(actions)}"
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Batch Modify Gmail Labels",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("batch_modify_gmail_message_labels", service_type="gmail")
 @require_google_service("gmail", GMAIL_MODIFY_SCOPE)
 async def batch_modify_gmail_message_labels(

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -913,7 +913,7 @@ async def get_gmail_attachment_content(
 @server.tool(
     annotations=ToolAnnotations(
         title="Send Gmail Message",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("send_gmail_message", service_type="gmail")
@@ -1024,7 +1024,7 @@ async def send_gmail_message(
 @server.tool(
     annotations=ToolAnnotations(
         title="Draft Gmail Message",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("draft_gmail_message", service_type="gmail")
@@ -1591,7 +1591,7 @@ async def list_gmail_filters(service, user_google_email: str) -> str:
 @server.tool(
     annotations=ToolAnnotations(
         title="Create Gmail Filter",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("create_gmail_filter", service_type="gmail")
@@ -1680,7 +1680,7 @@ async def delete_gmail_filter(
 @server.tool(
     annotations=ToolAnnotations(
         title="Modify Gmail Message Labels",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("modify_gmail_message_labels", service_type="gmail")
@@ -1741,7 +1741,7 @@ async def modify_gmail_message_labels(
 @server.tool(
     annotations=ToolAnnotations(
         title="Batch Modify Gmail Labels",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("batch_modify_gmail_message_labels", service_type="gmail")

--- a/gsearch/search_tools.py
+++ b/gsearch/search_tools.py
@@ -10,6 +10,8 @@ import os
 from typing import Optional, List, Literal
 
 from auth.service_decorator import require_google_service
+from mcp.types import ToolAnnotations
+
 from core.server import server
 from core.utils import handle_http_errors
 

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -962,7 +962,7 @@ async def create_spreadsheet(
 @server.tool(
     annotations=ToolAnnotations(
         title="Create Sheet",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("create_sheet", service_type="sheets")

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -11,6 +11,8 @@ import copy
 from typing import List, Optional, Union
 
 from auth.service_decorator import require_google_service
+from mcp.types import ToolAnnotations
+
 from core.server import server
 from core.utils import handle_http_errors, UserInputError
 from core.comments import create_comment_tools
@@ -957,7 +959,12 @@ async def create_spreadsheet(
     return text_output
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Create Sheet",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("create_sheet", service_type="sheets")
 @require_google_service("sheets", "sheets_write")
 async def create_sheet(

--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 @server.tool(
     annotations=ToolAnnotations(
         title="Create Presentation",
-        destructiveHint=True,
+        destructiveHint=False,
     ),
 )
 @handle_http_errors("create_presentation", service_type="slides")

--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -10,6 +10,8 @@ from typing import List, Dict, Any
 
 
 from auth.service_decorator import require_google_service
+from mcp.types import ToolAnnotations
+
 from core.server import server
 from core.utils import handle_http_errors
 from core.comments import create_comment_tools
@@ -17,7 +19,12 @@ from core.comments import create_comment_tools
 logger = logging.getLogger(__name__)
 
 
-@server.tool()
+@server.tool(
+    annotations=ToolAnnotations(
+        title="Create Presentation",
+        destructiveHint=True,
+    ),
+)
 @handle_http_errors("create_presentation", service_type="slides")
 @require_google_service("slides", "slides")
 async def create_presentation(

--- a/gtasks/tasks_tools.py
+++ b/gtasks/tasks_tools.py
@@ -13,6 +13,8 @@ from googleapiclient.errors import HttpError  # type: ignore
 from mcp import Resource
 
 from auth.service_decorator import require_google_service
+from mcp.types import ToolAnnotations
+
 from core.server import server
 from core.utils import handle_http_errors
 
@@ -67,9 +69,14 @@ def _adjust_due_max_for_tasks_api(due_max: str) -> str:
     return adjusted.isoformat()
 
 
-@server.tool()  # type: ignore
-@require_google_service("tasks", "tasks_read")  # type: ignore
-@handle_http_errors("list_task_lists", service_type="tasks")  # type: ignore
+@server.tool(
+    annotations=ToolAnnotations(
+        title="List Task Lists",
+        readOnlyHint=True,
+    ),
+)
+@require_google_service("tasks", "tasks_read")
+@handle_http_errors("list_task_lists", service_type="tasks")
 async def list_task_lists(
     service: Resource,
     user_google_email: str,


### PR DESCRIPTION
## Summary

Add `ToolAnnotations` to 47 MCP tools across Gmail, Google Docs, and Google Drive modules.

### Changes by Module

| Module | Tools | Read-Only | Additive | Modify/Update | Delete |
|--------|-------|-----------|----------|---------------|--------|
| gmail_tools.py | 15 | 8 | 3 | 2 | 2 |
| docs_tools.py | 14 | 5 | 3 | 6 | 0 |
| drive_tools.py | 14 | 7 | 3 | 3 | 1 |
| Other modules | 4 | 4 | 0 | 0 | 0 |
| **Total** | **47** | **24** | **9** | **11** | **3** |

### Annotation Types

- `title`: Human-readable names for better LLM understanding
- `readOnlyHint=True`: Query/fetch operations (search, get, list)
- `destructiveHint=False`: Create operations (create_doc, send_email, share_file)
- `destructiveHint=True`: Modify/update/delete operations

### destructiveHint Semantics

Following the official MCP filesystem server pattern:
- **write_file, edit_file** → `destructiveHint=true` (modifies existing content)
- **create_directory** → `destructiveHint=false` (purely additive)

**Additive operations** (`destructiveHint=False`):
- Create new documents, emails, files
- Share/grant permissions (adds without modifying)

**Modify operations** (`destructiveHint=True`):
- Modify doc text, find/replace, insert elements
- Update drive files, permissions
- Modify message labels

**Delete operations** (`destructiveHint=True`):
- Remove permissions, delete filters/labels

### Why This Matters

Tool annotations help MCP clients make safer, more informed decisions:
- **Read-only tools** can be auto-approved for faster workflows
- **Additive tools** get appropriate handling without unnecessary warnings
- **Modify/Delete tools** trigger confirmation prompts

## Test Plan

- [x] Verify server imports successfully
- [x] Check annotations appear in tools/list response
- [ ] Test with Claude Desktop or compatible MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)