### PR TITLE
fix: resolve OAuth port conflict on re-auth in stdio mode

### DIFF
--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -197,7 +197,24 @@ class MinimalOAuthServer:
         Returns:
             Tuple of (success: bool, error_message: str)
         """
-        if self.is_running:
+        # Check if this instance already has a running server — whether is_running
+        # is set or not.  The flag can be stale (e.g. set to False by an exception
+        # handler while the thread is still alive and holding the port).
+        if self.server_thread and self.server_thread.is_alive():
+            if self.is_actually_running():
+                logger.info(
+                    "Minimal OAuth server thread is still alive and port is responding, reusing"
+                )
+                self.is_running = True
+                return True, ""
+            else:
+                logger.warning(
+                    "Minimal OAuth server thread is alive but port is not responding. Restarting."
+                )
+                self.stop()
+                self.server = None
+                self.server_thread = None
+        elif self.is_running:
             if self.is_actually_running():
                 logger.info("Minimal OAuth server is already running")
                 return True, ""
@@ -221,6 +238,14 @@ class MinimalOAuthServer:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.bind((hostname, self.port))
         except OSError:
+            # Before failing, check if the port is held by a previous server
+            # instance in our own process that we can still use for callbacks.
+            if self.is_actually_running():
+                logger.info(
+                    f"Port {self.port} is in use by our own OAuth server, reusing"
+                )
+                self.is_running = True
+                return True, ""
             error_msg = f"Port {self.port} is already in use on {hostname}. Cannot start minimal OAuth server."
             logger.error(error_msg)
             return False, error_msg
@@ -268,10 +293,12 @@ class MinimalOAuthServer:
         return False, error_msg
 
     def stop(self):
-        """Stop the minimal OAuth server."""
-        if not self.is_running:
-            return
+        """Stop the minimal OAuth server.
 
+        Attempts to shut down the uvicorn server and join its thread regardless
+        of the ``is_running`` flag — the flag can be stale when an exception in
+        the server thread resets it while the thread is still alive.
+        """
         try:
             if self.server:
                 if hasattr(self.server, "should_exit"):
@@ -285,6 +312,7 @@ class MinimalOAuthServer:
 
         except Exception as e:
             logger.error(f"Error stopping minimal OAuth server: {e}", exc_info=True)
+            self.is_running = False
 
 
 # Global instance for stdio mode

--- a/tests/auth/test_oauth_callback_server.py
+++ b/tests/auth/test_oauth_callback_server.py
@@ -131,3 +131,100 @@ def test_ensure_oauth_callback_skips_start_when_other_instance_owns_port(monkeyp
     assert error == ""
     assert len(_PortInUseServer.instances) == 1
     assert _PortInUseServer.instances[0].start_calls == 0
+
+
+class _AliveThread:
+    def is_alive(self):
+        return True
+
+
+def test_start_reuses_server_when_thread_alive_and_port_responding():
+    """Reproduce the re-auth bug: is_running is False but the server thread is
+    still alive and holding the port.  start() should detect this and reuse
+    instead of failing with 'port in use'."""
+    server = oauth_callback_server.MinimalOAuthServer(8000, "http://localhost")
+    server.is_running = False  # Stale flag — simulates error handler resetting it
+    server.server_thread = _AliveThread()
+
+    # is_actually_running returns True (port is responding)
+    server.is_actually_running = lambda: True
+
+    success, error = server.start()
+
+    assert success is True
+    assert error == ""
+    assert server.is_running is True
+
+
+def test_start_recovers_when_port_in_use_by_own_server(monkeypatch):
+    """When the socket bind check fails but is_actually_running() confirms the
+    port is held by our own server, start() should succeed instead of erroring."""
+    server = oauth_callback_server.MinimalOAuthServer(8000, "http://localhost")
+    server.is_running = False
+    server.server_thread = None  # No thread reference — e.g. garbage collected
+
+    call_count = {"bind": 0, "running": 0}
+
+    class _BindFailSocket:
+        def __init__(self, *args, **kwargs):  # noqa: ARG002
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):  # noqa: ARG002
+            return False
+
+        def settimeout(self, timeout):  # noqa: ARG002
+            pass
+
+        def connect_ex(self, address):  # noqa: ARG002
+            return 0  # Port is accepting connections
+
+        def bind(self, address):  # noqa: ARG002
+            call_count["bind"] += 1
+            raise OSError(errno.EADDRINUSE, "Address already in use")
+
+    monkeypatch.setattr(oauth_callback_server.socket, "socket", _BindFailSocket)
+
+    # is_actually_running will use our patched socket and see connect_ex=0
+    success, error = server.start()
+
+    assert success is True
+    assert error == ""
+    assert server.is_running is True
+
+
+def test_stop_cleans_up_even_when_is_running_false():
+    """stop() must still signal the server thread to exit even when is_running
+    is False — that stale flag is exactly the scenario that causes the bug."""
+    server = oauth_callback_server.MinimalOAuthServer(8000, "http://localhost")
+    server.is_running = False
+
+    class _MockUvicornServer:
+        def __init__(self):
+            self.should_exit = False
+
+    mock_uvicorn = _MockUvicornServer()
+    server.server = mock_uvicorn
+
+    class _JoinableThread:
+        def __init__(self):
+            self.joined = False
+            self._alive = True
+
+        def is_alive(self):
+            return self._alive
+
+        def join(self, timeout=None):  # noqa: ARG002
+            self.joined = True
+            self._alive = False
+
+    mock_thread = _JoinableThread()
+    server.server_thread = mock_thread
+
+    server.stop()
+
+    assert mock_uvicorn.should_exit is True
+    assert mock_thread.joined is True
+    assert server.is_running is False


### PR DESCRIPTION
## Summary

- Fixes the OAuth port conflict bug where `MinimalOAuthServer` fails with "port already in use" when re-authenticating against its own process in stdio mode
- `start()` now detects a live server thread even when `is_running` is stale (set to `False` by an exception handler while the thread still holds the port)
- The socket bind fallback probes `is_actually_running()` before erroring, recovering when the port is held by our own server
- `stop()` no longer short-circuits on `is_running=False`, ensuring proper cleanup of the uvicorn server and thread

Fixes #546

## Root Cause

In stdio mode, `MinimalOAuthServer` starts a uvicorn server on a daemon thread. When the server thread encounters an error, it sets `is_running = False` but the thread and port binding persist. On the next re-auth attempt:

1. `start()` sees `is_running=False` and skips the "already running" check
2. The socket bind check fails because the port is held by the previous server thread in our own process
3. `start()` returns `"Port 8000 is already in use"` — blocking all subsequent MCP calls until restart

## Fix Details

Three targeted changes to `auth/oauth_callback_server.py`:

1. **`start()` — thread-alive check before `is_running` flag**: Checks `server_thread.is_alive()` first, which catches the stale-flag scenario. If the thread is alive and the port responds, reuses the server.

2. **`start()` — bind failure recovery**: When the socket bind fails with `EADDRINUSE`, probes `is_actually_running()` before giving up. If the port is responding (our own server), marks it as running and succeeds.

3. **`stop()` — unconditional cleanup**: Removed the `if not self.is_running: return` guard so `stop()` always signals `should_exit` and joins the thread, preventing zombie server threads.

## Test Plan

- [x] Added `test_start_reuses_server_when_thread_alive_and_port_responding` — reproduces the exact re-auth bug scenario
- [x] Added `test_start_recovers_when_port_in_use_by_own_server` — covers the bind-failure recovery path
- [x] Added `test_stop_cleans_up_even_when_is_running_false` — verifies stop() works with stale flag
- [x] All 4 existing tests continue to pass
- [x] Full test suite: 309 passed (2 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth server startup reliability by better detecting and reusing running instances when the internal state flag is stale.
  * Enhanced port-binding failure handling to recover when a server instance already occupies the port.
  * Strengthened server shutdown to complete cleanly even with inconsistent internal state.

* **Tests**
  * Added comprehensive test coverage for OAuth server lifecycle edge cases and error recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->