### PR TITLE
fix: share OAuth state across stdio processes to prevent auth failures

### DIFF
--- a/auth/oauth21_session_store.py
+++ b/auth/oauth21_session_store.py
@@ -7,7 +7,10 @@ session context management and credential conversion functionality.
 """
 
 import contextvars
+import json
 import logging
+import os
+from pathlib import Path
 from typing import Dict, Optional, Any, Tuple
 from threading import RLock
 from datetime import datetime, timedelta, timezone
@@ -201,6 +204,48 @@ class OAuth21SessionStore:
         self._oauth_states: Dict[str, Dict[str, Any]] = {}
         self._lock = RLock()
 
+        # Persist OAuth states to a shared file so that sibling stdio
+        # processes (each a separate workspace-mcp invocation) can see
+        # each other's states.  Fixes #546 / #588.
+        self._shared_state_file = Path(
+            os.environ.get(
+                "GOOGLE_MCP_CREDENTIALS_DIR",
+                Path.home() / ".google_workspace_mcp" / "credentials",
+            )
+        ) / ".oauth_states.json"
+        self._shared_state_file.parent.mkdir(parents=True, exist_ok=True)
+        self._load_shared_states()
+
+    def _load_shared_states(self):
+        """Load OAuth states from shared file into memory."""
+        try:
+            if self._shared_state_file.exists():
+                data = json.loads(self._shared_state_file.read_text())
+                for state, info in data.items():
+                    if "expires_at" in info and isinstance(info["expires_at"], str):
+                        info["expires_at"] = datetime.fromisoformat(info["expires_at"])
+                    if "created_at" in info and isinstance(info["created_at"], str):
+                        info["created_at"] = datetime.fromisoformat(info["created_at"])
+                    self._oauth_states[state] = info
+                logger.debug("Loaded %d OAuth states from shared file", len(data))
+        except Exception as e:
+            logger.debug("Could not load shared OAuth states: %s", e)
+
+    def _save_shared_states(self):
+        """Persist current OAuth states to shared file."""
+        try:
+            data = {}
+            for state, info in self._oauth_states.items():
+                entry = dict(info)
+                if isinstance(entry.get("expires_at"), datetime):
+                    entry["expires_at"] = entry["expires_at"].isoformat()
+                if isinstance(entry.get("created_at"), datetime):
+                    entry["created_at"] = entry["created_at"].isoformat()
+                data[state] = entry
+            self._shared_state_file.write_text(json.dumps(data))
+        except Exception as e:
+            logger.debug("Could not save shared OAuth states: %s", e)
+
     def _cleanup_expired_oauth_states_locked(self):
         """Remove expired OAuth state entries. Caller must hold lock."""
         now = datetime.now(timezone.utc)
@@ -239,6 +284,7 @@ class OAuth21SessionStore:
                 "created_at": now,
                 "code_verifier": code_verifier,
             }
+            self._save_shared_states()
             logger.debug(
                 "Stored OAuth state %s (expires at %s)",
                 state[:8] if len(state) > 8 else state,
@@ -267,6 +313,7 @@ class OAuth21SessionStore:
             raise ValueError("Missing OAuth state parameter")
 
         with self._lock:
+            self._load_shared_states()
             self._cleanup_expired_oauth_states_locked()
             state_info = self._oauth_states.get(state)
 
@@ -289,6 +336,7 @@ class OAuth21SessionStore:
 
             # State is valid – consume it to prevent reuse
             del self._oauth_states[state]
+            self._save_shared_states()
             logger.debug(
                 "Validated OAuth state %s",
                 state[:8] if len(state) > 8 else state,

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -154,6 +154,18 @@ class MinimalOAuthServer:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.bind((hostname, self.port))
         except OSError:
+            # Another workspace-mcp stdio process may already be serving
+            # the OAuth callback on this port.  Probe with connect_ex: if
+            # the port is actively listening we can delegate to it instead
+            # of blocking the entire auth flow.  Fixes #546 / #588.
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                if s.connect_ex((hostname, self.port)) == 0:
+                    logger.info(
+                        f"Port {self.port} is held by another workspace-mcp "
+                        "instance; reusing existing OAuth server."
+                    )
+                    self.is_running = True
+                    return True, ""
             error_msg = f"Port {self.port} is already in use on {hostname}. Cannot start minimal OAuth server."
             logger.error(error_msg)
             return False, error_msg


### PR DESCRIPTION
## Summary

In **stdio mode**, MCP clients like Cursor may spawn multiple `workspace-mcp` processes.  This causes two cascading failures:

1. **Port conflict** – the second process cannot bind port 8000 (already held by the first) and immediately returns *"Port 8000 is already in use … Cannot start minimal OAuth server"*, aborting the OAuth flow.
2. **State mismatch** – even when the port issue is manually resolved (e.g. by killing processes), the OAuth callback arrives at a different process than the one that created the PKCE state, producing *"Missing OAuth state parameter"* / *"Invalid or expired OAuth state parameter"* errors.

### Changes

| File | What changed |
|------|-------------|
| `auth/oauth_callback_server.py` | When the port-bind fails, probe with `connect_ex` whether another `workspace-mcp` instance is already listening. If so, mark the server as running and reuse it instead of returning an error. |
| `auth/oauth21_session_store.py` | Persist OAuth states to a shared JSON file (`~/.google_workspace_mcp/credentials/.oauth_states.json`). States are loaded before validation and saved after store/consume, so every sibling stdio process sees the same state pool. |

### How it was tested

- Reproduced the issue on Fedora 43 / Cursor with the Google Workspace MCP configured in stdio mode.
- After applying both patches, OAuth authentication completed successfully on the first attempt with multiple `workspace-mcp` processes running simultaneously.
- Calendar, Gmail, and Drive tools all returned data correctly after re-authentication.

Fixes #546