### PR TITLE
fix: validate RFC 3339 format for task due dates

### DIFF
--- a/gtasks/tasks_tools.py
+++ b/gtasks/tasks_tools.py
@@ -102,9 +102,11 @@ def _validate_rfc3339_date(due: str) -> None:
     if "T" not in due:
         raise UserInputError(error_msg)
     try:
-        parsed = datetime.fromisoformat(due[:-1] + "+00:00" if due.endswith("Z") else due)
+        parsed = datetime.fromisoformat(
+            due[:-1] + "+00:00" if due.endswith("Z") else due
+        )
     except ValueError:
-        raise UserInputError(error_msg)
+        raise UserInputError(error_msg) from None
     if parsed.tzinfo is None or parsed.utcoffset() is None:
         raise UserInputError(error_msg)
 

--- a/gtasks/tasks_tools.py
+++ b/gtasks/tasks_tools.py
@@ -98,16 +98,15 @@ def _adjust_due_max_for_tasks_api(due_max: str) -> str:
 
 def _validate_rfc3339_date(due: str) -> None:
     """Validate that due is a full RFC 3339 datetime (date-only strings are rejected by the API)."""
+    error_msg = f"Invalid due date format. Expected RFC 3339 datetime (e.g., '2026-04-25T00:00:00Z'), got '{due}'"
     if "T" not in due:
-        raise UserInputError(
-            f"Invalid due date format. Expected RFC 3339 datetime (e.g., '2026-04-25T00:00:00Z'), got '{due}'"
-        )
+        raise UserInputError(error_msg)
     try:
-        datetime.fromisoformat(due.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(due[:-1] + "+00:00" if due.endswith("Z") else due)
     except ValueError:
-        raise UserInputError(
-            f"Invalid due date format. Expected RFC 3339 datetime (e.g., '2026-04-25T00:00:00Z'), got '{due}'"
-        )
+        raise UserInputError(error_msg)
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise UserInputError(error_msg)
 
 
 @server.tool()  # type: ignore

--- a/gtasks/tasks_tools.py
+++ b/gtasks/tasks_tools.py
@@ -96,6 +96,20 @@ def _adjust_due_max_for_tasks_api(due_max: str) -> str:
     return adjusted.isoformat()
 
 
+def _validate_rfc3339_date(due: str) -> None:
+    """Validate that due is a full RFC 3339 datetime (date-only strings are rejected by the API)."""
+    if "T" not in due:
+        raise UserInputError(
+            f"Invalid due date format. Expected RFC 3339 datetime (e.g., '2026-04-25T00:00:00Z'), got '{due}'"
+        )
+    try:
+        datetime.fromisoformat(due.replace("Z", "+00:00"))
+    except ValueError:
+        raise UserInputError(
+            f"Invalid due date format. Expected RFC 3339 datetime (e.g., '2026-04-25T00:00:00Z'), got '{due}'"
+        )
+
+
 @server.tool()  # type: ignore
 @require_google_service("tasks", "tasks_read")  # type: ignore
 @handle_http_errors("list_task_lists", service_type="tasks")  # type: ignore
@@ -886,6 +900,9 @@ async def manage_task(
     allowed_statuses = {"needsAction", "completed"}
     if status is not None and status not in allowed_statuses:
         raise UserInputError("invalid status: must be 'needsAction' or 'completed'")
+
+    if due is not None:
+        _validate_rfc3339_date(due)
 
     valid_actions = ("create", "update", "delete", "move")
     if action not in valid_actions:

--- a/uv.lock
+++ b/uv.lock
@@ -2076,7 +2076,7 @@ wheels = [
 
 [[package]]
 name = "workspace-mcp"
-version = "1.17.2"
+version = "1.17.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

- Adds `_validate_rfc3339_date()` helper to `gtasks/tasks_tools.py` that validates `due` parameters before sending to the Google Tasks API
- Validates that the value contains a time component (`T`) — the API silently rejects date-only strings (e.g. `"2026-04-25"`) with a generic 400 "invalid argument" error
- Called in `manage_task` before any action is taken

## Problem

When `manage_task` received a date-only `due` value like `"2026-04-25"`, the Google Tasks API returned:

```
HttpError 400: "Request contains an invalid argument."
```

No indication of which parameter was wrong or what format was expected, making it very difficult to debug.

## Fix

Client-side validation now catches invalid formats immediately and returns a clear error:

```
Invalid due date format. Expected RFC 3339 datetime (e.g., '2026-04-25T00:00:00Z'), got '2026-04-25'
```

Valid formats accepted:
- `2026-04-25T00:00:00Z`
- `2026-04-25T23:59:59+00:00`

## Test plan

- [ ] `manage_task` with `due="2026-04-25"` returns clear validation error (not a 400 from Google)
- [ ] `manage_task` with `due="2026-04-25T00:00:00Z"` succeeds as before
- [ ] `manage_task` without `due` unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened date input validation for task due dates: now enforces RFC 3339/ISO formatting (requires a 'T' separator and a timezone/offset).
  * Normalizes common timezone notation and rejects malformed or timezone-less inputs with clearer, RFC-specific error messages.
  * Validation runs early and prevents creation or update of tasks when due dates are invalid, avoiding downstream failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->