### PR TITLE
fix: attachment route handler signature (Request vs path params)

### DIFF
--- a/core/server.py
+++ b/core/server.py
@@ -438,10 +438,11 @@ async def health_check(request: Request):
 
 
 @server.custom_route("/attachments/{file_id}", methods=["GET"])
-async def serve_attachment(file_id: str):
+async def serve_attachment(request):
     """Serve a stored attachment file."""
     from core.attachment_storage import get_attachment_storage
 
+    file_id = request.path_params["file_id"]
     storage = get_attachment_storage()
     metadata = storage.get_attachment_metadata(file_id)
 


### PR DESCRIPTION
## Summary

The `/attachments/{file_id}` endpoint returns 404 for all requests because `serve_attachment` uses a FastAPI-style function signature instead of the Starlette `Request` pattern required by FastMCP's `custom_route`.

## Problem

FastMCP's `custom_route` decorator creates Starlette routes that pass a `Request` object as the first argument to the handler. The current handler signature:

```python
async def serve_attachment(file_id: str):
```

receives the `Request` object as `file_id`, so `get_attachment_metadata()` is called with a Request object instead of a UUID string, and always fails.

The `health_check` handler on line 432 correctly uses `(request: Request)` — this fix applies the same pattern to `serve_attachment`.

## Fix

```diff
-async def serve_attachment(file_id: str):
+async def serve_attachment(request):
     """Serve a stored attachment file."""
     from core.attachment_storage import get_attachment_storage

+    file_id = request.path_params["file_id"]
     storage = get_attachment_storage()
```

## Testing

Verified end-to-end in a Docker deployment with `--transport streamable-http --tool-tier complete`:
1. Called `get_gmail_attachment_content` → file saved to disk, download URL returned
2. `curl` on the download URL → valid PDF returned (55 KB, PDF v1.3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to attachment handling to enhance code maintainability while preserving existing functionality and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->