### PR TITLE
feat(calendar): add rsvp_event tool for non-organizer RSVP responses

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -44,7 +44,6 @@ calendar:
     - list_calendars
     - get_events
     - manage_event
-    - rsvp_event
   extended:
     - query_freebusy
     - manage_out_of_office

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -1177,6 +1177,12 @@ async def _rsvp_event_impl(
             f"Invalid response '{response}'. Must be one of: {sorted(valid_responses)}"
         )
 
+    valid_send_updates = {"all", "externalOnly", "none"}
+    if send_updates not in valid_send_updates:
+        raise ValueError(
+            f"Invalid send_updates '{send_updates}'. Must be one of: {sorted(valid_send_updates)}"
+        )
+
     existing_event = await asyncio.to_thread(
         lambda: service.events().get(calendarId=calendar_id, eventId=event_id).execute()
     )
@@ -1247,13 +1253,16 @@ async def manage_event(
     guests_can_modify: Optional[bool] = None,
     guests_can_invite_others: Optional[bool] = None,
     guests_can_see_other_guests: Optional[bool] = None,
+    response: Optional[str] = None,
+    rsvp_comment: Optional[str] = None,
+    send_updates: Optional[str] = None,
 ) -> str:
     """
-    Manages calendar events. Supports creating, updating, and deleting events.
+    Manages calendar events. Supports creating, updating, deleting, and RSVP.
 
     Args:
         user_google_email (str): The user's Google email address. Required.
-        action (str): Action to perform - "create", "update", or "delete".
+        action (str): Action to perform - "create", "update", "delete", or "rsvp".
         summary (Optional[str]): Event title (required for create).
         start_time (Optional[str]): Start time in RFC3339 format (required for create).
         end_time (Optional[str]): End time in RFC3339 format (required for create).
@@ -1274,6 +1283,9 @@ async def manage_event(
         guests_can_modify (Optional[bool]): Whether attendees can modify.
         guests_can_invite_others (Optional[bool]): Whether attendees can invite others.
         guests_can_see_other_guests (Optional[bool]): Whether attendees can see other guests.
+        response (Optional[str]): RSVP response — "accepted", "declined", "tentative", or "needsAction" (rsvp action only).
+        rsvp_comment (Optional[str]): Optional message to include with the RSVP response (rsvp action only).
+        send_updates (Optional[str]): Notification behavior for RSVP — "all" (default), "externalOnly", or "none" (rsvp action only).
 
     Returns:
         str: Confirmation message with event details.
@@ -1343,52 +1355,24 @@ async def manage_event(
             event_id=event_id,
             calendar_id=calendar_id,
         )
+    elif action_lower == "rsvp":
+        if not event_id:
+            raise ValueError("event_id is required for rsvp action")
+        if not response:
+            raise ValueError("response is required for rsvp action")
+        return await _rsvp_event_impl(
+            service=service,
+            user_google_email=user_google_email,
+            event_id=event_id,
+            response=response,
+            calendar_id=calendar_id,
+            comment=rsvp_comment,
+            send_updates=send_updates or "all",
+        )
     else:
         raise ValueError(
-            f"Invalid action '{action_lower}'. Must be 'create', 'update', or 'delete'."
+            f"Invalid action '{action_lower}'. Must be 'create', 'update', 'delete', or 'rsvp'."
         )
-
-
-@server.tool()
-@handle_http_errors("rsvp_event", service_type="calendar")
-@require_google_service("calendar", "calendar_events")
-async def rsvp_event(
-    service,
-    user_google_email: str,
-    event_id: str,
-    response: str,
-    calendar_id: str = "primary",
-    comment: Optional[str] = None,
-    send_updates: str = "all",
-) -> str:
-    """
-    Respond to a calendar event invitation (accept, decline, tentative, or reset).
-
-    Uses events.patch with only the attendees array — the correct approach for
-    non-organizer RSVP updates. manage_event's "update" action uses events.update
-    (PUT), which requires organizer permission and cannot be used for RSVP.
-
-    Args:
-        user_google_email (str): The authenticated user's Google email. Required.
-        event_id (str): The ID of the event to respond to. Required.
-        response (str): One of "accepted", "declined", "tentative", "needsAction".
-        calendar_id (str): Calendar containing the event. Defaults to "primary".
-        comment (Optional[str]): Optional message to include with the response.
-        send_updates (str): Notification behavior — "all" (default), "externalOnly",
-            or "none".
-
-    Returns:
-        str: Confirmation with event title and updated response status.
-    """
-    return await _rsvp_event_impl(
-        service=service,
-        user_google_email=user_google_email,
-        event_id=event_id,
-        response=response,
-        calendar_id=calendar_id,
-        comment=comment,
-        send_updates=send_updates,
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gcalendar/test_rsvp_event.py
+++ b/tests/gcalendar/test_rsvp_event.py
@@ -1,0 +1,166 @@
+"""Unit tests for the RSVP action in manage_event."""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gcalendar.calendar_tools import _rsvp_event_impl
+
+
+def _make_event(attendees, organizer_self=False):
+    return {
+        "id": "evt123",
+        "summary": "Team Sync",
+        "attendees": attendees,
+        "organizer": {"self": organizer_self, "email": "org@example.com"},
+    }
+
+
+def _create_mock_service(event):
+    mock_service = Mock()
+    mock_service.events().get().execute = Mock(return_value=event)
+    mock_service.events().patch().execute = Mock(return_value=event)
+    return mock_service
+
+
+# -- Happy path tests --
+
+
+@pytest.mark.asyncio
+async def test_rsvp_accepted():
+    attendees = [
+        {"email": "user@example.com", "self": True, "responseStatus": "needsAction"},
+        {"email": "other@example.com", "responseStatus": "accepted"},
+    ]
+    service = _create_mock_service(_make_event(attendees))
+
+    result = await _rsvp_event_impl(
+        service=service,
+        user_google_email="user@example.com",
+        event_id="evt123",
+        response="accepted",
+    )
+
+    assert "accepted" in result
+    patch_kwargs = service.events().patch.call_args[1]
+    assert patch_kwargs["body"]["attendees"][0]["responseStatus"] == "accepted"
+    assert patch_kwargs["sendUpdates"] == "all"
+
+
+@pytest.mark.asyncio
+async def test_rsvp_declined_with_comment():
+    attendees = [
+        {"email": "user@example.com", "self": True, "responseStatus": "needsAction"},
+    ]
+    service = _create_mock_service(_make_event(attendees))
+
+    await _rsvp_event_impl(
+        service=service,
+        user_google_email="user@example.com",
+        event_id="evt123",
+        response="declined",
+        comment="Out of office",
+    )
+
+    patch_body = service.events().patch.call_args[1]["body"]
+    assert patch_body["attendees"][0]["responseStatus"] == "declined"
+    assert patch_body["attendees"][0]["comment"] == "Out of office"
+
+
+@pytest.mark.asyncio
+async def test_rsvp_custom_send_updates():
+    attendees = [
+        {"email": "user@example.com", "self": True, "responseStatus": "needsAction"},
+    ]
+    service = _create_mock_service(_make_event(attendees))
+
+    await _rsvp_event_impl(
+        service=service,
+        user_google_email="user@example.com",
+        event_id="evt123",
+        response="tentative",
+        send_updates="none",
+    )
+
+    assert service.events().patch.call_args[1]["sendUpdates"] == "none"
+
+
+# -- Validation tests --
+
+
+@pytest.mark.asyncio
+async def test_rsvp_invalid_response():
+    service = Mock()
+    with pytest.raises(ValueError, match="Invalid response 'maybe'"):
+        await _rsvp_event_impl(
+            service=service,
+            user_google_email="user@example.com",
+            event_id="evt123",
+            response="maybe",
+        )
+
+
+@pytest.mark.asyncio
+async def test_rsvp_invalid_send_updates():
+    service = Mock()
+    with pytest.raises(ValueError, match="Invalid send_updates 'invalid'"):
+        await _rsvp_event_impl(
+            service=service,
+            user_google_email="user@example.com",
+            event_id="evt123",
+            response="accepted",
+            send_updates="invalid",
+        )
+
+
+# -- Guard tests --
+
+
+@pytest.mark.asyncio
+async def test_rsvp_no_attendees():
+    event = {"id": "evt123", "summary": "Solo", "organizer": {"self": False}}
+    service = _create_mock_service(event)
+
+    with pytest.raises(Exception, match="no attendee list"):
+        await _rsvp_event_impl(
+            service=service,
+            user_google_email="user@example.com",
+            event_id="evt123",
+            response="accepted",
+        )
+
+
+@pytest.mark.asyncio
+async def test_rsvp_organizer_blocked():
+    attendees = [
+        {"email": "org@example.com", "self": True, "responseStatus": "accepted"},
+    ]
+    service = _create_mock_service(_make_event(attendees, organizer_self=True))
+
+    with pytest.raises(Exception, match="organizer"):
+        await _rsvp_event_impl(
+            service=service,
+            user_google_email="org@example.com",
+            event_id="evt123",
+            response="declined",
+        )
+
+
+@pytest.mark.asyncio
+async def test_rsvp_user_not_in_attendees():
+    attendees = [
+        {"email": "other@example.com", "responseStatus": "accepted"},
+    ]
+    service = _create_mock_service(_make_event(attendees))
+
+    with pytest.raises(Exception, match="not found in the event's attendee list"):
+        await _rsvp_event_impl(
+            service=service,
+            user_google_email="user@example.com",
+            event_id="evt123",
+            response="accepted",
+        )


### PR DESCRIPTION
## What
Adds a dedicated `rsvp_event` tool for accepting, declining, or marking tentative on calendar event invitations.

## Why
The existing `manage_event` tool uses `events.update()` (PUT), which requires organizer permission and overwrites the full event body. It cannot be used to update an attendee's own `responseStatus`. This adds `events.patch()` with only the attendees array — the correct approach per the Google Calendar API docs for non-organizer RSVP.

## Changes
- `gcalendar/calendar_tools.py`: adds `_rsvp_event_impl` and `rsvp_event` tool
- `core/tool_tiers.yaml`: registers `rsvp_event` under `calendar.core`

## Behavior
- Validates response is one of `accepted`, `declined`, `tentative`, `needsAction`
- Guards against attempting to RSVP as the organizer
- Raises clearly if the authenticated user isn't in the attendee list
- Supports optional `comment` and `send_updates` control
- Registered at `calendar.core` tier (same as `manage_event`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced calendar event management with new comprehensive RSVP capabilities. Users can now respond directly to calendar invitations with their attendance status (accept, decline, or tentative), optionally include personal comments with their responses, and customize notification settings to control whether other event attendees receive updates about their RSVP decision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->