### PR TITLE
Add --permissions flag for granular per-service permission levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,25 @@ Read-only mode provides secure, restricted access by:
 - Automatically filtering out tools that require write permissions at startup
 - Allowing read operations: list, get, search, and export across all services
 
+**🔐 Permission Levels**
+```bash
+# Per-service permission control
+uv run main.py --permissions gmail:organize         # Read + label + triage, no send
+uv run main.py --permissions gmail:drafts            # + draft management
+uv run main.py --permissions gmail:send              # + send messages
+uv run main.py --permissions gmail:readonly          # Read-only (same as --read-only --tools gmail)
+uv run main.py --permissions gmail:organize calendar:readonly  # Multi-service
+```
+
+Permission levels provide granular control between read-only and full access:
+- **readonly** — Read-only access (available for all services)
+- **organize** *(Gmail)* — Read + label management + message organization
+- **drafts** *(Gmail)* — + draft creation and management
+- **send** *(Gmail)* — + send messages
+- **full** — Full access (available for all services, default when not using --permissions)
+
+Only listed services are loaded. Mutually exclusive with `--read-only`, `--tools`, and `--tool-tier`.
+
 **★ Tool Tiers**
 ```bash
 uv run main.py --tool-tier core      # ● Essential tools only

--- a/auth/scopes.py
+++ b/auth/scopes.py
@@ -201,6 +201,37 @@ TOOL_SCOPES_MAP = {
     "appscript": SCRIPT_SCOPES,
 }
 
+# Per-service permission levels
+# Each level is cumulative — includes all scopes from previous levels plus new ones.
+# Only services with custom levels beyond readonly/full need entries here.
+PERMISSION_LEVELS = {
+    "gmail": {
+        "readonly": [GMAIL_READONLY_SCOPE],
+        "organize": [GMAIL_READONLY_SCOPE, GMAIL_LABELS_SCOPE, GMAIL_MODIFY_SCOPE],
+        "drafts": [
+            GMAIL_READONLY_SCOPE,
+            GMAIL_LABELS_SCOPE,
+            GMAIL_MODIFY_SCOPE,
+            GMAIL_COMPOSE_SCOPE,
+        ],
+        "send": [
+            GMAIL_READONLY_SCOPE,
+            GMAIL_LABELS_SCOPE,
+            GMAIL_MODIFY_SCOPE,
+            GMAIL_COMPOSE_SCOPE,
+            GMAIL_SEND_SCOPE,
+        ],
+        "full": [
+            GMAIL_READONLY_SCOPE,
+            GMAIL_LABELS_SCOPE,
+            GMAIL_MODIFY_SCOPE,
+            GMAIL_COMPOSE_SCOPE,
+            GMAIL_SEND_SCOPE,
+            GMAIL_SETTINGS_BASIC_SCOPE,
+        ],
+    },
+}
+
 # Tool-to-read-only-scopes mapping
 TOOL_READONLY_SCOPES_MAP = {
     "gmail": [GMAIL_READONLY_SCOPE],
@@ -257,6 +288,94 @@ def is_read_only_mode() -> bool:
     return _READ_ONLY_MODE
 
 
+# Per-service permission configuration (set by main.py)
+_PERMISSION_CONFIG: dict[str, str] = {}
+
+
+def set_permission_config(config: dict[str, str]):
+    """
+    Set the per-service permission configuration.
+
+    Args:
+        config: Dict mapping service names to permission level names,
+                e.g. {"gmail": "organize", "calendar": "readonly"}.
+    """
+    global _PERMISSION_CONFIG
+    _PERMISSION_CONFIG = config
+    logger.info(f"Permission config set: {config}")
+
+
+def get_permission_config() -> dict[str, str]:
+    """Get the current per-service permission configuration."""
+    return _PERMISSION_CONFIG
+
+
+def clear_permission_config():
+    """Reset the permission configuration to empty."""
+    global _PERMISSION_CONFIG
+    _PERMISSION_CONFIG = {}
+
+
+def get_scopes_for_permission_level(service: str, level: str) -> list[str]:
+    """
+    Get the OAuth scopes for a specific service and permission level.
+
+    Three cases:
+    - Known service + known level (e.g. gmail:organize): return PERMISSION_LEVELS entry.
+    - Any service + generic level (readonly/full): return from TOOL_READONLY_SCOPES_MAP / TOOL_SCOPES_MAP.
+    - Unknown combination: raise ValueError.
+
+    Args:
+        service: Service name (e.g. "gmail", "calendar").
+        level: Permission level name (e.g. "readonly", "organize", "full").
+
+    Returns:
+        List of OAuth scope strings.
+
+    Raises:
+        ValueError: If the service/level combination is invalid.
+    """
+    # Check for service-specific custom levels
+    if service in PERMISSION_LEVELS:
+        service_levels = PERMISSION_LEVELS[service]
+        if level in service_levels:
+            return service_levels[level]
+        valid_levels = sorted(service_levels.keys())
+        raise ValueError(
+            f"Unknown permission level '{level}' for service '{service}'. "
+            f"Valid levels: {valid_levels}"
+        )
+
+    # Generic fallback for services without custom levels
+    if level == "readonly":
+        if service in TOOL_READONLY_SCOPES_MAP:
+            return TOOL_READONLY_SCOPES_MAP[service]
+        raise ValueError(f"Unknown service '{service}'")
+    if level == "full":
+        if service in TOOL_SCOPES_MAP:
+            return TOOL_SCOPES_MAP[service]
+        raise ValueError(f"Unknown service '{service}'")
+
+    raise ValueError(
+        f"Unknown permission level '{level}' for service '{service}'. "
+        f"Service '{service}' only supports generic levels: ['full', 'readonly']"
+    )
+
+
+def get_allowed_scopes_for_permissions() -> set[str]:
+    """
+    Build the union of all allowed scopes across all services in the
+    current permission config. Always includes BASE_SCOPES.
+
+    Returns:
+        Set of allowed OAuth scope strings.
+    """
+    allowed = set(BASE_SCOPES)
+    for service, level in _PERMISSION_CONFIG.items():
+        allowed.update(get_scopes_for_permission_level(service, level))
+    return allowed
+
+
 def get_all_read_only_scopes() -> list[str]:
     """Get all possible read-only scopes across all tools."""
     all_scopes = set(BASE_SCOPES)
@@ -298,14 +417,26 @@ def get_scopes_for_tools(enabled_tools=None):
     # Start with base scopes (always required)
     scopes = BASE_SCOPES.copy()
 
-    # Determine which map to use based on read-only mode
-    scope_map = TOOL_READONLY_SCOPES_MAP if _READ_ONLY_MODE else TOOL_SCOPES_MAP
-    mode_str = "read-only" if _READ_ONLY_MODE else "full"
+    # When permission config is active, use per-service permission levels
+    if _PERMISSION_CONFIG:
+        mode_str = "permissions"
+        for tool in enabled_tools:
+            if tool in _PERMISSION_CONFIG:
+                scopes.extend(
+                    get_scopes_for_permission_level(tool, _PERMISSION_CONFIG[tool])
+                )
+            elif tool in TOOL_SCOPES_MAP:
+                # Service enabled but not in permission config — use full scopes
+                scopes.extend(TOOL_SCOPES_MAP[tool])
+    else:
+        # Determine which map to use based on read-only mode
+        scope_map = TOOL_READONLY_SCOPES_MAP if _READ_ONLY_MODE else TOOL_SCOPES_MAP
+        mode_str = "read-only" if _READ_ONLY_MODE else "full"
 
-    # Add scopes for each enabled tool
-    for tool in enabled_tools:
-        if tool in scope_map:
-            scopes.extend(scope_map[tool])
+        # Add scopes for each enabled tool
+        for tool in enabled_tools:
+            if tool in scope_map:
+                scopes.extend(scope_map[tool])
 
     logger.debug(
         f"Generated {mode_str} scopes for tools {list(enabled_tools)}: {len(set(scopes))} unique scopes"

--- a/core/tool_registry.py
+++ b/core/tool_registry.py
@@ -9,7 +9,12 @@ import logging
 from typing import Set, Optional, Callable
 
 from auth.oauth_config import is_oauth21_enabled
-from auth.scopes import is_read_only_mode, get_all_read_only_scopes
+from auth.scopes import (
+    is_read_only_mode,
+    get_all_read_only_scopes,
+    get_permission_config,
+    get_allowed_scopes_for_permissions,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +88,15 @@ def filter_server_tools(server):
     """Remove disabled tools from the server after registration."""
     enabled_tools = get_enabled_tools()
     oauth21_enabled = is_oauth21_enabled()
-    if enabled_tools is None and not oauth21_enabled:
+    read_only_mode = is_read_only_mode()
+    permission_config = get_permission_config()
+
+    if (
+        enabled_tools is None
+        and not oauth21_enabled
+        and not read_only_mode
+        and not permission_config
+    ):
         return
 
     tools_removed = 0
@@ -94,8 +107,13 @@ def filter_server_tools(server):
         if hasattr(tool_manager, "_tools"):
             tool_registry = tool_manager._tools
 
-            read_only_mode = is_read_only_mode()
-            allowed_scopes = set(get_all_read_only_scopes()) if read_only_mode else None
+            # Determine allowed scopes based on mode
+            if read_only_mode:
+                allowed_scopes = set(get_all_read_only_scopes())
+            elif permission_config:
+                allowed_scopes = get_allowed_scopes_for_permissions()
+            else:
+                allowed_scopes = None
 
             tools_to_remove = set()
 
@@ -110,8 +128,9 @@ def filter_server_tools(server):
                 tools_to_remove.add("start_google_auth")
                 logger.info("OAuth 2.1 enabled: disabling start_google_auth tool")
 
-            # 3. Read-only mode filtering
-            if read_only_mode:
+            # 3. Scope-based filtering (read-only mode or permission levels)
+            if allowed_scopes is not None:
+                mode_label = "Read-only" if read_only_mode else "Permissions"
                 for tool_name in list(tool_registry.keys()):
                     if tool_name in tools_to_remove:
                         continue
@@ -128,12 +147,12 @@ def filter_server_tools(server):
                     )
 
                     if required_scopes:
-                        # If ANY required scope is not in the allowed read-only scopes, disable the tool
+                        # If ANY required scope is not in the allowed scopes, disable the tool
                         if not all(
                             scope in allowed_scopes for scope in required_scopes
                         ):
                             logger.info(
-                                f"Read-only mode: Disabling tool '{tool_name}' (requires write scopes: {required_scopes})"
+                                f"{mode_label} mode: Disabling tool '{tool_name}' (requires scopes: {required_scopes})"
                             )
                             tools_to_remove.add(tool_name)
 
@@ -143,7 +162,12 @@ def filter_server_tools(server):
 
     if tools_removed > 0:
         enabled_count = len(enabled_tools) if enabled_tools is not None else "all"
-        mode = "Read-Only" if is_read_only_mode() else "Full"
+        if read_only_mode:
+            mode = "Read-Only"
+        elif permission_config:
+            mode = f"Permissions ({permission_config})"
+        else:
+            mode = "Full"
         logger.info(
             f"Tool filtering: removed {tools_removed} tools, {enabled_count} enabled. Mode: {mode}"
         )

--- a/main.py
+++ b/main.py
@@ -155,12 +155,65 @@ def main():
         action="store_true",
         help="Run in read-only mode - requests only read-only scopes and disables tools requiring write permissions",
     )
+    parser.add_argument(
+        "--permissions",
+        nargs="+",
+        metavar="SERVICE:LEVEL",
+        help="Per-service permission levels (e.g., gmail:organize calendar:readonly). "
+        "Only listed services are loaded. Mutually exclusive with --read-only, --tools, and --tool-tier.",
+        default=None,
+    )
     args = parser.parse_args()
 
     # Clean up CLI args - argparse.REMAINDER may include leading dashes from first arg
     if args.cli is not None:
         # Filter out empty strings that might appear
         args.cli = [a for a in args.cli if a]
+
+    # Validate --permissions mutual exclusivity and parse
+    if args.permissions:
+        if args.read_only:
+            parser.error("--permissions and --read-only are mutually exclusive")
+        if args.tools is not None:
+            parser.error(
+                "--permissions and --tools are mutually exclusive "
+                "(--permissions implies which services to load)"
+            )
+        if args.tool_tier is not None:
+            parser.error("--permissions and --tool-tier are mutually exclusive")
+
+        from auth.scopes import (
+            TOOL_SCOPES_MAP,
+            get_scopes_for_permission_level,
+            set_permission_config,
+        )
+
+        permission_config = {}
+        for perm in args.permissions:
+            if ":" not in perm:
+                parser.error(
+                    f"Invalid format '{perm}'. Expected SERVICE:LEVEL "
+                    f"(e.g., gmail:organize)"
+                )
+            service, level = perm.split(":", 1)
+            service = service.strip().lower()
+            level = level.strip().lower()
+            if service not in TOOL_SCOPES_MAP:
+                parser.error(
+                    f"Unknown service '{service}'. "
+                    f"Valid services: {sorted(TOOL_SCOPES_MAP.keys())}"
+                )
+            if service in permission_config:
+                parser.error(
+                    f"Duplicate service '{service}'. "
+                    f"Specify each service only once."
+                )
+            try:
+                get_scopes_for_permission_level(service, level)
+            except ValueError as e:
+                parser.error(str(e))
+            permission_config[service] = level
+        set_permission_config(permission_config)
 
     # Set port and base URI once for reuse throughout the function
     port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", 8000)))
@@ -184,6 +237,8 @@ def main():
     safe_print(f"   👤 Mode: {'Single-user' if args.single_user else 'Multi-user'}")
     if args.read_only:
         safe_print("   🔒 Read-Only: Enabled")
+    if args.permissions:
+        safe_print(f"   🔐 Permissions: {' '.join(args.permissions)}")
     safe_print(f"   🐍 Python: {sys.version.split()[0]}")
     safe_print("")
 
@@ -265,7 +320,13 @@ def main():
     }
 
     # Determine which tools to import based on arguments
-    if args.tool_tier is not None:
+    if args.permissions:
+        # Permission config already parsed and set above
+        from auth.scopes import get_permission_config
+
+        tools_to_import = list(get_permission_config().keys())
+        set_enabled_tool_names(None)
+    elif args.tool_tier is not None:
         # Use tier-based tool selection, optionally filtered by services
         try:
             tier_tools, suggested_services = resolve_tools_from_tier(

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -11,7 +11,10 @@ import os
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+import pytest
+
 from auth.scopes import (
+    BASE_SCOPES,
     CALENDAR_READONLY_SCOPE,
     CALENDAR_SCOPE,
     CONTACTS_READONLY_SCOPE,
@@ -27,8 +30,13 @@ from auth.scopes import (
     GMAIL_SETTINGS_BASIC_SCOPE,
     SHEETS_READONLY_SCOPE,
     SHEETS_WRITE_SCOPE,
+    clear_permission_config,
+    get_allowed_scopes_for_permissions,
+    get_permission_config,
+    get_scopes_for_permission_level,
     get_scopes_for_tools,
     has_required_scopes,
+    set_permission_config,
     set_read_only,
 )
 
@@ -195,3 +203,264 @@ class TestHasRequiredScopes:
         available = [GMAIL_MODIFY_SCOPE]
         required = [GMAIL_READONLY_SCOPE, DRIVE_READONLY_SCOPE]
         assert not has_required_scopes(available, required)
+
+
+class TestPermissionLevelScopes:
+    """Tests for per-service permission level scope generation."""
+
+    def setup_method(self):
+        set_read_only(False)
+        clear_permission_config()
+
+    def teardown_method(self):
+        set_read_only(False)
+        clear_permission_config()
+
+    # --- Gmail level scopes ---
+
+    def test_gmail_organize_scopes(self):
+        """gmail:organize includes readonly, labels, modify."""
+        set_permission_config({"gmail": "organize"})
+        scopes = get_scopes_for_tools(["gmail"])
+        assert GMAIL_READONLY_SCOPE in scopes
+        assert GMAIL_LABELS_SCOPE in scopes
+        assert GMAIL_MODIFY_SCOPE in scopes
+        assert GMAIL_COMPOSE_SCOPE not in scopes
+        assert GMAIL_SEND_SCOPE not in scopes
+        assert GMAIL_SETTINGS_BASIC_SCOPE not in scopes
+
+    def test_gmail_drafts_scopes(self):
+        """gmail:drafts includes organize scopes + compose."""
+        set_permission_config({"gmail": "drafts"})
+        scopes = get_scopes_for_tools(["gmail"])
+        assert GMAIL_READONLY_SCOPE in scopes
+        assert GMAIL_LABELS_SCOPE in scopes
+        assert GMAIL_MODIFY_SCOPE in scopes
+        assert GMAIL_COMPOSE_SCOPE in scopes
+        assert GMAIL_SEND_SCOPE not in scopes
+        assert GMAIL_SETTINGS_BASIC_SCOPE not in scopes
+
+    def test_gmail_send_scopes(self):
+        """gmail:send includes drafts scopes + send."""
+        set_permission_config({"gmail": "send"})
+        scopes = get_scopes_for_tools(["gmail"])
+        assert GMAIL_READONLY_SCOPE in scopes
+        assert GMAIL_LABELS_SCOPE in scopes
+        assert GMAIL_MODIFY_SCOPE in scopes
+        assert GMAIL_COMPOSE_SCOPE in scopes
+        assert GMAIL_SEND_SCOPE in scopes
+        assert GMAIL_SETTINGS_BASIC_SCOPE not in scopes
+
+    def test_gmail_full_scopes(self):
+        """gmail:full includes all 6 Gmail scopes."""
+        set_permission_config({"gmail": "full"})
+        scopes = get_scopes_for_tools(["gmail"])
+        assert GMAIL_READONLY_SCOPE in scopes
+        assert GMAIL_LABELS_SCOPE in scopes
+        assert GMAIL_MODIFY_SCOPE in scopes
+        assert GMAIL_COMPOSE_SCOPE in scopes
+        assert GMAIL_SEND_SCOPE in scopes
+        assert GMAIL_SETTINGS_BASIC_SCOPE in scopes
+
+    def test_gmail_readonly_scopes(self):
+        """gmail:readonly includes only gmail.readonly."""
+        set_permission_config({"gmail": "readonly"})
+        scopes = get_scopes_for_tools(["gmail"])
+        assert GMAIL_READONLY_SCOPE in scopes
+        assert GMAIL_LABELS_SCOPE not in scopes
+        assert GMAIL_MODIFY_SCOPE not in scopes
+        assert GMAIL_COMPOSE_SCOPE not in scopes
+        assert GMAIL_SEND_SCOPE not in scopes
+        assert GMAIL_SETTINGS_BASIC_SCOPE not in scopes
+
+    # --- Generic fallback ---
+
+    def test_calendar_readonly_fallback(self):
+        """calendar:readonly uses TOOL_READONLY_SCOPES_MAP fallback."""
+        scopes = get_scopes_for_permission_level("calendar", "readonly")
+        assert CALENDAR_READONLY_SCOPE in scopes
+        assert CALENDAR_SCOPE not in scopes
+
+    def test_calendar_full_fallback(self):
+        """calendar:full uses TOOL_SCOPES_MAP fallback."""
+        scopes = get_scopes_for_permission_level("calendar", "full")
+        assert CALENDAR_SCOPE in scopes
+
+    # --- Invalid combinations ---
+
+    def test_gmail_invalid_level_raises(self):
+        """gmail:superadmin should raise ValueError."""
+        with pytest.raises(ValueError, match="Unknown permission level 'superadmin'"):
+            get_scopes_for_permission_level("gmail", "superadmin")
+
+    def test_calendar_organize_raises(self):
+        """calendar:organize should raise ValueError (no custom levels defined)."""
+        with pytest.raises(ValueError, match="Unknown permission level 'organize'"):
+            get_scopes_for_permission_level("calendar", "organize")
+
+    # --- Multi-service union ---
+
+    def test_multi_service_allowed_scopes(self):
+        """get_allowed_scopes_for_permissions() returns union of all services."""
+        set_permission_config({"gmail": "organize", "calendar": "readonly"})
+        allowed = get_allowed_scopes_for_permissions()
+        # Gmail organize scopes
+        assert GMAIL_READONLY_SCOPE in allowed
+        assert GMAIL_LABELS_SCOPE in allowed
+        assert GMAIL_MODIFY_SCOPE in allowed
+        # Calendar readonly scope
+        assert CALENDAR_READONLY_SCOPE in allowed
+        # Base scopes always included
+        for scope in BASE_SCOPES:
+            assert scope in allowed
+        # Not included
+        assert GMAIL_SEND_SCOPE not in allowed
+        assert CALENDAR_SCOPE not in allowed
+
+    # --- State lifecycle ---
+
+    def test_clear_permission_config(self):
+        """clear_permission_config() resets to empty dict."""
+        set_permission_config({"gmail": "organize"})
+        assert get_permission_config() == {"gmail": "organize"}
+        clear_permission_config()
+        assert get_permission_config() == {}
+
+    # --- get_scopes_for_tools integration ---
+
+    def test_scopes_for_tools_with_permission_config(self):
+        """get_scopes_for_tools uses permission config when set."""
+        set_permission_config({"gmail": "organize"})
+        scopes = get_scopes_for_tools(["gmail"])
+        scope_set = set(scopes)
+        # Should have base scopes + gmail organize scopes
+        assert GMAIL_READONLY_SCOPE in scope_set
+        assert GMAIL_LABELS_SCOPE in scope_set
+        assert GMAIL_MODIFY_SCOPE in scope_set
+        # Should NOT have compose/send/settings
+        assert GMAIL_COMPOSE_SCOPE not in scope_set
+        assert GMAIL_SEND_SCOPE not in scope_set
+
+    def test_scopes_unique(self):
+        """Returned scopes should be unique."""
+        set_permission_config({"gmail": "drafts"})
+        scopes = get_scopes_for_tools(["gmail"])
+        assert len(scopes) == len(set(scopes))
+
+
+class TestPermissionToolFiltering:
+    """Tests for filter_server_tools() with permission levels."""
+
+    def setup_method(self):
+        set_read_only(False)
+        clear_permission_config()
+
+    def teardown_method(self):
+        set_read_only(False)
+        clear_permission_config()
+
+    def _make_mock_tool(self, required_scopes=None):
+        """Create a mock tool object with _required_google_scopes."""
+
+        class MockTool:
+            pass
+
+        tool = MockTool()
+        fn = MockTool()
+        if required_scopes is not None:
+            fn._required_google_scopes = required_scopes
+        tool.fn = fn
+        return tool
+
+    def _make_tool_registry(self, tools_dict):
+        """Create a mock server with a tool registry."""
+
+        class MockToolManager:
+            def __init__(self, tools):
+                self._tools = dict(tools)
+
+        class MockServer:
+            def __init__(self, tools):
+                self._tool_manager = MockToolManager(tools)
+
+        return MockServer(tools_dict)
+
+    def test_permission_filtering_removes_disallowed_tools(self):
+        """Tools requiring scopes outside permission level should be removed."""
+        from core.tool_registry import filter_server_tools
+
+        set_permission_config({"gmail": "organize"})
+
+        tools = {
+            "search_gmail_messages": self._make_mock_tool([GMAIL_READONLY_SCOPE]),
+            "manage_gmail_label": self._make_mock_tool([GMAIL_LABELS_SCOPE]),
+            "send_gmail_message": self._make_mock_tool([GMAIL_SEND_SCOPE]),
+            "create_gmail_filter": self._make_mock_tool(
+                [GMAIL_SETTINGS_BASIC_SCOPE]
+            ),
+        }
+        mock_server = self._make_tool_registry(tools)
+        filter_server_tools(mock_server)
+
+        remaining = set(mock_server._tool_manager._tools.keys())
+        assert "search_gmail_messages" in remaining
+        assert "manage_gmail_label" in remaining
+        assert "send_gmail_message" not in remaining
+        assert "create_gmail_filter" not in remaining
+
+    def test_permission_filtering_keeps_tools_without_scopes(self):
+        """Tools without _required_google_scopes (e.g. start_google_auth) should be kept."""
+        from core.tool_registry import filter_server_tools
+
+        set_permission_config({"gmail": "readonly"})
+
+        tools = {
+            "search_gmail_messages": self._make_mock_tool([GMAIL_READONLY_SCOPE]),
+            "start_google_auth": self._make_mock_tool(),  # No scopes
+        }
+        mock_server = self._make_tool_registry(tools)
+        filter_server_tools(mock_server)
+
+        remaining = set(mock_server._tool_manager._tools.keys())
+        assert "search_gmail_messages" in remaining
+        assert "start_google_auth" in remaining
+
+    def test_permission_filtering_subset_behavior(self):
+        """Tool requiring multiple scopes: kept only if ALL are allowed."""
+        from core.tool_registry import filter_server_tools
+
+        set_permission_config({"gmail": "organize"})
+
+        tools = {
+            "tool_a": self._make_mock_tool([GMAIL_READONLY_SCOPE]),
+            "tool_ab": self._make_mock_tool(
+                [GMAIL_READONLY_SCOPE, GMAIL_LABELS_SCOPE]
+            ),
+            "tool_abc": self._make_mock_tool(
+                [GMAIL_READONLY_SCOPE, GMAIL_LABELS_SCOPE, GMAIL_SEND_SCOPE]
+            ),
+        }
+        mock_server = self._make_tool_registry(tools)
+        filter_server_tools(mock_server)
+
+        remaining = set(mock_server._tool_manager._tools.keys())
+        assert "tool_a" in remaining
+        assert "tool_ab" in remaining
+        assert "tool_abc" not in remaining
+
+    def test_drafts_level_allows_compose(self):
+        """gmail:drafts should allow tools requiring gmail.compose."""
+        from core.tool_registry import filter_server_tools
+
+        set_permission_config({"gmail": "drafts"})
+
+        tools = {
+            "draft_gmail_message": self._make_mock_tool([GMAIL_COMPOSE_SCOPE]),
+            "send_gmail_message": self._make_mock_tool([GMAIL_SEND_SCOPE]),
+        }
+        mock_server = self._make_tool_registry(tools)
+        filter_server_tools(mock_server)
+
+        remaining = set(mock_server._tool_manager._tools.keys())
+        assert "draft_gmail_message" in remaining
+        assert "send_gmail_message" not in remaining


### PR DESCRIPTION
## Summary

- Adds a `--permissions` CLI flag for per-service permission levels (e.g., `--permissions gmail:organize calendar:readonly`), providing granular control between `--read-only` and full access
- Implements Gmail-specific permission levels: `readonly`, `organize`, `drafts`, `send`, `full` — each cumulative, gated by risk category (destruction > external-facing > admin > internal)
- Generalizes the existing scope-based tool filtering in `filter_server_tools()` to work with both read-only mode and the new permission levels
- Includes 17 new tests covering scope generation, tool filtering, edge cases, and multi-service combinations

Closes #491

### Motivation

Users who want an AI assistant to triage and organize Gmail (read, label, draft) without the ability to send, delete, or manage filters have no way to express that today. The current binary choice (`--read-only` vs full access) is too coarse.

Google's OAuth scopes don't map cleanly to risk categories — `gmail.compose` bundles drafts with send, `gmail.modify` covers labeling and trash — so the feature enforces two layers: OAuth scope selection limits what the token can do, and MCP tool filtering removes tools the LLM shouldn't see.

### Usage

```bash
uv run main.py --permissions gmail:readonly              # Same as --read-only --tools gmail
uv run main.py --permissions gmail:organize              # Read + label + triage, no send
uv run main.py --permissions gmail:drafts                # + draft management
uv run main.py --permissions gmail:send                  # + send messages
uv run main.py --permissions gmail:organize calendar:readonly  # Multi-service
```

### Design

The `PERMISSION_LEVELS` dict in `auth/scopes.py` makes it straightforward to add levels for other services (Calendar, Drive, etc.) — services without custom levels automatically support `readonly` and `full` via the existing scope maps.

`--permissions` is mutually exclusive with `--read-only`, `--tools`, and `--tool-tier` to avoid confusing interactions. Invalid services, levels, and duplicates produce clear error messages at startup.

### Files changed

| File | Change |
|------|--------|
| `auth/scopes.py` | `PERMISSION_LEVELS` data, config state, scope resolution |
| `core/tool_registry.py` | Generalized scope-based tool filtering (also fixes a latent bug where `--read-only` without `--tools` skipped filtering) |
| `main.py` | CLI argument, parsing, validation |
| `tests/test_scopes.py` | 17 new tests |
| `README.md` | Documentation for the new flag |

## Test plan

- [x] `uv run pytest tests/` — all 17 new tests pass, existing tests unaffected
- [ ] Manual: `--permissions gmail:organize` loads only Gmail, requests correct scopes, hides send/filter tools
- [ ] Manual: `--permissions gmail:drafts` exposes `draft_gmail_message`, hides `send_gmail_message`
- [ ] Manual: `--read-only` behavior unchanged
- [ ] Manual: No flags = full access unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced granular per-service permission levels (e.g., gmail:organize, gmail:drafts, gmail:readonly) for fine-grained access control.
  * Added --permissions CLI option to specify service-level permissions.

* **Documentation**
  * Updated README with permission system documentation, definitions, and CLI examples.

* **Tests**
  * Added comprehensive test coverage for the new permission system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->