### PR TITLE
feat(gmail): Add from_name parameter for sender display name

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -356,7 +356,9 @@ def _prepare_gmail_message(
     if from_email:
         if from_name:
             # Sanitize from_name to prevent header injection
-            safe_name = from_name.replace("\r", "").replace("\n", "").replace("\x00", "")
+            safe_name = (
+                from_name.replace("\r", "").replace("\n", "").replace("\x00", "")
+            )
             message["From"] = formataddr((safe_name, from_email))
         else:
             message["From"] = from_email


### PR DESCRIPTION
## Summary
- Adds optional `from_name` parameter to `send_gmail_message` and `draft_gmail_message` functions
- When provided, the From header is formatted as `"Name <email>"` instead of just the email address

## Motivation
Currently, emails sent via the MCP server only include the bare email address in the From header, even when the user has a display name configured in their Gmail account settings. This differs from composing emails directly in Gmail, where the display name is automatically included.

This change allows users to specify their display name when sending emails, resulting in a more professional appearance and consistency with Gmail's native behaviour.

## Example usage
```python
send_gmail_message(
    to="recipient@example.com",
    subject="Hello",
    body="Hi there!",
    from_name="Peter Hartree"
)
```

Results in: `From: Peter Hartree <user@gmail.com>`

## Test plan
- [x] Tested `send_gmail_message` with `from_name` parameter - From header correctly formatted
- [x] Tested `draft_gmail_message` with `from_name` parameter - draft shows correct From header
- [x] Tested without `from_name` parameter - backwards compatible, behaves as before

🤖 Generated with [Claude Code](https://claude.ai/code)