### PR TITLE
fix(gdocs): create_table_with_data silently fails to populate cells

### DIFF
--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -692,9 +692,13 @@ async def _create_event_impl(
     event_body: Dict[str, Any] = {
         "summary": summary,
         "start": (
-            {"date": start_time} if "T" not in start_time else {"dateTime": effective_start}
+            {"date": start_time}
+            if "T" not in start_time
+            else {"dateTime": effective_start}
         ),
-        "end": ({"date": end_time} if "T" not in end_time else {"dateTime": effective_end}),
+        "end": (
+            {"date": end_time} if "T" not in end_time else {"dateTime": effective_end}
+        ),
     }
     if recurrence:
         event_body["recurrence"] = recurrence
@@ -943,7 +947,9 @@ async def _modify_event_impl(
         if timezone is not None and "T" in start_time:
             effective_start = _strip_utc_offset(start_time)
         event_body["start"] = (
-            {"date": start_time} if "T" not in start_time else {"dateTime": effective_start}
+            {"date": start_time}
+            if "T" not in start_time
+            else {"dateTime": effective_start}
         )
         if timezone is not None and "dateTime" in event_body["start"]:
             event_body["start"]["timeZone"] = timezone
@@ -1238,7 +1244,9 @@ async def _rsvp_event_impl(
 
     user_index = next((i for i, a in enumerate(attendees) if a.get("self")), None)
     if user_index is None:
-        raise Exception(f"{user_google_email} was not found in the event's attendee list.")
+        raise Exception(
+            f"{user_google_email} was not found in the event's attendee list."
+        )
 
     updated_attendees = [dict(a) for a in attendees]
     updated_attendees[user_index]["responseStatus"] = response
@@ -1246,12 +1254,16 @@ async def _rsvp_event_impl(
         updated_attendees[user_index]["comment"] = comment
 
     updated_event = await asyncio.to_thread(
-        lambda: service.events().patch(
-            calendarId=calendar_id,
-            eventId=event_id,
-            body={"attendees": updated_attendees},
-            sendUpdates=send_updates,
-        ).execute()
+        lambda: (
+            service.events()
+            .patch(
+                calendarId=calendar_id,
+                eventId=event_id,
+                body={"attendees": updated_attendees},
+                sendUpdates=send_updates,
+            )
+            .execute()
+        )
     )
 
     summary = updated_event.get("summary", "Unknown event")

--- a/gdocs/managers/table_operation_manager.py
+++ b/gdocs/managers/table_operation_manager.py
@@ -112,7 +112,12 @@ class TableOperationManager:
             return False, f"Table creation failed: {str(e)}", {}
 
     async def _create_empty_table(
-        self, document_id: str, index: int, rows: int, cols: int, tab_id: Optional[str] = None
+        self,
+        document_id: str,
+        index: int,
+        rows: int,
+        cols: int,
+        tab_id: Optional[str] = None,
     ) -> None:
         """Create an empty table at the specified index."""
         logger.debug(f"Creating {rows}x{cols} table at index {index}")
@@ -254,7 +259,13 @@ class TableOperationManager:
         # so that earlier insertions don't shift the indices of later ones
         cell_operations.sort(key=lambda x: x[0], reverse=True)
 
-        for insertion_index, row_idx, col_idx, cell_text, should_bold in cell_operations:
+        for (
+            insertion_index,
+            row_idx,
+            col_idx,
+            cell_text,
+            should_bold,
+        ) in cell_operations:
             # Insert text using the helper that properly handles tab_id
             requests.append(
                 create_insert_text_request(

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -1306,8 +1306,7 @@ async def list_sheet_tables(
     else:
         text_output = (
             f"Found {len(tables_found)} table(s) in spreadsheet {spreadsheet_id} "
-            f"for {user_google_email}:\n\n"
-            + "\n\n".join(tables_found)
+            f"for {user_google_email}:\n\n" + "\n\n".join(tables_found)
         )
 
     logger.info(
@@ -1388,7 +1387,7 @@ async def append_table_rows(
         if not isinstance(row_values, list):
             raise UserInputError(
                 "Each row in values must be a list. "
-                "Expected format: [[\"val1\", \"val2\"], [\"val3\", \"val4\"]]"
+                'Expected format: [["val1", "val2"], ["val3", "val4"]]'
             )
         cells = []
         for val in row_values:
@@ -1420,9 +1419,7 @@ async def append_table_rows(
         f"in spreadsheet {spreadsheet_id} for {user_google_email}."
     )
 
-    logger.info(
-        f"[append_table_rows] Appended {num_rows} rows for {user_google_email}"
-    )
+    logger.info(f"[append_table_rows] Appended {num_rows} rows for {user_google_email}")
     return text_output
 
 


### PR DESCRIPTION
## Summary

- Fixes 6 bugs in `TableOperationManager` that caused `create_table_with_data` to create the table structure but silently fail to insert any cell content
- Reduces API calls from ~36 (for a 9x2 table) to 3 by batching all cell insertions into a single `batchUpdate`
- Validated against live Google Docs with multiple test scenarios

## Bugs Fixed

| # | Bug | Root Cause | Fix |
|---|-----|-----------|-----|
| 1 | Cell text not inserted | `insertText` requests omitted `tabId` from location | Use `create_insert_text_request()` helper which includes `tab_id` |
| 2 | Bold headers not applied | `updateTextStyle` range omitted `tabId` | Add `tabId` to style range when `tab_id` is provided |
| 3 | Wrong table targeted | `tables[-1]` assumes new table is last in document | New `_find_table_near_index()` matches by `start_index` proximity |
| 4 | ~36 API calls for 9x2 table | 2 API calls per cell (fetch doc + batchUpdate) | Single doc fetch + single `batchUpdate` with reverse-sorted cell ops |
| 5 | "populated 8 cells" for 18-cell table | Inaccurate count from per-cell error handling | Accurate count; metadata now includes `total_cells` |
| 6 | Valid index 0 rejected | `if not insertion_index:` is falsy for 0 | Changed to `if insertion_index is None:` |

## How It Worked Before (Broken)

1. `InsertTableRequest` creates the table ✅
2. For each cell: fetch entire document, find `tables[-1]`, build `insertText` without `tabId`, send `batchUpdate` ❌
3. API silently drops insertions that lack `tabId` for tabbed documents
4. Reports misleading success message

## How It Works Now (Fixed)

1. `InsertTableRequest` creates the table
2. Single document fetch to get actual cell positions
3. `_find_table_near_index()` locates the correct table by `start_index`
4. All `insertText` + `updateTextStyle` requests built with proper `tab_id`, sorted in reverse index order
5. Single `batchUpdate` sends all cell operations at once
6. Accurate cell count reported

## Test plan

Validated against live Google Docs:

- [x] Basic table creation — 7x2 table created and all 14 cells populated
- [x] Tab ID (`t.0`) — content inserted in correct tab (was the original failure case)
- [x] `bold_headers: true` — header formatting applied
- [x] Document with existing tables — new table at index 121, existing tables at 186 and 260 unaffected
- [x] Cell count accuracy — "populated 14 cells" matches 7x2 = 14
- [x] Cell content accuracy — all 14 cells verified via `debug_table_structure`
- [x] All 105 existing gdocs unit tests pass (1 pre-existing failure from missing golden file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster table creation and cell population via batched updates for improved performance and reliability
  * Better detection and placement of newly inserted tables, with safeguards when insertion location is ambiguous
  * Improved handling for operations across multiple document tabs

* **Chores**
  * Minor formatting and messaging cleanups across calendar and spreadsheet interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->