### PR TITLE
feat: Auto-detect user_google_email from OAuth credentials

### DIFF
--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -315,29 +315,80 @@ def _extract_oauth21_user_email(
 
 
 def _extract_oauth20_user_email(
-    args: tuple, kwargs: dict, wrapper_sig: inspect.Signature
+    args: tuple, kwargs: dict, wrapper_sig: inspect.Signature, func_name: str = ""
 ) -> str:
     """
-    Extract user email for OAuth 2.0 mode from function arguments.
+    Extract user email for OAuth 2.0 mode with automatic detection.
+
+    BACKWARD COMPATIBILITY: The user_google_email parameter is kept for compatibility
+    with existing configurations, but is now effectively optional in single-account
+    setups. When only one Google account is authenticated, the email is auto-detected
+    and the provided parameter value is ignored.
+
+    Detection priority:
+    1. Auto-detect from credentials (if unambiguous - single account)
+    2. Fall back to provided user_google_email parameter (for multi-account setups)
+    3. Error with helpful message if neither works
+
+    This approach ensures:
+    - Existing tool configurations continue to work without modification
+    - New users don't need to configure USER_GOOGLE_EMAIL for single-account usage
+    - Multi-account users can still specify which account to use
 
     Args:
         args: Positional arguments passed to wrapper
         kwargs: Keyword arguments passed to wrapper
         wrapper_sig: Function signature for parameter binding
+        func_name: Name of the function being decorated (for error messages)
 
     Returns:
         User email string
 
     Raises:
-        Exception: If user_google_email parameter not found
+        Exception: If email cannot be determined (no credentials or ambiguous)
     """
+    from core.config import get_auto_detected_email, list_authenticated_emails
+
     bound_args = wrapper_sig.bind(*args, **kwargs)
     bound_args.apply_defaults()
 
     user_google_email = bound_args.arguments.get("user_google_email")
-    if not user_google_email:
-        raise Exception("'user_google_email' parameter is required but was not found.")
-    return user_google_email
+
+    # Priority 1: Attempt auto-detection first (works for single-account setups)
+    auto_detected = get_auto_detected_email()
+    if auto_detected:
+        if user_google_email and user_google_email != auto_detected and "@" in user_google_email:
+            logger.warning(
+                f"[{func_name}] User provided email '{user_google_email}' but using auto-detected "
+                f"single account '{auto_detected}' instead."
+            )
+        logger.info(f"[{func_name}] Auto-detected user email: {auto_detected}")
+        return auto_detected
+
+    # Priority 2: Fall back to provided email (for multi-account or explicit override)
+    if user_google_email and "@" in user_google_email:
+        logger.debug(
+            f"[{func_name}] Using provided user_google_email: {user_google_email}"
+        )
+        return user_google_email
+
+    # Neither worked - provide actionable error message
+    available_emails = list_authenticated_emails()
+
+    if not available_emails:
+        raise Exception(
+            f"'{func_name}' requires authentication. No stored credentials found.\n\n"
+            "To authenticate, use the 'start_google_auth' tool with your Google email address.\n"
+            "Example: start_google_auth(user_google_email='your.email@gmail.com', service_name='Gmail')"
+        )
+    else:
+        # Multiple credentials exist - user must specify which one
+        raise Exception(
+            f"'{func_name}' requires a 'user_google_email' parameter.\n\n"
+            f"Multiple authenticated accounts found: {', '.join(available_emails)}\n\n"
+            "Please specify which account to use by providing the 'user_google_email' parameter.\n"
+            f"Example: {func_name}(..., user_google_email='{available_emails[0]}')"
+        )
 
 
 def _remove_user_email_arg_from_docstring(docstring: str) -> str:
@@ -551,7 +602,7 @@ def require_google_service(
                 )
             else:
                 user_google_email = _extract_oauth20_user_email(
-                    args, kwargs, wrapper_sig
+                    args, kwargs, wrapper_sig, func.__name__
                 )
 
             # Get service configuration from the decorator's arguments
@@ -690,7 +741,7 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
                 )
             else:
                 user_google_email = _extract_oauth20_user_email(
-                    args, kwargs, wrapper_sig
+                    args, kwargs, wrapper_sig, tool_name
                 )
 
             # Authenticate all services

--- a/core/config.py
+++ b/core/config.py
@@ -7,7 +7,12 @@ NOTE: OAuth configuration has been moved to auth.oauth_config for centralization
 This module now imports from there for backward compatibility.
 """
 
+import logging
 import os
+import threading
+from pathlib import Path
+from typing import List, Optional
+
 from auth.oauth_config import (
     get_oauth_base_url,
     get_oauth_redirect_uri,
@@ -16,14 +21,161 @@ from auth.oauth_config import (
     is_oauth21_enabled,
 )
 
+logger = logging.getLogger(__name__)
+
 # Server configuration
 WORKSPACE_MCP_PORT = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", 8000)))
 WORKSPACE_MCP_BASE_URI = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
 
 # Disable USER_GOOGLE_EMAIL in OAuth 2.1 multi-user mode
+# This env var is now optional - email can be auto-detected from credentials
 USER_GOOGLE_EMAIL = (
     None if is_oauth21_enabled() else os.getenv("USER_GOOGLE_EMAIL", None)
 )
+
+# --- Auto-detection of user email from credentials ---
+# Thread-safe lazy detection with caching
+
+_detected_email: Optional[str] = None
+_email_detection_attempted: bool = False
+_email_lock = threading.Lock()
+
+
+def _get_credentials_dir() -> Path:
+    """Get the credentials directory path."""
+    if os.getenv("GOOGLE_MCP_CREDENTIALS_DIR"):
+        return Path(os.getenv("GOOGLE_MCP_CREDENTIALS_DIR"))
+
+    home_dir = Path.home()
+    if home_dir and str(home_dir) != "~":
+        return home_dir / ".google_workspace_mcp" / "credentials"
+
+    return Path.cwd() / ".credentials"
+
+
+def list_authenticated_emails() -> List[str]:
+    """
+    List all authenticated user emails from credential files.
+
+    This uses fast filename-based detection (parsing filenames like 'user@example.com.json')
+    rather than loading and parsing the JSON files, which is more efficient.
+
+    Returns:
+        List of email addresses that have stored credentials, sorted alphabetically.
+    """
+    creds_dir = _get_credentials_dir()
+
+    if not creds_dir.exists():
+        logger.debug(f"Credentials directory does not exist: {creds_dir}")
+        return []
+
+    emails = []
+    try:
+        for f in creds_dir.glob("*.json"):
+            # Extract email from filename (e.g., 'user@example.com.json' -> 'user@example.com')
+            email = f.stem
+            # Basic validation - must contain @ to be an email
+            if "@" in email and email not in ("service_account", "client_secret"):
+                emails.append(email)
+
+        logger.debug(f"Found {len(emails)} authenticated emails in {creds_dir}")
+    except OSError as e:
+        logger.error(f"Error listing credential files in {creds_dir}: {e}")
+
+    return sorted(emails)
+
+
+def _detect_single_user_email() -> Optional[str]:
+    """
+    Internal function to detect user email in single-user mode.
+
+    Detection priority:
+    1. USER_GOOGLE_EMAIL environment variable (explicit configuration)
+    2. Single credential file in credentials directory
+    3. If multiple credentials exist, return None (ambiguous - user must specify)
+
+    Returns:
+        Detected email address or None if detection fails or is ambiguous.
+    """
+    # Priority 1: Explicit environment variable
+    env_email = os.getenv("USER_GOOGLE_EMAIL")
+    if env_email and "@" in env_email:
+        logger.debug(f"Using USER_GOOGLE_EMAIL from environment: {env_email}")
+        return env_email
+
+    # Priority 2: Auto-detect from credentials
+    emails = list_authenticated_emails()
+
+    if not emails:
+        logger.debug("No credential files found for auto-detection")
+        return None
+
+    if len(emails) == 1:
+        detected = emails[0]
+        logger.info(f"Auto-detected user email from credentials: {detected}")
+        return detected
+
+    # Multiple credentials - ambiguous, cannot auto-detect
+    logger.warning(
+        f"Multiple credential files found ({len(emails)}), cannot auto-detect email. "
+        f"Available: {', '.join(emails)}. "
+        "Please specify user_google_email parameter or set USER_GOOGLE_EMAIL environment variable."
+    )
+    return None
+
+
+def get_auto_detected_email() -> Optional[str]:
+    """
+    Get the auto-detected user email with thread-safe lazy initialization.
+
+    This function caches the result of email detection so subsequent calls
+    are fast. The detection is only performed once per process.
+
+    In single-user mode (--single-user flag), this will attempt to auto-detect
+    the user's email from stored credentials if USER_GOOGLE_EMAIL is not set.
+
+    Returns:
+        The auto-detected email address, or None if:
+        - No credentials exist
+        - Multiple credentials exist (ambiguous)
+        - OAuth 2.1 mode is enabled (multi-user mode)
+    """
+    global _detected_email, _email_detection_attempted
+
+    # Fast path - already detected
+    if _email_detection_attempted:
+        return _detected_email
+
+    with _email_lock:
+        # Double-check after acquiring lock
+        if _email_detection_attempted:
+            return _detected_email
+
+        # OAuth 2.1 mode doesn't use auto-detection (multi-user mode)
+        if is_oauth21_enabled():
+            logger.debug("OAuth 2.1 mode enabled, skipping email auto-detection")
+            _email_detection_attempted = True
+            return None
+
+        # Perform detection
+        _detected_email = _detect_single_user_email()
+        _email_detection_attempted = True
+
+        return _detected_email
+
+
+def clear_auto_detected_email_cache():
+    """
+    Clear the auto-detected email cache.
+
+    This is useful for testing or when credentials change.
+    """
+    global _detected_email, _email_detection_attempted
+    with _email_lock:
+        _detected_email = None
+        _email_detection_attempted = False
+        logger.debug("Cleared auto-detected email cache")
+
 
 # Re-export OAuth functions for backward compatibility
 __all__ = [
@@ -34,4 +186,7 @@ __all__ = [
     "get_oauth_redirect_uri",
     "set_transport_mode",
     "get_transport_mode",
+    "list_authenticated_emails",
+    "get_auto_detected_email",
+    "clear_auto_detected_email_cache",
 ]

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -398,7 +398,7 @@ async def search_gmail_messages(
 
     Args:
         query (str): The search query. Supports standard Gmail search operators.
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
         page_size (int): The maximum number of messages to return. Defaults to 10.
         page_token (Optional[str]): Token for retrieving the next page of results. Use the next_page_token from a previous response.
 
@@ -458,7 +458,7 @@ async def get_gmail_message_content(
 
     Args:
         message_id (str): The unique ID of the Gmail message to retrieve.
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
 
     Returns:
         str: The message details including subject, sender, date, Message-ID, recipients (To, Cc), and body content.
@@ -562,7 +562,7 @@ async def get_gmail_messages_content_batch(
 
     Args:
         message_ids (List[str]): List of Gmail message IDs to retrieve (max 25 per batch).
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
         format (Literal["full", "metadata"]): Message format. "full" includes body, "metadata" only headers.
 
     Returns:
@@ -761,7 +761,7 @@ async def get_gmail_attachment_content(
     Args:
         message_id (str): The ID of the Gmail message containing the attachment.
         attachment_id (str): The ID of the attachment to download.
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
 
     Returns:
         str: Attachment metadata and base64-encoded content that can be decoded and saved.
@@ -926,7 +926,7 @@ async def send_gmail_message(
         body_format (Literal['plain', 'html']): Email body format. Defaults to 'plain'.
         cc (Optional[str]): Optional CC email address.
         bcc (Optional[str]): Optional BCC email address.
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
         thread_id (Optional[str]): Optional Gmail thread ID to reply within. When provided, sends a reply.
         in_reply_to (Optional[str]): Optional Message-ID of the message being replied to. Used for proper threading.
         references (Optional[str]): Optional chain of Message-IDs for proper threading. Should include all previous Message-IDs.
@@ -1026,7 +1026,7 @@ async def draft_gmail_message(
     Creates a draft email in the user's Gmail account. Supports both new drafts and reply drafts.
 
     Args:
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
         subject (str): Email subject.
         body (str): Email body (plain text).
         body_format (Literal['plain', 'html']): Email body format. Defaults to 'plain'.
@@ -1077,7 +1077,7 @@ async def draft_gmail_message(
         draft_gmail_message(
             subject="Re: Meeting tomorrow",
             body="<strong>Thanks for the update!</strong>",
-            body_format="html,
+            body_format="html",
             to="user@example.com",
             thread_id="thread_123",
             in_reply_to="<message123@gmail.com>",
@@ -1203,7 +1203,7 @@ async def get_gmail_thread_content(
 
     Args:
         thread_id (str): The unique ID of the Gmail thread to retrieve.
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
 
     Returns:
         str: The complete thread content with all messages formatted for reading.
@@ -1236,7 +1236,7 @@ async def get_gmail_threads_content_batch(
 
     Args:
         thread_ids (List[str]): A list of Gmail thread IDs to retrieve. The function will automatically batch requests in chunks of 25.
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
 
     Returns:
         str: A formatted list of thread contents with separators.
@@ -1337,7 +1337,7 @@ async def list_gmail_labels(service, user_google_email: str) -> str:
     Lists all labels in the user's Gmail account.
 
     Args:
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
 
     Returns:
         str: A formatted list of all labels with their IDs, names, and types.
@@ -1393,7 +1393,7 @@ async def manage_gmail_label(
     Manages Gmail labels: create, update, or delete labels.
 
     Args:
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
         action (Literal["create", "update", "delete"]): Action to perform on the label.
         name (Optional[str]): Label name. Required for create, optional for update.
         label_id (Optional[str]): Label ID. Required for update and delete operations.
@@ -1464,7 +1464,7 @@ async def list_gmail_filters(service, user_google_email: str) -> str:
     Lists all Gmail filters configured in the user's mailbox.
 
     Args:
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
 
     Returns:
         str: A formatted list of filters with their criteria and actions.
@@ -1551,7 +1551,7 @@ async def create_gmail_filter(
     Creates a Gmail filter using the users.settings.filters API.
 
     Args:
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
         criteria (Dict[str, Any]): Criteria for matching messages.
         action (Dict[str, Any]): Actions to apply to matched messages.
 
@@ -1586,7 +1586,7 @@ async def delete_gmail_filter(
     Deletes a Gmail filter by ID.
 
     Args:
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
         filter_id (str): The ID of the filter to delete.
 
     Returns:
@@ -1633,7 +1633,7 @@ async def modify_gmail_message_labels(
     To delete an email, add the TRASH label.
 
     Args:
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
         message_id (str): The ID of the message to modify.
         add_label_ids (Optional[List[str]]): List of label IDs to add to the message.
         remove_label_ids (Optional[List[str]]): List of label IDs to remove from the message.
@@ -1687,7 +1687,7 @@ async def batch_modify_gmail_message_labels(
     Adds or removes labels from multiple Gmail messages in a single batch request.
 
     Args:
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required (but ignored if a single account is auto-detected).
         message_ids (List[str]): A list of message IDs to modify.
         add_label_ids (Optional[List[str]]): List of label IDs to add to the messages.
         remove_label_ids (Optional[List[str]]): List of label IDs to remove from the messages.


### PR DESCRIPTION
## Summary

This PR improves the developer experience by automatically detecting the authenticated user's email from stored OAuth credentials, eliminating the need to configure `USER_GOOGLE_EMAIL` for single-account setups.

## Backward Compatibility Approach

The `user_google_email` parameter is **intentionally kept as-is** in all tool signatures (required, same position) to maintain backward compatibility with existing configurations. However, the runtime behavior now:

1. **Auto-detects first** - If only one Google account is authenticated, that email is used automatically (the provided parameter value is ignored)
2. **Falls back to provided value** - For multi-account setups where auto-detection is ambiguous, the provided `user_google_email` parameter is used
3. **Errors helpfully** - If neither works, provides actionable guidance

This means:
- ✅ Existing tool configs continue to work without modification
- ✅ New users don't need to configure `USER_GOOGLE_EMAIL` at all
- ✅ Multi-account users can still specify which account to use

## Why This Approach?

Changing function signatures (making `user_google_email` optional with defaults) would require reordering parameters, which is a **breaking change** for positional argument calls. By keeping signatures unchanged and modifying only the decorator behavior, we achieve the UX improvement while maintaining **full backward compatibility**.

## Changes

- Add lazy email auto-detection in `core/config.py` with thread-safe caching
- Modify `_extract_oauth20_user_email` decorator to prefer auto-detection
- Fix typo in `draft_gmail_message` docstring example

## Test plan

- [ ] Verify auto-detection works with a single credential file
- [ ] Verify provided `user_google_email` is used when multiple accounts exist
- [ ] Verify error message with multiple credential files lists available accounts
- [ ] Verify error message with no credentials guides user to authenticate
- [ ] Verify existing configurations continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)