### PR TITLE
fix: use RFC 2231 encoding for non-ASCII attachment filenames

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -337,7 +337,7 @@ def _prepare_gmail_message(
                     .replace("\r", "")
                     .replace("\n", "")
                     .replace("\x00", "")
-                )
+                ) or "attachment"
 
                 part.add_header(
                     "Content-Disposition", "attachment", filename=safe_filename


### PR DESCRIPTION
## Summary

Fixes #500 — Gmail displays "noname" for attachments whose filenames contain non-ASCII characters (e.g. `Prüfbericht Q1.pdf`).

## Root Cause

`Content-Disposition` was constructed via string formatting:

```python
part.add_header('Content-Disposition', f'attachment; filename="{safe_filename}"')
```

This embeds raw non-ASCII bytes directly in the MIME header. Gmail cannot parse them and falls back to "noname".

## Fix

Pass the filename as a keyword argument to `add_header()`:

```python
part.add_header('Content-Disposition', 'attachment', filename=safe_filename)
```

Python's `email` library then automatically applies [RFC 2231](https://datatracker.ietf.org/doc/html/rfc2231) encoding for non-ASCII filenames:

```
Content-Disposition: attachment; filename*=utf-8''Pr%C3%BCfbericht%20Q1.pdf
```

ASCII-only filenames remain unchanged (`filename="Statusbericht Projekt.pdf"`).

## Verification

```python
from email.mime.base import MIMEBase
from email import encoders

part = MIMEBase('application', 'pdf')
part.set_payload(b'test')
encoders.encode_base64(part)
part.add_header('Content-Disposition', 'attachment', filename='Prüfbericht Q1.pdf')
print(part['Content-Disposition'])
# → attachment; filename*=utf-8''Pr%C3%BCfbericht%20Q1.pdf  ✅
```

The backslash/quote escaping that was previously applied is no longer needed — `add_header()` handles all quoting and encoding internally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attachments with non-ASCII filenames now display correctly instead of appearing unnamed.
  * Filename handling improved: non-ASCII characters preserved, CR/LF/null chars removed, backslash/quote escaping avoided.
  * A sensible default filename ("attachment") is used when none is provided and encoding is handled properly for safe display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->