### PR TITLE
fix: improve OAuth response pages for browser compatibility

### DIFF
--- a/auth/oauth_responses.py
+++ b/auth/oauth_responses.py
@@ -196,10 +196,10 @@ def create_success_response(verified_user_id: Optional[str] = None) -> HTMLRespo
             You've been authenticated as <span class="user-id">{user_display}</span>
         </div>
         <div class="message">
-            Your credentials have been securely saved. You can now close this window and retry your original command.
+            Your credentials have been securely saved. You can now close this tab and retry your original command.
         </div>
-        <button class="button" onclick="tryClose()">Close Window</button>
-        <div class="auto-close">This window will close automatically in 10 seconds</div>
+        <button class="button" onclick="tryClose()">Close Tab</button>
+        <div class="auto-close">This tab will close automatically in 10 seconds</div>
     </div>
 </body>
 </html>"""


### PR DESCRIPTION
## Summary
- `window.close()` is blocked by modern browsers (Chrome, Firefox, Safari) for tabs that were not opened via `window.open()`. Since the OAuth callback opens in a regular browser tab, the success page's close button and auto-close timer silently fail
- Adds `tryClose()` function that attempts `window.close()` and gracefully falls back to updating the button text to "You can close this tab manually" after 500ms
- Removes ineffective `window.close()` auto-close scripts from error pages, replacing with plain text instructions

## Test plan
- [ ] Complete an OAuth flow and verify the success page close button works or shows fallback text
- [ ] Trigger an OAuth error and verify the error page displays correctly without JS errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated messaging across error and success pages to reference "close this tab" instead of "close this window"
* **Improvements**
  * Success and error flows now attempt to automatically close the tab and gracefully fall back to an updated UI when auto-close is blocked (button text and hints update; timer behavior adjusted)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->