### PR TITLE
Fix YAML indentation error in tool_tiers.yaml

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -47,7 +47,7 @@ calendar:
     - get_events
     - create_event
     - modify_event
-extended:
+  extended:
     - delete_event
     - query_freebusy
   complete: []


### PR DESCRIPTION
## Summary
- Fixes missing indentation for `extended` key under `calendar` section in `core/tool_tiers.yaml`
- This was causing YAML parsing errors when loading tools with `--tool-tier complete`

## Error fixed
```
❌ Error loading tools for tier 'complete': Invalid YAML in tool tiers configuration: while parsing a block mapping
  in "core/tool_tiers.yaml", line 1, column 1
expected <block end>, but found '<block mapping start>'
  in "core/tool_tiers.yaml", line 53, column 3
```

## Change
Line 50: `extended:` → `  extended:` (added 2 spaces for proper indentation)

Fixes #398