### PR TITLE
enh: Add tool schema attribute system and Code Mode engine

### DIFF
--- a/auth/permissions.py
+++ b/auth/permissions.py
@@ -14,7 +14,7 @@ Other services: readonly, full (extensible by adding entries to SERVICE_PERMISSI
 """
 
 import logging
-from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Dict, FrozenSet, List, Optional, Tuple
 
 from auth.scopes import (
     GMAIL_READONLY_SCOPE,

--- a/core/cli_handler.py
+++ b/core/cli_handler.py
@@ -20,7 +20,9 @@ import sys
 from typing import Any, Dict, List, Optional
 
 from auth.oauth_config import set_transport_mode
+from core.schema_cli import discover_service, list_tools_by_schema
 from core.tool_registry import get_tool_components
+from core.tool_schema import SchemaRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -111,16 +113,22 @@ def list_tools(server, output_format: str = "text") -> str:
             )
         return json.dumps({"tools": tool_list}, indent=2)
 
-    # Text format for human reading
+    # Text format — use SchemaRegistry for proper service grouping
+    registry = SchemaRegistry.instance()
+    if registry.all_schemas():
+        output = list_tools_by_schema(registry)
+        output += "\nUse --cli <tool_name> --help for detailed tool information"
+        output += "\nUse --cli <tool_name> --args '{...}' to run a tool"
+        output += "\nUse --cli discover <service> for service details"
+        return output
+
+    # Fallback: prefix-based grouping when SchemaRegistry is empty
     lines = [
         f"Available tools ({len(tools)}):",
         "",
     ]
-
-    # Group tools by service
     services = {}
     for name, info in tools.items():
-        # Extract service prefix from tool name
         prefix = name.split("_")[0] if "_" in name else "other"
         if prefix not in services:
             services[prefix] = []
@@ -130,7 +138,6 @@ def list_tools(server, output_format: str = "text") -> str:
         lines.append(f"  {service.upper()}:")
         for name, info in sorted(services[service]):
             desc = info["description"] or "(no description)"
-            # Get first line only and truncate
             first_line = desc.split("\n")[0].strip()
             if len(first_line) > 70:
                 first_line = first_line[:67] + "..."
@@ -295,7 +302,18 @@ def parse_cli_args(args: List[str]) -> Dict[str, Any]:
     while i < len(args):
         arg = args[i]
 
-        if arg in ("list", "-l", "--list"):
+        if arg == "discover":
+            result["command"] = "discover"
+            # Next arg is the service name
+            if i + 1 < len(args) and not args[i + 1].startswith("-"):
+                result["discover_service"] = args[i + 1]
+                i += 1
+                # Optional query filter
+                if i + 1 < len(args) and not args[i + 1].startswith("-"):
+                    result["discover_query"] = args[i + 1]
+                    i += 1
+            i += 1
+        elif arg in ("list", "-l", "--list"):
             result["command"] = "list"
             i += 1
         elif arg in ("--json", "-j"):
@@ -377,6 +395,20 @@ async def handle_cli_mode(server, cli_args: List[str]) -> int:
 
     try:
         parsed = parse_cli_args(cli_args)
+
+        if parsed["command"] == "discover":
+            registry = SchemaRegistry.instance()
+            service = parsed.get("discover_service")
+            if not service:
+                print("Usage: workspace-mcp --cli discover <service> [query]")
+                services = sorted(registry.all_services())
+                if services:
+                    print(f"Available services: {', '.join(services)}")
+                return 0
+            query = parsed.get("discover_query")
+            output = discover_service(registry, service, query)
+            print(output)
+            return 0
 
         if parsed["command"] == "list":
             output = list_tools(server, parsed["output_format"])

--- a/core/code_mode.py
+++ b/core/code_mode.py
@@ -1,0 +1,300 @@
+"""
+Code Mode engine for Workspace MCP.
+
+Generates typed Python API stubs from SchemaRegistry and provides
+an AST-validated sandbox for LLM-generated code execution.
+"""
+
+import ast
+import io
+import logging
+import textwrap
+from contextlib import redirect_stdout
+from typing import Any, Dict
+
+from core.tool_registry import get_tool_components
+from core.tool_schema import SchemaRegistry
+
+logger = logging.getLogger(__name__)
+
+FORBIDDEN_NODES = (ast.Import, ast.ImportFrom)
+
+FORBIDDEN_BUILTINS = frozenset(
+    {
+        "__import__",
+        "exec",
+        "eval",
+        "compile",
+        "open",
+        "globals",
+        "locals",
+        "breakpoint",
+        "exit",
+        "quit",
+        "input",
+        "memoryview",
+        "type",
+        "__build_class__",
+    }
+)
+
+EXECUTION_TIMEOUT = 30
+MAX_OUTPUT_SIZE = 50_000
+
+
+class CodeModeError(Exception):
+    """Raised when code validation or execution fails."""
+
+
+def generate_api_stubs(registry: SchemaRegistry, server) -> str:
+    """Generate typed Python API surface from the schema registry."""
+    tool_components = get_tool_components(server)
+    lines = []
+
+    for service_name in sorted(registry.all_services()):
+        schemas = registry.by_service(service_name)
+        if not schemas:
+            continue
+
+        lines.append(f"class {service_name}:")
+        for schema in sorted(schemas, key=lambda s: s.name):
+            component = tool_components.get(schema.name)
+            if component is None:
+                continue
+
+            params = _extract_user_params(component)
+            sig = ", ".join(params)
+            method_name = _to_method_name(schema)
+            desc = schema.description or schema.name
+
+            lines.append(f"    async def {method_name}({sig}) -> str:")
+            lines.append(f'        """{desc}"""')
+            lines.append("        ...")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _extract_user_params(tool_component) -> list[str]:
+    """Extract user-facing parameter signatures from a tool component."""
+    params = []
+    if hasattr(tool_component, "parameters") and isinstance(
+        tool_component.parameters, dict
+    ):
+        props = tool_component.parameters.get("properties", {})
+        required = set(tool_component.parameters.get("required", []))
+        for name, prop in props.items():
+            ptype = prop.get("type", "Any")
+            type_map = {
+                "string": "str",
+                "integer": "int",
+                "boolean": "bool",
+                "number": "float",
+                "array": "list",
+                "object": "dict",
+            }
+            py_type = type_map.get(ptype, "Any")
+            default = prop.get("default")
+            if name in required:
+                params.append(f"{name}: {py_type}")
+            elif default is not None:
+                params.append(f"{name}: {py_type} = {default!r}")
+            else:
+                params.append(f"{name}: {py_type} = None")
+    return params
+
+
+def _to_method_name(schema) -> str:
+    """Convert tool name to method name by stripping service prefix."""
+    name = schema.name
+    service = schema.service
+
+    prefixes = [
+        f"{service}_",
+        f"g{service}_",
+    ]
+    prefix_overrides = {
+        "appscript": ["script_", "apps_script_"],
+        "search": ["search_custom"],
+        "contacts": ["contact_", "contacts_"],
+    }
+
+    for prefix in prefixes:
+        if name.startswith(prefix):
+            return name[len(prefix) :]
+
+    for prefix in prefix_overrides.get(service, []):
+        if name.startswith(prefix):
+            remainder = name[len(prefix) :]
+            return remainder if remainder else name
+
+    return name
+
+
+def validate_code(code: str) -> ast.Module:
+    """Parse and validate code against sandbox restrictions."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as e:
+        raise CodeModeError(f"Syntax error: {e}") from e
+
+    for node in ast.walk(tree):
+        if isinstance(node, FORBIDDEN_NODES):
+            raise CodeModeError(
+                f"Forbidden: {type(node).__name__} is not allowed. "
+                "Use the provided API classes directly."
+            )
+        if isinstance(node, ast.Name) and node.id in FORBIDDEN_BUILTINS:
+            raise CodeModeError(
+                f"Forbidden: '{node.id}' is not available in the sandbox."
+            )
+        if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
+            raise CodeModeError(
+                f"Forbidden: dunder attribute access '{node.attr}' is not allowed."
+            )
+
+    return tree
+
+
+class ServiceProxy:
+    """Thin async proxy that maps method calls to actual tool functions."""
+
+    def __init__(self, service_name: str, tool_map: Dict[str, Any], auth_context: dict):
+        self._service = service_name
+        self._tools = tool_map
+        self._auth = auth_context
+
+    def __getattr__(self, method_name: str):
+        tool_fn = self._tools.get(method_name)
+        if tool_fn is None:
+            available = ", ".join(sorted(self._tools.keys()))
+            raise AttributeError(
+                f"{self._service}.{method_name} does not exist. Available: {available}"
+            )
+
+        async def proxy(**kwargs):
+            return await tool_fn(**kwargs)
+
+        return proxy
+
+    def __repr__(self) -> str:
+        return f"<{self._service} API: {len(self._tools)} methods>"
+
+
+def build_namespace(registry: SchemaRegistry, server, auth_context: dict) -> dict:
+    """Build the sandbox namespace with API proxy classes."""
+    tool_components = get_tool_components(server)
+    namespace = {}
+
+    safe_builtins = {
+        "print": print,
+        "len": len,
+        "range": range,
+        "enumerate": enumerate,
+        "zip": zip,
+        "map": map,
+        "filter": filter,
+        "sorted": sorted,
+        "reversed": reversed,
+        "list": list,
+        "dict": dict,
+        "set": set,
+        "tuple": tuple,
+        "str": str,
+        "int": int,
+        "float": float,
+        "bool": bool,
+        "isinstance": isinstance,
+        "hasattr": hasattr,
+        "getattr": getattr,
+        "min": min,
+        "max": max,
+        "sum": sum,
+        "abs": abs,
+        "round": round,
+        "any": any,
+        "all": all,
+        "repr": repr,
+        "True": True,
+        "False": False,
+        "None": None,
+    }
+    namespace["__builtins__"] = safe_builtins
+
+    for service_name in sorted(registry.all_services()):
+        schemas = registry.by_service(service_name)
+        tool_map = {}
+        for schema in schemas:
+            component = tool_components.get(schema.name)
+            if component is None:
+                continue
+            fn = getattr(component, "fn", None) or component
+            method_name = _to_method_name(schema)
+            tool_map[method_name] = fn
+
+        if tool_map:
+            namespace[service_name] = ServiceProxy(service_name, tool_map, auth_context)
+
+    return namespace
+
+
+async def execute_code(code: str, namespace: dict) -> str:
+    """Execute LLM-generated code in the sandbox."""
+    validate_code(code)
+
+    indented = textwrap.indent(code, "    ")
+    wrapped = f"async def __code_mode_main__():\n{indented}\n"
+
+    compiled = compile(ast.parse(wrapped), "<code-mode>", "exec")
+    exec(compiled, namespace)  # noqa: S102
+
+    stdout_buf = io.StringIO()
+    with redirect_stdout(stdout_buf):
+        result = await namespace["__code_mode_main__"]()
+
+    output_parts = []
+    captured = stdout_buf.getvalue()
+    if captured:
+        output_parts.append(captured.rstrip())
+    if result is not None:
+        output_parts.append(f"\n=> {result}")
+
+    output = "\n".join(output_parts) if output_parts else "(no output)"
+
+    if len(output) > MAX_OUTPUT_SIZE:
+        output = (
+            output[:MAX_OUTPUT_SIZE] + f"\n... (truncated at {MAX_OUTPUT_SIZE} chars)"
+        )
+
+    return output
+
+
+def register_code_mode(server) -> None:
+    """Register the execute_code meta-tool on the server."""
+    registry = SchemaRegistry.instance()
+    stubs = generate_api_stubs(registry, server)
+
+    description = (
+        "Execute Python code against the Google Workspace API. "
+        "The following typed API is available in the sandbox:\n\n"
+        f"```python\n{stubs}\n```\n\n"
+        "Call methods with `await`, e.g.: "
+        "`results = await gmail.search_messages(query='from:boss')`\n"
+        "Use `print()` to output results. No imports needed."
+    )
+
+    @server.tool(description=description)
+    async def execute_workspace_code(code: str) -> str:
+        """Execute Python code against the Google Workspace API."""
+        auth_context = {}
+        try:
+            from fastmcp import Context
+
+            ctx = Context.current()
+            auth_context["access_token"] = await ctx.get_state("access_token")
+            auth_context["user_email"] = await ctx.get_state("user_email")
+        except Exception:
+            pass
+
+        ns = build_namespace(registry, server, auth_context)
+        return await execute_code(code, ns)

--- a/core/schema_cli.py
+++ b/core/schema_cli.py
@@ -1,0 +1,86 @@
+"""Schema-driven CLI output for tool listing and discovery."""
+
+from typing import Optional
+
+from core.tool_schema import SchemaRegistry, ToolTier
+
+
+def list_tools_by_schema(
+    registry: SchemaRegistry,
+    tier: Optional[ToolTier] = None,
+    service_filter: Optional[str] = None,
+) -> str:
+    """Schema-aware tool listing grouped by service."""
+    lines = []
+    total = 0
+
+    for service in sorted(registry.all_services()):
+        if service_filter and service != service_filter:
+            continue
+
+        schemas = registry.by_service(service)
+        if tier:
+            order = [ToolTier.CORE, ToolTier.EXTENDED, ToolTier.COMPLETE]
+            allowed = set(order[: order.index(tier) + 1])
+            schemas = [s for s in schemas if s.tier in allowed]
+
+        if not schemas:
+            continue
+
+        lines.append(f"  {service.upper()} ({len(schemas)} tools):")
+        for schema in sorted(schemas, key=lambda s: (s.tier.value, s.name)):
+            tier_badge = {"core": "[C]", "extended": "[E]", "complete": "[+]"}[
+                schema.tier.value
+            ]
+            rw = "R" if schema.read_only else "W"
+            desc = (
+                schema.description[:65] + "..."
+                if len(schema.description) > 65
+                else schema.description
+            )
+            lines.append(f"    {tier_badge} {rw} {schema.name}")
+            if desc:
+                lines.append(f"         {desc}")
+            total += 1
+        lines.append("")
+
+    header = f"Available tools ({total}):"
+    if tier:
+        header += f" [tier: {tier.value}]"
+    return header + "\n\n" + "\n".join(lines)
+
+
+def discover_service(
+    registry: SchemaRegistry, service: str, query: Optional[str] = None
+) -> str:
+    """Detailed discovery for a specific service."""
+    schemas = registry.by_service(service)
+    if not schemas:
+        return f"No tools found for service '{service}'."
+
+    if query:
+        schemas = [
+            s
+            for s in schemas
+            if query.lower() in s.name.lower()
+            or any(query.lower() in t for t in s.tags)
+        ]
+
+    lines = [f"Service: {service} ({len(schemas)} tools)", ""]
+
+    for schema in sorted(schemas, key=lambda s: s.name):
+        lines.append(f"  {schema.name}")
+        lines.append(
+            f"    Tier: {schema.tier.value} | "
+            f"{'Read-only' if schema.read_only else 'Read-write'}"
+        )
+        lines.append(f"    Scopes: {', '.join(schema.scopes) or 'none'}")
+        if schema.tags:
+            lines.append(f"    Tags: {', '.join(schema.tags)}")
+        if schema.paginated:
+            lines.append("    Paginated: yes")
+        if schema.multi_service:
+            lines.append("    Multi-service: yes")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/core/tool_registry.py
+++ b/core/tool_registry.py
@@ -11,6 +11,7 @@ from typing import Set, Optional, Callable
 from auth.oauth_config import is_oauth21_enabled
 from auth.permissions import is_permissions_mode, get_allowed_scopes_set
 from auth.scopes import is_read_only_mode, get_all_read_only_scopes
+from auth.service_decorator import SCOPE_GROUPS
 
 logger = logging.getLogger(__name__)
 
@@ -101,85 +102,94 @@ def get_tool_components(server) -> dict:
     return tools
 
 
+def _resolve_scope_urls(scope_groups: tuple) -> list:
+    """Convert scope group names to full OAuth URLs."""
+    urls = []
+    for group in scope_groups:
+        if group in SCOPE_GROUPS:
+            scopes = SCOPE_GROUPS[group]
+            if isinstance(scopes, list):
+                urls.extend(scopes)
+            else:
+                urls.append(scopes)
+    return urls
+
+
+def _get_required_scopes_from_obj(tool_obj) -> list:
+    """Fallback: introspect _required_google_scopes from wrapper chain."""
+    func_to_check = tool_obj
+    if hasattr(tool_obj, "fn"):
+        func_to_check = tool_obj.fn
+    return getattr(func_to_check, "_required_google_scopes", [])
+
+
 def filter_server_tools(server):
     """Remove disabled tools from the server after registration."""
+    from core.tool_schema import SchemaRegistry
+
+    registry = SchemaRegistry.instance()
     enabled_tools = get_enabled_tools()
     oauth21_enabled = is_oauth21_enabled()
     permissions_mode = is_permissions_mode()
+    read_only_mode = is_read_only_mode()
+
     if (
         enabled_tools is None
         and not oauth21_enabled
-        and not is_read_only_mode()
+        and not read_only_mode
         and not permissions_mode
     ):
         return
 
-    tools_removed = 0
+    allowed_ro_scopes = set(get_all_read_only_scopes()) if read_only_mode else None
+    perm_allowed = get_allowed_scopes_set() if permissions_mode else None
     tool_components = get_tool_components(server)
-
-    read_only_mode = is_read_only_mode()
-    allowed_scopes = set(get_all_read_only_scopes()) if read_only_mode else None
-
     tools_to_remove = set()
 
-    # 1. Tier filtering
-    if enabled_tools is not None:
-        for tool_name in tool_components:
-            if not is_tool_enabled(tool_name):
+    for tool_name, tool_obj in tool_components.items():
+        # 1. Tier filtering
+        if enabled_tools is not None and tool_name not in enabled_tools:
+            tools_to_remove.add(tool_name)
+            continue
+
+        # 2. OAuth 2.1 filtering
+        if oauth21_enabled and tool_name == "start_google_auth":
+            tools_to_remove.add(tool_name)
+            logger.info("OAuth 2.1 enabled: disabling start_google_auth tool")
+            continue
+
+        # Resolve required scopes — prefer SchemaRegistry, fall back to introspection
+        schema = registry.get(tool_name)
+        if schema is not None:
+            required_scopes = _resolve_scope_urls(schema.scopes)
+        else:
+            required_scopes = _get_required_scopes_from_obj(tool_obj)
+
+        # 3. Read-only mode filtering (skipped when granular permissions active)
+        if read_only_mode and not permissions_mode:
+            if required_scopes and not all(
+                s in allowed_ro_scopes for s in required_scopes
+            ):
+                logger.info(
+                    "Read-only mode: Disabling tool '%s' (requires write scopes: %s)",
+                    tool_name,
+                    required_scopes,
+                )
                 tools_to_remove.add(tool_name)
-
-    # 2. OAuth 2.1 filtering
-    if oauth21_enabled and "start_google_auth" in tool_components:
-        tools_to_remove.add("start_google_auth")
-        logger.info("OAuth 2.1 enabled: disabling start_google_auth tool")
-
-    # 3. Read-only mode filtering (skipped when granular permissions are active)
-    if read_only_mode and not permissions_mode:
-        for tool_name, tool_obj in tool_components.items():
-            if tool_name in tools_to_remove:
                 continue
 
-            # Check if tool has required scopes attached (from @require_google_service)
-            func_to_check = tool_obj
-            if hasattr(tool_obj, "fn"):
-                func_to_check = tool_obj.fn
-
-            required_scopes = getattr(func_to_check, "_required_google_scopes", [])
-
-            if required_scopes:
-                # If ANY required scope is not in the allowed read-only scopes, disable the tool
-                if not all(scope in allowed_scopes for scope in required_scopes):
-                    logger.info(
-                        f"Read-only mode: Disabling tool '{tool_name}' (requires write scopes: {required_scopes})"
-                    )
-                    tools_to_remove.add(tool_name)
-
-    # 4. Granular permissions filtering
-    # No scope hierarchy expansion here — permission levels are already cumulative
-    # and explicitly define allowed scopes. Hierarchy expansion would defeat the
-    # purpose (e.g. gmail.modify in the hierarchy covers gmail.send, but the
-    # "organize" permission level intentionally excludes gmail.send).
-    if permissions_mode:
-        perm_allowed = get_allowed_scopes_set() or set()
-
-        for tool_name, tool_obj in tool_components.items():
-            if tool_name in tools_to_remove:
+        # 4. Granular permissions filtering
+        if permissions_mode and perm_allowed is not None:
+            if required_scopes and not all(s in perm_allowed for s in required_scopes):
+                logger.info(
+                    "Permissions mode: Disabling tool '%s' (requires: %s)",
+                    tool_name,
+                    required_scopes,
+                )
+                tools_to_remove.add(tool_name)
                 continue
 
-            func_to_check = tool_obj
-            if hasattr(tool_obj, "fn"):
-                func_to_check = tool_obj.fn
-
-            required_scopes = getattr(func_to_check, "_required_google_scopes", [])
-            if required_scopes:
-                if not all(scope in perm_allowed for scope in required_scopes):
-                    logger.info(
-                        "Permissions mode: Disabling tool '%s' (requires: %s)",
-                        tool_name,
-                        required_scopes,
-                    )
-                    tools_to_remove.add(tool_name)
-
+    tools_removed = 0
     for tool_name in tools_to_remove:
         try:
             server.local_provider.remove_tool(tool_name)
@@ -202,10 +212,13 @@ def filter_server_tools(server):
         enabled_count = len(enabled_tools) if enabled_tools is not None else "all"
         if permissions_mode:
             mode = "Permissions"
-        elif is_read_only_mode():
+        elif read_only_mode:
             mode = "Read-Only"
         else:
             mode = "Full"
         logger.info(
-            f"Tool filtering: removed {tools_removed} tools, {enabled_count} enabled. Mode: {mode}"
+            "Tool filtering: removed %d tools, %s enabled. Mode: %s",
+            tools_removed,
+            enabled_count,
+            mode,
         )

--- a/core/tool_schema.py
+++ b/core/tool_schema.py
@@ -1,0 +1,173 @@
+"""
+Unified tool schema system.
+
+Provides a single source of truth for tool metadata: service, tier,
+scopes, read-only status, pagination support, and semantic tags.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Dict, List, Optional, Set
+
+
+class ToolTier(str, Enum):
+    CORE = "core"
+    EXTENDED = "extended"
+    COMPLETE = "complete"
+
+
+@dataclass(frozen=True)
+class ToolSchema:
+    """Structured metadata for a single MCP tool."""
+
+    name: str
+    service: str
+    tier: ToolTier
+    scopes: tuple[str, ...]
+    read_only: bool = True
+    description: str = ""
+    tags: tuple[str, ...] = ()
+    paginated: bool = False
+    supports_upload: bool = False
+    supports_download: bool = False
+    service_type: str = ""
+    multi_service: bool = False
+
+
+class SchemaRegistry:
+    """Singleton collecting all tool schemas at decoration time."""
+
+    _instance: Optional["SchemaRegistry"] = None
+    _schemas: Dict[str, ToolSchema]
+
+    def __init__(self) -> None:
+        self._schemas = {}
+
+    @classmethod
+    def instance(cls) -> "SchemaRegistry":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset for testing."""
+        cls._instance = None
+
+    def register(self, schema: ToolSchema) -> None:
+        self._schemas[schema.name] = schema
+
+    def get(self, name: str) -> Optional[ToolSchema]:
+        return self._schemas.get(name)
+
+    def by_service(self, service: str) -> List[ToolSchema]:
+        return [s for s in self._schemas.values() if s.service == service]
+
+    def by_tier(self, tier: ToolTier) -> List[ToolSchema]:
+        return [s for s in self._schemas.values() if s.tier == tier]
+
+    def up_to_tier(
+        self, tier: ToolTier, services: Optional[Set[str]] = None
+    ) -> List[ToolSchema]:
+        """Return schemas from core through the given tier."""
+        order = [ToolTier.CORE, ToolTier.EXTENDED, ToolTier.COMPLETE]
+        allowed = set(order[: order.index(tier) + 1])
+        return [
+            s
+            for s in self._schemas.values()
+            if s.tier in allowed and (services is None or s.service in services)
+        ]
+
+    def tool_names_up_to_tier(
+        self, tier: ToolTier, services: Optional[Set[str]] = None
+    ) -> List[str]:
+        """Return tool name list for backwards-compat with set_enabled_tools."""
+        return [s.name for s in self.up_to_tier(tier, services)]
+
+    def services_for_tier(self, tier: ToolTier) -> Set[str]:
+        """Which services have at least one tool in this tier or below."""
+        return {s.service for s in self.up_to_tier(tier)}
+
+    def all_services(self) -> Set[str]:
+        return {s.service for s in self._schemas.values()}
+
+    def all_schemas(self) -> Dict[str, ToolSchema]:
+        return dict(self._schemas)
+
+    def read_only_tools(self) -> List[ToolSchema]:
+        return [s for s in self._schemas.values() if s.read_only]
+
+    def write_tools(self) -> List[ToolSchema]:
+        return [s for s in self._schemas.values() if not s.read_only]
+
+    def paginated_tools(self) -> List[ToolSchema]:
+        return [s for s in self._schemas.values() if s.paginated]
+
+
+def tool_schema(
+    service: str,
+    tier: str | ToolTier,
+    scopes: list[str],
+    read_only: bool = True,
+    tags: list[str] | None = None,
+    paginated: bool = False,
+    supports_upload: bool = False,
+    supports_download: bool = False,
+    service_type: str = "",
+    multi_service: bool = False,
+) -> Callable:
+    """Attach structured schema metadata to a tool function.
+
+    Must be the outermost decorator (before @server.tool()).
+    Purely additive — does not alter the function's behavior.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        schema = ToolSchema(
+            name=func.__name__,
+            service=service,
+            tier=ToolTier(tier) if isinstance(tier, str) else tier,
+            scopes=tuple(scopes),
+            read_only=read_only,
+            description=(func.__doc__ or "").strip().split("\n")[0],
+            tags=tuple(tags or []),
+            paginated=paginated,
+            supports_upload=supports_upload,
+            supports_download=supports_download,
+            service_type=service_type or service,
+            multi_service=multi_service,
+        )
+        SchemaRegistry.instance().register(schema)
+        func._tool_schema = schema
+        return func
+
+    return decorator
+
+
+def register_comment_schemas(app_name: str, service: str) -> None:
+    """Register schemas for factory-generated comment tools."""
+    registry = SchemaRegistry.instance()
+    registry.register(
+        ToolSchema(
+            name=f"list_{app_name}_comments",
+            service=service,
+            tier=ToolTier.COMPLETE,
+            scopes=("drive_read",),
+            read_only=True,
+            description=f"List all comments from a Google {app_name.title()}.",
+            tags=("comments",),
+            service_type="drive",
+        )
+    )
+    registry.register(
+        ToolSchema(
+            name=f"manage_{app_name}_comment",
+            service=service,
+            tier=ToolTier.COMPLETE,
+            scopes=("drive_file",),
+            read_only=False,
+            description=f"Create, reply to, or resolve comments on a Google {app_name.title()}.",
+            tags=("comments",),
+            service_type="drive",
+        )
+    )

--- a/gappsscript/apps_script_tools.py
+++ b/gappsscript/apps_script_tools.py
@@ -10,6 +10,7 @@ from typing import List, Dict, Any, Optional
 
 from auth.service_decorator import require_google_service
 from core.server import server
+from core.tool_schema import tool_schema
 from core.utils import handle_http_errors
 
 logger = logging.getLogger(__name__)
@@ -69,6 +70,15 @@ async def _list_script_projects_impl(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="appscript",
+    tier="core",
+    scopes=["drive_read"],
+    read_only=True,
+    tags=["projects"],
+    paginated=True,
+    service_type="drive",
+)
 @server.tool()
 @handle_http_errors("list_script_projects", is_read_only=True, service_type="drive")
 @require_google_service("drive", "drive_read")
@@ -141,6 +151,14 @@ async def _get_script_project_impl(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="appscript",
+    tier="core",
+    scopes=["script_readonly"],
+    read_only=True,
+    tags=["projects"],
+    service_type="script",
+)
 @server.tool()
 @handle_http_errors("get_script_project", is_read_only=True, service_type="script")
 @require_google_service("script", "script_readonly")
@@ -199,6 +217,14 @@ async def _get_script_content_impl(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="appscript",
+    tier="core",
+    scopes=["script_readonly"],
+    read_only=True,
+    tags=["projects"],
+    service_type="script",
+)
 @server.tool()
 @handle_http_errors("get_script_content", is_read_only=True, service_type="script")
 @require_google_service("script", "script_readonly")
@@ -256,6 +282,14 @@ async def _create_script_project_impl(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="appscript",
+    tier="core",
+    scopes=["script_projects"],
+    read_only=False,
+    tags=["projects"],
+    service_type="script",
+)
 @server.tool()
 @handle_http_errors("create_script_project", service_type="script")
 @require_google_service("script", "script_projects")
@@ -310,6 +344,14 @@ async def _update_script_content_impl(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="appscript",
+    tier="core",
+    scopes=["script_projects"],
+    read_only=False,
+    tags=["projects"],
+    service_type="script",
+)
 @server.tool()
 @handle_http_errors("update_script_content", service_type="script")
 @require_google_service("script", "script_projects")
@@ -381,6 +423,14 @@ async def _run_script_function_impl(
         return f"Execution failed\nFunction: {function_name}\nError: {str(e)}"
 
 
+@tool_schema(
+    service="appscript",
+    tier="core",
+    scopes=["script_projects"],
+    read_only=False,
+    tags=["execution"],
+    service_type="script",
+)
 @server.tool()
 @handle_http_errors("run_script_function", service_type="script")
 @require_google_service("script", "script_projects")
@@ -463,6 +513,14 @@ async def _create_deployment_impl(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="appscript",
+    tier="extended",
+    scopes=["script_deployments"],
+    read_only=False,
+    tags=["deployments"],
+    service_type="script",
+)
 @server.tool()
 @handle_http_errors("manage_deployment", service_type="script")
 @require_google_service("script", "script_deployments")
@@ -549,6 +607,14 @@ async def _list_deployments_impl(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="appscript",
+    tier="extended",
+    scopes=["script_deployments_readonly"],
+    read_only=True,
+    tags=["deployments"],
+    service_type="script",
+)
 @server.tool()
 @handle_http_errors("list_deployments", is_read_only=True, service_type="script")
 @require_google_service("script", "script_deployments_readonly")
@@ -670,6 +736,14 @@ async def _list_script_processes_impl(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="appscript",
+    tier="extended",
+    scopes=["script_readonly"],
+    read_only=True,
+    tags=["processes"],
+    service_type="script",
+)
 @server.tool()
 @handle_http_errors("list_script_processes", is_read_only=True, service_type="script")
 @require_google_service("script", "script_readonly")
@@ -718,6 +792,14 @@ async def _delete_script_project_impl(
     return f"Deleted Apps Script project: {script_id}"
 
 
+@tool_schema(
+    service="appscript",
+    tier="extended",
+    scopes=["drive_full"],
+    read_only=False,
+    tags=["projects"],
+    service_type="drive",
+)
 @server.tool()
 @handle_http_errors("delete_script_project", is_read_only=False, service_type="drive")
 @require_google_service("drive", "drive_full")
@@ -779,6 +861,14 @@ async def _list_versions_impl(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="appscript",
+    tier="extended",
+    scopes=["script_readonly"],
+    read_only=True,
+    tags=["versions"],
+    service_type="script",
+)
 @server.tool()
 @handle_http_errors("list_versions", is_read_only=True, service_type="script")
 @require_google_service("script", "script_readonly")
@@ -837,6 +927,14 @@ async def _create_version_impl(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="appscript",
+    tier="extended",
+    scopes=["script_full"],
+    read_only=False,
+    tags=["versions"],
+    service_type="script",
+)
 @server.tool()
 @handle_http_errors("create_version", is_read_only=False, service_type="script")
 @require_google_service("script", "script_full")
@@ -898,6 +996,14 @@ async def _get_version_impl(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="appscript",
+    tier="extended",
+    scopes=["script_readonly"],
+    read_only=True,
+    tags=["versions"],
+    service_type="script",
+)
 @server.tool()
 @handle_http_errors("get_version", is_read_only=True, service_type="script")
 @require_google_service("script", "script_readonly")
@@ -995,6 +1101,14 @@ async def _get_script_metrics_impl(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="appscript",
+    tier="extended",
+    scopes=["script_readonly"],
+    read_only=True,
+    tags=["metrics"],
+    service_type="script",
+)
 @server.tool()
 @handle_http_errors("get_script_metrics", is_read_only=True, service_type="script")
 @require_google_service("script", "script_readonly")
@@ -1246,6 +1360,14 @@ def _generate_trigger_code_impl(
     return "\n".join(instructions) + "\n\n" + code
 
 
+@tool_schema(
+    service="appscript",
+    tier="core",
+    scopes=[],
+    read_only=True,
+    tags=["triggers"],
+    service_type="",
+)
 @server.tool()
 async def generate_trigger_code(
     trigger_type: str,

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -19,6 +19,7 @@ from auth.service_decorator import require_google_service
 from core.utils import handle_http_errors
 
 from core.server import server
+from core.tool_schema import tool_schema
 
 
 # Configure module logger
@@ -301,6 +302,13 @@ def _correct_time_format_for_api(
     return time_str
 
 
+@tool_schema(
+    service="calendar",
+    tier="core",
+    scopes=["calendar_read"],
+    read_only=True,
+    tags=["calendars"],
+)
 @server.tool()
 @handle_http_errors("list_calendars", is_read_only=True, service_type="calendar")
 @require_google_service("calendar", "calendar_read")
@@ -335,6 +343,13 @@ async def list_calendars(service, user_google_email: str) -> str:
     return text_output
 
 
+@tool_schema(
+    service="calendar",
+    tier="core",
+    scopes=["calendar_read"],
+    read_only=True,
+    tags=["events"],
+)
 @server.tool()
 @handle_http_errors("get_events", is_read_only=True, service_type="calendar")
 @require_google_service("calendar", "calendar_read")
@@ -1078,6 +1093,13 @@ async def _delete_event_impl(
 # ---------------------------------------------------------------------------
 
 
+@tool_schema(
+    service="calendar",
+    tier="core",
+    scopes=["calendar_events"],
+    read_only=False,
+    tags=["events"],
+)
 @server.tool()
 @handle_http_errors("manage_event", service_type="calendar")
 @require_google_service("calendar", "calendar_events")
@@ -1208,6 +1230,13 @@ async def manage_event(
 # ---------------------------------------------------------------------------
 
 
+@tool_schema(
+    service="calendar",
+    tier="extended",
+    scopes=["calendar_read"],
+    read_only=True,
+    tags=["freebusy"],
+)
 @server.tool()
 @handle_http_errors("query_freebusy", is_read_only=True, service_type="calendar")
 @require_google_service("calendar", "calendar_read")

--- a/gchat/chat_tools.py
+++ b/gchat/chat_tools.py
@@ -16,6 +16,7 @@ from googleapiclient.errors import HttpError
 from auth.service_decorator import require_google_service, require_multiple_services
 from core.server import server
 from core.utils import handle_http_errors
+from core.tool_schema import tool_schema
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +101,13 @@ def _extract_rich_links(msg: dict) -> List[str]:
     return urls
 
 
+@tool_schema(
+    service="chat",
+    tier="extended",
+    scopes=["chat_spaces_readonly"],
+    read_only=True,
+    tags=["spaces"],
+)
 @server.tool()
 @require_google_service("chat", "chat_spaces_readonly")
 @handle_http_errors("list_spaces", service_type="chat")
@@ -144,6 +152,14 @@ async def list_spaces(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="chat",
+    tier="core",
+    scopes=["chat_read", "contacts_read"],
+    read_only=True,
+    tags=["messages"],
+    multi_service=True,
+)
 @server.tool()
 @require_multiple_services(
     [
@@ -251,6 +267,13 @@ async def get_messages(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="chat",
+    tier="core",
+    scopes=["chat_write"],
+    read_only=False,
+    tags=["messages", "send"],
+)
 @server.tool()
 @require_google_service("chat", "chat_write")
 @handle_http_errors("send_message", service_type="chat")
@@ -300,6 +323,14 @@ async def send_message(
     return msg
 
 
+@tool_schema(
+    service="chat",
+    tier="core",
+    scopes=["chat_read", "contacts_read"],
+    read_only=True,
+    tags=["search", "messages"],
+    multi_service=True,
+)
 @server.tool()
 @require_multiple_services(
     [
@@ -412,6 +443,13 @@ async def search_messages(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="chat",
+    tier="core",
+    scopes=["chat_write"],
+    read_only=False,
+    tags=["reactions"],
+)
 @server.tool()
 @require_google_service("chat", "chat_write")
 @handle_http_errors("create_reaction", service_type="chat")
@@ -448,6 +486,14 @@ async def create_reaction(
     return f"Reacted with {emoji_unicode} on message {message_id}. Reaction ID: {reaction_name}"
 
 
+@tool_schema(
+    service="chat",
+    tier="extended",
+    scopes=["chat_read"],
+    read_only=True,
+    tags=["attachments"],
+    supports_download=True,
+)
 @server.tool()
 @handle_http_errors("download_chat_attachment", is_read_only=True, service_type="chat")
 @require_google_service("chat", "chat_read")

--- a/gcontacts/contacts_tools.py
+++ b/gcontacts/contacts_tools.py
@@ -13,6 +13,7 @@ from mcp import Resource
 
 from auth.service_decorator import require_google_service
 from core.server import server
+from core.tool_schema import tool_schema
 from core.utils import UserInputError, handle_http_errors
 
 logger = logging.getLogger(__name__)
@@ -225,6 +226,14 @@ async def _warmup_search_cache(service: Resource, user_google_email: str) -> Non
 # =============================================================================
 
 
+@tool_schema(
+    service="contacts",
+    tier="core",
+    scopes=["contacts_read"],
+    read_only=True,
+    tags=["contacts"],
+    paginated=True,
+)
 @server.tool()
 @require_google_service("people", "contacts_read")
 @handle_http_errors("list_contacts", service_type="people")
@@ -289,6 +298,13 @@ async def list_contacts(
     return response
 
 
+@tool_schema(
+    service="contacts",
+    tier="core",
+    scopes=["contacts_read"],
+    read_only=True,
+    tags=["contacts"],
+)
 @server.tool()
 @require_google_service("people", "contacts_read")
 @handle_http_errors("get_contact", service_type="people")
@@ -330,6 +346,13 @@ async def get_contact(
     return response
 
 
+@tool_schema(
+    service="contacts",
+    tier="core",
+    scopes=["contacts_read"],
+    read_only=True,
+    tags=["search"],
+)
 @server.tool()
 @require_google_service("people", "contacts_read")
 @handle_http_errors("search_contacts", service_type="people")
@@ -388,6 +411,13 @@ async def search_contacts(
     return response
 
 
+@tool_schema(
+    service="contacts",
+    tier="core",
+    scopes=["contacts"],
+    read_only=False,
+    tags=["contacts"],
+)
 @server.tool()
 @require_google_service("people", "contacts")
 @handle_http_errors("manage_contact", service_type="people")
@@ -547,6 +577,14 @@ async def manage_contact(
 # =============================================================================
 
 
+@tool_schema(
+    service="contacts",
+    tier="extended",
+    scopes=["contacts_read"],
+    read_only=True,
+    tags=["groups"],
+    paginated=True,
+)
 @server.tool()
 @require_google_service("people", "contacts_read")
 @handle_http_errors("list_contact_groups", service_type="people")
@@ -610,6 +648,13 @@ async def list_contact_groups(
     return response
 
 
+@tool_schema(
+    service="contacts",
+    tier="extended",
+    scopes=["contacts_read"],
+    read_only=True,
+    tags=["groups"],
+)
 @server.tool()
 @require_google_service("people", "contacts_read")
 @handle_http_errors("get_contact_group", service_type="people")
@@ -680,6 +725,13 @@ async def get_contact_group(
 # =============================================================================
 
 
+@tool_schema(
+    service="contacts",
+    tier="complete",
+    scopes=["contacts"],
+    read_only=False,
+    tags=["contacts", "batch"],
+)
 @server.tool()
 @require_google_service("people", "contacts")
 @handle_http_errors("manage_contacts_batch", service_type="people")
@@ -886,6 +938,13 @@ async def manage_contacts_batch(
     return response
 
 
+@tool_schema(
+    service="contacts",
+    tier="complete",
+    scopes=["contacts"],
+    read_only=False,
+    tags=["groups"],
+)
 @server.tool()
 @require_google_service("people", "contacts")
 @handle_http_errors("manage_contact_group", service_type="people")

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -17,6 +17,7 @@ from auth.service_decorator import require_google_service, require_multiple_serv
 from core.utils import extract_office_xml_text, handle_http_errors
 from core.server import server
 from core.comments import create_comment_tools
+from core.tool_schema import tool_schema, register_comment_schemas
 
 # Import helper functions for document operations
 from gdocs.docs_helpers import (
@@ -59,6 +60,13 @@ import json
 logger = logging.getLogger(__name__)
 
 
+@tool_schema(
+    service="docs",
+    tier="extended",
+    scopes=["drive_read"],
+    read_only=True,
+    tags=["search"],
+)
 @server.tool()
 @handle_http_errors("search_docs", is_read_only=True, service_type="docs")
 @require_google_service("drive", "drive_read")
@@ -101,6 +109,14 @@ async def search_docs(
     return "\n".join(output)
 
 
+@tool_schema(
+    service="docs",
+    tier="core",
+    scopes=["drive_read", "docs_read"],
+    read_only=True,
+    tags=["documents"],
+    multi_service=True,
+)
 @server.tool()
 @handle_http_errors("get_doc_content", is_read_only=True, service_type="docs")
 @require_multiple_services(
@@ -288,6 +304,13 @@ async def get_doc_content(
     return header + body_text
 
 
+@tool_schema(
+    service="docs",
+    tier="extended",
+    scopes=["drive_read"],
+    read_only=True,
+    tags=["documents"],
+)
 @server.tool()
 @handle_http_errors("list_docs_in_folder", is_read_only=True, service_type="docs")
 @require_google_service("drive", "drive_read")
@@ -326,6 +349,13 @@ async def list_docs_in_folder(
     return "\n".join(out)
 
 
+@tool_schema(
+    service="docs",
+    tier="core",
+    scopes=["docs_write"],
+    read_only=False,
+    tags=["documents"],
+)
 @server.tool()
 @handle_http_errors("create_doc", service_type="docs")
 @require_google_service("docs", "docs_write")
@@ -362,6 +392,13 @@ async def create_doc(
     return msg
 
 
+@tool_schema(
+    service="docs",
+    tier="core",
+    scopes=["docs_write"],
+    read_only=False,
+    tags=["documents"],
+)
 @server.tool()
 @handle_http_errors("modify_doc_text", service_type="docs")
 @require_google_service("docs", "docs_write")
@@ -554,6 +591,13 @@ async def modify_doc_text(
     return f"{operation_summary} in document {document_id}.{text_info} Link: {link}"
 
 
+@tool_schema(
+    service="docs",
+    tier="extended",
+    scopes=["docs_write"],
+    read_only=False,
+    tags=["documents"],
+)
 @server.tool()
 @handle_http_errors("find_and_replace_doc", service_type="docs")
 @require_google_service("docs", "docs_write")
@@ -605,6 +649,13 @@ async def find_and_replace_doc(
     return f"Replaced {replacements} occurrence(s) of '{find_text}' with '{replace_text}' in document {document_id}. Link: {link}"
 
 
+@tool_schema(
+    service="docs",
+    tier="extended",
+    scopes=["docs_write"],
+    read_only=False,
+    tags=["documents"],
+)
 @server.tool()
 @handle_http_errors("insert_doc_elements", service_type="docs")
 @require_google_service("docs", "docs_write")
@@ -687,6 +738,14 @@ async def insert_doc_elements(
     return f"Inserted {description} at index {index} in document {document_id}. Link: {link}"
 
 
+@tool_schema(
+    service="docs",
+    tier="complete",
+    scopes=["docs_write", "drive_read"],
+    read_only=False,
+    tags=["documents", "images"],
+    multi_service=True,
+)
 @server.tool()
 @handle_http_errors("insert_doc_image", service_type="docs")
 @require_multiple_services(
@@ -779,6 +838,13 @@ async def insert_doc_image(
     return f"Inserted {source_description}{size_info} at index {index} in document {document_id}. Link: {link}"
 
 
+@tool_schema(
+    service="docs",
+    tier="complete",
+    scopes=["docs_write"],
+    read_only=False,
+    tags=["documents"],
+)
 @server.tool()
 @handle_http_errors("update_doc_headers_footers", service_type="docs")
 @require_google_service("docs", "docs_write")
@@ -836,6 +902,13 @@ async def update_doc_headers_footers(
         return f"Error: {message}"
 
 
+@tool_schema(
+    service="docs",
+    tier="complete",
+    scopes=["docs_write"],
+    read_only=False,
+    tags=["documents", "batch"],
+)
 @server.tool()
 @handle_http_errors("batch_update_doc", service_type="docs")
 @require_google_service("docs", "docs_write")
@@ -919,6 +992,13 @@ async def batch_update_doc(
         return f"Error: {message}"
 
 
+@tool_schema(
+    service="docs",
+    tier="complete",
+    scopes=["docs_read"],
+    read_only=True,
+    tags=["documents"],
+)
 @server.tool()
 @handle_http_errors("inspect_doc_structure", is_read_only=True, service_type="docs")
 @require_google_service("docs", "docs_read")
@@ -1100,6 +1180,13 @@ async def inspect_doc_structure(
     return f"Document structure analysis for {document_id}:\n\n{json.dumps(result, indent=2)}\n\nLink: {link}"
 
 
+@tool_schema(
+    service="docs",
+    tier="complete",
+    scopes=["docs_write"],
+    read_only=False,
+    tags=["documents", "tables"],
+)
 @server.tool()
 @handle_http_errors("create_table_with_data", service_type="docs")
 @require_google_service("docs", "docs_write")
@@ -1200,6 +1287,13 @@ async def create_table_with_data(
         return f"ERROR: {message}"
 
 
+@tool_schema(
+    service="docs",
+    tier="complete",
+    scopes=["docs_read"],
+    read_only=True,
+    tags=["documents", "tables"],
+)
 @server.tool()
 @handle_http_errors("debug_table_structure", is_read_only=True, service_type="docs")
 @require_google_service("docs", "docs_read")
@@ -1287,6 +1381,13 @@ async def debug_table_structure(
     return f"Table structure debug for table {table_index}:\n\n{json.dumps(debug_info, indent=2)}\n\nLink: {link}"
 
 
+@tool_schema(
+    service="docs",
+    tier="extended",
+    scopes=["drive_file"],
+    read_only=False,
+    tags=["documents", "export"],
+)
 @server.tool()
 @handle_http_errors("export_doc_to_pdf", service_type="drive")
 @require_google_service("drive", "drive_file")
@@ -1442,6 +1543,13 @@ async def _get_paragraph_start_indices_in_range(
     return paragraph_starts or [start_index]
 
 
+@tool_schema(
+    service="docs",
+    tier="extended",
+    scopes=["docs_write"],
+    read_only=False,
+    tags=["documents", "formatting"],
+)
 @server.tool()
 @handle_http_errors("update_paragraph_style", service_type="docs")
 @require_google_service("docs", "docs_write")
@@ -1660,6 +1768,14 @@ async def update_paragraph_style(
     return f"Applied paragraph formatting ({', '.join(summary_parts)}) to range {start_index}-{end_index} in document {document_id}. Link: {link}"
 
 
+@tool_schema(
+    service="docs",
+    tier="extended",
+    scopes=["drive_read", "docs_read"],
+    read_only=True,
+    tags=["documents", "export"],
+    multi_service=True,
+)
 @server.tool()
 @handle_http_errors("get_doc_as_markdown", is_read_only=True, service_type="docs")
 @require_multiple_services(
@@ -1764,6 +1880,13 @@ async def get_doc_as_markdown(
         return markdown.rstrip("\n") + "\n\n" + appendix
 
 
+@tool_schema(
+    service="docs",
+    tier="extended",
+    scopes=["docs_write"],
+    read_only=False,
+    tags=["documents", "tabs"],
+)
 @server.tool()
 @handle_http_errors("insert_doc_tab", service_type="docs")
 @require_google_service("docs", "docs_write")
@@ -1813,6 +1936,13 @@ async def insert_doc_tab(
     return f"{msg} Link: {link}"
 
 
+@tool_schema(
+    service="docs",
+    tier="extended",
+    scopes=["docs_write"],
+    read_only=False,
+    tags=["documents", "tabs"],
+)
 @server.tool()
 @handle_http_errors("delete_doc_tab", service_type="docs")
 @require_google_service("docs", "docs_write")
@@ -1846,6 +1976,13 @@ async def delete_doc_tab(
     return f"Deleted tab '{tab_id}' from document {document_id}. Link: {link}"
 
 
+@tool_schema(
+    service="docs",
+    tier="extended",
+    scopes=["docs_write"],
+    read_only=False,
+    tags=["documents", "tabs"],
+)
 @server.tool()
 @handle_http_errors("update_doc_tab", service_type="docs")
 @require_google_service("docs", "docs_write")
@@ -1891,3 +2028,4 @@ _comment_tools = create_comment_tools("document", "document_id")
 # Extract and register the functions
 list_document_comments = _comment_tools["list_comments"]
 manage_document_comment = _comment_tools["manage_comment"]
+register_comment_schemas("document", "docs")

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -28,6 +28,7 @@ from core.attachment_storage import get_attachment_storage, get_attachment_url
 from core.utils import extract_office_xml_text, handle_http_errors, validate_file_path
 from core.server import server
 from core.config import get_transport_mode
+from core.tool_schema import tool_schema
 from gdrive.drive_helpers import (
     DRIVE_QUERY_PATTERNS,
     FOLDER_MIME_TYPE,
@@ -50,6 +51,14 @@ UPLOAD_CHUNK_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB (Google recommended minimum)
 MAX_DOWNLOAD_BYTES = 2 * 1024 * 1024 * 1024  # 2 GB safety limit for URL downloads
 
 
+@tool_schema(
+    service="drive",
+    tier="core",
+    scopes=["drive_read"],
+    read_only=True,
+    tags=["search"],
+    paginated=True,
+)
 @server.tool()
 @handle_http_errors("search_drive_files", is_read_only=True, service_type="drive")
 @require_google_service("drive", "drive_read")
@@ -149,6 +158,9 @@ async def search_drive_files(
     return text_output
 
 
+@tool_schema(
+    service="drive", tier="core", scopes=["drive_read"], read_only=True, tags=["files"]
+)
 @server.tool()
 @handle_http_errors("get_drive_file_content", is_read_only=True, service_type="drive")
 @require_google_service("drive", "drive_read")
@@ -240,6 +252,9 @@ async def get_drive_file_content(
     return header + body_text
 
 
+@tool_schema(
+    service="drive", tier="core", scopes=["drive_read"], read_only=True, tags=["files"]
+)
 @server.tool()
 @handle_http_errors(
     "get_drive_file_download_url", is_read_only=True, service_type="drive"
@@ -429,6 +444,14 @@ async def get_drive_file_download_url(
         )
 
 
+@tool_schema(
+    service="drive",
+    tier="extended",
+    scopes=["drive_read"],
+    read_only=True,
+    tags=["files"],
+    paginated=True,
+)
 @server.tool()
 @handle_http_errors("list_drive_items", is_read_only=True, service_type="drive")
 @require_google_service("drive", "drive_read")
@@ -545,6 +568,13 @@ async def _create_drive_folder_impl(
     )
 
 
+@tool_schema(
+    service="drive",
+    tier="core",
+    scopes=["drive_file"],
+    read_only=False,
+    tags=["folders"],
+)
 @server.tool()
 @handle_http_errors("create_drive_folder", service_type="drive")
 @require_google_service("drive", "drive_file")
@@ -574,6 +604,9 @@ async def create_drive_folder(
     )
 
 
+@tool_schema(
+    service="drive", tier="core", scopes=["drive_file"], read_only=False, tags=["files"]
+)
 @server.tool()
 @handle_http_errors("create_drive_file", service_type="drive")
 @require_google_service("drive", "drive_file")
@@ -1130,6 +1163,13 @@ def _detect_source_format(file_name: str, content: Optional[str] = None) -> str:
     return "text/plain"
 
 
+@tool_schema(
+    service="drive",
+    tier="core",
+    scopes=["drive_file"],
+    read_only=False,
+    tags=["files", "import"],
+)
 @server.tool()
 @handle_http_errors("import_to_google_doc", service_type="drive")
 @require_google_service("drive", "drive_file")
@@ -1330,6 +1370,13 @@ async def import_to_google_doc(
     return confirmation
 
 
+@tool_schema(
+    service="drive",
+    tier="complete",
+    scopes=["drive_read"],
+    read_only=True,
+    tags=["sharing"],
+)
 @server.tool()
 @handle_http_errors(
     "get_drive_file_permissions", is_read_only=True, service_type="drive"
@@ -1439,6 +1486,13 @@ async def get_drive_file_permissions(
         return f"Error getting file permissions: {e}"
 
 
+@tool_schema(
+    service="drive",
+    tier="complete",
+    scopes=["drive_read"],
+    read_only=True,
+    tags=["sharing"],
+)
 @server.tool()
 @handle_http_errors(
     "check_drive_file_public_access", is_read_only=True, service_type="drive"
@@ -1536,6 +1590,13 @@ async def check_drive_file_public_access(
     return "\n".join(output_parts)
 
 
+@tool_schema(
+    service="drive",
+    tier="extended",
+    scopes=["drive_file"],
+    read_only=False,
+    tags=["files"],
+)
 @server.tool()
 @handle_http_errors("update_drive_file", is_read_only=False, service_type="drive")
 @require_google_service("drive", "drive_file")
@@ -1713,6 +1774,13 @@ async def update_drive_file(
     return "\n".join(output_parts)
 
 
+@tool_schema(
+    service="drive",
+    tier="core",
+    scopes=["drive_read"],
+    read_only=True,
+    tags=["sharing"],
+)
 @server.tool()
 @handle_http_errors("get_drive_shareable_link", is_read_only=True, service_type="drive")
 @require_google_service("drive", "drive_read")
@@ -1773,6 +1841,13 @@ async def get_drive_shareable_link(
     return "\n".join(output_parts)
 
 
+@tool_schema(
+    service="drive",
+    tier="extended",
+    scopes=["drive_file"],
+    read_only=False,
+    tags=["sharing"],
+)
 @server.tool()
 @handle_http_errors("manage_drive_access", is_read_only=False, service_type="drive")
 @require_google_service("drive", "drive_file")
@@ -2140,6 +2215,13 @@ async def manage_drive_access(
     return "\n".join(output_parts)
 
 
+@tool_schema(
+    service="drive",
+    tier="extended",
+    scopes=["drive_file"],
+    read_only=False,
+    tags=["files"],
+)
 @server.tool()
 @handle_http_errors("copy_drive_file", is_read_only=False, service_type="drive")
 @require_google_service("drive", "drive_file")
@@ -2212,6 +2294,13 @@ async def copy_drive_file(
     return "\n".join(output_parts)
 
 
+@tool_schema(
+    service="drive",
+    tier="extended",
+    scopes=["drive_file"],
+    read_only=False,
+    tags=["sharing"],
+)
 @server.tool()
 @handle_http_errors(
     "set_drive_file_permissions", is_read_only=False, service_type="drive"

--- a/gforms/forms_tools.py
+++ b/gforms/forms_tools.py
@@ -12,10 +12,14 @@ from typing import List, Optional, Dict, Any
 from auth.service_decorator import require_google_service
 from core.server import server
 from core.utils import handle_http_errors
+from core.tool_schema import tool_schema
 
 logger = logging.getLogger(__name__)
 
 
+@tool_schema(
+    service="forms", tier="core", scopes=["forms"], read_only=False, tags=["forms"]
+)
 @server.tool()
 @handle_http_errors("create_form", service_type="forms")
 @require_google_service("forms", "forms")
@@ -63,6 +67,9 @@ async def create_form(
     return confirmation_message
 
 
+@tool_schema(
+    service="forms", tier="core", scopes=["forms"], read_only=True, tags=["forms"]
+)
 @server.tool()
 @handle_http_errors("get_form", is_read_only=True, service_type="forms")
 @require_google_service("forms", "forms")
@@ -119,6 +126,9 @@ async def get_form(service, user_google_email: str, form_id: str) -> str:
     return result
 
 
+@tool_schema(
+    service="forms", tier="complete", scopes=["forms"], read_only=False, tags=["forms"]
+)
 @server.tool()
 @handle_http_errors("set_publish_settings", service_type="forms")
 @require_google_service("forms", "forms")
@@ -161,6 +171,13 @@ async def set_publish_settings(
     return confirmation_message
 
 
+@tool_schema(
+    service="forms",
+    tier="complete",
+    scopes=["forms"],
+    read_only=True,
+    tags=["responses"],
+)
 @server.tool()
 @handle_http_errors("get_form_response", is_read_only=True, service_type="forms")
 @require_google_service("forms", "forms")
@@ -216,6 +233,14 @@ async def get_form_response(
     return result
 
 
+@tool_schema(
+    service="forms",
+    tier="extended",
+    scopes=["forms"],
+    read_only=True,
+    tags=["responses"],
+    paginated=True,
+)
 @server.tool()
 @handle_http_errors("list_form_responses", is_read_only=True, service_type="forms")
 @require_google_service("forms", "forms")
@@ -337,6 +362,13 @@ async def _batch_update_form_impl(
     return confirmation_message
 
 
+@tool_schema(
+    service="forms",
+    tier="complete",
+    scopes=["forms"],
+    read_only=False,
+    tags=["forms", "batch"],
+)
 @server.tool()
 @handle_http_errors("batch_update_form", service_type="forms")
 @require_google_service("forms", "forms")

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -30,6 +30,7 @@ from auth.scopes import (
     GMAIL_MODIFY_SCOPE,
     GMAIL_LABELS_SCOPE,
 )
+from core.tool_schema import tool_schema
 
 logger = logging.getLogger(__name__)
 
@@ -571,6 +572,14 @@ def _format_gmail_results_plain(
     return "\n".join(lines)
 
 
+@tool_schema(
+    service="gmail",
+    tier="core",
+    scopes=["gmail_read"],
+    read_only=True,
+    tags=["search", "messages"],
+    paginated=True,
+)
 @server.tool()
 @handle_http_errors("search_gmail_messages", is_read_only=True, service_type="gmail")
 @require_google_service("gmail", "gmail_read")
@@ -635,6 +644,13 @@ async def search_gmail_messages(
     return formatted_output
 
 
+@tool_schema(
+    service="gmail",
+    tier="core",
+    scopes=["gmail_read"],
+    read_only=True,
+    tags=["messages"],
+)
 @server.tool()
 @handle_http_errors(
     "get_gmail_message_content", is_read_only=True, service_type="gmail"
@@ -735,6 +751,13 @@ async def get_gmail_message_content(
     return "\n".join(content_lines)
 
 
+@tool_schema(
+    service="gmail",
+    tier="core",
+    scopes=["gmail_read"],
+    read_only=True,
+    tags=["messages", "batch"],
+)
 @server.tool()
 @handle_http_errors(
     "get_gmail_messages_content_batch", is_read_only=True, service_type="gmail"
@@ -934,6 +957,14 @@ async def get_gmail_messages_content_batch(
     return final_output
 
 
+@tool_schema(
+    service="gmail",
+    tier="extended",
+    scopes=["gmail_read"],
+    read_only=True,
+    tags=["attachments"],
+    supports_download=True,
+)
 @server.tool()
 @handle_http_errors(
     "get_gmail_attachment_content", is_read_only=True, service_type="gmail"
@@ -1113,6 +1144,13 @@ async def get_gmail_attachment_content(
         return "\n".join(result_lines)
 
 
+@tool_schema(
+    service="gmail",
+    tier="core",
+    scopes=["gmail_send"],
+    read_only=False,
+    tags=["messages", "send"],
+)
 @server.tool()
 @handle_http_errors("send_gmail_message", service_type="gmail")
 @require_google_service("gmail", GMAIL_SEND_SCOPE)
@@ -1315,6 +1353,13 @@ async def send_gmail_message(
     return f"Email sent! Message ID: {message_id}"
 
 
+@tool_schema(
+    service="gmail",
+    tier="extended",
+    scopes=["gmail_compose"],
+    read_only=False,
+    tags=["drafts"],
+)
 @server.tool()
 @handle_http_errors("draft_gmail_message", service_type="gmail")
 @require_google_service("gmail", GMAIL_COMPOSE_SCOPE)
@@ -1608,6 +1653,13 @@ def _format_thread_content(thread_data: dict, thread_id: str) -> str:
     return "\n".join(content_lines)
 
 
+@tool_schema(
+    service="gmail",
+    tier="extended",
+    scopes=["gmail_read"],
+    read_only=True,
+    tags=["threads"],
+)
 @server.tool()
 @require_google_service("gmail", "gmail_read")
 @handle_http_errors("get_gmail_thread_content", is_read_only=True, service_type="gmail")
@@ -1636,6 +1688,13 @@ async def get_gmail_thread_content(
     return _format_thread_content(thread_response, thread_id)
 
 
+@tool_schema(
+    service="gmail",
+    tier="complete",
+    scopes=["gmail_read"],
+    read_only=True,
+    tags=["threads", "batch"],
+)
 @server.tool()
 @require_google_service("gmail", "gmail_read")
 @handle_http_errors(
@@ -1745,6 +1804,13 @@ async def get_gmail_threads_content_batch(
     return header + "\n\n" + "\n---\n\n".join(output_threads)
 
 
+@tool_schema(
+    service="gmail",
+    tier="extended",
+    scopes=["gmail_read"],
+    read_only=True,
+    tags=["labels"],
+)
 @server.tool()
 @handle_http_errors("list_gmail_labels", is_read_only=True, service_type="gmail")
 @require_google_service("gmail", "gmail_read")
@@ -1793,6 +1859,13 @@ async def list_gmail_labels(service, user_google_email: str) -> str:
     return "\n".join(lines)
 
 
+@tool_schema(
+    service="gmail",
+    tier="extended",
+    scopes=["gmail_labels"],
+    read_only=False,
+    tags=["labels"],
+)
 @server.tool()
 @handle_http_errors("manage_gmail_label", service_type="gmail")
 @require_google_service("gmail", GMAIL_LABELS_SCOPE)
@@ -1872,6 +1945,13 @@ async def manage_gmail_label(
         return f"Label '{label_name}' (ID: {label_id}) deleted successfully!"
 
 
+@tool_schema(
+    service="gmail",
+    tier="extended",
+    scopes=["gmail_settings_basic"],
+    read_only=True,
+    tags=["filters"],
+)
 @server.tool()
 @handle_http_errors("list_gmail_filters", is_read_only=True, service_type="gmail")
 @require_google_service("gmail", "gmail_settings_basic")
@@ -1950,6 +2030,13 @@ async def list_gmail_filters(service, user_google_email: str) -> str:
     return "\n".join(lines).rstrip()
 
 
+@tool_schema(
+    service="gmail",
+    tier="extended",
+    scopes=["gmail_settings_basic"],
+    read_only=False,
+    tags=["filters"],
+)
 @server.tool()
 @handle_http_errors("manage_gmail_filter", service_type="gmail")
 @require_google_service("gmail", "gmail_settings_basic")
@@ -2019,6 +2106,13 @@ async def manage_gmail_filter(
         )
 
 
+@tool_schema(
+    service="gmail",
+    tier="extended",
+    scopes=["gmail_modify"],
+    read_only=False,
+    tags=["labels"],
+)
 @server.tool()
 @handle_http_errors("modify_gmail_message_labels", service_type="gmail")
 @require_google_service("gmail", GMAIL_MODIFY_SCOPE)
@@ -2071,6 +2165,13 @@ async def modify_gmail_message_labels(
     return f"Message labels updated successfully!\nMessage ID: {message_id}\n{'; '.join(actions)}"
 
 
+@tool_schema(
+    service="gmail",
+    tier="complete",
+    scopes=["gmail_modify"],
+    read_only=False,
+    tags=["labels", "batch"],
+)
 @server.tool()
 @handle_http_errors("batch_modify_gmail_message_labels", service_type="gmail")
 @require_google_service("gmail", GMAIL_MODIFY_SCOPE)

--- a/gsearch/search_tools.py
+++ b/gsearch/search_tools.py
@@ -12,10 +12,18 @@ from typing import Optional, List, Literal
 from auth.service_decorator import require_google_service
 from core.server import server
 from core.utils import handle_http_errors
+from core.tool_schema import tool_schema
 
 logger = logging.getLogger(__name__)
 
 
+@tool_schema(
+    service="search",
+    tier="core",
+    scopes=["customsearch"],
+    read_only=True,
+    tags=["search"],
+)
 @server.tool()
 @handle_http_errors("search_custom", is_read_only=True, service_type="customsearch")
 @require_google_service("customsearch", "customsearch")
@@ -163,6 +171,13 @@ async def search_custom(
     return confirmation_message
 
 
+@tool_schema(
+    service="search",
+    tier="complete",
+    scopes=["customsearch"],
+    read_only=True,
+    tags=["search"],
+)
 @server.tool()
 @handle_http_errors(
     "get_search_engine_info", is_read_only=True, service_type="customsearch"

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -13,6 +13,7 @@ from typing import List, Optional, Union
 from auth.service_decorator import require_google_service
 from core.server import server
 from core.utils import handle_http_errors, UserInputError
+from core.tool_schema import tool_schema, register_comment_schemas
 from core.comments import create_comment_tools
 from gsheets.sheets_helpers import (
     _a1_range_cell_count,
@@ -39,6 +40,13 @@ logger = logging.getLogger(__name__)
 MAX_HYPERLINK_FETCH_CELLS = 5000
 
 
+@tool_schema(
+    service="sheets",
+    tier="extended",
+    scopes=["drive_read"],
+    read_only=True,
+    tags=["search"],
+)
 @server.tool()
 @handle_http_errors("list_spreadsheets", is_read_only=True, service_type="sheets")
 @require_google_service("drive", "drive_read")
@@ -92,6 +100,13 @@ async def list_spreadsheets(
     return text_output
 
 
+@tool_schema(
+    service="sheets",
+    tier="extended",
+    scopes=["sheets_read"],
+    read_only=True,
+    tags=["spreadsheets"],
+)
 @server.tool()
 @handle_http_errors("get_spreadsheet_info", is_read_only=True, service_type="sheets")
 @require_google_service("sheets", "sheets_read")
@@ -170,6 +185,13 @@ async def get_spreadsheet_info(
     return text_output
 
 
+@tool_schema(
+    service="sheets",
+    tier="core",
+    scopes=["sheets_read"],
+    read_only=True,
+    tags=["spreadsheets"],
+)
 @server.tool()
 @handle_http_errors("read_sheet_values", is_read_only=True, service_type="sheets")
 @require_google_service("sheets", "sheets_read")
@@ -280,6 +302,13 @@ async def read_sheet_values(
     return text_output + hyperlink_section + detailed_errors_section
 
 
+@tool_schema(
+    service="sheets",
+    tier="core",
+    scopes=["sheets_write"],
+    read_only=False,
+    tags=["spreadsheets"],
+)
 @server.tool()
 @handle_http_errors("modify_sheet_values", service_type="sheets")
 @require_google_service("sheets", "sheets_write")
@@ -649,6 +678,13 @@ async def _format_sheet_range_impl(
     }
 
 
+@tool_schema(
+    service="sheets",
+    tier="extended",
+    scopes=["sheets_write"],
+    read_only=False,
+    tags=["spreadsheets", "formatting"],
+)
 @server.tool()
 @handle_http_errors("format_sheet_range", service_type="sheets")
 @require_google_service("sheets", "sheets_write")
@@ -728,6 +764,13 @@ async def format_sheet_range(
     )
 
 
+@tool_schema(
+    service="sheets",
+    tier="complete",
+    scopes=["sheets_write"],
+    read_only=False,
+    tags=["spreadsheets", "formatting"],
+)
 @server.tool()
 @handle_http_errors("manage_conditional_formatting", service_type="sheets")
 @require_google_service("sheets", "sheets_write")
@@ -1126,6 +1169,13 @@ async def manage_conditional_formatting(
         )
 
 
+@tool_schema(
+    service="sheets",
+    tier="core",
+    scopes=["sheets_write"],
+    read_only=False,
+    tags=["spreadsheets"],
+)
 @server.tool()
 @handle_http_errors("create_spreadsheet", service_type="sheets")
 @require_google_service("sheets", "sheets_write")
@@ -1182,6 +1232,13 @@ async def create_spreadsheet(
     return text_output
 
 
+@tool_schema(
+    service="sheets",
+    tier="complete",
+    scopes=["sheets_write"],
+    read_only=False,
+    tags=["spreadsheets"],
+)
 @server.tool()
 @handle_http_errors("create_sheet", service_type="sheets")
 @require_google_service("sheets", "sheets_write")
@@ -1230,3 +1287,4 @@ _comment_tools = create_comment_tools("spreadsheet", "spreadsheet_id")
 # Extract and register the functions
 list_spreadsheet_comments = _comment_tools["list_comments"]
 manage_spreadsheet_comment = _comment_tools["manage_comment"]
+register_comment_schemas("spreadsheet", "sheets")

--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -13,10 +13,18 @@ from auth.service_decorator import require_google_service
 from core.server import server
 from core.utils import handle_http_errors
 from core.comments import create_comment_tools
+from core.tool_schema import tool_schema, register_comment_schemas
 
 logger = logging.getLogger(__name__)
 
 
+@tool_schema(
+    service="slides",
+    tier="core",
+    scopes=["slides"],
+    read_only=False,
+    tags=["presentations"],
+)
 @server.tool()
 @handle_http_errors("create_presentation", service_type="slides")
 @require_google_service("slides", "slides")
@@ -54,6 +62,13 @@ async def create_presentation(
     return confirmation_message
 
 
+@tool_schema(
+    service="slides",
+    tier="core",
+    scopes=["slides_read"],
+    read_only=True,
+    tags=["presentations"],
+)
 @server.tool()
 @handle_http_errors("get_presentation", is_read_only=True, service_type="slides")
 @require_google_service("slides", "slides_read")
@@ -147,6 +162,13 @@ Slides Breakdown:
     return confirmation_message
 
 
+@tool_schema(
+    service="slides",
+    tier="extended",
+    scopes=["slides"],
+    read_only=False,
+    tags=["presentations", "batch"],
+)
 @server.tool()
 @handle_http_errors("batch_update_presentation", service_type="slides")
 @require_google_service("slides", "slides")
@@ -207,6 +229,13 @@ async def batch_update_presentation(
     return confirmation_message
 
 
+@tool_schema(
+    service="slides",
+    tier="extended",
+    scopes=["slides_read"],
+    read_only=True,
+    tags=["pages"],
+)
 @server.tool()
 @handle_http_errors("get_page", is_read_only=True, service_type="slides")
 @require_google_service("slides", "slides_read")
@@ -268,6 +297,13 @@ Page Elements:
     return confirmation_message
 
 
+@tool_schema(
+    service="slides",
+    tier="extended",
+    scopes=["slides_read"],
+    read_only=True,
+    tags=["pages"],
+)
 @server.tool()
 @handle_http_errors("get_page_thumbnail", is_read_only=True, service_type="slides")
 @require_google_service("slides", "slides_read")
@@ -324,6 +360,7 @@ You can view or download the thumbnail using the provided URL."""
 _comment_tools = create_comment_tools("presentation", "presentation_id")
 list_presentation_comments = _comment_tools["list_comments"]
 manage_presentation_comment = _comment_tools["manage_comment"]
+register_comment_schemas("presentation", "slides")
 
 # Aliases for backwards compatibility and intuitive naming
 list_slide_comments = list_presentation_comments

--- a/gtasks/tasks_tools.py
+++ b/gtasks/tasks_tools.py
@@ -16,6 +16,7 @@ from auth.oauth_config import is_oauth21_enabled, is_external_oauth21_provider
 from auth.permissions import is_action_denied
 from auth.service_decorator import require_google_service
 from core.server import server
+from core.tool_schema import tool_schema
 from core.utils import UserInputError, handle_http_errors
 
 logger = logging.getLogger(__name__)
@@ -96,6 +97,14 @@ def _adjust_due_max_for_tasks_api(due_max: str) -> str:
     return adjusted.isoformat()
 
 
+@tool_schema(
+    service="tasks",
+    tier="complete",
+    scopes=["tasks_read"],
+    read_only=True,
+    tags=["task_lists"],
+    paginated=True,
+)
 @server.tool()  # type: ignore
 @require_google_service("tasks", "tasks_read")  # type: ignore
 @handle_http_errors("list_task_lists", service_type="tasks")  # type: ignore
@@ -154,6 +163,13 @@ async def list_task_lists(
         raise Exception(message)
 
 
+@tool_schema(
+    service="tasks",
+    tier="complete",
+    scopes=["tasks_read"],
+    read_only=True,
+    tags=["task_lists"],
+)
 @server.tool()  # type: ignore
 @require_google_service("tasks", "tasks_read")  # type: ignore
 @handle_http_errors("get_task_list", service_type="tasks")  # type: ignore
@@ -289,6 +305,13 @@ async def _clear_completed_tasks_impl(
 # --- Consolidated manage_task_list tool ---
 
 
+@tool_schema(
+    service="tasks",
+    tier="complete",
+    scopes=["tasks"],
+    read_only=False,
+    tags=["task_lists"],
+)
 @server.tool()  # type: ignore
 @require_google_service("tasks", "tasks")  # type: ignore
 @handle_http_errors("manage_task_list", service_type="tasks")  # type: ignore
@@ -356,6 +379,14 @@ async def manage_task_list(
 # --- Task tools ---
 
 
+@tool_schema(
+    service="tasks",
+    tier="core",
+    scopes=["tasks_read"],
+    read_only=True,
+    tags=["tasks"],
+    paginated=True,
+)
 @server.tool()  # type: ignore
 @require_google_service("tasks", "tasks_read")  # type: ignore
 @handle_http_errors("list_tasks", service_type="tasks")  # type: ignore
@@ -600,6 +631,9 @@ This can also occur due to filtering that excludes parent tasks while including 
     return response
 
 
+@tool_schema(
+    service="tasks", tier="core", scopes=["tasks_read"], read_only=True, tags=["tasks"]
+)
 @server.tool()  # type: ignore
 @require_google_service("tasks", "tasks_read")  # type: ignore
 @handle_http_errors("get_task", service_type="tasks")  # type: ignore
@@ -843,6 +877,9 @@ async def _move_task_impl(
 # --- Consolidated manage_task tool ---
 
 
+@tool_schema(
+    service="tasks", tier="core", scopes=["tasks"], read_only=False, tags=["tasks"]
+)
 @server.tool()  # type: ignore
 @require_google_service("tasks", "tasks")  # type: ignore
 @handle_http_errors("manage_task", service_type="tasks")  # type: ignore

--- a/main.py
+++ b/main.py
@@ -182,6 +182,11 @@ def main():
         help="Run in read-only mode - requests only read-only scopes and disables tools requiring write permissions",
     )
     parser.add_argument(
+        "--code-mode",
+        action="store_true",
+        help="Enable Code Mode: expose a single execute_code tool with typed API stubs",
+    )
+    parser.add_argument(
         "--permissions",
         nargs="+",
         metavar="SERVICE:LEVEL",
@@ -408,6 +413,13 @@ def main():
 
     # Filter tools based on tier configuration (if tier-based loading is enabled)
     filter_server_tools(server)
+
+    # Enable Code Mode if requested
+    if args.code_mode:
+        from core.code_mode import register_code_mode
+
+        register_code_mode(server)
+        safe_print("   Code Mode: Enabled (execute_workspace_code tool registered)")
 
     # Handle CLI mode - execute tool and exit
     if args.cli is not None:


### PR DESCRIPTION
This is a major refactor that unlocks some extremely significant improvements around reduced context usage and extensibility. 

Example:
```bash
⏺ workspace - execute_workspace_code (MCP)(code: "\n# Get current date\ntoday_str = \"2026-03-08\"  # Based
                                          on system context\n\n# Calculate week range (Monday to Sunday)\n#
                                          March 8, 2026 is a Sunday\n# So week is Monday March 2 to Sunday
                                          March 8\ntime_min = \"2026-03-02T00:00:00Z\"\ntime_max =
                                          \"2026-03-08T23:59:59Z\"\n\nprint(f\"Getting events for week:
                                          2026-03-02 to 2026-03-08\")\nprint()\n\n# Get events for the
                                          week\nevents = await calendar.get_events(\n
                                          calendar_id='primary',\n    time_min=time_min,\n
                                          time_max=time_max,\n    detailed=True\n)\n\nprint(events)\n")
  ⎿ {
      "result": "Getting events for week: 2026-03-02 to 2026-03-08\n\nSuccessfully retrieved 21 events
    from calendar 'primary' forremoved@gmail.com:\n- \"Renew tennis permit\" (Starts: 2026-03-
    … +114 lines (ctrl+o to expand)


⏺ Here's your calendar for the week of March 2-8, 2026. You have 21 events scheduled, including:

  Key Events:
  - Monday, March 8 at 9:30 AM - pii santiized
  - Monday, March 9 at 10:30 AM - pii santiized

  Other Events:
names removed
```



Introduces a unified ToolSchema/SchemaRegistry system that replaces scattered tool metadata across decorators and YAML. Each tool now carries structured schema attributes (service, tier, scopes, tags, read_only, paginated, etc.) via @tool_schema() decorator. Adds a Code Mode engine that generates typed Python API stubs and provides AST-validated sandbox execution for multi-step workflows. Refactors filter_server_tools to use SchemaRegistry with fallback, and adds schema-driven CLI enhancements including service discovery.

- 113 tools across 12 services decorated with @tool_schema()
- New core/tool_schema.py: ToolSchema, SchemaRegistry, decorator
- New core/code_mode.py: stub generation, sandbox, execute_workspace_code
- New core/schema_cli.py: schema-aware CLI listing and discovery
- Modified core/tool_registry.py: SchemaRegistry-based filtering
- Modified core/cli_handler.py: discover command, SchemaRegistry output
- Modified main.py: --code-mode flag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code Mode: Execute Python code safely against workspace APIs with auto-generated API stubs
  * Enhanced tool discovery: New `discover` command to search and filter tools by service
  * Improved tool listing: Tools now organized by service and tier for better visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->