### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,10 @@ uv run main.py --tools docs sheets --tool-tier complete    # Full access to Docs
 uv run main.py --permissions gmail:organize drive:full --tool-tier core
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/taylorwilsdon-google-workspace-mcp).
+
 ## 📋 Credential Configuration
 
 <details open>


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/taylorwilsdon-google-workspace-mcp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation with information about hosted deployment availability on Frontier AI, including a direct URL for accessing the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->