### PR TITLE
fix: add missing token_uri, client_id, client_secret to OAuth 2.1 refresh store_session

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -612,9 +612,13 @@ def get_credentials(
                                     user_email=user_email,
                                     access_token=credentials.token,
                                     refresh_token=credentials.refresh_token,
+                                    token_uri=credentials.token_uri,
+                                    client_id=credentials.client_id,
+                                    client_secret=credentials.client_secret,
                                     scopes=credentials.scopes,
                                     expiry=credentials.expiry,
                                     mcp_session_id=session_id,
+                                    issuer="https://accounts.google.com",
                                 )
                                 # Persist to file so rotated refresh tokens survive restarts
                                 if not is_stateless_mode():


### PR DESCRIPTION
## Description

The `store_session` call in the OAuth 2.1 credential refresh path (`get_credentials`, line 611) omits `token_uri`, `client_id`, `client_secret`, and `issuer`. These fields are stored as `None`, which causes the next token refresh attempt to fail — forcing a full re-authentication every time the access token expires (~1 hour).

The correct pattern already exists in three other `store_session` calls in the same file:
- `save_credentials_to_session()` (line 151)
- `handle_auth_callback()` (line 522)
- `get_credentials()` non-OAuth-2.1 path (line 750)

This PR aligns the OAuth 2.1 refresh path to match, adding the three missing credential fields plus the `issuer` parameter.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] I have tested this change manually
- Confirmed that after this fix, OAuth tokens refresh correctly across multi-hour sessions without requiring re-authentication

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

Discovered while building an MCP-based workflow system. The bug manifests as Google Workspace tools becoming inaccessible after ~1 hour of use, requiring a full browser-based re-auth flow. The fix is a 4-line addition that brings the refresh path in line with the rest of the codebase.