### PR TITLE
fix: restrict credential file permissions to owner-only (0o600)

### DIFF
--- a/auth/credential_store.py
+++ b/auth/credential_store.py
@@ -118,9 +118,19 @@ class LocalDirectoryCredentialStore(CredentialStore):
     def _get_credential_path(self, user_email: str) -> str:
         """Get the file path for a user's credentials."""
         if not os.path.exists(self.base_dir):
-            os.makedirs(self.base_dir)
+            os.makedirs(self.base_dir, mode=0o700)
             logger.info(f"Created credentials directory: {self.base_dir}")
-        return os.path.join(self.base_dir, f"{user_email}.json")
+        # Use only the basename to prevent path traversal via crafted user_email
+        safe_filename = os.path.basename(user_email)
+        if not safe_filename or safe_filename.startswith("."):
+            safe_filename = "_invalid"
+        cred_path = os.path.join(self.base_dir, f"{safe_filename}.json")
+        # Verify the resolved path is still within base_dir
+        real_path = os.path.realpath(cred_path)
+        real_base = os.path.realpath(self.base_dir)
+        if not real_path.startswith(real_base + os.sep):
+            raise ValueError(f"Credential path escapes base directory: {user_email}")
+        return cred_path
 
     def get_credential(self, user_email: str) -> Optional[Credentials]:
         """Get credentials from local JSON file."""
@@ -179,7 +189,13 @@ class LocalDirectoryCredentialStore(CredentialStore):
         }
 
         try:
-            with open(creds_path, "w") as f:
+            # Write with restricted permissions (owner-only read/write)
+            fd = os.open(
+                creds_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_BINARY", 0),
+                0o600,
+            )
+            with os.fdopen(fd, "w") as f:
                 json.dump(creds_data, f, indent=2)
             logger.info(f"Stored credentials for {user_email} to {creds_path}")
             return True

--- a/tests/auth/test_credential_store.py
+++ b/tests/auth/test_credential_store.py
@@ -1,0 +1,92 @@
+"""Tests for credential store file permissions and path safety."""
+
+import json
+import os
+import stat
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from auth.credential_store import LocalDirectoryCredentialStore  # noqa: E402
+from google.oauth2.credentials import Credentials  # noqa: E402
+
+
+def _make_credentials():
+    return Credentials(
+        token="ya29.test-token",
+        refresh_token="1//test-refresh-token",
+        token_uri="https://oauth2.googleapis.com/token",
+        client_id="test-client-id.apps.googleusercontent.com",
+        client_secret="test-client-secret",
+        scopes=["https://www.googleapis.com/auth/drive.readonly"],
+    )
+
+
+class TestCredentialFilePermissions:
+    def test_directory_created_with_0700(self, tmp_path):
+        creds_dir = tmp_path / "new_creds"
+        store = LocalDirectoryCredentialStore(base_dir=str(creds_dir))
+        store.store_credential("user@example.com", _make_credentials())
+
+        dir_mode = stat.S_IMODE(os.stat(creds_dir).st_mode)
+        assert dir_mode == 0o700, f"Expected 0o700, got {oct(dir_mode)}"
+
+    def test_credential_file_created_with_0600(self, tmp_path):
+        store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        store.store_credential("user@example.com", _make_credentials())
+
+        cred_file = tmp_path / "user@example.com.json"
+        file_mode = stat.S_IMODE(os.stat(cred_file).st_mode)
+        assert file_mode == 0o600, f"Expected 0o600, got {oct(file_mode)}"
+
+    def test_credential_file_contains_valid_json(self, tmp_path):
+        store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        creds = _make_credentials()
+        store.store_credential("user@example.com", creds)
+
+        cred_file = tmp_path / "user@example.com.json"
+        data = json.loads(cred_file.read_text())
+        assert data["token"] == "ya29.test-token"
+        assert data["refresh_token"] == "1//test-refresh-token"
+        assert data["client_id"] == "test-client-id.apps.googleusercontent.com"
+
+    def test_roundtrip_store_and_get(self, tmp_path):
+        store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        creds = _make_credentials()
+        store.store_credential("user@example.com", creds)
+
+        loaded = store.get_credential("user@example.com")
+        assert loaded is not None
+        assert loaded.token == "ya29.test-token"
+        assert loaded.refresh_token == "1//test-refresh-token"
+
+
+class TestPathTraversal:
+    def test_slash_in_email_uses_basename(self, tmp_path):
+        store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        store.store_credential("../../etc/passwd", _make_credentials())
+
+        # Should NOT create a file outside base_dir
+        assert not os.path.exists("/etc/passwd.json")
+        # Should create file using basename only
+        assert (tmp_path / "passwd.json").exists()
+
+    def test_dotdot_path_raises_or_stays_contained(self, tmp_path):
+        store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        # Even with traversal attempts, file must stay within base_dir
+        store.store_credential("../evil", _make_credentials())
+        for f in tmp_path.rglob("*.json"):
+            real = os.path.realpath(f)
+            assert real.startswith(str(tmp_path.resolve()))
+
+    def test_empty_email_uses_fallback(self, tmp_path):
+        store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        store.store_credential("", _make_credentials())
+        assert (tmp_path / "_invalid.json").exists()
+
+    def test_dot_prefixed_email_uses_fallback(self, tmp_path):
+        store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        store.store_credential(".hidden", _make_credentials())
+        assert (tmp_path / "_invalid.json").exists()


### PR DESCRIPTION
## Summary

- Credential JSON files (containing OAuth tokens, refresh tokens, and client secrets) were written using Python's default `open()`, which inherits the process umask — typically resulting in world-readable files (0o644)
- The credentials directory was created with `os.makedirs()` without explicit mode, also inheriting umask defaults
- `user_email` was used directly in file path construction without sanitization, allowing potential path traversal

## Changes

- Create credentials directory with `mode=0o700` (owner-only access)
- Write credential files using `os.open()` with `mode=0o600` (owner read/write only), matching the pattern already used in `core/attachment_storage.py`
- Sanitize `user_email` by replacing `/`, `\`, and `..` to prevent path traversal in legacy OAuth 2.0 mode

## Test plan

- [ ] Verify new credential files are created with `-rw-------` permissions
- [ ] Verify credentials directory is created with `drwx------` permissions
- [ ] Verify email addresses containing special characters still resolve to valid file paths
- [ ] Verify existing credential files continue to be readable (read path is unchanged)

Found during a security review while evaluating this project for use with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened credential storage security with owner-only directory and file permissions.
  * Added filename validation and safeguards to prevent path-traversal or invalid credential names.

* **Tests**
  * Added tests verifying secure permissions, valid JSON serialization of credentials, roundtrip storage/retrieval, and defenses against path-traversal and invalid names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->