### PR TITLE
fix: Add missing Gmail filter tools to tool_tiers.yaml

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -12,6 +12,9 @@ gmail:
     - list_gmail_labels
     - manage_gmail_label
     - draft_gmail_message
+    - list_gmail_filters
+    - create_gmail_filter
+    - delete_gmail_filter
 
   complete:
     - get_gmail_threads_content_batch


### PR DESCRIPTION
The list_gmail_filters, create_gmail_filter, and delete_gmail_filter tools were implemented in gmail_tools.py but not exposed in the tool_tiers.yaml configuration, causing them to be filtered out when using the tier-based tool loading system.

Ref #302 

Changes:
- Added list_gmail_filters to extended tier
- Added create_gmail_filter to extended tier
- Added delete_gmail_filter to extended tier