### PR TITLE
fix: add SSRF protection to create_drive_file

### DIFF
--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -565,6 +565,9 @@ async def create_drive_file(
             )
         # Handle HTTP/HTTPS URLs
         elif parsed_url.scheme in ("http", "https"):
+            # SSRF protection: block internal/private network URLs
+            _validate_url_not_internal(fileUrl)
+
             # when running in stateless mode, deployment may not have access to local file system
             if is_stateless_mode():
                 async with httpx.AsyncClient(follow_redirects=True) as client:


### PR DESCRIPTION
## Summary

- Adds `_validate_url_not_internal(fileUrl)` check to `create_drive_file` for HTTP/HTTPS URLs, matching the existing protection in `import_to_google_doc` (line 888)
- The validation function already exists and is used elsewhere — this just closes the gap in coverage

## Context

`create_drive_file` accepts a `fileUrl` parameter and fetches arbitrary HTTP/HTTPS URLs without SSRF validation. `import_to_google_doc` correctly calls `_validate_url_not_internal()` before fetching. This PR applies the same check.

Closes #452

## Test plan

- [ ] Verify `create_drive_file` with a valid external URL still works
- [ ] Verify `create_drive_file` with `http://localhost:*` or `http://127.0.0.1:*` raises `ValueError`
- [ ] Verify `create_drive_file` with private IP ranges (e.g., `http://192.168.1.1/`) raises `ValueError`
- [ ] Verify `import_to_google_doc` behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)