### PR TITLE
Potential fix for code scanning alert no. 51: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/taylorwilsdon/google_workspace_mcp/security/code-scanning/51](https://github.com/taylorwilsdon/google_workspace_mcp/security/code-scanning/51)

In general, to fix this class of issue you add a `permissions:` block either at the top level of the workflow (applies to all jobs that don’t override it) or inside a specific job. For a lint/check workflow like this one, the `GITHUB_TOKEN` only needs to read repository contents, so `contents: read` is sufficient and aligns with the principle of least privilege.

For this specific file, the minimal and least invasive fix is to add a top-level `permissions:` block right after the `on:` section. This will apply to the `ruff` job without changing its behavior, since the job only reads the code and does not attempt any write operations. No imports or other code changes are needed; we only modify `.github/workflows/ruff.yml` to introduce:

```yaml
permissions:
  contents: read
```

Concretely, edit `.github/workflows/ruff.yml` to insert the `permissions` section between the `on:` block (lines 3–7) and the `jobs:` block (line 9). No other files or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
