### PR TITLE
fix: Enable protocol-level 401 responses in external OAuth mode

### DIFF
--- a/core/server.py
+++ b/core/server.py
@@ -359,13 +359,14 @@ def configure_server_for_http():
                     redirect_path=config.redirect_path,
                     required_scopes=required_scopes,
                 )
-                # Disable protocol-level auth, expect bearer tokens in tool calls
-                server.auth = None
+                # Enable protocol-level auth for 401 responses on unauthenticated requests
+                # ExternalOAuthProvider.verify_token() will accept ya29.* tokens from external OAuth
+                server.auth = provider
                 logger.info(
-                    "OAuth 2.1 enabled with EXTERNAL provider mode - protocol-level auth disabled"
+                    "OAuth 2.1 enabled with EXTERNAL provider mode - protocol-level auth ENABLED"
                 )
                 logger.info(
-                    "Expecting Authorization bearer tokens in tool call headers"
+                    "Server returns 401 for unauthenticated requests, accepts ya29.* tokens"
                 )
             else:
                 # Standard OAuth 2.1 mode: use FastMCP's GoogleProvider


### PR DESCRIPTION
## Summary
- Enable protocol-level 401 responses when `EXTERNAL_OAUTH21_PROVIDER=true`
- Server now properly signals authentication required to clients like LibreChat
- Eliminates need for Caddy proxy to inject 401 responses

## Problem
When `EXTERNAL_OAUTH21_PROVIDER=true`, the server set `server.auth = None`, which disabled protocol-level authentication entirely. This meant:
- Unauthenticated requests were accepted (failing later in middleware)
- Clients like LibreChat that expect a 401 to trigger their OAuth flow never received one
- Required a Caddy reverse proxy to inject 401 responses

## Solution
Change `server.auth = None` to `server.auth = provider` in external OAuth mode. The `ExternalOAuthProvider` already:
- Extends `GoogleProvider` for protocol-level auth
- Validates `ya29.*` tokens via Google's userinfo API in `verify_token()`
- Falls back to JWT validation for standard tokens

This makes external OAuth mode a true "hybrid" that:
1. Returns 401 for unauthenticated requests (triggers client OAuth)
2. Accepts `ya29.*` tokens from external OAuth flows
3. Also accepts JWTs from clients using FastMCP's OAuth endpoints

## Test plan
- [ ] Test with `MCP_ENABLE_OAUTH21=true` and `EXTERNAL_OAUTH21_PROVIDER=true`
- [ ] Verify unauthenticated request returns 401
- [ ] Verify request with valid `ya29.*` token succeeds
- [ ] Test with LibreChat OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)