### PR TITLE
Fix YAML indentation in tool_tiers.yaml

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -47,7 +47,7 @@ calendar:
     - get_events
     - create_event
     - modify_event
-extended:
+  extended:
     - delete_event
     - query_freebusy
   complete: []


### PR DESCRIPTION
This PR fixes invalid YAML syntax in `core/tool_tiers.yaml`.

## Issue
The `extended:` key under the `calendar:` section was missing proper indentation, causing the YAML file to be invalid.

## Fix
- Corrected the indentation of `extended:` to align with `core:` and `complete:` keys

## Changes
- Only modifies `core/tool_tiers.yaml` - no other files changed

## Validation
- Verified YAML syntax is now valid using Python's YAML parser