### PR TITLE
enh: Implement DWD Service Account Mode / OpenClaw Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ uv run main.py --tools gmail drive calendar
 | `OAUTH_ALLOWED_ORIGINS` | | Comma-separated additional CORS origins |
 | `WORKSPACE_MCP_OAUTH_PROXY_STORAGE_BACKEND` | | `memory`, `disk`, or `valkey` — see [storage backends](#oauth-proxy-storage-backends) |
 | `FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY` | | Custom encryption key for OAuth proxy storage |
+| **🔧 Service Account** | | |
+| `GOOGLE_SERVICE_ACCOUNT_KEY_FILE` | | Path to service account JSON key file (domain-wide delegation) |
+| `GOOGLE_SERVICE_ACCOUNT_KEY_JSON` | | Inline service account JSON key (alternative to file) |
 | **🔍 Custom Search** | | |
 | `GOOGLE_PSE_API_KEY` | | API key for Programmable Search Engine |
 | `GOOGLE_PSE_ENGINE_ID` | | Search Engine ID for PSE |
@@ -955,13 +958,14 @@ The server includes OAuth 2.1 support for bearer token authentication, enabling 
 - Production environments requiring secure session management
 - Browser-based clients requiring CORS support
 
-**⚠️ Important: OAuth 2.1 and Single-User Mode are mutually exclusive**
+**⚠️ Important: Mutually exclusive authentication modes**
 
-OAuth 2.1 mode (`MCP_ENABLE_OAUTH21=true`) cannot be used together with the `--single-user` flag:
+OAuth 2.1 mode (`MCP_ENABLE_OAUTH21=true`) cannot be used together with `--single-user` or service account mode:
 - **Single-user mode**: For legacy clients that pass user emails in tool calls
 - **OAuth 2.1 mode**: For modern multi-user scenarios with bearer token authentication
+- **Service account mode**: For headless/server-to-server use via domain-wide delegation
 
-Choose one authentication method - using both will result in a startup error.
+Choose one authentication method - combining incompatible modes will result in a startup error.
 
 **Enabling OAuth 2.1:**
 To enable OAuth 2.1, set the `MCP_ENABLE_OAUTH21` environment variable to `true`.
@@ -1110,6 +1114,49 @@ uv run main.py --transport streamable-http
 - Multi-tenant SaaS applications with centralized auth
 - Mobile or web apps with their own OAuth implementation
 
+
+### Service Account Mode (Domain-Wide Delegation)
+
+> **WARNING: This mode uses Google Workspace domain-wide delegation, which grants the service account the ability to impersonate any user in your domain for the configured scopes. This is powerful and dangerous — do not use this unless you fully understand the security implications. A misconfigured service account with broad scopes can read, modify, and delete data across every user in your organization. Only use this in tightly controlled environments where you know exactly what you're doing.**
+
+Service account mode allows the server to authenticate using a Google Cloud service account with domain-wide delegation instead of interactive OAuth flows. The service account impersonates a single configured domain user for all API calls.
+
+**When to use service account mode:**
+- Headless or unattended environments where no browser is available for OAuth consent
+- Server-to-server integrations that need to act on behalf of a specific domain user
+- CI/CD pipelines or automation scripts
+- Environments where you cannot or do not want to manage per-user OAuth tokens
+
+**Enabling Service Account Mode:**
+
+```bash
+# Option 1: Key file on disk
+export GOOGLE_SERVICE_ACCOUNT_KEY_FILE="/path/to/service-account-key.json"
+export USER_GOOGLE_EMAIL="user@yourdomain.com"
+uv run main.py
+
+# Option 2: Inline JSON key (e.g., from a secret manager)
+export GOOGLE_SERVICE_ACCOUNT_KEY_JSON='{"type":"service_account","project_id":"...","private_key":"...","client_email":"..."}'
+export USER_GOOGLE_EMAIL="user@yourdomain.com"
+uv run main.py
+```
+
+**Prerequisites:**
+1. A Google Cloud service account with a JSON key
+2. Domain-wide delegation enabled for the service account in your Google Workspace Admin Console (Security → API controls → Domain-wide delegation)
+3. The required OAuth scopes authorized for the service account's client ID in the Admin Console
+4. `USER_GOOGLE_EMAIL` set to the domain user the service account will impersonate
+
+**Incompatibilities:**
+- Cannot be combined with `--single-user` mode
+- Cannot be combined with `MCP_ENABLE_OAUTH21=true`
+- Only one key source may be provided — set either `GOOGLE_SERVICE_ACCOUNT_KEY_FILE` or `GOOGLE_SERVICE_ACCOUNT_KEY_JSON`, not both
+
+**Key Behaviors:**
+- The OAuth callback server is not started (no interactive auth needed)
+- Credentials directory permission checks are skipped
+- Caller-supplied email addresses in tool calls are ignored — the server always uses the configured `USER_GOOGLE_EMAIL`
+- The service account key is validated at startup (checks for required fields and correct type)
 
 ### VS Code MCP Client Support
 

--- a/README.md
+++ b/README.md
@@ -1155,7 +1155,7 @@ uv run main.py
 **Key Behaviors:**
 - The OAuth callback server is not started (no interactive auth needed)
 - Credentials directory permission checks are skipped
-- Caller-supplied email addresses in tool calls are ignored — the server always uses the configured `USER_GOOGLE_EMAIL`
+- **All operations impersonate the configured `USER_GOOGLE_EMAIL`** — any email addresses supplied in tool calls (e.g., `user_email` parameters) are ignored. This differs from OAuth modes where each user authenticates separately.
 - The service account key is validated at startup (checks for required fields and correct type)
 
 ### VS Code MCP Client Support

--- a/auth/credential_store.py
+++ b/auth/credential_store.py
@@ -127,7 +127,7 @@ class LocalDirectoryCredentialStore(CredentialStore):
             logger.info(f"Created credentials directory: {self.base_dir}")
 
         # Sanitize email to prevent path traversal
-        safe_email = re.sub(r'[^a-zA-Z0-9@._-]', '_', user_email)
+        safe_email = re.sub(r"[^a-zA-Z0-9@._-]", "_", user_email)
         creds_path = os.path.join(self.base_dir, f"{safe_email}.json")
 
         # Verify resolved path is still under base_dir

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -883,7 +883,9 @@ def get_credentials(
                 logger.info(
                     f"[get_credentials] Single-user mode: no credentials for {user_google_email}, falling back to any"
                 )
-                credentials, found_user_email = _find_any_credentials(credentials_base_dir)
+                credentials, found_user_email = _find_any_credentials(
+                    credentials_base_dir
+                )
         else:
             credentials, found_user_email = _find_any_credentials(credentials_base_dir)
         if not credentials:

--- a/auth/oauth_config.py
+++ b/auth/oauth_config.py
@@ -63,6 +63,19 @@ class OAuthConfig:
                 "WORKSPACE_MCP_STATELESS_MODE requires MCP_ENABLE_OAUTH21=true"
             )
 
+        # Service account (domain-wide delegation) configuration
+        self.service_account_key_file = os.getenv("GOOGLE_SERVICE_ACCOUNT_KEY_FILE")
+        self.service_account_key_json = os.getenv("GOOGLE_SERVICE_ACCOUNT_KEY_JSON")
+        self.service_account_enabled = bool(
+            self.service_account_key_file or self.service_account_key_json
+        )
+        if self.service_account_enabled and self.oauth21_enabled:
+            raise ValueError(
+                "Service account mode is incompatible with OAuth 2.1 mode. "
+                "Set GOOGLE_SERVICE_ACCOUNT_KEY_FILE or GOOGLE_SERVICE_ACCOUNT_KEY_JSON, "
+                "but not MCP_ENABLE_OAUTH21=true."
+            )
+
         # Transport mode (will be set at runtime)
         self._transport_mode = "stdio"  # Default
 
@@ -221,6 +234,7 @@ class OAuthConfig:
             "oauth21_enabled": self.oauth21_enabled,
             "external_oauth21_provider": self.external_oauth21_provider,
             "pkce_required": self.pkce_required,
+            "service_account_enabled": self.service_account_enabled,
             "transport_mode": self._transport_mode,
             "total_redirect_uris": len(self.get_redirect_uris()),
             "total_allowed_origins": len(self.get_allowed_origins()),
@@ -264,6 +278,15 @@ class OAuthConfig:
             True if external OAuth 2.1 provider is enabled
         """
         return self.external_oauth21_provider
+
+    def is_service_account_enabled(self) -> bool:
+        """
+        Check if service account (domain-wide delegation) mode is enabled.
+
+        Returns:
+            True if service account mode is enabled
+        """
+        return self.service_account_enabled
 
     def detect_oauth_version(self, request_params: Dict[str, Any]) -> str:
         """
@@ -442,3 +465,8 @@ def is_stateless_mode() -> bool:
 def is_external_oauth21_provider() -> bool:
     """Check if external OAuth 2.1 provider mode is enabled."""
     return get_oauth_config().is_external_oauth21_provider()
+
+
+def is_service_account_enabled() -> bool:
+    """Check if service account (domain-wide delegation) mode is enabled."""
+    return get_oauth_config().is_service_account_enabled()

--- a/auth/oauth_config.py
+++ b/auth/oauth_config.py
@@ -66,6 +66,12 @@ class OAuthConfig:
         # Service account (domain-wide delegation) configuration
         self.service_account_key_file = os.getenv("GOOGLE_SERVICE_ACCOUNT_KEY_FILE")
         self.service_account_key_json = os.getenv("GOOGLE_SERVICE_ACCOUNT_KEY_JSON")
+        if self.service_account_key_file and self.service_account_key_json:
+            raise ValueError(
+                "Only one service account key source may be provided. "
+                "Set either GOOGLE_SERVICE_ACCOUNT_KEY_FILE or "
+                "GOOGLE_SERVICE_ACCOUNT_KEY_JSON, not both."
+            )
         self.service_account_enabled = bool(
             self.service_account_key_file or self.service_account_key_json
         )

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -221,7 +221,10 @@ def _get_service_account_credentials(
                 config.service_account_key_file, scopes=scopes, subject=subject
             )
         service_account_key_json = config.service_account_key_json
-        if not isinstance(service_account_key_json, str) or not service_account_key_json.strip():
+        if (
+            not isinstance(service_account_key_json, str)
+            or not service_account_key_json.strip()
+        ):
             raise GoogleAuthenticationError(
                 "Service account credentials require either service_account_key_file "
                 "or a non-empty service_account_key_json."

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import logging
 
 import re
@@ -7,6 +8,7 @@ from typing import Dict, List, Optional, Any, Callable, Union, Tuple
 from contextlib import ExitStack
 
 from google.auth.exceptions import RefreshError
+from google.oauth2 import service_account as google_service_account
 from googleapiclient.discovery import build
 from fastmcp.server.dependencies import get_access_token, get_context
 from auth.google_auth import get_authenticated_google_service, GoogleAuthenticationError
@@ -20,6 +22,7 @@ from auth.oauth_config import (
     is_oauth21_enabled,
     get_oauth_config,
     is_external_oauth21_provider,
+    is_service_account_enabled,
 )
 from core.context import set_fastmcp_session_id
 from auth.scopes import (
@@ -190,6 +193,38 @@ def _override_oauth21_user_email(
     return authenticated_user, args
 
 
+def _get_service_account_credentials(
+    scopes: List[str], subject: str
+) -> google_service_account.Credentials:
+    """
+    Build service account credentials for domain-wide delegation.
+
+    Args:
+        scopes: OAuth scopes to request
+        subject: Email of the domain user to impersonate
+
+    Returns:
+        google.oauth2.service_account.Credentials instance
+
+    Raises:
+        GoogleAuthenticationError: If credentials cannot be built
+    """
+    config = get_oauth_config()
+    try:
+        if config.service_account_key_file:
+            return google_service_account.Credentials.from_service_account_file(
+                config.service_account_key_file, scopes=scopes, subject=subject
+            )
+        info = json.loads(config.service_account_key_json)
+        return google_service_account.Credentials.from_service_account_info(
+            info, scopes=scopes, subject=subject
+        )
+    except Exception as e:
+        raise GoogleAuthenticationError(
+            f"Failed to build service account credentials: {e}"
+        ) from e
+
+
 async def _authenticate_service(
     use_oauth21: bool,
     service_name: str,
@@ -206,6 +241,16 @@ async def _authenticate_service(
     Returns:
         Tuple of (service, actual_user_email)
     """
+    if is_service_account_enabled():
+        credentials = _get_service_account_credentials(
+            resolved_scopes, user_google_email
+        )
+        service = build(service_name, service_version, credentials=credentials)
+        logger.info(
+            f"[{tool_name}] Service account: {service_name} impersonating {user_google_email}"
+        )
+        return service, user_google_email
+
     if use_oauth21:
         logger.debug(f"[{tool_name}] Using OAuth 2.1 flow")
         return await get_authenticated_google_service_oauth21(

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -220,10 +220,23 @@ def _get_service_account_credentials(
             return google_service_account.Credentials.from_service_account_file(
                 config.service_account_key_file, scopes=scopes, subject=subject
             )
-        info = json.loads(config.service_account_key_json)
+        service_account_key_json = config.service_account_key_json
+        if not isinstance(service_account_key_json, str) or not service_account_key_json.strip():
+            raise GoogleAuthenticationError(
+                "Service account credentials require either service_account_key_file "
+                "or a non-empty service_account_key_json."
+            )
+        try:
+            info = json.loads(service_account_key_json)
+        except json.JSONDecodeError as e:
+            raise GoogleAuthenticationError(
+                "Failed to parse service_account_key_json: invalid JSON."
+            ) from e
         return google_service_account.Credentials.from_service_account_info(
             info, scopes=scopes, subject=subject
         )
+    except GoogleAuthenticationError:
+        raise
     except Exception as e:
         raise GoogleAuthenticationError(
             f"Failed to build service account credentials: {e}"

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import logging
+import os
 
 import re
 from functools import wraps
@@ -64,6 +65,11 @@ from auth.scopes import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _get_configured_user_google_email() -> Optional[str]:
+    """Return the configured default user email, preferring the live environment."""
+    return os.getenv("USER_GOOGLE_EMAIL") or _ENV_USER_EMAIL
 
 
 # Authentication helper functions
@@ -241,7 +247,7 @@ async def _authenticate_service(
         Tuple of (service, actual_user_email)
     """
     if is_service_account_enabled():
-        canonical_email = _ENV_USER_EMAIL
+        canonical_email = _get_configured_user_google_email()
         if not canonical_email:
             raise GoogleAuthenticationError(
                 "Service account mode requires USER_GOOGLE_EMAIL to be configured."
@@ -429,7 +435,7 @@ def _extract_oauth20_user_email(
     if not user_google_email:
         # Fall back to USER_GOOGLE_EMAIL env var for single-user / self-hosted mode.
         # This allows callers (agents) to omit the parameter when a default is configured.
-        user_google_email = _ENV_USER_EMAIL
+        user_google_email = _get_configured_user_google_email()
     if not user_google_email:
         raise Exception("'user_google_email' parameter is required but was not found.")
     # Ensure the resolved email is visible to the original function via kwargs
@@ -710,7 +716,7 @@ def require_google_service(
             try:
                 tool_name = func.__name__
 
-                # Log tool invocation with user identity for admin visibility
+                # Log requested user identity for audit visibility.
                 logger.info(
                     f"[{tool_name}] {user_google_email} -> "
                     f"{service_name}/{service_version}"
@@ -844,7 +850,7 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
                     args, kwargs, wrapper_sig
                 )
 
-            # Log tool invocation with user identity for admin visibility
+            # Log requested user identity for audit visibility.
             services_desc = ", ".join(c["service_type"] for c in service_configs)
             logger.info(f"[{tool_name}] {user_google_email} -> [{services_desc}]")
 

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -122,9 +122,7 @@ def _detect_oauth_version(
     # be available even if middleware state wasn't populated.
     try:
         if get_access_token() is not None:
-            logger.debug(
-                f"[{tool_name}] OAuth 2.1 selected via validated access token"
-            )
+            logger.debug(f"[{tool_name}] OAuth 2.1 selected via validated access token")
             return True
     except Exception as e:
         logger.debug(
@@ -254,9 +252,7 @@ async def _authenticate_service(
                 f"'{user_google_email}', using configured USER_GOOGLE_EMAIL "
                 f"'{canonical_email}'"
             )
-        credentials = _get_service_account_credentials(
-            resolved_scopes, canonical_email
-        )
+        credentials = _get_service_account_credentials(resolved_scopes, canonical_email)
         service = build(service_name, service_version, credentials=credentials)
         logger.info(
             f"[{tool_name}] Authenticated {service_name} for "
@@ -834,8 +830,8 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
         async def wrapper(*args, **kwargs):
             # Get authentication context early
             tool_name = func.__name__
-            authenticated_user, auth_method, mcp_session_id = (
-                await _get_auth_context(tool_name)
+            authenticated_user, auth_method, mcp_session_id = await _get_auth_context(
+                tool_name
             )
 
             # Extract user_google_email based on OAuth mode
@@ -850,9 +846,7 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
 
             # Log tool invocation with user identity for admin visibility
             services_desc = ", ".join(c["service_type"] for c in service_configs)
-            logger.info(
-                f"[{tool_name}] {user_google_email} -> [{services_desc}]"
-            )
+            logger.info(f"[{tool_name}] {user_google_email} -> [{services_desc}]")
 
             # Authenticate all services
             with ExitStack() as stack:

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -88,8 +88,9 @@ async def _get_auth_context(
         if mcp_session_id:
             set_fastmcp_session_id(mcp_session_id)
 
-        logger.info(
-            f"[{tool_name}] Auth from middleware: authenticated_user={authenticated_user}, auth_method={auth_method}, session_id={mcp_session_id}"
+        logger.debug(
+            f"[{tool_name}] Middleware context: user={authenticated_user}, "
+            f"method={auth_method}, session={mcp_session_id}"
         )
         return authenticated_user, auth_method, mcp_session_id
 
@@ -112,8 +113,8 @@ def _detect_oauth_version(
 
     # When OAuth 2.1 is enabled globally, ALWAYS use OAuth 2.1 for authenticated users
     if authenticated_user:
-        logger.info(
-            f"[{tool_name}] OAuth 2.1 mode: Using OAuth 2.1 for authenticated user '{authenticated_user}'"
+        logger.debug(
+            f"[{tool_name}] OAuth 2.1 selected for authenticated user '{authenticated_user}'"
         )
         return True
 
@@ -121,8 +122,8 @@ def _detect_oauth_version(
     # be available even if middleware state wasn't populated.
     try:
         if get_access_token() is not None:
-            logger.info(
-                f"[{tool_name}] OAuth 2.1 mode: Using OAuth 2.1 based on validated access token"
+            logger.debug(
+                f"[{tool_name}] OAuth 2.1 selected via validated access token"
             )
             return True
     except Exception as e:
@@ -138,8 +139,8 @@ def _detect_oauth_version(
 
     oauth_version = config.detect_oauth_version(request_params)
     use_oauth21 = oauth_version == "oauth21"
-    logger.info(
-        f"[{tool_name}] OAuth version detected: {oauth_version}, will use OAuth 2.1: {use_oauth21}"
+    logger.debug(
+        f"[{tool_name}] OAuth version detected: {oauth_version} (use_oauth21={use_oauth21})"
     )
     return use_oauth21
 
@@ -242,14 +243,26 @@ async def _authenticate_service(
         Tuple of (service, actual_user_email)
     """
     if is_service_account_enabled():
+        canonical_email = _ENV_USER_EMAIL
+        if not canonical_email:
+            raise GoogleAuthenticationError(
+                "Service account mode requires USER_GOOGLE_EMAIL to be configured."
+            )
+        if user_google_email != canonical_email:
+            logger.warning(
+                f"[{tool_name}] Service account: ignoring caller-supplied email "
+                f"'{user_google_email}', using configured USER_GOOGLE_EMAIL "
+                f"'{canonical_email}'"
+            )
         credentials = _get_service_account_credentials(
-            resolved_scopes, user_google_email
+            resolved_scopes, canonical_email
         )
         service = build(service_name, service_version, credentials=credentials)
         logger.info(
-            f"[{tool_name}] Service account: {service_name} impersonating {user_google_email}"
+            f"[{tool_name}] Authenticated {service_name} for "
+            f"{canonical_email} via service-account"
         )
-        return service, user_google_email
+        return service, canonical_email
 
     if use_oauth21:
         logger.debug(f"[{tool_name}] Using OAuth 2.1 flow")
@@ -330,7 +343,10 @@ async def get_authenticated_google_service_oauth21(
             )
 
         service = build(service_name, version, credentials=credentials)
-        logger.info(f"[{tool_name}] Authenticated {service_name} for {resolved_email}")
+        logger.info(
+            f"[{tool_name}] Authenticated {service_name} for "
+            f"{resolved_email} via oauth2.1"
+        )
         return service, resolved_email
 
     store = get_oauth21_session_store()
@@ -360,7 +376,10 @@ async def get_authenticated_google_service_oauth21(
         )
 
     service = build(service_name, version, credentials=credentials)
-    logger.info(f"[{tool_name}] Authenticated {service_name} for {user_google_email}")
+    logger.info(
+        f"[{tool_name}] Authenticated {service_name} for "
+        f"{user_google_email} via oauth2.1"
+    )
 
     return service, user_google_email
 
@@ -695,9 +714,10 @@ def require_google_service(
             try:
                 tool_name = func.__name__
 
-                # Log authentication status
-                logger.debug(
-                    f"[{tool_name}] Auth: {authenticated_user or 'none'} via {auth_method or 'none'} (session: {mcp_session_id[:8] if mcp_session_id else 'none'})"
+                # Log tool invocation with user identity for admin visibility
+                logger.info(
+                    f"[{tool_name}] {user_google_email} -> "
+                    f"{service_name}/{service_version}"
                 )
 
                 # Detect OAuth version
@@ -732,9 +752,9 @@ def require_google_service(
                 )
             except GoogleAuthenticationError as e:
                 logger.error(
-                    f"[{tool_name}] GoogleAuthenticationError during authentication. "
-                    f"Method={auth_method or 'none'}, User={authenticated_user or 'none'}, "
-                    f"Service={service_name} v{service_version}, MCPSessionID={mcp_session_id or 'none'}: {e}"
+                    f"[{tool_name}] Auth failed for {user_google_email} | "
+                    f"{service_name}/{service_version} | "
+                    f"method={auth_method or 'none'} | {e}"
                 )
                 # Re-raise the original error without wrapping it
                 raise
@@ -814,7 +834,9 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
         async def wrapper(*args, **kwargs):
             # Get authentication context early
             tool_name = func.__name__
-            authenticated_user, _, mcp_session_id = await _get_auth_context(tool_name)
+            authenticated_user, auth_method, mcp_session_id = (
+                await _get_auth_context(tool_name)
+            )
 
             # Extract user_google_email based on OAuth mode
             if is_oauth21_enabled():
@@ -825,6 +847,12 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
                 user_google_email = _extract_oauth20_user_email(
                     args, kwargs, wrapper_sig
                 )
+
+            # Log tool invocation with user identity for admin visibility
+            services_desc = ", ".join(c["service_type"] for c in service_configs)
+            logger.info(
+                f"[{tool_name}] {user_google_email} -> [{services_desc}]"
+            )
 
             # Authenticate all services
             with ExitStack() as stack:
@@ -879,7 +907,9 @@ def require_multiple_services(service_configs: List[Dict[str, Any]]):
 
                     except GoogleAuthenticationError as e:
                         logger.error(
-                            f"[{tool_name}] GoogleAuthenticationError for service '{service_type}' (user: {user_google_email}): {e}"
+                            f"[{tool_name}] Auth failed for {user_google_email} | "
+                            f"{service_name}/{service_version} | "
+                            f"method={auth_method or 'none'} | {e}"
                         )
                         # Re-raise the original error without wrapping it
                         raise

--- a/core/log_formatter.py
+++ b/core/log_formatter.py
@@ -183,9 +183,7 @@ def configure_file_logging(logger_name: str = None) -> bool:
         target_logger = logging.getLogger(logger_name)
 
         # Write logs to user-specific directory, not the package directory
-        log_dir = os.path.join(
-            os.path.expanduser("~"), ".google_workspace_mcp", "logs"
-        )
+        log_dir = os.path.join(os.path.expanduser("~"), ".google_workspace_mcp", "logs")
         os.makedirs(log_dir, mode=0o700, exist_ok=True)
         log_file_path = os.path.join(log_dir, "mcp_server_debug.log")
 

--- a/core/log_formatter.py
+++ b/core/log_formatter.py
@@ -70,6 +70,9 @@ class EnhancedLogFormatter(logging.Formatter):
             "gslides.slides_tools": "[SLIDES]",
             "gtasks.tasks_tools": "[TASKS]",
             "gsearch.search_tools": "[SEARCH]",
+            "auth.service_decorator": "[TOOL]",
+            "gcontacts.contacts_tools": "[CONTACTS]",
+            "gappsscript.apps_script_tools": "[APPSCRIPT]",
         }
 
         return ascii_prefixes.get(logger_name, f"[{level_name}]")

--- a/main.py
+++ b/main.py
@@ -15,7 +15,11 @@ _original_stdout = sys.stdout
 if sys.platform == "darwin":
     sys.stdout = io.StringIO()
 
-from auth.oauth_config import reload_oauth_config, is_stateless_mode, is_service_account_enabled  # noqa: E402
+from auth.oauth_config import (
+    reload_oauth_config,
+    is_stateless_mode,
+    is_service_account_enabled,
+)  # noqa: E402
 from core.log_formatter import EnhancedLogFormatter, configure_file_logging  # noqa: E402
 from core.utils import check_credentials_directory_permissions  # noqa: E402
 from core.server import server, set_transport_mode, configure_server_for_http  # noqa: E402
@@ -287,7 +291,9 @@ def main():
             "OAUTHLIB_INSECURE_TRANSPORT", "false"
         ),
         "GOOGLE_CLIENT_SECRET_PATH": os.getenv("GOOGLE_CLIENT_SECRET_PATH", "Not Set"),
-        "GOOGLE_SERVICE_ACCOUNT_KEY_FILE": os.getenv("GOOGLE_SERVICE_ACCOUNT_KEY_FILE", "Not Set"),
+        "GOOGLE_SERVICE_ACCOUNT_KEY_FILE": os.getenv(
+            "GOOGLE_SERVICE_ACCOUNT_KEY_FILE", "Not Set"
+        ),
     }
 
     for key, value in config_vars.items():
@@ -466,9 +472,7 @@ def main():
         user_email = os.getenv("USER_GOOGLE_EMAIL")
         if not user_email:
             safe_print("❌ Service account mode requires USER_GOOGLE_EMAIL to be set")
-            safe_print(
-                "   Set USER_GOOGLE_EMAIL to the domain user to impersonate"
-            )
+            safe_print("   Set USER_GOOGLE_EMAIL to the domain user to impersonate")
             sys.exit(1)
         safe_print("🔐 Service account mode enabled (domain-wide delegation)")
         safe_print(f"   Impersonating: {user_email}")
@@ -489,7 +493,9 @@ def main():
             logger.error(f"Failed credentials directory permission check: {e}")
             sys.exit(1)
     else:
-        skip_reason = "stateless mode" if is_stateless_mode() else "service account mode"
+        skip_reason = (
+            "stateless mode" if is_stateless_mode() else "service account mode"
+        )
         safe_print(f"🔍 Skipping credentials directory check ({skip_reason})")
         safe_print("")
 

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ _original_stdout = sys.stdout
 if sys.platform == "darwin":
     sys.stdout = io.StringIO()
 
-from auth.oauth_config import reload_oauth_config, is_stateless_mode  # noqa: E402
+from auth.oauth_config import reload_oauth_config, is_stateless_mode, is_service_account_enabled  # noqa: E402
 from core.log_formatter import EnhancedLogFormatter, configure_file_logging  # noqa: E402
 from core.utils import check_credentials_directory_permissions  # noqa: E402
 from core.server import server, set_transport_mode, configure_server_for_http  # noqa: E402
@@ -287,6 +287,7 @@ def main():
             "OAUTHLIB_INSECURE_TRANSPORT", "false"
         ),
         "GOOGLE_CLIENT_SECRET_PATH": os.getenv("GOOGLE_CLIENT_SECRET_PATH", "Not Set"),
+        "GOOGLE_SERVICE_ACCOUNT_KEY_FILE": os.getenv("GOOGLE_SERVICE_ACCOUNT_KEY_FILE", "Not Set"),
     }
 
     for key, value in config_vars.items():
@@ -445,12 +446,36 @@ def main():
             safe_print("❌ Single-user mode is incompatible with stateless mode")
             safe_print("   Stateless mode requires OAuth 2.1 which is multi-user")
             sys.exit(1)
+
+        if is_service_account_enabled():
+            safe_print("❌ Single-user mode is incompatible with service account mode")
+            safe_print(
+                "   Service account mode handles auth via domain-wide delegation"
+            )
+            safe_print(
+                "   Please choose one mode: either --single-user OR GOOGLE_SERVICE_ACCOUNT_KEY_FILE"
+            )
+            sys.exit(1)
+
         os.environ["MCP_SINGLE_USER_MODE"] = "1"
         safe_print("🔐 Single-user mode enabled")
         safe_print("")
 
-    # Check credentials directory permissions before starting (skip in stateless mode)
-    if not is_stateless_mode():
+    # Service account mode startup validation
+    if is_service_account_enabled():
+        user_email = os.getenv("USER_GOOGLE_EMAIL")
+        if not user_email:
+            safe_print("❌ Service account mode requires USER_GOOGLE_EMAIL to be set")
+            safe_print(
+                "   Set USER_GOOGLE_EMAIL to the domain user to impersonate"
+            )
+            sys.exit(1)
+        safe_print("🔐 Service account mode enabled (domain-wide delegation)")
+        safe_print(f"   Impersonating: {user_email}")
+        safe_print("")
+
+    # Check credentials directory permissions before starting (skip in stateless/service-account mode)
+    if not is_stateless_mode() and not is_service_account_enabled():
         try:
             safe_print("🔍 Checking credentials directory permissions...")
             check_credentials_directory_permissions()
@@ -464,7 +489,8 @@ def main():
             logger.error(f"Failed credentials directory permission check: {e}")
             sys.exit(1)
     else:
-        safe_print("🔍 Skipping credentials directory check (stateless mode)")
+        skip_reason = "stateless mode" if is_stateless_mode() else "service account mode"
+        safe_print(f"🔍 Skipping credentials directory check ({skip_reason})")
         safe_print("")
 
     try:
@@ -481,21 +507,22 @@ def main():
         else:
             safe_print("")
             safe_print("🚀 Starting STDIO server")
-            # Start minimal OAuth callback server for stdio mode
-            from auth.oauth_callback_server import ensure_oauth_callback_available
+            # Start minimal OAuth callback server for stdio mode (not needed for service accounts)
+            if not is_service_account_enabled():
+                from auth.oauth_callback_server import ensure_oauth_callback_available
 
-            success, error_msg = ensure_oauth_callback_available(
-                "stdio", port, base_uri
-            )
-            if success:
-                safe_print(
-                    f"   OAuth callback server started on {display_url}/oauth2callback"
+                success, error_msg = ensure_oauth_callback_available(
+                    "stdio", port, base_uri
                 )
-            else:
-                warning_msg = "   ⚠️  Warning: Failed to start OAuth callback server"
-                if error_msg:
-                    warning_msg += f": {error_msg}"
-                safe_print(warning_msg)
+                if success:
+                    safe_print(
+                        f"   OAuth callback server started on {display_url}/oauth2callback"
+                    )
+                else:
+                    warning_msg = "   ⚠️  Warning: Failed to start OAuth callback server"
+                    if error_msg:
+                        warning_msg += f": {error_msg}"
+                    safe_print(warning_msg)
 
         safe_print("✅ Ready for MCP connections")
         safe_print("")

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ _original_stdout = sys.stdout
 if sys.platform == "darwin":
     sys.stdout = io.StringIO()
 
+
 def _load_startup_dependencies():
     from auth.oauth_config import (
         get_oauth_config,

--- a/main.py
+++ b/main.py
@@ -16,21 +16,57 @@ _original_stdout = sys.stdout
 if sys.platform == "darwin":
     sys.stdout = io.StringIO()
 
-from auth.oauth_config import (
+def _load_startup_dependencies():
+    from auth.oauth_config import (
+        get_oauth_config,
+        reload_oauth_config,
+        is_stateless_mode,
+        is_service_account_enabled,
+    )
+    from core.log_formatter import EnhancedLogFormatter, configure_file_logging
+    from core.utils import check_credentials_directory_permissions
+    from core.server import server, set_transport_mode, configure_server_for_http
+    from core.tool_tier_loader import resolve_tools_from_tier
+    from core.tool_registry import (
+        set_enabled_tools as set_enabled_tool_names,
+        wrap_server_tool_method,
+        filter_server_tools,
+    )
+
+    return (
+        get_oauth_config,
+        reload_oauth_config,
+        is_stateless_mode,
+        is_service_account_enabled,
+        EnhancedLogFormatter,
+        configure_file_logging,
+        check_credentials_directory_permissions,
+        server,
+        set_transport_mode,
+        configure_server_for_http,
+        resolve_tools_from_tier,
+        set_enabled_tool_names,
+        wrap_server_tool_method,
+        filter_server_tools,
+    )
+
+
+(
     get_oauth_config,
     reload_oauth_config,
     is_stateless_mode,
     is_service_account_enabled,
-)  # noqa: E402
-from core.log_formatter import EnhancedLogFormatter, configure_file_logging  # noqa: E402
-from core.utils import check_credentials_directory_permissions  # noqa: E402
-from core.server import server, set_transport_mode, configure_server_for_http  # noqa: E402
-from core.tool_tier_loader import resolve_tools_from_tier  # noqa: E402
-from core.tool_registry import (  # noqa: E402
-    set_enabled_tools as set_enabled_tool_names,
+    EnhancedLogFormatter,
+    configure_file_logging,
+    check_credentials_directory_permissions,
+    server,
+    set_transport_mode,
+    configure_server_for_http,
+    resolve_tools_from_tier,
+    set_enabled_tool_names,
     wrap_server_tool_method,
     filter_server_tools,
-)
+) = _load_startup_dependencies()
 
 dotenv_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
 load_dotenv(dotenv_path=dotenv_path)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import io
 import argparse
+import json
 import logging
 import os
 import socket
@@ -15,7 +16,7 @@ _original_stdout = sys.stdout
 if sys.platform == "darwin":
     sys.stdout = io.StringIO()
 
-from auth.oauth_config import reload_oauth_config, is_stateless_mode, is_service_account_enabled  # noqa: E402
+from auth.oauth_config import reload_oauth_config, get_oauth_config, is_stateless_mode, is_service_account_enabled  # noqa: E402
 from core.log_formatter import EnhancedLogFormatter, configure_file_logging  # noqa: E402
 from core.utils import check_credentials_directory_permissions  # noqa: E402
 from core.server import server, set_transport_mode, configure_server_for_http  # noqa: E402
@@ -469,6 +470,37 @@ def main():
             safe_print(
                 "   Set USER_GOOGLE_EMAIL to the domain user to impersonate"
             )
+            sys.exit(1)
+        # Validate service account key material before advertising readiness
+        sa_config = get_oauth_config()
+        try:
+            if sa_config.service_account_key_file:
+                with open(sa_config.service_account_key_file) as f:
+                    key_data = json.load(f)
+            else:
+                key_data = json.loads(sa_config.service_account_key_json)
+            required_fields = {"type", "project_id", "private_key", "client_email"}
+            missing = required_fields - set(key_data.keys())
+            if missing:
+                safe_print(
+                    f"❌ Service account key missing required fields: "
+                    f"{', '.join(sorted(missing))}"
+                )
+                sys.exit(1)
+            if key_data.get("type") != "service_account":
+                safe_print(
+                    f"❌ Service account key has unexpected type: "
+                    f"{key_data.get('type')!r}"
+                )
+                sys.exit(1)
+        except FileNotFoundError as e:
+            safe_print(f"❌ Service account key file not found: {e}")
+            sys.exit(1)
+        except json.JSONDecodeError as e:
+            safe_print(f"❌ Service account key contains invalid JSON: {e}")
+            sys.exit(1)
+        except (IOError, OSError) as e:
+            safe_print(f"❌ Failed to read service account key: {e}")
             sys.exit(1)
         safe_print("🔐 Service account mode enabled (domain-wide delegation)")
         safe_print(f"   Impersonating: {user_email}")

--- a/tests/core/test_http_oauth_scope_config.py
+++ b/tests/core/test_http_oauth_scope_config.py
@@ -49,6 +49,7 @@ def test_configure_server_for_http_uses_base_required_scopes(monkeypatch):
 
     assert captured["required_scopes"] == sorted(server_module.BASE_SCOPES)
     assert captured["valid_scopes"] == sorted(server_module.get_current_scopes())
-    assert server_module.server.auth.client_registration_options.default_scopes == sorted(
-        server_module.get_current_scopes()
+    assert (
+        server_module.server.auth.client_registration_options.default_scopes
+        == sorted(server_module.get_current_scopes())
     )

--- a/tests/core/test_user_google_email_defaults.py
+++ b/tests/core/test_user_google_email_defaults.py
@@ -1,4 +1,5 @@
 import inspect
+from types import SimpleNamespace
 
 import pytest
 
@@ -116,6 +117,25 @@ def test_extract_oauth20_user_email_reads_runtime_env(monkeypatch):
     assert kwargs["user_google_email"] == "configured@example.com"
 
 
+def test_get_service_account_credentials_raises_without_key_source(monkeypatch):
+    monkeypatch.setattr(
+        service_decorator,
+        "get_oauth_config",
+        lambda: SimpleNamespace(
+            service_account_key_file=None,
+            service_account_key_json=None,
+        ),
+    )
+
+    with pytest.raises(
+        service_decorator.GoogleAuthenticationError,
+        match="service_account_key_json",
+    ):
+        service_decorator._get_service_account_credentials(
+            ["scope-a"], "configured@example.com"
+        )
+
+
 @pytest.mark.asyncio
 async def test_authenticate_service_account_uses_runtime_configured_user(monkeypatch):
     monkeypatch.setattr(service_decorator, "_ENV_USER_EMAIL", None)
@@ -164,3 +184,27 @@ async def test_authenticate_service_account_uses_runtime_configured_user(monkeyp
         "service_version": "v1",
         "credentials": fake_credentials,
     }
+
+
+@pytest.mark.asyncio
+async def test_authenticate_service_account_raises_without_configured_user(
+    monkeypatch,
+):
+    monkeypatch.setattr(service_decorator, "_ENV_USER_EMAIL", None)
+    monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
+    monkeypatch.setattr(service_decorator, "is_service_account_enabled", lambda: True)
+
+    with pytest.raises(
+        service_decorator.GoogleAuthenticationError,
+        match="Service account mode requires USER_GOOGLE_EMAIL to be configured",
+    ):
+        await service_decorator._authenticate_service(
+            use_oauth21=False,
+            service_name="gmail",
+            service_version="v1",
+            tool_name="sample_tool",
+            user_google_email="caller@example.com",
+            resolved_scopes=["scope-a"],
+            mcp_session_id=None,
+            authenticated_user=None,
+        )

--- a/tests/core/test_user_google_email_defaults.py
+++ b/tests/core/test_user_google_email_defaults.py
@@ -101,3 +101,66 @@ async def test_call_tool_injects_default_email_before_validation(monkeypatch):
     result = await server.call_tool("echo_email", None)
 
     assert _result_text(result) == "configured@example.com"
+
+
+def test_extract_oauth20_user_email_reads_runtime_env(monkeypatch):
+    monkeypatch.setattr(service_decorator, "_ENV_USER_EMAIL", None)
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "configured@example.com")
+    kwargs = {}
+
+    user_google_email = service_decorator._extract_oauth20_user_email(
+        (), kwargs, _sample_sig()
+    )
+
+    assert user_google_email == "configured@example.com"
+    assert kwargs["user_google_email"] == "configured@example.com"
+
+
+@pytest.mark.asyncio
+async def test_authenticate_service_account_uses_runtime_configured_user(monkeypatch):
+    monkeypatch.setattr(service_decorator, "_ENV_USER_EMAIL", None)
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "configured@example.com")
+    monkeypatch.setattr(service_decorator, "is_service_account_enabled", lambda: True)
+
+    captured = {}
+    fake_service = object()
+    fake_credentials = object()
+
+    def fake_get_service_account_credentials(scopes, subject):
+        captured["scopes"] = scopes
+        captured["subject"] = subject
+        return fake_credentials
+
+    def fake_build(service_name, service_version, credentials):
+        captured["service_name"] = service_name
+        captured["service_version"] = service_version
+        captured["credentials"] = credentials
+        return fake_service
+
+    monkeypatch.setattr(
+        service_decorator,
+        "_get_service_account_credentials",
+        fake_get_service_account_credentials,
+    )
+    monkeypatch.setattr(service_decorator, "build", fake_build)
+
+    service, actual_user = await service_decorator._authenticate_service(
+        use_oauth21=False,
+        service_name="gmail",
+        service_version="v1",
+        tool_name="sample_tool",
+        user_google_email="caller@example.com",
+        resolved_scopes=["scope-a"],
+        mcp_session_id=None,
+        authenticated_user=None,
+    )
+
+    assert service is fake_service
+    assert actual_user == "configured@example.com"
+    assert captured == {
+        "scopes": ["scope-a"],
+        "subject": "configured@example.com",
+        "service_name": "gmail",
+        "service_version": "v1",
+        "credentials": fake_credentials,
+    }


### PR DESCRIPTION
This is scary and should not be used unless you know exactly why you're doing it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service-account authentication (domain-wide delegation) via key file or inline JSON; startup validates keys, rejects providing both sources, and requires USER_GOOGLE_EMAIL; incompatible with single-user and OAuth2.1 modes.

* **Bug Fixes / Behavior**
  * Service-account mode skips the OAuth callback server, enforces runtime USER_GOOGLE_EMAIL for impersonation, tightens startup validation and error messages, and skips credential-dir permission checks when appropriate.

* **Chores**
  * Improved audit and debug logging, startup loading refactor, README updated with service-account docs, and tests added for email/runtime and service-account behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->