### PR TITLE
fix(auth): prefer requested user credentials in single-user mode

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -869,7 +869,23 @@ def get_credentials(
         logger.info(
             "[get_credentials] Single-user mode: bypassing session mapping, finding any credentials"
         )
-        credentials, found_user_email = _find_any_credentials(credentials_base_dir)
+        # If a specific email was requested, try to load that user's credentials first
+        # to avoid session binding conflicts when multiple credential files exist
+        if user_google_email:
+            credential_store = get_credential_store()
+            credentials = credential_store.get_credential(user_google_email)
+            if credentials:
+                logger.info(
+                    f"[get_credentials] Single-user mode: found credentials for requested user {user_google_email}"
+                )
+                found_user_email = user_google_email
+            else:
+                logger.info(
+                    f"[get_credentials] Single-user mode: no credentials for {user_google_email}, falling back to any"
+                )
+                credentials, found_user_email = _find_any_credentials(credentials_base_dir)
+        else:
+            credentials, found_user_email = _find_any_credentials(credentials_base_dir)
         if not credentials:
             logger.info(
                 f"[get_credentials] Single-user mode: No credentials found in {credentials_base_dir}"


### PR DESCRIPTION
## Summary

- In single-user mode, when `user_google_email` is provided, try loading that specific user's credentials from the credential store **before** falling back to `_find_any_credentials()`
- Prevents session binding conflicts (`ValueError: Session is already bound to a different user`) when multiple credential files exist in the credentials directory
- Falls back gracefully to the existing `_find_any_credentials()` behavior when the specific user's credentials aren't found

## Problem

When `MCP_SINGLE_USER_MODE=1` and multiple credential files exist (e.g., `alice@example.com.json` and `bob@example.com.json`), calling a tool with `user_google_email="bob@example.com"` would:

1. `_find_any_credentials()` picks the first file alphabetically (Alice's)
2. Token refreshes using Alice's credentials
3. Session binding is created for Bob's email
4. Saving credentials fails with session rebinding error
5. User gets "ACTION REQUIRED: Authentication Needed" despite valid credentials existing

## Fix

Added a credential store lookup for the requested email before the `_find_any_credentials()` fallback:

```python
if user_google_email:
    credential_store = get_credential_store()
    credentials = credential_store.get_credential(user_google_email)
    if credentials:
        found_user_email = user_google_email
    else:
        credentials, found_user_email = _find_any_credentials(...)
else:
    credentials, found_user_email = _find_any_credentials(...)
```

## Test plan

- [x] All 16 existing auth tests pass
- [ ] Manual: single-user mode with 1 credential file (unchanged behavior)
- [ ] Manual: single-user mode with 2+ credential files, requesting specific user
- [ ] Manual: single-user mode with `user_google_email` not matching any file (falls back to any)

Fixes #506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved credential loading logic to prioritize explicitly requested user credentials while maintaining backward compatibility with existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->