### PR TITLE
Optional hidden details in drive search and list

### DIFF
--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -181,6 +181,7 @@ def build_drive_list_params(
     drive_id: Optional[str] = None,
     include_items_from_all_drives: bool = True,
     corpora: Optional[str] = None,
+    detailed: bool = True,
 ) -> Dict[str, Any]:
     """
     Helper function to build common list parameters for Drive API calls.
@@ -191,14 +192,20 @@ def build_drive_list_params(
         drive_id: Optional shared drive ID
         include_items_from_all_drives: Whether to include items from all drives
         corpora: Optional corpus specification
+        detailed: Whether to request size, modifiedTime, and webViewLink fields.
+                  Defaults to True to preserve existing behavior.
 
     Returns:
         Dictionary of parameters for Drive API list calls
     """
+    if detailed:
+        fields = "nextPageToken, files(id, name, mimeType, webViewLink, iconLink, modifiedTime, size)"
+    else:
+        fields = "nextPageToken, files(id, name, mimeType)"
     list_params = {
         "q": query,
         "pageSize": page_size,
-        "fields": "nextPageToken, files(id, name, mimeType, webViewLink, iconLink, modifiedTime, size)",
+        "fields": fields,
         "supportsAllDrives": True,
         "includeItemsFromAllDrives": include_items_from_all_drives,
     }

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -60,6 +60,7 @@ async def search_drive_files(
     drive_id: Optional[str] = None,
     include_items_from_all_drives: bool = True,
     corpora: Optional[str] = None,
+    detailed: bool = True,
 ) -> str:
     """
     Searches for files and folders within a user's Google Drive, including shared drives.
@@ -73,9 +74,10 @@ async def search_drive_files(
         corpora (Optional[str]): Bodies of items to query (e.g., 'user', 'domain', 'drive', 'allDrives').
                                  If 'drive_id' is specified and 'corpora' is None, it defaults to 'drive'.
                                  Otherwise, Drive API default behavior applies. Prefer 'user' or 'drive' over 'allDrives' for efficiency.
+        detailed (bool): Whether to include size, modified time, and link in results. Defaults to True.
 
     Returns:
-        str: A formatted list of found files/folders with their details (ID, name, type, size, modified time, link).
+        str: A formatted list of found files/folders with their details (ID, name, type, and optionally size, modified time, link).
     """
     logger.info(
         f"[search_drive_files] Invoked. Email: '{user_google_email}', Query: '{query}'"
@@ -104,6 +106,7 @@ async def search_drive_files(
         drive_id=drive_id,
         include_items_from_all_drives=include_items_from_all_drives,
         corpora=corpora,
+        detailed=detailed,
     )
 
     results = await asyncio.to_thread(service.files().list(**list_params).execute)
@@ -115,10 +118,15 @@ async def search_drive_files(
         f"Found {len(files)} files for {user_google_email} matching '{query}':"
     ]
     for item in files:
-        size_str = f", Size: {item.get('size', 'N/A')}" if "size" in item else ""
-        formatted_files_text_parts.append(
-            f'- Name: "{item["name"]}" (ID: {item["id"]}, Type: {item["mimeType"]}{size_str}, Modified: {item.get("modifiedTime", "N/A")}) Link: {item.get("webViewLink", "#")}'
-        )
+        if detailed:
+            size_str = f", Size: {item.get('size', 'N/A')}" if "size" in item else ""
+            formatted_files_text_parts.append(
+                f'- Name: "{item["name"]}" (ID: {item["id"]}, Type: {item["mimeType"]}{size_str}, Modified: {item.get("modifiedTime", "N/A")}) Link: {item.get("webViewLink", "#")}'
+            )
+        else:
+            formatted_files_text_parts.append(
+                f'- Name: "{item["name"]}" (ID: {item["id"]}, Type: {item["mimeType"]})'
+            )
     text_output = "\n".join(formatted_files_text_parts)
     return text_output
 
@@ -414,6 +422,7 @@ async def list_drive_items(
     drive_id: Optional[str] = None,
     include_items_from_all_drives: bool = True,
     corpora: Optional[str] = None,
+    detailed: bool = True,
 ) -> str:
     """
     Lists files and folders, supporting shared drives.
@@ -427,6 +436,7 @@ async def list_drive_items(
         drive_id (Optional[str]): ID of the shared drive. If provided, the listing is scoped to this drive.
         include_items_from_all_drives (bool): Whether items from all accessible shared drives should be included if `drive_id` is not set. Defaults to True.
         corpora (Optional[str]): Corpus to query ('user', 'drive', 'allDrives'). If `drive_id` is set and `corpora` is None, 'drive' is used. If None and no `drive_id`, API defaults apply.
+        detailed (bool): Whether to include size, modified time, and link in results. Defaults to True.
 
     Returns:
         str: A formatted list of files/folders in the specified folder.
@@ -444,6 +454,7 @@ async def list_drive_items(
         drive_id=drive_id,
         include_items_from_all_drives=include_items_from_all_drives,
         corpora=corpora,
+        detailed=detailed,
     )
 
     results = await asyncio.to_thread(service.files().list(**list_params).execute)
@@ -455,10 +466,15 @@ async def list_drive_items(
         f"Found {len(files)} items in folder '{folder_id}' for {user_google_email}:"
     ]
     for item in files:
-        size_str = f", Size: {item.get('size', 'N/A')}" if "size" in item else ""
-        formatted_items_text_parts.append(
-            f'- Name: "{item["name"]}" (ID: {item["id"]}, Type: {item["mimeType"]}{size_str}, Modified: {item.get("modifiedTime", "N/A")}) Link: {item.get("webViewLink", "#")}'
-        )
+        if detailed:
+            size_str = f", Size: {item.get('size', 'N/A')}" if "size" in item else ""
+            formatted_items_text_parts.append(
+                f'- Name: "{item["name"]}" (ID: {item["id"]}, Type: {item["mimeType"]}{size_str}, Modified: {item.get("modifiedTime", "N/A")}) Link: {item.get("webViewLink", "#")}'
+            )
+        else:
+            formatted_items_text_parts.append(
+                f'- Name: "{item["name"]}" (ID: {item["id"]}, Type: {item["mimeType"]})'
+            )
     text_output = "\n".join(formatted_items_text_parts)
     return text_output
 

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -1,7 +1,9 @@
 """
 Unit tests for Google Drive MCP tools.
 
-Tests create_drive_folder with mocked API responses.
+Tests create_drive_folder with mocked API responses, and the `detailed`
+parameter added to search_drive_files, list_drive_items, and
+build_drive_list_params.
 """
 
 import pytest
@@ -10,6 +12,51 @@ import sys
 import os
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gdrive.drive_helpers import build_drive_list_params
+from gdrive.drive_tools import list_drive_items, search_drive_files
+
+
+def _unwrap(tool):
+    """Unwrap a FunctionTool + decorator chain to the original async function.
+
+    Handles both older FastMCP (FunctionTool with .fn) and newer FastMCP
+    (server.tool() returns the function directly).
+    """
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_file(
+    file_id: str,
+    name: str,
+    mime_type: str,
+    link: str = "http://link",
+    modified: str = "2024-01-01T00:00:00Z",
+    size: str | None = None,
+) -> dict:
+    item = {
+        "id": file_id,
+        "name": name,
+        "mimeType": mime_type,
+        "webViewLink": link,
+        "modifiedTime": modified,
+    }
+    if size is not None:
+        item["size"] = size
+    return item
+
+
+# ---------------------------------------------------------------------------
+# create_drive_folder
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -44,3 +91,319 @@ async def test_create_drive_folder():
     assert "folder123" in result
     assert "user@example.com" in result
     assert "https://drive.google.com/drive/folders/folder123" in result
+
+
+# ---------------------------------------------------------------------------
+# build_drive_list_params — detailed flag (pure unit tests, no I/O)
+# ---------------------------------------------------------------------------
+
+
+def test_build_params_detailed_true_includes_extra_fields():
+    """detailed=True requests modifiedTime, webViewLink, and size from the API."""
+    params = build_drive_list_params(query="name='x'", page_size=10, detailed=True)
+    assert "modifiedTime" in params["fields"]
+    assert "webViewLink" in params["fields"]
+    assert "size" in params["fields"]
+
+
+def test_build_params_detailed_false_omits_extra_fields():
+    """detailed=False omits modifiedTime, webViewLink, and size from the API request."""
+    params = build_drive_list_params(query="name='x'", page_size=10, detailed=False)
+    assert "modifiedTime" not in params["fields"]
+    assert "webViewLink" not in params["fields"]
+    assert "size" not in params["fields"]
+
+
+def test_build_params_detailed_false_keeps_core_fields():
+    """detailed=False still requests id, name, and mimeType."""
+    params = build_drive_list_params(query="name='x'", page_size=10, detailed=False)
+    assert "id" in params["fields"]
+    assert "name" in params["fields"]
+    assert "mimeType" in params["fields"]
+
+
+def test_build_params_default_is_detailed():
+    """Omitting detailed behaves identically to detailed=True."""
+    params_default = build_drive_list_params(query="q", page_size=5)
+    params_true = build_drive_list_params(query="q", page_size=5, detailed=True)
+    assert params_default["fields"] == params_true["fields"]
+
+
+# ---------------------------------------------------------------------------
+# search_drive_files — detailed flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_detailed_true_output_includes_metadata():
+    """detailed=True (default) includes modified time and link in output."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {
+        "files": [
+            _make_file(
+                "f1",
+                "My Doc",
+                "application/vnd.google-apps.document",
+                modified="2024-06-01T12:00:00Z",
+                link="http://link/f1",
+            )
+        ]
+    }
+
+    result = await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="my doc",
+        detailed=True,
+    )
+
+    assert "My Doc" in result
+    assert "2024-06-01T12:00:00Z" in result
+    assert "http://link/f1" in result
+
+
+@pytest.mark.asyncio
+async def test_search_detailed_false_output_excludes_metadata():
+    """detailed=False omits modified time and link from output."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {
+        "files": [
+            _make_file(
+                "f1",
+                "My Doc",
+                "application/vnd.google-apps.document",
+                modified="2024-06-01T12:00:00Z",
+                link="http://link/f1",
+            )
+        ]
+    }
+
+    result = await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="my doc",
+        detailed=False,
+    )
+
+    assert "My Doc" in result
+    assert "f1" in result
+    assert "2024-06-01T12:00:00Z" not in result
+    assert "http://link/f1" not in result
+
+
+@pytest.mark.asyncio
+async def test_search_detailed_true_with_size():
+    """When the item has a size field, detailed=True includes it in output."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {
+        "files": [
+            _make_file("f2", "Big File", "application/pdf", size="102400"),
+        ]
+    }
+
+    result = await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="big",
+        detailed=True,
+    )
+
+    assert "102400" in result
+
+
+@pytest.mark.asyncio
+async def test_search_detailed_true_requests_extra_api_fields():
+    """detailed=True passes full fields string to the Drive API."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {"files": []}
+
+    await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="anything",
+        detailed=True,
+    )
+
+    call_kwargs = mock_service.files.return_value.list.call_args.kwargs
+    assert "modifiedTime" in call_kwargs["fields"]
+    assert "webViewLink" in call_kwargs["fields"]
+    assert "size" in call_kwargs["fields"]
+
+
+@pytest.mark.asyncio
+async def test_search_detailed_false_requests_compact_api_fields():
+    """detailed=False passes compact fields string to the Drive API."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {"files": []}
+
+    await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="anything",
+        detailed=False,
+    )
+
+    call_kwargs = mock_service.files.return_value.list.call_args.kwargs
+    assert "modifiedTime" not in call_kwargs["fields"]
+    assert "webViewLink" not in call_kwargs["fields"]
+    assert "size" not in call_kwargs["fields"]
+
+
+@pytest.mark.asyncio
+async def test_search_default_detailed_matches_detailed_true():
+    """Omitting detailed produces the same output as detailed=True."""
+    file = _make_file(
+        "f1",
+        "Doc",
+        "application/vnd.google-apps.document",
+        modified="2024-01-01T00:00:00Z",
+        link="http://l",
+    )
+
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {"files": [file]}
+    result_default = await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="doc",
+    )
+
+    mock_service.files().list().execute.return_value = {"files": [file]}
+    result_true = await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="doc",
+        detailed=True,
+    )
+
+    assert result_default == result_true
+
+
+# ---------------------------------------------------------------------------
+# list_drive_items — detailed flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+async def test_list_detailed_true_output_includes_metadata(mock_resolve_folder):
+    """detailed=True (default) includes modified time and link in output."""
+    mock_resolve_folder.return_value = "resolved_root"
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {
+        "files": [
+            _make_file(
+                "id1",
+                "Report",
+                "application/vnd.google-apps.document",
+                modified="2024-03-15T08:00:00Z",
+                link="http://link/id1",
+            )
+        ]
+    }
+
+    result = await _unwrap(list_drive_items)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        folder_id="root",
+        detailed=True,
+    )
+
+    assert "Report" in result
+    assert "2024-03-15T08:00:00Z" in result
+    assert "http://link/id1" in result
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+async def test_list_detailed_false_output_excludes_metadata(mock_resolve_folder):
+    """detailed=False omits modified time and link from output."""
+    mock_resolve_folder.return_value = "resolved_root"
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {
+        "files": [
+            _make_file(
+                "id1",
+                "Report",
+                "application/vnd.google-apps.document",
+                modified="2024-03-15T08:00:00Z",
+                link="http://link/id1",
+            )
+        ]
+    }
+
+    result = await _unwrap(list_drive_items)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        folder_id="root",
+        detailed=False,
+    )
+
+    assert "Report" in result
+    assert "id1" in result
+    assert "2024-03-15T08:00:00Z" not in result
+    assert "http://link/id1" not in result
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+async def test_list_detailed_true_with_size(mock_resolve_folder):
+    """When item has a size field, detailed=True includes it in output."""
+    mock_resolve_folder.return_value = "resolved_root"
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {
+        "files": [
+            _make_file("id2", "Big File", "application/pdf", size="204800"),
+        ]
+    }
+
+    result = await _unwrap(list_drive_items)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        folder_id="root",
+        detailed=True,
+    )
+
+    assert "204800" in result
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+async def test_list_detailed_true_requests_extra_api_fields(mock_resolve_folder):
+    """detailed=True passes full fields string to the Drive API."""
+    mock_resolve_folder.return_value = "resolved_root"
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {"files": []}
+
+    await _unwrap(list_drive_items)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        folder_id="root",
+        detailed=True,
+    )
+
+    call_kwargs = mock_service.files.return_value.list.call_args.kwargs
+    assert "modifiedTime" in call_kwargs["fields"]
+    assert "webViewLink" in call_kwargs["fields"]
+    assert "size" in call_kwargs["fields"]
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+async def test_list_detailed_false_requests_compact_api_fields(mock_resolve_folder):
+    """detailed=False passes compact fields string to the Drive API."""
+    mock_resolve_folder.return_value = "resolved_root"
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {"files": []}
+
+    await _unwrap(list_drive_items)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        folder_id="root",
+        detailed=False,
+    )
+
+    call_kwargs = mock_service.files.return_value.list.call_args.kwargs
+    assert "modifiedTime" not in call_kwargs["fields"]
+    assert "webViewLink" not in call_kwargs["fields"]
+    assert "size" not in call_kwargs["fields"]


### PR DESCRIPTION
Right now, the items from the results from search_drive_files and list_drive_items include Modified time, Size and Link. This makes the response huge, increasing the context size required.

This change adds a 'detailed' parameter to each of those methods, in the same way it's used in Calentar tools.
It's set to True by default, to maintain consistency with the current way the method works.

## Testing
- [ +] I have added tests that prove my fix is effective or that my feature works
- [ +] New and existing unit tests pass locally with my changes
- [ +] I have tested this change manually

## Checklist
- [ +] My code follows the style guidelines of this project
- [ +] I have performed a self-review of my own code
- [ +] I have commented my code, particularly in hard-to-understand areas
- [ +] My changes generate no new warnings
- [ +] **I have enabled "Allow edits from maintainers" for this pull request**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a detailed mode parameter to Drive file search and listing operations. When enabled, results include additional metadata such as file size, modification time, and preview links. By default, comprehensive information is provided; disable for compact results with names and IDs only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->