### PR TITLE
feat(gchat): expose filter param in get_messages and add time_filter to search_messages

### DIFF
--- a/gchat/chat_tools.py
+++ b/gchat/chat_tools.py
@@ -163,9 +163,18 @@ async def get_messages(
     space_id: str,
     page_size: int = 50,
     order_by: str = "createTime desc",
+    filter: Optional[str] = None,
 ) -> str:
     """
     Retrieves messages from a Google Chat space.
+
+    Args:
+        filter: Optional filter string using the Chat API filter syntax.
+                Supports createTime and thread.name.
+                Examples:
+                  'createTime > "2026-03-18T00:00:00-03:00"'
+                  'createTime > "2026-03-18T00:00:00-03:00" AND createTime < "2026-03-19T00:00:00-03:00"'
+                  'thread.name = spaces/X/threads/Y'
 
     Returns:
         str: Formatted messages from the specified space.
@@ -179,11 +188,11 @@ async def get_messages(
     space_name = space_info.get("displayName", "Unknown Space")
 
     # Get messages
+    list_params = {"parent": space_id, "pageSize": page_size, "orderBy": order_by}
+    if filter:
+        list_params["filter"] = filter
     response = await asyncio.to_thread(
-        chat_service.spaces()
-        .messages()
-        .list(parent=space_id, pageSize=page_size, orderBy=order_by)
-        .execute
+        chat_service.spaces().messages().list(**list_params).execute
     )
 
     messages = response.get("messages", [])
@@ -316,46 +325,63 @@ async def search_messages(
     chat_service,
     people_service,
     user_google_email: str,
-    query: str,
+    query: Optional[str] = None,
     space_id: Optional[str] = None,
     page_size: int = 25,
+    time_filter: Optional[str] = None,
+    max_spaces: int = 10,
 ) -> str:
     """
-    Searches for messages in Google Chat spaces by text content.
+    Searches for messages in Google Chat spaces by text content and/or time range.
+
+    Args:
+        query: Optional text to search for. If omitted, only time_filter is applied.
+        space_id: Optional space to restrict the search to.
+        page_size: Maximum number of messages to return per space.
+        time_filter: Optional filter using Chat API createTime syntax.
+                     Examples:
+                       'createTime > "2026-03-18T00:00:00-03:00"'
+                       'createTime > "2026-03-18T00:00:00-03:00" AND createTime < "2026-03-19T00:00:00-03:00"'
+        max_spaces: Maximum number of spaces to search when space_id is not provided (default 10).
 
     Returns:
-        str: A formatted list of messages matching the search query.
+        str: A formatted list of messages matching the search criteria.
     """
-    logger.info(f"[search_messages] Email={user_google_email}, Query='{query}'")
+    logger.info(f"[search_messages] Email={user_google_email}, Query='{query}', TimeFilter='{time_filter}'")
+
+    # Build combined filter string
+    parts = []
+    if query:
+        parts.append(f'text:"{query}"')
+    if time_filter:
+        parts.append(time_filter)
+    filter_str = " AND ".join(parts) if parts else None
 
     # If specific space provided, search within that space
     if space_id:
+        list_params = {"parent": space_id, "pageSize": page_size}
+        if filter_str:
+            list_params["filter"] = filter_str
         response = await asyncio.to_thread(
-            chat_service.spaces()
-            .messages()
-            .list(parent=space_id, pageSize=page_size, filter=f'text:"{query}"')
-            .execute
+            chat_service.spaces().messages().list(**list_params).execute
         )
         messages = response.get("messages", [])
         context = f"space '{space_id}'"
     else:
-        # Search across all accessible spaces (this may require iterating through spaces)
-        # For simplicity, we'll search the user's spaces first
+        # Search across all accessible spaces
         spaces_response = await asyncio.to_thread(
             chat_service.spaces().list(pageSize=100).execute
         )
         spaces = spaces_response.get("spaces", [])
 
         messages = []
-        for space in spaces[:10]:  # Limit to first 10 spaces to avoid timeout
+        for space in spaces[:max_spaces]:
             try:
+                list_params = {"parent": space.get("name"), "pageSize": 5}
+                if filter_str:
+                    list_params["filter"] = filter_str
                 space_messages = await asyncio.to_thread(
-                    chat_service.spaces()
-                    .messages()
-                    .list(
-                        parent=space.get("name"), pageSize=5, filter=f'text:"{query}"'
-                    )
-                    .execute
+                    chat_service.spaces().messages().list(**list_params).execute
                 )
                 space_msgs = space_messages.get("messages", [])
                 for msg in space_msgs:
@@ -368,8 +394,9 @@ async def search_messages(
                 continue
         context = "all accessible spaces"
 
+    search_desc = query or time_filter or "all messages"
     if not messages:
-        return f"No messages found matching '{query}' in {context}."
+        return f"No messages found matching '{search_desc}' in {context}."
 
     # Pre-resolve unique senders in parallel
     sender_lookup = {}
@@ -383,7 +410,7 @@ async def search_messages(
     )
     sender_map = dict(zip(sender_lookup.keys(), resolved_names))
 
-    output = [f"Found {len(messages)} messages matching '{query}' in {context}:"]
+    output = [f"Found {len(messages)} messages matching '{search_desc}' in {context}:"]
     for msg in messages:
         sender_obj = msg.get("sender", {})
         sender_key = sender_obj.get("name", "")


### PR DESCRIPTION
## Problem

`get_messages` does not expose the `filter` parameter from the [Google Chat API `spaces.messages.list`](https://developers.google.com/chat/api/reference/rest/v1/spaces.messages/list), which supports filtering by `createTime` and `thread.name`.

`search_messages` hardcodes the filter as `text:"{query}"` via f-string, making it impossible to pass date filters or any other combination without going through the text wrapper.

## Changes

### `get_messages` — new `filter` parameter
- Added `filter: Optional[str] = None` to the signature
- Forwarded to the API call via a `list_params` dict (only included when not `None`)
- Updated docstring with usage examples (`createTime`, `thread.name`)

### `search_messages` — flexible filtering
- Made `query` optional (`Optional[str] = None`) instead of required
- Added `time_filter: Optional[str] = None` for date-based filtering
- Added `max_spaces: int = 10` to replace the hardcoded `[:10]` slice
- Combined `query` and `time_filter` with `AND` when both are provided
- If neither is provided, lists messages without a filter

### Backward compatibility
All new parameters have defaults that preserve the existing behavior. No existing callers need to change.

## Examples

```python
# get_messages with date filter
get_messages(..., filter='createTime > "2026-03-18T00:00:00-03:00"')

# search_messages with text + time filter
search_messages(..., query="deploy", time_filter='createTime > "2026-03-18T00:00:00-03:00"')

# search_messages with only time filter (no text query)
search_messages(..., time_filter='createTime > "2026-03-18T00:00:00-03:00"')
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added optional message filtering capabilities with combined filter parameters
- Introduced time-based message search filtering for targeted queries
- Enabled cross-space message searching with customizable scope
- Query parameters are now optional for more flexible search operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->