### PR TITLE
feat(gmail): support quoted reply content and signature positioning

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -1528,6 +1528,9 @@ async def draft_gmail_message(
               - 'mime_type' (optional): MIME type (defaults to 'application/octet-stream')
         include_signature (bool): Whether to append Gmail signature HTML from send-as settings.
             If unavailable (e.g., missing gmail.settings.basic scope), the draft is still created without signature.
+        quote_original (bool): Whether to include the original message as a quoted reply.
+            Requires thread_id to be provided. When enabled, fetches the original message
+            and appends it below the signature. Defaults to False.
 
     Returns:
         str: Confirmation message with the created draft's ID.


### PR DESCRIPTION
## Summary
- Fixes #547 — adds `quote_original` parameter to `draft_gmail_message` for proper reply formatting
- When enabled, automatically fetches the original message and constructs a Gmail-style quoted reply
- Signature is positioned correctly between the reply body and the quoted original

## Implementation
- `quote_original: bool = False` parameter (backward compatible)
- `_fetch_original_for_quote()` — fetches thread, finds target message by Message-ID or falls back to last message, extracts sender/date/body
- `_build_quoted_reply_body()` — assembles reply in correct order:
  1. Reply body
  2. Signature (if enabled)
  3. Attribution line: "On {date}, {sender} wrote:"
  4. Quoted original (`<blockquote>` for HTML, `>` prefix for plain text)
- Graceful fallback — if original can't be fetched, falls back to simple body + signature

## Test plan
- [ ] Create reply draft with `quote_original=True` — verify quoted content appears with attribution
- [ ] Verify HTML replies use `<blockquote>` styling
- [ ] Verify plain text replies use `>` prefix
- [ ] Verify signature appears between reply body and quoted content
- [ ] Verify `quote_original=False` (default) — unchanged behavior
- [ ] Verify without `thread_id` — `quote_original` is ignored gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft replies can now include the original message quoted inline; users can toggle quoting when composing within a thread.
  * Quoting supports both plain-text and HTML formats and preserves user signatures when included.
  * When enabled, drafts automatically assemble the reply with the quoted original for clearer conversation context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->