### PR TITLE
feat: enable multi-account access within single OAuth 2.1 session

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -544,8 +544,55 @@ def get_credentials(
     Returns:
         Valid Credentials object or None.
     """
-    # First, try OAuth 2.1 session store if we have a session_id (FastMCP session)
-    if session_id:
+    # PRIORITY 1: If user_google_email is specified, always try to get credentials for that user first
+    # This ensures multi-account support works correctly in streamable-http mode
+    if user_google_email:
+        try:
+            store = get_oauth21_session_store()
+            # Try to get credentials directly for the requested user email
+            credentials = store.get_credentials(user_google_email)
+            if credentials:
+                logger.info(
+                    f"[get_credentials] Found credentials for requested user {user_google_email}"
+                )
+                # Check scopes
+                if not all(scope in credentials.scopes for scope in required_scopes):
+                    logger.warning(
+                        f"[get_credentials] Credentials for {user_google_email} lack required scopes. Need: {required_scopes}, Have: {credentials.scopes}"
+                    )
+                    # Don't return None yet - fall through to try file-based credentials
+                else:
+                    # Return if valid
+                    if credentials.valid:
+                        return credentials
+                    elif credentials.expired and credentials.refresh_token:
+                        # Try to refresh
+                        try:
+                            credentials.refresh(Request())
+                            logger.info(
+                                f"[get_credentials] Refreshed credentials for {user_google_email}"
+                            )
+                            # Update stored credentials
+                            store.store_session(
+                                user_email=user_google_email,
+                                access_token=credentials.token,
+                                refresh_token=credentials.refresh_token,
+                                scopes=credentials.scopes,
+                                expiry=credentials.expiry,
+                                mcp_session_id=session_id,
+                            )
+                            return credentials
+                        except Exception as e:
+                            logger.error(
+                                f"[get_credentials] Failed to refresh credentials for {user_google_email}: {e}"
+                            )
+                            # Fall through to try file-based credentials
+        except Exception as e:
+            logger.debug(f"[get_credentials] Error checking OAuth 2.1 store for {user_google_email}: {e}")
+
+    # PRIORITY 2: Only use session-based lookup if no user_google_email was specified
+    # This is the fallback for single-user scenarios
+    if not user_google_email and session_id:
         try:
             store = get_oauth21_session_store()
 
@@ -633,10 +680,28 @@ def get_credentials(
         )
 
         if session_id:
-            credentials = load_credentials_from_session(session_id)
-            if credentials:
+            # MULTI-ACCOUNT FIX: Only use session credentials if they match the requested user
+            # Check who the session is bound to before loading credentials
+            session_bound_user = None
+            try:
+                store = get_oauth21_session_store()
+                session_bound_user = store.get_user_by_mcp_session(session_id)
+            except Exception as e:
+                logger.debug(f"[get_credentials] Could not check session binding: {e}")
+
+            # Only load from session if:
+            # 1. No specific user was requested (user_google_email is None), OR
+            # 2. The session is bound to the requested user
+            if not user_google_email or session_bound_user == user_google_email:
+                credentials = load_credentials_from_session(session_id)
+                if credentials:
+                    logger.debug(
+                        f"[get_credentials] Loaded credentials from session for session_id '{session_id}'."
+                    )
+            elif session_bound_user:
                 logger.debug(
-                    f"[get_credentials] Loaded credentials from session for session_id '{session_id}'."
+                    f"[get_credentials] Skipping session credentials: session bound to '{session_bound_user}' "
+                    f"but requested user is '{user_google_email}'"
                 )
 
         if not credentials and user_google_email:

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -213,10 +213,40 @@ async def get_authenticated_google_service_oauth21(
 ) -> tuple[Any, str]:
     """
     OAuth 2.1 authentication using the session store with security validation.
+
+    IMPORTANT: When user_google_email is explicitly provided, we prioritize looking up
+    credentials for that specific user. This enables multi-account support where a single
+    MCP session can access multiple pre-authenticated Google accounts.
     """
     provider = get_auth_provider()
     access_token = get_access_token()
 
+    # PRIORITY 1: If user_google_email is explicitly provided, use it
+    # This is the key fix for multi-account support - the explicitly requested
+    # account takes priority over the session's authenticated account
+    if user_google_email:
+        store = get_oauth21_session_store()
+
+        # Try to get credentials for the explicitly requested user
+        credentials = store.get_credentials(user_google_email)
+        if credentials:
+            logger.info(
+                f"[{tool_name}] Found credentials for explicitly requested user {user_google_email}"
+            )
+
+            # Validate scopes
+            scopes_available = set(credentials.scopes or [])
+            if not all(scope in scopes_available for scope in required_scopes):
+                raise GoogleAuthenticationError(
+                    f"OAuth credentials for {user_google_email} lack required scopes. "
+                    f"Need: {required_scopes}, Have: {sorted(scopes_available)}"
+                )
+
+            service = build(service_name, version, credentials=credentials)
+            logger.info(f"[{tool_name}] Authenticated {service_name} for {user_google_email}")
+            return service, user_google_email
+
+    # PRIORITY 2: Fall back to access token from provider (for single-account scenarios)
     if provider and access_token:
         token_email = None
         if getattr(access_token, "claims", None):
@@ -233,10 +263,9 @@ async def get_authenticated_google_service_oauth21(
                 "Access token email does not match authenticated session context."
             )
 
-        if token_email and user_google_email and token_email != user_google_email:
-            raise GoogleAuthenticationError(
-                f"Authenticated account {token_email} does not match requested user {user_google_email}."
-            )
+        # Note: We removed the strict check that blocked access when token_email != user_google_email
+        # because in multi-account scenarios, the session token may be for one account while
+        # accessing credentials for another pre-authenticated account
 
         credentials = ensure_session_from_access_token(
             access_token, resolved_email, session_id
@@ -259,6 +288,7 @@ async def get_authenticated_google_service_oauth21(
         logger.info(f"[{tool_name}] Authenticated {service_name} for {resolved_email}")
         return service, resolved_email
 
+    # PRIORITY 3: Fall back to session store validation
     store = get_oauth21_session_store()
 
     # Use the validation method to ensure session can only access its own credentials
@@ -545,10 +575,22 @@ def require_google_service(
             )
 
             # Extract user_google_email based on OAuth mode
+            # MULTI-ACCOUNT FIX: Check if user_google_email was explicitly provided
+            # If so, honor the explicit request instead of using session's authenticated user
+            explicit_user_email = kwargs.get("user_google_email")
+
             if is_oauth21_enabled():
-                user_google_email = _extract_oauth21_user_email(
-                    authenticated_user, func.__name__
-                )
+                if explicit_user_email:
+                    # Honor explicitly provided user_google_email for multi-account support
+                    logger.debug(
+                        f"[{func.__name__}] Multi-account: Using explicit user_google_email '{explicit_user_email}' "
+                        f"instead of session user '{authenticated_user}'"
+                    )
+                    user_google_email = explicit_user_email
+                else:
+                    user_google_email = _extract_oauth21_user_email(
+                        authenticated_user, func.__name__
+                    )
             else:
                 user_google_email = _extract_oauth20_user_email(
                     args, kwargs, wrapper_sig
@@ -684,10 +726,21 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
             authenticated_user, _, mcp_session_id = _get_auth_context(tool_name)
 
             # Extract user_google_email based on OAuth mode
+            # MULTI-ACCOUNT FIX: Check if user_google_email was explicitly provided
+            explicit_user_email = kwargs.get("user_google_email")
+
             if is_oauth21_enabled():
-                user_google_email = _extract_oauth21_user_email(
-                    authenticated_user, tool_name
-                )
+                if explicit_user_email:
+                    # Honor explicitly provided user_google_email for multi-account support
+                    logger.debug(
+                        f"[{tool_name}] Multi-account: Using explicit user_google_email '{explicit_user_email}' "
+                        f"instead of session user '{authenticated_user}'"
+                    )
+                    user_google_email = explicit_user_email
+                else:
+                    user_google_email = _extract_oauth21_user_email(
+                        authenticated_user, tool_name
+                    )
             else:
                 user_google_email = _extract_oauth20_user_email(
                     args, kwargs, wrapper_sig


### PR DESCRIPTION
## Summary

Enables a single MCP session to access multiple pre-authenticated Google accounts by honoring the explicit `user_google_email` parameter in OAuth 2.1 mode.

## Problem

In OAuth 2.1 mode with `streamable-http` transport, credential lookup was incorrectly bound to the session's authenticated user, ignoring the explicit `user_google_email` parameter. This caused all API operations to use the first authenticated account's credentials regardless of which account was specified.

**Example:** Querying calendar events for `work@company.com` would return events from `personal@gmail.com` if personal was authenticated first in the session.

## Root Cause

The OAuth 2.1 implementation assumed a 1:1 mapping between MCP sessions and Google accounts. While the session store supported multiple users, the authentication code in both `get_credentials()` and the service decorators would:

1. Look up credentials by session ID first
2. Ignore the `user_google_email` parameter when found
3. Return whatever credentials were bound to the session

## Solution

Changed credential lookup priority across all authentication paths:

| Priority | Lookup Method | When Used |
|----------|--------------|-----------|
| 1 | Explicit `user_google_email` | When parameter is provided |
| 2 | Session-based lookup | Fallback for single-account usage |
| 3 | File-based credentials | Legacy OAuth 2.0 fallback |

## Changes

### `auth/google_auth.py`
- `get_credentials()`: Added priority lookup for explicit `user_google_email`
- Added session-user validation before loading session credentials

### `auth/service_decorator.py`  
- `get_authenticated_google_service_oauth21()`: Added priority lookup for explicit user
- `require_google_service()`: Honor explicit `user_google_email` in kwargs
- `require_multiple_services()`: Honor explicit `user_google_email` in kwargs
- Removed strict check that blocked cross-account access in multi-account scenarios

## Backward Compatibility

| Scenario | Behavior |
|----------|----------|
| Single-account (OAuth 2.1) | ✅ No change - session lookup works as fallback |
| OAuth 2.0 mode | ✅ No change - `user_google_email` always explicit |
| Multi-account | ✅ Now correctly uses the specified account |

## Use Case

Enables scenarios where a single MCP session needs to access multiple Google accounts:

```
Session authenticates → work@company.com
Session also has stored credentials for → personal@gmail.com

# Before: Both return work@company.com's data
get_calendar_events(user_google_email="personal@gmail.com")  # ❌ Wrong account

# After: Returns correct account's data  
get_calendar_events(user_google_email="personal@gmail.com")  # ✅ Correct account
```

All accounts must be pre-authenticated in the session store.

## Testing

Tested with 3 Google accounts in streamable-http mode:
- Before fix: Calendar events returned from wrong account
- After fix: Calendar events returned from correct specified account