### PR TITLE
Add --host argument for configurable bind address

### DIFF
--- a/main.py
+++ b/main.py
@@ -115,6 +115,11 @@ def main():
         help="Load tools based on tier level. Can be combined with --tools to filter services.",
     )
     parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="Host address to bind to (default: 0.0.0.0). Use 127.0.0.1 for localhost only.",
+    )
+    parser.add_argument(
         "--transport",
         choices=["stdio", "streamable-http"],
         default="stdio",
@@ -373,7 +378,7 @@ def main():
                 )
                 sys.exit(1)
 
-            server.run(transport="streamable-http", host="0.0.0.0", port=port)
+            server.run(transport="streamable-http", host=args.host, port=port)
         else:
             server.run()
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary

This PR adds a `--host` command line argument to configure which network interface the HTTP server binds to.

**Changes:**
- Added `--host` argument with default value `0.0.0.0` (preserving current behavior)
- Updated `server.run()` call to use the configurable host instead of hardcoded value

## Motivation

When deploying the MCP server in containerized environments (Kubernetes, Docker), it's often desirable to bind the server to localhost only (`127.0.0.1`) while using a sidecar container (like nginx) for TLS termination and external access.

Currently, the server always binds to `0.0.0.0`, which means it's accessible on all network interfaces within the pod/container. This creates a potential security concern in multi-container deployments where you want the MCP server to only be accessible through the TLS-terminating proxy.

## Use Case

**Kubernetes deployment with nginx sidecar for HTTPS termination:**

```yaml
containers:
- name: mcp
  image: google-workspace-mcp
  args:
  - --transport
  - streamable-http
  - --host
  - "127.0.0.1"  # Only accessible via localhost
  ports:
  - containerPort: 8000  # Not exposed externally

- name: nginx
  image: nginx:alpine
  ports:
  - containerPort: 8443  # HTTPS endpoint
  # nginx proxies to localhost:8000
```

This pattern provides defense-in-depth security:
1. MCP server is only accessible via localhost within the pod
2. nginx handles TLS termination with proper certificates
3. Only HTTPS traffic is exposed to the network

## Backward Compatibility

- Default value is `0.0.0.0`, so existing deployments are unaffected
- The argument is optional and only relevant for `streamable-http` transport

## Testing

Tested in a Kubernetes environment with:
- nginx sidecar handling TLS termination
- MCP server bound to 127.0.0.1
- OAuth 2.1 authentication working correctly through the HTTPS endpoint