### PR TITLE
feat(gmail): Add Send As support for send_gmail_message and draft_gmail_message

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -906,6 +906,10 @@ async def send_gmail_message(
     ),
     cc: Optional[str] = Body(None, description="Optional CC email address."),
     bcc: Optional[str] = Body(None, description="Optional BCC email address."),
+    from_email: Optional[str] = Body(
+        None,
+        description="Optional 'Send As' alias email address. Must be configured in Gmail settings (Settings > Accounts > Send mail as). If not provided, uses the authenticated user's email.",
+    ),
     thread_id: Optional[str] = Body(
         None, description="Optional Gmail thread ID to reply within."
     ),
@@ -918,6 +922,7 @@ async def send_gmail_message(
 ) -> str:
     """
     Sends an email using the user's Gmail account. Supports both new emails and replies.
+    Supports Gmail's "Send As" feature to send from configured alias addresses.
 
     Args:
         to (str): Recipient email address.
@@ -926,7 +931,10 @@ async def send_gmail_message(
         body_format (Literal['plain', 'html']): Email body format. Defaults to 'plain'.
         cc (Optional[str]): Optional CC email address.
         bcc (Optional[str]): Optional BCC email address.
-        user_google_email (str): The user's Google email address. Required.
+        from_email (Optional[str]): Optional 'Send As' alias email address. The alias must be
+            configured in Gmail settings (Settings > Accounts > Send mail as). If not provided,
+            the email will be sent from the authenticated user's primary email address.
+        user_google_email (str): The user's Google email address. Required for authentication.
         thread_id (Optional[str]): Optional Gmail thread ID to reply within. When provided, sends a reply.
         in_reply_to (Optional[str]): Optional Message-ID of the message being replied to. Used for proper threading.
         references (Optional[str]): Optional chain of Message-IDs for proper threading. Should include all previous Message-IDs.
@@ -944,6 +952,14 @@ async def send_gmail_message(
             subject="Hello",
             body="<strong>Hi there!</strong>",
             body_format="html"
+        )
+
+        # Send from a configured alias (Send As)
+        send_gmail_message(
+            to="user@example.com",
+            subject="Business Inquiry",
+            body="Hello from my business address...",
+            from_email="business@mydomain.com"
         )
 
         # Send an email with CC and BCC
@@ -970,6 +986,8 @@ async def send_gmail_message(
     )
 
     # Prepare the email message
+    # Use from_email (Send As alias) if provided, otherwise default to authenticated user
+    sender_email = from_email or user_google_email
     raw_message, thread_id_final = _prepare_gmail_message(
         subject=subject,
         body=body,
@@ -980,7 +998,7 @@ async def send_gmail_message(
         in_reply_to=in_reply_to,
         references=references,
         body_format=body_format,
-        from_email=user_google_email,
+        from_email=sender_email,
     )
 
     send_body = {"raw": raw_message}
@@ -1012,6 +1030,10 @@ async def draft_gmail_message(
     to: Optional[str] = Body(None, description="Optional recipient email address."),
     cc: Optional[str] = Body(None, description="Optional CC email address."),
     bcc: Optional[str] = Body(None, description="Optional BCC email address."),
+    from_email: Optional[str] = Body(
+        None,
+        description="Optional 'Send As' alias email address. Must be configured in Gmail settings (Settings > Accounts > Send mail as). If not provided, uses the authenticated user's email.",
+    ),
     thread_id: Optional[str] = Body(
         None, description="Optional Gmail thread ID to reply within."
     ),
@@ -1024,15 +1046,19 @@ async def draft_gmail_message(
 ) -> str:
     """
     Creates a draft email in the user's Gmail account. Supports both new drafts and reply drafts.
+    Supports Gmail's "Send As" feature to draft from configured alias addresses.
 
     Args:
-        user_google_email (str): The user's Google email address. Required.
+        user_google_email (str): The user's Google email address. Required for authentication.
         subject (str): Email subject.
         body (str): Email body (plain text).
         body_format (Literal['plain', 'html']): Email body format. Defaults to 'plain'.
         to (Optional[str]): Optional recipient email address. Can be left empty for drafts.
         cc (Optional[str]): Optional CC email address.
         bcc (Optional[str]): Optional BCC email address.
+        from_email (Optional[str]): Optional 'Send As' alias email address. The alias must be
+            configured in Gmail settings (Settings > Accounts > Send mail as). If not provided,
+            the draft will be from the authenticated user's primary email address.
         thread_id (Optional[str]): Optional Gmail thread ID to reply within. When provided, creates a reply draft.
         in_reply_to (Optional[str]): Optional Message-ID of the message being replied to. Used for proper threading.
         references (Optional[str]): Optional chain of Message-IDs for proper threading. Should include all previous Message-IDs.
@@ -1043,6 +1069,14 @@ async def draft_gmail_message(
     Examples:
         # Create a new draft
         draft_gmail_message(subject="Hello", body="Hi there!", to="user@example.com")
+
+        # Create a draft from a configured alias (Send As)
+        draft_gmail_message(
+            subject="Business Inquiry",
+            body="Hello from my business address...",
+            to="user@example.com",
+            from_email="business@mydomain.com"
+        )
 
         # Create a plaintext draft with CC and BCC
         draft_gmail_message(
@@ -1077,7 +1111,7 @@ async def draft_gmail_message(
         draft_gmail_message(
             subject="Re: Meeting tomorrow",
             body="<strong>Thanks for the update!</strong>",
-            body_format="html,
+            body_format="html",
             to="user@example.com",
             thread_id="thread_123",
             in_reply_to="<message123@gmail.com>",
@@ -1089,6 +1123,8 @@ async def draft_gmail_message(
     )
 
     # Prepare the email message
+    # Use from_email (Send As alias) if provided, otherwise default to authenticated user
+    sender_email = from_email or user_google_email
     raw_message, thread_id_final = _prepare_gmail_message(
         subject=subject,
         body=body,
@@ -1099,7 +1135,7 @@ async def draft_gmail_message(
         thread_id=thread_id,
         in_reply_to=in_reply_to,
         references=references,
-        from_email=user_google_email,
+        from_email=sender_email,
     )
 
     # Create a draft instead of sending


### PR DESCRIPTION
## Summary

This PR adds support for Gmail's "Send As" feature to the `send_gmail_message` and `draft_gmail_message` tools, allowing users to send and draft emails from configured alias addresses.

### Changes

- Added optional `from_email` parameter to `send_gmail_message`
- Added optional `from_email` parameter to `draft_gmail_message`
- Both functions now accept an optional sender email that must be configured in Gmail's "Send mail as" settings
- Falls back to the authenticated user's primary email if `from_email` is not provided
- Updated docstrings with comprehensive documentation and usage examples

### Use Case

Many users manage multiple email identities through a single Gmail account (e.g., personal email, business alias, domain-specific addresses). Gmail's "Send As" feature allows sending from these configured addresses. This PR exposes that functionality through the MCP tools.

### Example Usage

```python
# Send from primary account (existing behavior, unchanged)
send_gmail_message(to="user@example.com", subject="Hello", body="Hi there!")

# Send from a configured alias (new functionality)
send_gmail_message(
    to="user@example.com",
    subject="Business Inquiry",
    body="Hello from my business address...",
    from_email="business@mydomain.com"
)
```

### Prerequisites

The `from_email` address must be configured in Gmail settings:
**Gmail → Settings → Accounts and Import → Send mail as**

### Backward Compatibility

This change is fully backward compatible. The `from_email` parameter is optional and defaults to `None`, which preserves the existing behavior of using the authenticated user's email.

## Test Plan

- [ ] Test sending email without `from_email` (should use authenticated user's email)
- [ ] Test sending email with valid `from_email` (should send from alias)
- [ ] Test drafting email without `from_email`
- [ ] Test drafting email with valid `from_email`
- [ ] Verify error handling when `from_email` is not configured in Gmail

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)