### PR TITLE
fix(auth): filter non-credential files from list_users()

### DIFF
--- a/auth/credential_store.py
+++ b/auth/credential_store.py
@@ -215,10 +215,13 @@ class LocalDirectoryCredentialStore(CredentialStore):
             return []
 
         users = []
+        non_credential_files = {"oauth_states"}
         try:
             for filename in os.listdir(self.base_dir):
                 if filename.endswith(".json"):
                     user_email = filename[:-5]  # Remove .json extension
+                    if user_email in non_credential_files or "@" not in user_email:
+                        continue
                     users.append(user_email)
             logger.debug(
                 f"Found {len(users)} users with credentials in {self.base_dir}"


### PR DESCRIPTION
## Summary

`LocalDirectoryCredentialStore.list_users()` enumerates all `.json` files in the credentials directory, but `oauth_states.json` (written by `PersistentOAuthStateStore`) is not a user credential file. 

In single-user mode, `oauth_states.json` can sort alphabetically before actual credential files, causing a `TypeError` when accessing `credentials.scopes` (which is `None` since the state file has no scopes field).

**Fix:** Filter out known non-credential files (`oauth_states`) and filenames without `@` to ensure only actual user credential files are returned.

## Reproduction

1. Run server in `--single-user` mode
2. Complete OAuth flow (creates both `user@example.com.json` and `oauth_states.json` in credentials dir)
3. On next tool call, `list_users()` picks up `oauth_states.json` first
4. `_find_any_credentials()` loads it → `credentials.scopes` is `None` → `TypeError: argument of type 'NoneType' is not iterable`

## Test plan

- [ ] Verify `list_users()` returns only email-based credential files
- [ ] Verify `oauth_states.json` is excluded from user enumeration
- [ ] Verify single-user mode works correctly after OAuth flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced credential listing functionality to exclude non-credential files and invalid user entries, ensuring only valid credentials are displayed in user lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->