### PR TITLE
fix: suppress platform string output to stdout on macOS

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,12 +7,13 @@ import sys
 from importlib import metadata, import_module
 from dotenv import load_dotenv
 
-# Prevent any stray output (e.g. platform identifiers like "darwin" on macOS)
-# from corrupting the MCP JSON-RPC handshake on stdout.  We capture anything
-# written to stdout during module-level initialisation and replay it to stderr
-# so that diagnostic information is not lost.
+# Prevent any stray startup output on macOS (e.g. platform identifiers) from
+# corrupting the MCP JSON-RPC handshake on stdout. We capture anything written
+# to stdout during module-level initialisation and replay it to stderr so that
+# diagnostic information is not lost.
 _original_stdout = sys.stdout
-sys.stdout = io.StringIO()
+if sys.platform == "darwin":
+    sys.stdout = io.StringIO()
 
 # Check for CLI mode early - before loading oauth_config
 # CLI mode requires OAuth 2.0 since there's no MCP session context


### PR DESCRIPTION
## Summary
- Fixes #567 — server crashes on macOS when `"darwin"` is printed to stdout before the MCP JSON-RPC handshake
- Captures any stray stdout during module-level initialization and replays it to stderr so diagnostic info is preserved
- Zero behavioral change on platforms that don't produce stray output

## Root cause
On macOS, a dependency or Python runtime writes the platform identifier (`"darwin"`) to stdout during module import. The MCP client (Claude Desktop) tries to parse this as JSON and fails with `Unexpected token 'd'`.

## Approach
Redirect `sys.stdout` to an `io.StringIO` buffer before imports, restore it in `main()` before the MCP server starts, and replay any captured output to stderr.

## Test plan
- [ ] Verify on macOS that `"darwin"` no longer appears on stdout
- [ ] Verify on Linux/Windows that behavior is unchanged
- [ ] Verify MCP handshake completes successfully in stdio mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup diagnostic output is now captured during initialization and replayed after startup, preventing stray messages from disrupting startup communication.
  * Restoration of normal output is idempotent and safe, ensuring captured messages are flushed reliably without affecting server behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->