### PR TITLE
feat: add body_format parameter for HTML and raw email retrieval

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -153,7 +153,11 @@ def _extract_message_bodies(payload):
     return {"text": text_body, "html": html_body}
 
 
-def _format_body_content(text_body: str, html_body: str) -> str:
+def _format_body_content(
+    text_body: str,
+    html_body: str,
+    body_format: Literal["text", "html"] = "text",
+) -> str:
     """
     Helper function to format message body content with HTML fallback and truncation.
     Detects useless text/plain fallbacks (e.g., "Your client does not support HTML").
@@ -161,10 +165,25 @@ def _format_body_content(text_body: str, html_body: str) -> str:
     Args:
         text_body: Plain text body content
         html_body: HTML body content
+        body_format: Output format - "text" converts HTML to plaintext (default),
+                     "html" returns raw HTML body as-is
 
     Returns:
         Formatted body content string
     """
+    if body_format == "html":
+        html_stripped = html_body.strip()
+        if html_stripped:
+            if len(html_stripped) > HTML_BODY_TRUNCATE_LIMIT:
+                return (
+                    html_stripped[:HTML_BODY_TRUNCATE_LIMIT]
+                    + "\n\n[Content truncated...]"
+                )
+            return html_stripped
+        # Fall back to text body when no HTML is available
+        text_stripped = text_body.strip()
+        return text_stripped if text_stripped else "[No readable content found]"
+
     text_stripped = text_body.strip()
     html_stripped = html_body.strip()
     html_text = _html_to_text(html_stripped).strip() if html_stripped else ""
@@ -641,14 +660,31 @@ async def search_gmail_messages(
 )
 @require_google_service("gmail", "gmail_read")
 async def get_gmail_message_content(
-    service, message_id: str, user_google_email: str
+    service,
+    message_id: str,
+    user_google_email: str,
+    body_format: Annotated[
+        Literal["text", "html", "raw"],
+        Field(
+            description=(
+                "Body output format. "
+                "'text' (default) returns plaintext (HTML converted to text as fallback). "
+                "'html' returns the raw HTML body as-is without conversion. "
+                "'raw' fetches the full raw MIME message and returns the base64url-decoded content."
+            ),
+        ),
+    ] = "text",
 ) -> str:
     """
-    Retrieves the full content (subject, sender, recipients, plain text body) of a specific Gmail message.
+    Retrieves the full content (subject, sender, recipients, body) of a specific Gmail message.
 
     Args:
         message_id (str): The unique ID of the Gmail message to retrieve.
         user_google_email (str): The user's Google email address. Required.
+        body_format (Literal["text", "html", "raw"]): Body output format.
+            "text" (default) returns plaintext (HTML converted to text as fallback).
+            "html" returns the raw HTML body as-is without conversion.
+            "raw" fetches the full raw MIME message and returns the base64url-decoded content.
 
     Returns:
         str: The message details including subject, sender, date, Message-ID, recipients (To, Cc), and body content.
@@ -681,6 +717,36 @@ async def get_gmail_message_content(
     cc = headers.get("Cc", "")
     rfc822_msg_id = headers.get("Message-ID", "")
 
+    # Handle raw format separately - fetch with format="raw" and return decoded MIME
+    if body_format == "raw":
+        message_raw = await asyncio.to_thread(
+            service.users()
+            .messages()
+            .get(userId="me", id=message_id, format="raw")
+            .execute
+        )
+        raw_data = message_raw.get("raw", "")
+        if raw_data:
+            decoded_raw = base64.urlsafe_b64decode(raw_data).decode(
+                "utf-8", errors="replace"
+            )
+        else:
+            decoded_raw = "[No raw content found]"
+
+        content_lines = [
+            f"Subject: {subject}",
+            f"From:    {sender}",
+            f"Date:    {headers.get('Date', '(unknown date)')}",
+        ]
+        if rfc822_msg_id:
+            content_lines.append(f"Message-ID: {rfc822_msg_id}")
+        if to:
+            content_lines.append(f"To:      {to}")
+        if cc:
+            content_lines.append(f"Cc:      {cc}")
+        content_lines.append(f"\n--- RAW MIME ---\n{decoded_raw}")
+        return "\n".join(content_lines)
+
     # Now fetch the full message to get the body parts
     message_full = await asyncio.to_thread(
         service.users()
@@ -700,7 +766,7 @@ async def get_gmail_message_content(
     html_body = bodies.get("html", "")
 
     # Format body content with HTML fallback
-    body_data = _format_body_content(text_body, html_body)
+    body_data = _format_body_content(text_body, html_body, body_format=body_format)
 
     # Extract attachment metadata
     attachments = _extract_attachments(payload)
@@ -745,6 +811,16 @@ async def get_gmail_messages_content_batch(
     message_ids: List[str],
     user_google_email: str,
     format: Literal["full", "metadata"] = "full",
+    body_format: Annotated[
+        Literal["text", "html"],
+        Field(
+            description=(
+                "Body output format (only applies when format='full'). "
+                "'text' (default) returns plaintext (HTML converted to text as fallback). "
+                "'html' returns the raw HTML body as-is without conversion."
+            ),
+        ),
+    ] = "text",
 ) -> str:
     """
     Retrieves the content of multiple Gmail messages in a single batch request.
@@ -754,6 +830,9 @@ async def get_gmail_messages_content_batch(
         message_ids (List[str]): List of Gmail message IDs to retrieve (max 25 per batch).
         user_google_email (str): The user's Google email address. Required.
         format (Literal["full", "metadata"]): Message format. "full" includes body, "metadata" only headers.
+        body_format (Literal["text", "html"]): Body output format (only applies when format='full').
+            "text" (default) returns plaintext (HTML converted to text as fallback).
+            "html" returns the raw HTML body as-is without conversion.
 
     Returns:
         str: A formatted list of message contents including subject, sender, date, Message-ID, recipients (To, Cc), and body (if full format).
@@ -908,7 +987,9 @@ async def get_gmail_messages_content_batch(
                     html_body = bodies.get("html", "")
 
                     # Format body content with HTML fallback
-                    body_data = _format_body_content(text_body, html_body)
+                    body_data = _format_body_content(
+                        text_body, html_body, body_format=body_format
+                    )
 
                     msg_output = (
                         f"Message ID: {mid}\nSubject: {subject}\nFrom: {sender}\n"
@@ -1523,13 +1604,18 @@ async def draft_gmail_message(
     return f"Draft created{attachment_info}! Draft ID: {draft_id}"
 
 
-def _format_thread_content(thread_data: dict, thread_id: str) -> str:
+def _format_thread_content(
+    thread_data: dict,
+    thread_id: str,
+    body_format: Literal["text", "html"] = "text",
+) -> str:
     """
     Helper function to format thread content from Gmail API response.
 
     Args:
         thread_data (dict): Thread data from Gmail API
         thread_id (str): Thread ID for display
+        body_format: Output format - "text" (default) or "html"
 
     Returns:
         str: Formatted thread content
@@ -1575,7 +1661,7 @@ def _format_thread_content(thread_data: dict, thread_id: str) -> str:
         html_body = bodies.get("html", "")
 
         # Format body content with HTML fallback
-        body_data = _format_body_content(text_body, html_body)
+        body_data = _format_body_content(text_body, html_body, body_format=body_format)
 
         # Add message to content
         content_lines.extend(
@@ -1612,7 +1698,19 @@ def _format_thread_content(thread_data: dict, thread_id: str) -> str:
 @require_google_service("gmail", "gmail_read")
 @handle_http_errors("get_gmail_thread_content", is_read_only=True, service_type="gmail")
 async def get_gmail_thread_content(
-    service, thread_id: str, user_google_email: str
+    service,
+    thread_id: str,
+    user_google_email: str,
+    body_format: Annotated[
+        Literal["text", "html"],
+        Field(
+            description=(
+                "Body output format. "
+                "'text' (default) returns plaintext (HTML converted to text as fallback). "
+                "'html' returns the raw HTML body as-is without conversion."
+            ),
+        ),
+    ] = "text",
 ) -> str:
     """
     Retrieves the complete content of a Gmail conversation thread, including all messages.
@@ -1620,6 +1718,9 @@ async def get_gmail_thread_content(
     Args:
         thread_id (str): The unique ID of the Gmail thread to retrieve.
         user_google_email (str): The user's Google email address. Required.
+        body_format (Literal["text", "html"]): Body output format.
+            "text" (default) returns plaintext (HTML converted to text as fallback).
+            "html" returns the raw HTML body as-is without conversion.
 
     Returns:
         str: The complete thread content with all messages formatted for reading.
@@ -1633,7 +1734,7 @@ async def get_gmail_thread_content(
         service.users().threads().get(userId="me", id=thread_id, format="full").execute
     )
 
-    return _format_thread_content(thread_response, thread_id)
+    return _format_thread_content(thread_response, thread_id, body_format=body_format)
 
 
 @server.tool()
@@ -1645,6 +1746,16 @@ async def get_gmail_threads_content_batch(
     service,
     thread_ids: List[str],
     user_google_email: str,
+    body_format: Annotated[
+        Literal["text", "html"],
+        Field(
+            description=(
+                "Body output format. "
+                "'text' (default) returns plaintext (HTML converted to text as fallback). "
+                "'html' returns the raw HTML body as-is without conversion."
+            ),
+        ),
+    ] = "text",
 ) -> str:
     """
     Retrieves the content of multiple Gmail threads in a single batch request.
@@ -1653,6 +1764,9 @@ async def get_gmail_threads_content_batch(
     Args:
         thread_ids (List[str]): A list of Gmail thread IDs to retrieve. The function will automatically batch requests in chunks of 25.
         user_google_email (str): The user's Google email address. Required.
+        body_format (Literal["text", "html"]): Body output format.
+            "text" (default) returns plaintext (HTML converted to text as fallback).
+            "html" returns the raw HTML body as-is without conversion.
 
     Returns:
         str: A formatted list of thread contents with separators.
@@ -1738,7 +1852,9 @@ async def get_gmail_threads_content_batch(
                     output_threads.append(f"⚠️ Thread {tid}: No data returned\n")
                     continue
 
-                output_threads.append(_format_thread_content(thread, tid))
+                output_threads.append(
+                    _format_thread_content(thread, tid, body_format=body_format)
+                )
 
     # Combine all threads with separators
     header = f"Retrieved {len(thread_ids)} threads:"

--- a/tests/gmail/test_body_format.py
+++ b/tests/gmail/test_body_format.py
@@ -1,0 +1,164 @@
+"""Tests for body_format parameter support in Gmail tools."""
+
+import base64
+import sys
+import os
+
+
+# Ensure the project root is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from gmail.gmail_tools import _format_body_content, _extract_message_bodies
+
+
+class TestFormatBodyContentTextMode:
+    """Verify default 'text' body_format preserves existing behavior."""
+
+    def test_returns_text_body_when_available(self):
+        result = _format_body_content("Hello world", "<b>Hello world</b>")
+        assert result == "Hello world"
+
+    def test_returns_text_body_default_format(self):
+        result = _format_body_content(
+            "Hello world", "<b>Hello world</b>", body_format="text"
+        )
+        assert result == "Hello world"
+
+    def test_falls_back_to_html_when_text_empty(self):
+        result = _format_body_content("", "<p>HTML content here</p>")
+        assert "HTML content here" in result
+
+    def test_returns_no_content_when_both_empty(self):
+        result = _format_body_content("", "")
+        assert result == "[No readable content found]"
+
+    def test_detects_low_value_placeholder_text(self):
+        low_value = "Your client does not support HTML messages"
+        html = "<p>This is the actual email content with much more detail</p>"
+        result = _format_body_content(low_value, html)
+        assert "actual email content" in result
+
+    def test_truncates_long_html_fallback(self):
+        long_html = "<p>" + "x" * 25000 + "</p>"
+        result = _format_body_content("", long_html)
+        assert "[Content truncated...]" in result
+
+
+class TestFormatBodyContentHtmlMode:
+    """Verify 'html' body_format returns raw HTML."""
+
+    def test_returns_raw_html_body(self):
+        html = "<div><b>Hello</b> <em>world</em></div>"
+        result = _format_body_content("Hello world", html, body_format="html")
+        assert result == html
+
+    def test_returns_html_without_conversion(self):
+        html = "<table><tr><td>Cell</td></tr></table>"
+        result = _format_body_content("Cell", html, body_format="html")
+        assert "<table>" in result
+        assert "<td>Cell</td>" in result
+
+    def test_falls_back_to_text_when_no_html(self):
+        result = _format_body_content("Plain text only", "", body_format="html")
+        assert result == "Plain text only"
+
+    def test_returns_no_content_when_both_empty(self):
+        result = _format_body_content("", "", body_format="html")
+        assert result == "[No readable content found]"
+
+    def test_strips_whitespace_from_html(self):
+        result = _format_body_content("text", "  <b>html</b>  ", body_format="html")
+        assert result == "<b>html</b>"
+
+    def test_truncates_long_html(self):
+        long_html = "<div>" + "x" * 25000 + "</div>"
+        result = _format_body_content("text", long_html, body_format="html")
+        assert "[Content truncated...]" in result
+        assert len(result) < len(long_html)
+
+    def test_preserves_html_entities(self):
+        html = "<p>Price: &lt;$100 &amp; free shipping</p>"
+        result = _format_body_content("", html, body_format="html")
+        assert "&lt;" in result
+        assert "&amp;" in result
+
+    def test_preserves_style_and_script_tags(self):
+        html = "<style>body { color: red; }</style><p>Content</p>"
+        result = _format_body_content("Content", html, body_format="html")
+        assert "<style>" in result
+        assert "color: red" in result
+
+    def test_whitespace_only_html_falls_back_to_text(self):
+        result = _format_body_content("Fallback text", "   \n\t  ", body_format="html")
+        assert result == "Fallback text"
+
+
+class TestExtractMessageBodies:
+    """Verify _extract_message_bodies extracts both text and HTML parts."""
+
+    def _encode(self, text: str) -> str:
+        return base64.urlsafe_b64encode(text.encode()).decode()
+
+    def test_extracts_text_and_html_from_multipart(self):
+        payload = {
+            "mimeType": "multipart/alternative",
+            "parts": [
+                {
+                    "mimeType": "text/plain",
+                    "body": {"data": self._encode("Plain text")},
+                },
+                {
+                    "mimeType": "text/html",
+                    "body": {"data": self._encode("<b>HTML</b>")},
+                },
+            ],
+        }
+        bodies = _extract_message_bodies(payload)
+        assert bodies["text"] == "Plain text"
+        assert bodies["html"] == "<b>HTML</b>"
+
+    def test_extracts_text_only(self):
+        payload = {
+            "mimeType": "text/plain",
+            "body": {"data": self._encode("Just text")},
+        }
+        bodies = _extract_message_bodies(payload)
+        assert bodies["text"] == "Just text"
+        assert bodies["html"] == ""
+
+    def test_extracts_html_only(self):
+        payload = {
+            "mimeType": "text/html",
+            "body": {"data": self._encode("<p>Just HTML</p>")},
+        }
+        bodies = _extract_message_bodies(payload)
+        assert bodies["text"] == ""
+        assert bodies["html"] == "<p>Just HTML</p>"
+
+    def test_handles_empty_payload(self):
+        bodies = _extract_message_bodies({})
+        assert bodies["text"] == ""
+        assert bodies["html"] == ""
+
+    def test_handles_nested_multipart(self):
+        payload = {
+            "mimeType": "multipart/mixed",
+            "parts": [
+                {
+                    "mimeType": "multipart/alternative",
+                    "parts": [
+                        {
+                            "mimeType": "text/plain",
+                            "body": {"data": self._encode("Nested text")},
+                        },
+                        {
+                            "mimeType": "text/html",
+                            "body": {"data": self._encode("<p>Nested HTML</p>")},
+                        },
+                    ],
+                },
+            ],
+        }
+        bodies = _extract_message_bodies(payload)
+        assert bodies["text"] == "Nested text"
+        assert bodies["html"] == "<p>Nested HTML</p>"


### PR DESCRIPTION
## Summary

Adds a `body_format` parameter to Gmail message and thread retrieval tools, allowing callers to request the email body in different output formats:

- **`"text"`** (default) - existing behavior, returns plaintext with HTML converted to text as fallback
- **`"html"`** - returns the raw HTML body as-is without conversion, useful for inspecting email formatting or preserving rich content
- **`"raw"`** (single message only) - fetches the full raw MIME message via Gmail API `format="raw"` and returns the base64url-decoded RFC 822 content

### Affected tools

| Tool | Supported formats |
|------|------------------|
| `get_gmail_message_content` | text, html, raw |
| `get_gmail_messages_content_batch` | text, html |
| `get_gmail_thread_content` | text, html |
| `get_gmail_threads_content_batch` | text, html |

### Implementation details

- The existing `_extract_message_bodies()` already extracts both text and HTML bodies - this change exposes the HTML body through `_format_body_content()` instead of always converting to plaintext
- For `"raw"` format, an additional Gmail API call is made with `format="raw"` and the response is base64url-decoded
- Default behavior (`"text"`) is completely unchanged - this is a backward-compatible addition
- HTML truncation uses the existing `HTML_BODY_TRUNCATE_LIMIT` (20,000 chars)

### Motivation

When debugging email formatting issues (e.g., paragraph spacing being lost when sending HTML emails), the current plaintext-only output makes it impossible to inspect the actual HTML structure. The `"html"` format enables direct inspection of the email's HTML body, and `"raw"` provides the complete MIME message for full diagnostics.

## Test plan

- [x] 20 new tests added in `tests/gmail/test_body_format.py`
- [x] All 284 tests pass (264 existing + 20 new)
- [x] Ruff linting and formatting clean
- [x] Default `"text"` behavior verified unchanged
- [x] HTML mode returns raw HTML, falls back to text when no HTML exists
- [x] Raw mode returns decoded MIME content
- [x] Truncation applies correctly in HTML mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable body format options to Gmail message and thread retrieval functions—users can now select between text, HTML, or raw output formats for message content.

* **Tests**
  * Added comprehensive test coverage for body format handling, including edge cases across various message payload types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->