### PR TITLE
fix: FieldInfo not JSON serializable in CLI mode for label functions

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -1829,12 +1829,8 @@ async def modify_gmail_message_labels(
     service,
     user_google_email: str,
     message_id: str,
-    add_label_ids: List[str] = Field(
-        default=[], description="Label IDs to add to the message."
-    ),
-    remove_label_ids: List[str] = Field(
-        default=[], description="Label IDs to remove from the message."
-    ),
+    add_label_ids: List[str] = [],
+    remove_label_ids: List[str] = [],
 ) -> str:
     """
     Adds or removes labels from a Gmail message.
@@ -1885,12 +1881,8 @@ async def batch_modify_gmail_message_labels(
     service,
     user_google_email: str,
     message_ids: List[str],
-    add_label_ids: List[str] = Field(
-        default=[], description="Label IDs to add to messages."
-    ),
-    remove_label_ids: List[str] = Field(
-        default=[], description="Label IDs to remove from messages."
-    ),
+    add_label_ids: List[str] = [],
+    remove_label_ids: List[str] = [],
 ) -> str:
     """
     Adds or removes labels from multiple Gmail messages in a single batch request.


### PR DESCRIPTION
## Summary

Fixes #440

`modify_gmail_message_labels` and `batch_modify_gmail_message_labels` crash with `Object of type FieldInfo is not JSON serializable` when invoked via `--cli` mode.

## Root Cause

`Field(default=[], description="...")` returns a `FieldInfo` metadata object, not `[]`. When FastMCP serves tools via MCP protocol, Pydantic resolves `FieldInfo` into the actual default — so the MCP server works fine. But when the CLI handler calls `fn(**args)` directly, Python uses the raw `FieldInfo` object as the default, which is not serializable.

## Fix

Replace `Field(default=[], description="...")` with plain `[]` defaults in both functions. The parameter descriptions are already documented in the docstrings, which FastMCP uses for schema generation.

## Changes

- `gmail/gmail_tools.py`: Replace `Field(default=...)` with `[]` for `add_label_ids` and `remove_label_ids` in:
  - `modify_gmail_message_labels` (line ~1832)
  - `batch_modify_gmail_message_labels` (line ~1888)

+4 / -12 lines.