### PR TITLE
feat(gdocs): extract smart chips (date, person, rich link) when reading documents

### DIFF
--- a/gdocs/docs_markdown.py
+++ b/gdocs/docs_markdown.py
@@ -122,7 +122,34 @@ def _convert_paragraph_text(
     for elem in para.get("elements", []):
         if "textRun" in elem:
             parts.append(_convert_text_run(elem["textRun"], skip_strikethrough))
+        elif "richLink" in elem:
+            parts.append(_convert_rich_link(elem["richLink"]))
+        elif "person" in elem:
+            parts.append(_convert_person(elem["person"]))
+        elif "dateElement" in elem:
+            props = elem["dateElement"].get("dateElementProperties", {})
+            parts.append(props.get("displayText", ""))
     return "".join(parts).strip()
+
+
+def _convert_rich_link(rich_link: dict[str, Any]) -> str:
+    """Convert a richLink element (URL chip) to markdown."""
+    props = rich_link.get("richLinkProperties", {})
+    title = props.get("title", "")
+    uri = props.get("uri", "")
+    if title and uri:
+        return f"[{title}]({uri})"
+    return title or uri
+
+
+def _convert_person(person: dict[str, Any]) -> str:
+    """Convert a person element (person chip) to markdown."""
+    props = person.get("personProperties", {})
+    name = props.get("name", "")
+    email = props.get("email", "")
+    if name and email:
+        return f"{name} ({email})"
+    return name or email
 
 
 def _convert_text_run(

--- a/gdocs/docs_structure.py
+++ b/gdocs/docs_structure.py
@@ -205,7 +205,7 @@ def _parse_segment(segment_data: dict[str, Any]) -> dict[str, Any]:
     text_parts = []
     for element in content:
         if "paragraph" in element:
-            text_parts.append(_extract_paragraph_text(element["paragraph"]))
+            text_parts.append(extract_paragraph_text(element["paragraph"]))
 
     return {
         "content": content,

--- a/gdocs/docs_structure.py
+++ b/gdocs/docs_structure.py
@@ -92,7 +92,7 @@ def _parse_element(element: dict[str, Any]) -> Optional[dict[str, Any]]:
     if "paragraph" in element:
         paragraph = element["paragraph"]
         element_info["type"] = "paragraph"
-        element_info["text"] = _extract_paragraph_text(paragraph)
+        element_info["text"] = extract_paragraph_text(paragraph)
         element_info["style"] = paragraph.get("paragraphStyle", {})
 
     elif "table" in element:
@@ -162,12 +162,31 @@ def _parse_table_cells(table: dict[str, Any]) -> list[list[dict[str, Any]]]:
     return cells
 
 
-def _extract_paragraph_text(paragraph: dict[str, Any]) -> str:
+def extract_paragraph_text(paragraph: dict[str, Any]) -> str:
     """Extract text from a paragraph element."""
     text_parts = []
     for element in paragraph.get("elements", []):
         if "textRun" in element:
             text_parts.append(element["textRun"].get("content", ""))
+        elif "dateElement" in element:
+            props = element["dateElement"].get("dateElementProperties", {})
+            text_parts.append(props.get("displayText", ""))
+        elif "richLink" in element:
+            props = element["richLink"].get("richLinkProperties", {})
+            title = props.get("title", "")
+            uri = props.get("uri", "")
+            if title and uri:
+                text_parts.append(f"{title} ({uri})")
+            else:
+                text_parts.append(title or uri)
+        elif "person" in element:
+            props = element["person"].get("personProperties", {})
+            name = props.get("name", "")
+            email = props.get("email", "")
+            if name and email:
+                text_parts.append(f"{name} ({email})")
+            else:
+                text_parts.append(name or email)
     return "".join(text_parts)
 
 
@@ -176,7 +195,7 @@ def _extract_cell_text(cell: dict[str, Any]) -> str:
     text_parts = []
     for element in cell.get("content", []):
         if "paragraph" in element:
-            text_parts.append(_extract_paragraph_text(element["paragraph"]))
+            text_parts.append(extract_paragraph_text(element["paragraph"]))
     return "".join(text_parts)
 
 

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -41,6 +41,7 @@ from gdocs.docs_structure import (
     parse_document_structure,
     find_tables,
     analyze_document_complexity,
+    extract_paragraph_text,
 )
 from gdocs.docs_tables import extract_table_as_data
 from gdocs.docs_markdown import (
@@ -193,13 +194,7 @@ async def get_doc_content(
 
             for element in elements:
                 if "paragraph" in element:
-                    paragraph = element.get("paragraph", {})
-                    para_elements = paragraph.get("elements", [])
-                    current_line_text = ""
-                    for pe in para_elements:
-                        text_run = pe.get("textRun", {})
-                        if text_run and "content" in text_run:
-                            current_line_text += text_run["content"]
+                    current_line_text = extract_paragraph_text(element["paragraph"])
                     if current_line_text.strip():
                         text_lines.append(current_line_text)
                 elif "table" in element:

--- a/tests/gdocs/test_docs_markdown.py
+++ b/tests/gdocs/test_docs_markdown.py
@@ -11,6 +11,7 @@ from gdocs.docs_markdown import (
     format_comments_inline,
     parse_drive_comments,
 )
+from gdocs.docs_structure import parse_document_structure
 
 
 # --- Fixtures ---
@@ -453,3 +454,369 @@ class TestAppendixComments:
 
     def test_empty(self):
         assert format_comments_appendix([]).strip() == ""
+
+
+# --- Smart chip fixtures ---
+
+RICH_LINK_DOC = {
+    "title": "Rich Link Test",
+    "body": {
+        "content": [
+            {"sectionBreak": {"sectionStyle": {}}},
+            {
+                "paragraph": {
+                    "elements": [
+                        {"textRun": {"content": "Meeting on ", "textStyle": {}}},
+                        {
+                            "richLink": {
+                                "richLinkProperties": {
+                                    "title": "March 28, 2026",
+                                    "uri": "https://calendar.google.com/event/abc123",
+                                }
+                            }
+                        },
+                        {"textRun": {"content": " confirmed.\n", "textStyle": {}}},
+                    ],
+                    "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                }
+            },
+        ]
+    },
+}
+
+RICH_LINK_TITLE_ONLY_DOC = {
+    "title": "Rich Link Title Only",
+    "body": {
+        "content": [
+            {
+                "paragraph": {
+                    "elements": [
+                        {
+                            "richLink": {
+                                "richLinkProperties": {
+                                    "title": "March 28, 2026",
+                                }
+                            }
+                        },
+                        {"textRun": {"content": "\n", "textStyle": {}}},
+                    ],
+                    "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                }
+            },
+        ]
+    },
+}
+
+RICH_LINK_URI_ONLY_DOC = {
+    "title": "Rich Link URI Only",
+    "body": {
+        "content": [
+            {
+                "paragraph": {
+                    "elements": [
+                        {
+                            "richLink": {
+                                "richLinkProperties": {
+                                    "uri": "https://docs.google.com/document/d/abc",
+                                }
+                            }
+                        },
+                        {"textRun": {"content": "\n", "textStyle": {}}},
+                    ],
+                    "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                }
+            },
+        ]
+    },
+}
+
+PERSON_DOC = {
+    "title": "Person Chip Test",
+    "body": {
+        "content": [
+            {
+                "paragraph": {
+                    "elements": [
+                        {"textRun": {"content": "Assigned to ", "textStyle": {}}},
+                        {
+                            "person": {
+                                "personProperties": {
+                                    "name": "Jane Doe",
+                                    "email": "jane@example.com",
+                                }
+                            }
+                        },
+                        {"textRun": {"content": " for review.\n", "textStyle": {}}},
+                    ],
+                    "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                }
+            },
+        ]
+    },
+}
+
+PERSON_EMAIL_ONLY_DOC = {
+    "title": "Person Email Only",
+    "body": {
+        "content": [
+            {
+                "paragraph": {
+                    "elements": [
+                        {
+                            "person": {
+                                "personProperties": {
+                                    "email": "unknown@example.com",
+                                }
+                            }
+                        },
+                        {"textRun": {"content": "\n", "textStyle": {}}},
+                    ],
+                    "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                }
+            },
+        ]
+    },
+}
+
+MIXED_CHIPS_DOC = {
+    "title": "Mixed Chips",
+    "body": {
+        "content": [
+            {
+                "paragraph": {
+                    "elements": [
+                        {
+                            "person": {
+                                "personProperties": {
+                                    "name": "Alice",
+                                    "email": "alice@example.com",
+                                }
+                            }
+                        },
+                        {"textRun": {"content": " scheduled ", "textStyle": {}}},
+                        {
+                            "richLink": {
+                                "richLinkProperties": {
+                                    "title": "April 1, 2026",
+                                    "uri": "https://calendar.google.com/event/xyz",
+                                }
+                            }
+                        },
+                        {"textRun": {"content": "\n", "textStyle": {}}},
+                    ],
+                    "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                }
+            },
+        ]
+    },
+}
+
+TABLE_WITH_CHIPS_DOC = {
+    "title": "Table with Chips",
+    "body": {
+        "content": [
+            {
+                "table": {
+                    "rows": 1,
+                    "columns": 2,
+                    "tableRows": [
+                        {
+                            "tableCells": [
+                                {
+                                    "content": [
+                                        {
+                                            "paragraph": {
+                                                "elements": [
+                                                    {
+                                                        "richLink": {
+                                                            "richLinkProperties": {
+                                                                "title": "March 28, 2026",
+                                                                "uri": "https://cal.google.com/e/1",
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "textRun": {
+                                                            "content": "\n",
+                                                            "textStyle": {},
+                                                        }
+                                                    },
+                                                ],
+                                                "paragraphStyle": {
+                                                    "namedStyleType": "NORMAL_TEXT"
+                                                },
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "content": [
+                                        {
+                                            "paragraph": {
+                                                "elements": [
+                                                    {
+                                                        "person": {
+                                                            "personProperties": {
+                                                                "name": "Bob",
+                                                                "email": "bob@example.com",
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "textRun": {
+                                                            "content": "\n",
+                                                            "textStyle": {},
+                                                        }
+                                                    },
+                                                ],
+                                                "paragraphStyle": {
+                                                    "namedStyleType": "NORMAL_TEXT"
+                                                },
+                                            }
+                                        }
+                                    ]
+                                },
+                            ]
+                        },
+                    ],
+                }
+            },
+        ]
+    },
+}
+
+
+# --- Smart chip tests ---
+
+
+class TestRichLink:
+    def test_rich_link_with_title_and_uri(self):
+        md = convert_doc_to_markdown(RICH_LINK_DOC)
+        assert "[March 28, 2026](https://calendar.google.com/event/abc123)" in md
+        assert "Meeting on" in md
+        assert "confirmed." in md
+
+    def test_rich_link_title_only(self):
+        md = convert_doc_to_markdown(RICH_LINK_TITLE_ONLY_DOC)
+        assert "March 28, 2026" in md
+
+    def test_rich_link_uri_only(self):
+        md = convert_doc_to_markdown(RICH_LINK_URI_ONLY_DOC)
+        assert "https://docs.google.com/document/d/abc" in md
+
+
+class TestPersonChip:
+    def test_person_with_name_and_email(self):
+        md = convert_doc_to_markdown(PERSON_DOC)
+        assert "Jane Doe (jane@example.com)" in md
+        assert "Assigned to" in md
+
+    def test_person_email_only(self):
+        md = convert_doc_to_markdown(PERSON_EMAIL_ONLY_DOC)
+        assert "unknown@example.com" in md
+
+
+class TestMixedChips:
+    def test_mixed_person_and_date(self):
+        md = convert_doc_to_markdown(MIXED_CHIPS_DOC)
+        assert "Alice (alice@example.com)" in md
+        assert "scheduled" in md
+        assert "[April 1, 2026](https://calendar.google.com/event/xyz)" in md
+
+
+class TestSmartChipsInTable:
+    def test_table_with_chips(self):
+        md = convert_doc_to_markdown(TABLE_WITH_CHIPS_DOC)
+        assert "[March 28, 2026](https://cal.google.com/e/1)" in md
+        assert "Bob (bob@example.com)" in md
+
+
+class TestStructureWithChips:
+    def test_structure_extracts_rich_link_text(self):
+        structure = parse_document_structure(RICH_LINK_DOC)
+        paragraphs = [e for e in structure["body"] if e["type"] == "paragraph"]
+        assert any("March 28, 2026" in p["text"] for p in paragraphs)
+
+    def test_structure_extracts_person_text(self):
+        structure = parse_document_structure(PERSON_DOC)
+        paragraphs = [e for e in structure["body"] if e["type"] == "paragraph"]
+        assert any("Jane Doe" in p["text"] for p in paragraphs)
+
+    def test_structure_extracts_date_element_text(self):
+        structure = parse_document_structure(DATE_ELEMENT_DOC)
+        paragraphs = [e for e in structure["body"] if e["type"] == "paragraph"]
+        assert any("Mar 28, 2026" in p["text"] for p in paragraphs)
+
+
+# --- Date element (date chip) fixtures ---
+
+DATE_ELEMENT_DOC = {
+    "title": "Date Element Test",
+    "body": {
+        "content": [
+            {
+                "paragraph": {
+                    "elements": [
+                        {"textRun": {"content": "Due by ", "textStyle": {}}},
+                        {
+                            "dateElement": {
+                                "dateId": "kix.m0mpxr9nmt8c",
+                                "textStyle": {},
+                                "dateElementProperties": {
+                                    "timestamp": "2026-03-28T12:00:00Z",
+                                    "locale": "en",
+                                    "dateFormat": "DATE_FORMAT_MONTH_DAY_YEAR_ABBREVIATED",
+                                    "timeFormat": "TIME_FORMAT_DISABLED",
+                                    "displayText": "Mar 28, 2026",
+                                },
+                            }
+                        },
+                        {"textRun": {"content": " please.\n", "textStyle": {}}},
+                    ],
+                    "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                }
+            },
+        ]
+    },
+}
+
+DATE_ELEMENT_ONLY_DOC = {
+    "title": "Date Only",
+    "body": {
+        "content": [
+            {
+                "paragraph": {
+                    "elements": [
+                        {
+                            "dateElement": {
+                                "dateId": "kix.abc123",
+                                "textStyle": {},
+                                "dateElementProperties": {
+                                    "timestamp": "2026-01-15T12:00:00Z",
+                                    "locale": "en",
+                                    "dateFormat": "DATE_FORMAT_MONTH_DAY_YEAR_ABBREVIATED",
+                                    "timeFormat": "TIME_FORMAT_DISABLED",
+                                    "displayText": "Jan 15, 2026",
+                                },
+                            }
+                        },
+                        {"textRun": {"content": "\n", "textStyle": {}}},
+                    ],
+                    "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
+                }
+            },
+        ]
+    },
+}
+
+
+class TestDateElement:
+    def test_date_chip_with_surrounding_text(self):
+        md = convert_doc_to_markdown(DATE_ELEMENT_DOC)
+        assert "Due by" in md
+        assert "Mar 28, 2026" in md
+        assert "please." in md
+
+    def test_date_chip_standalone(self):
+        md = convert_doc_to_markdown(DATE_ELEMENT_ONLY_DOC)
+        assert "Jan 15, 2026" in md


### PR DESCRIPTION
## Description
Date chips, person chips, and rich link chips were silently dropped when reading Google Docs because only textRun elements were handled. Add support for dateElement, person, and richLink paragraph elements across markdown conversion, plain text extraction, and structure parsing. Consolidate duplicated paragraph extraction logic into a shared extract_paragraph_text() function.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ x ] I have tested this change manually

## Checklist
- [ ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] My changes generate no new warnings
- [ x ] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Add any other context about the pull request here.
- Tests were failing on a clean main branch run before my changes.
---

**⚠️ IMPORTANT:** This repository requires that you enable "Allow edits from maintainers" when creating your pull request. This allows maintainers to make small fixes and improvements directly to your branch, speeding up the review process.

To enable this setting:
1. When creating the PR, check the "Allow edits from maintainers" checkbox
2. If you've already created the PR, you can enable this in the PR sidebar under "Allow edits from maintainers"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Docs rich links, person references, and date elements are now recognized and converted into appropriate Markdown/text representations within paragraphs and table cells.

* **Tests**
  * Added comprehensive tests covering rich links, person chips, date elements, mixed paragraphs, and table cell handling to validate Markdown output and structure extraction.

* **Chores**
  * Paragraph text extraction was made a public/shared utility (resulting in an API surface change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->