### PR TITLE
Fix: resolve conflict between Single User Mode and OAuth 2.1

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -849,11 +849,16 @@ async def get_authenticated_google_service(
         f"[{tool_name}] Attempting to get authenticated {service_name} service. Email: '{user_google_email}', Session: '{session_id}'"
     )
 
-    # Validate email format
-    if not user_google_email or "@" not in user_google_email:
+    # Validate email format (unless single-user mode, where it can be None)
+    is_single_user = os.getenv("MCP_SINGLE_USER_MODE") == "1"
+    if not is_single_user and (not user_google_email or "@" not in user_google_email):
         error_msg = f"Authentication required for {tool_name}. No valid 'user_google_email' provided. Please provide a valid Google email address."
         logger.info(f"[{tool_name}] {error_msg}")
         raise GoogleAuthenticationError(error_msg)
+    elif is_single_user and not user_google_email:
+        logger.debug(
+            f"[{tool_name}] Single-user mode: user_google_email is None, will try to find any credentials."
+        )
 
     credentials = await asyncio.to_thread(
         get_credentials,
@@ -870,6 +875,18 @@ async def get_authenticated_google_service(
         logger.info(
             f"[{tool_name}] Valid email '{user_google_email}' provided, initiating auth flow."
         )
+
+        # In single user mode without an email, we need one to start auth flow
+        if is_single_user and not user_google_email:
+            # Try to get default email from env
+            from core.config import USER_GOOGLE_EMAIL
+
+            if USER_GOOGLE_EMAIL:
+                user_google_email = USER_GOOGLE_EMAIL
+            else:
+                error_msg = f"Authentication required for {tool_name} in Single User Mode. No credentials found and no 'USER_GOOGLE_EMAIL' environment variable set. Please set USER_GOOGLE_EMAIL or provide email in the tool call to initiate authentication."
+                logger.error(f"[{tool_name}] {error_msg}")
+                raise GoogleAuthenticationError(error_msg)
 
         # Ensure OAuth callback is available
         from auth.oauth_callback_server import ensure_oauth_callback_available

--- a/auth/oauth_config.py
+++ b/auth/oauth_config.py
@@ -36,9 +36,17 @@ class OAuthConfig:
         self.client_secret = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET")
 
         # OAuth 2.1 configuration
+        # Disable OAuth 2.1 if Single User Mode is active
+        self.single_user_mode = os.getenv("MCP_SINGLE_USER_MODE", "false").lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
         self.oauth21_enabled = (
             os.getenv("MCP_ENABLE_OAUTH21", "false").lower() == "true"
-        )
+        ) and not self.single_user_mode
+
         self.pkce_required = self.oauth21_enabled  # PKCE is mandatory in OAuth 2.1
         self.supported_code_challenge_methods = (
             ["S256", "plain"] if not self.oauth21_enabled else ["S256"]

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+import os
 
 import re
 from functools import wraps
@@ -526,7 +527,10 @@ def require_google_service(
 
         # Create a new signature for the wrapper that excludes the 'service' parameter.
         # In OAuth 2.1 mode, also exclude 'user_google_email' since it's automatically determined.
-        if is_oauth21_enabled():
+        # In Single User Mode, also exclude 'user_google_email' to make it optional in schema.
+        is_single_user = os.getenv("MCP_SINGLE_USER_MODE") == "1"
+
+        if is_oauth21_enabled() or is_single_user:
             # Remove both 'service' and 'user_google_email' parameters
             filtered_params = [p for p in params[1:] if p.name != "user_google_email"]
             wrapper_sig = original_sig.replace(parameters=filtered_params)
@@ -549,6 +553,10 @@ def require_google_service(
                 user_google_email = _extract_oauth21_user_email(
                     authenticated_user, func.__name__
                 )
+            elif is_single_user:
+                # In single user mode, user_google_email is optional (hidden from schema)
+                # We can try to get it from kwargs if passed (e.g. explicitly), or default to None
+                user_google_email = kwargs.get("user_google_email")
             else:
                 user_google_email = _extract_oauth20_user_email(
                     args, kwargs, wrapper_sig
@@ -614,7 +622,7 @@ def require_google_service(
 
             try:
                 # In OAuth 2.1 mode, we need to add user_google_email to kwargs since it was removed from signature
-                if is_oauth21_enabled():
+                if is_oauth21_enabled() or is_single_user:
                     kwargs["user_google_email"] = user_google_email
 
                 # Prepend the fetched service object to the original arguments
@@ -629,9 +637,9 @@ def require_google_service(
         wrapper.__signature__ = wrapper_sig
 
         # Conditionally modify docstring to remove user_google_email parameter documentation
-        if is_oauth21_enabled():
+        if is_oauth21_enabled() or is_single_user:
             logger.debug(
-                "OAuth 2.1 mode enabled, removing user_google_email from docstring"
+                "OAuth 2.1 or Single User mode enabled, removing user_google_email from docstring"
             )
             if func.__doc__:
                 wrapper.__doc__ = _remove_user_email_arg_from_docstring(func.__doc__)
@@ -669,7 +677,10 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
 
         # Remove injected service params from the wrapper signature; drop user_google_email only for OAuth 2.1.
         filtered_params = [p for p in params if p.name not in service_param_names]
-        if is_oauth21_enabled():
+
+        is_single_user = os.getenv("MCP_SINGLE_USER_MODE") == "1"
+
+        if is_oauth21_enabled() or is_single_user:
             filtered_params = [
                 p for p in filtered_params if p.name != "user_google_email"
             ]
@@ -688,6 +699,8 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
                 user_google_email = _extract_oauth21_user_email(
                     authenticated_user, tool_name
                 )
+            elif is_single_user:
+                user_google_email = kwargs.get("user_google_email")
             else:
                 user_google_email = _extract_oauth20_user_email(
                     args, kwargs, wrapper_sig
@@ -752,7 +765,7 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
             # Call the original function with refresh error handling
             try:
                 # In OAuth 2.1 mode, we need to add user_google_email to kwargs since it was removed from signature
-                if is_oauth21_enabled():
+                if is_oauth21_enabled() or is_single_user:
                     kwargs["user_google_email"] = user_google_email
 
                 return await func(*args, **kwargs)
@@ -767,9 +780,9 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
         wrapper.__signature__ = wrapper_sig
 
         # Conditionally modify docstring to remove user_google_email parameter documentation
-        if is_oauth21_enabled():
+        if is_oauth21_enabled() or is_single_user:
             logger.debug(
-                "OAuth 2.1 mode enabled, removing user_google_email from docstring"
+                "OAuth 2.1 or Single User mode enabled, removing user_google_email from docstring"
             )
             if func.__doc__:
                 wrapper.__doc__ = _remove_user_email_arg_from_docstring(func.__doc__)

--- a/main.py
+++ b/main.py
@@ -120,6 +120,16 @@ def main():
     )
     args = parser.parse_args()
 
+    # Set global single-user mode flag early to influence config loading
+    if args.single_user:
+        if is_stateless_mode():
+            safe_print("❌ Single-user mode is incompatible with stateless mode")
+            safe_print("   Stateless mode requires OAuth 2.1 which is multi-user")
+            sys.exit(1)
+        os.environ["MCP_SINGLE_USER_MODE"] = "1"
+        # Reload config to apply single user mode setting to OAuthConfig
+        reload_oauth_config()
+
     # Set port and base URI once for reuse throughout the function
     port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", 8000)))
     base_uri = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
@@ -264,13 +274,7 @@ def main():
     safe_print(f"   📝 Log Level: {logging.getLogger().getEffectiveLevel()}")
     safe_print("")
 
-    # Set global single-user mode flag
     if args.single_user:
-        if is_stateless_mode():
-            safe_print("❌ Single-user mode is incompatible with stateless mode")
-            safe_print("   Stateless mode requires OAuth 2.1 which is multi-user")
-            sys.exit(1)
-        os.environ["MCP_SINGLE_USER_MODE"] = "1"
         safe_print("🔐 Single-user mode enabled")
         safe_print("")
 


### PR DESCRIPTION
- Ensure `--single-user` CLI flag takes precedence over `MCP_ENABLE_OAUTH21=true` in .env
- Early setting of MCP_SINGLE_USER_MODE to influence configuration loading
- Remove `user_google_email` from tool signatures and docstrings in single-user mode
- Allow implicit authentication in single-user mode by relaxing email validation

Original objective: Fix google-workspace-mcp server error 'OAuth 2.1 mode requires an authenticated user' when running in single-user mode. Resolve conflict where MCP_ENABLE_OAUTH21=true in .env blocks --single-user mode, and make user_google_email optional in tool schemas for single-user operation.

Generated-by: Gemini

Note this is related to https://github.com/taylorwilsdon/google_workspace_mcp/issues/338