### PR TITLE
Guard modify_doc_text from full-document replacements

### DIFF
--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -56,6 +56,42 @@ import json
 logger = logging.getLogger(__name__)
 
 
+def _extract_body_end_index(document_metadata: Dict[str, Any]) -> int:
+    """Return the largest endIndex in document body content, or 0 if unavailable."""
+    body = document_metadata.get("body")
+    if not isinstance(body, dict):
+        return 0
+    content = body.get("content")
+    if not isinstance(content, list):
+        return 0
+
+    max_end = 0
+    for element in content:
+        if not isinstance(element, dict):
+            continue
+        end_index = element.get("endIndex")
+        if isinstance(end_index, int) and end_index > max_end:
+            max_end = end_index
+    return max_end
+
+
+def _is_full_document_replacement_request(
+    *, start_index: int, end_index: int, body_end_index: int
+) -> bool:
+    """
+    Detect a replacement request that targets the full body segment.
+
+    Google Docs keeps a terminal newline at the end of each segment; deleting across
+    that boundary is invalid. If a request starts at the beginning and reaches the
+    segment end (or beyond), it should use find_and_replace_doc instead.
+    """
+    if body_end_index <= 0 or end_index <= start_index:
+        return False
+
+    normalized_start = 1 if start_index == 0 else start_index
+    return normalized_start <= 1 and end_index >= (body_end_index - 1)
+
+
 @server.tool()
 @handle_http_errors("search_docs", is_read_only=True, service_type="docs")
 @require_google_service("drive", "drive_read")
@@ -448,6 +484,38 @@ async def modify_doc_text(
 
     requests = []
     operations = []
+
+    # Guard against whole-document replacement attempts which are brittle with
+    # Docs segment boundaries and should use the dedicated global replace tool.
+    if (
+        text is not None
+        and end_index is not None
+        and end_index > start_index
+        and not any(p is not None for p in formatting_params)
+    ):
+        try:
+            document_metadata = await asyncio.to_thread(
+                service.documents()
+                .get(documentId=document_id, fields="body/content(endIndex)")
+                .execute
+            )
+            body_end_index = _extract_body_end_index(document_metadata)
+        except Exception as exc:
+            body_end_index = 0
+            logger.warning(
+                "[modify_doc_text] Failed to inspect document bounds for full replacement guard: %s",
+                exc,
+            )
+
+        if _is_full_document_replacement_request(
+            start_index=start_index,
+            end_index=end_index,
+            body_end_index=body_end_index,
+        ):
+            return (
+                "Error: Full-document replacement is blocked in modify_doc_text. "
+                "Use find_and_replace_doc for global substitutions."
+            )
 
     # Handle text insertion/replacement
     if text is not None:

--- a/tests/gdocs/test_modify_doc_text_guard.py
+++ b/tests/gdocs/test_modify_doc_text_guard.py
@@ -1,0 +1,109 @@
+"""Unit tests for modify_doc_text full-document replacement guard."""
+
+import inspect
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gdocs.docs_tools import (  # noqa: E402
+    _extract_body_end_index,
+    _is_full_document_replacement_request,
+    modify_doc_text,
+)
+
+
+def _create_mock_docs_service(body_end_index: int = 100) -> tuple[Mock, Mock]:
+    """Create a Google Docs service mock with configurable body end index."""
+    mock_service = Mock()
+    docs_resource = Mock()
+    mock_service.documents.return_value = docs_resource
+
+    get_request = Mock()
+    get_request.execute = Mock(
+        return_value={"body": {"content": [{"endIndex": body_end_index}]}}
+    )
+    docs_resource.get.return_value = get_request
+
+    batch_request = Mock()
+    batch_request.execute = Mock(return_value={})
+    docs_resource.batchUpdate.return_value = batch_request
+
+    return mock_service, docs_resource
+
+
+def test_extract_body_end_index_uses_max_content_end_index() -> None:
+    document_metadata = {
+        "body": {"content": [{"endIndex": 5}, {"endIndex": 17}, {"endIndex": 12}]}
+    }
+    assert _extract_body_end_index(document_metadata) == 17
+
+
+def test_extract_body_end_index_handles_missing_body() -> None:
+    assert _extract_body_end_index({}) == 0
+    assert _extract_body_end_index({"body": {"content": "invalid"}}) == 0
+
+
+def test_is_full_document_replacement_request_detection() -> None:
+    assert (
+        _is_full_document_replacement_request(
+            start_index=1, end_index=99, body_end_index=100
+        )
+        is True
+    )
+    assert (
+        _is_full_document_replacement_request(
+            start_index=0, end_index=99, body_end_index=100
+        )
+        is True
+    )
+    assert (
+        _is_full_document_replacement_request(
+            start_index=10, end_index=20, body_end_index=100
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_modify_doc_text_rejects_full_document_replacement() -> None:
+    service, docs_resource = _create_mock_docs_service(body_end_index=100)
+    raw_modify_doc_text = inspect.unwrap(modify_doc_text)
+
+    result = await raw_modify_doc_text(
+        service=service,
+        user_google_email="user@example.com",
+        document_id="1A2B3C4D5E6F7G8H9I0JkLmNoPqR",
+        start_index=1,
+        end_index=99,
+        text="replacement",
+    )
+
+    assert (
+        result
+        == "Error: Full-document replacement is blocked in modify_doc_text. Use find_and_replace_doc for global substitutions."
+    )
+    docs_resource.batchUpdate.assert_not_called()
+    docs_resource.get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_modify_doc_text_allows_partial_replacement() -> None:
+    service, docs_resource = _create_mock_docs_service(body_end_index=100)
+    raw_modify_doc_text = inspect.unwrap(modify_doc_text)
+
+    result = await raw_modify_doc_text(
+        service=service,
+        user_google_email="user@example.com",
+        document_id="1A2B3C4D5E6F7G8H9I0JkLmNoPqR",
+        start_index=10,
+        end_index=20,
+        text="replacement",
+    )
+
+    assert "Replaced text from index 10 to 20" in result
+    docs_resource.batchUpdate.assert_called_once()
+    docs_resource.get.assert_called_once()


### PR DESCRIPTION
## Summary
- add a safety guard in `modify_doc_text` to block full-document replacement attempts
- return a clear error directing callers to `find_and_replace_doc` for global substitutions
- add focused tests for boundary extraction, replacement detection, and guard behavior

## Why
`modify_doc_text` can be selected for global replacement intents, which is brittle at Google Docs segment boundaries and can trigger range-corruption-style failures. This change prevents that misuse path explicitly.

## Details
- New helpers in `gdocs/docs_tools.py`:
  - `_extract_body_end_index(document_metadata)`
  - `_is_full_document_replacement_request(...)`
- In `modify_doc_text`, when handling pure replacement (no formatting), inspect `body/content(endIndex)` and reject full-body replacements with:
  - `Error: Full-document replacement is blocked in modify_doc_text. Use find_and_replace_doc for global substitutions.`

## Tests
- `uv run pytest tests/gdocs/test_modify_doc_text_guard.py`
  - verifies helper behavior
  - verifies full-document replacement is rejected
  - verifies partial replacement still proceeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent accidental full-document replacements when editing text. Users attempting to replace the entire document will now receive guidance to use the appropriate function for complete document updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->