### PR TITLE
fix(auth): propagate valid scopes to CIMD manager for OAuth 2.1

### DIFF
--- a/core/server.py
+++ b/core/server.py
@@ -490,6 +490,11 @@ def configure_server_for_http():
                     provider.client_registration_options.default_scopes = (
                         provider_valid_scopes
                     )
+                # Propagate valid scopes to the CIMD manager so that CIMD
+                # clients (e.g. Claude Code) are registered with all enabled
+                # tool scopes, not just BASE_SCOPES.
+                if hasattr(provider, '_cimd_manager') and provider._cimd_manager is not None:
+                    provider._cimd_manager.default_scope = " ".join(provider_valid_scopes)
                 # Enable protocol-level auth
                 server.auth = provider
                 logger.info(


### PR DESCRIPTION
## Summary

- Fixes #668 — CIMD clients (e.g. Claude Code) were registered with only `BASE_SCOPES` (openid, email, profile), causing `invalid_scope` errors when requesting tool-specific scopes
- Propagates `provider_valid_scopes` to the CIMD manager's `default_scope` so that CIMD clients without a `scope` field in their metadata document are registered with all enabled tool scopes

## Root Cause

The existing fix (`client_registration_options.default_scopes`) from commit `8b21589` applies to the MCP SDK's standard DCR registration handler. However, the CIMD flow in FastMCP's `CIMDClientManager` bypasses that handler entirely and uses its own `default_scope` attribute, which was only initialized with `required_scopes` (BASE_SCOPES).

## Test plan

- [ ] Run server with `MCP_ENABLE_OAUTH21=true` and `TOOLS="drive"`
- [ ] Connect from Claude Code — OAuth flow should complete successfully
- [ ] Verify tool-specific scopes (e.g. `drive`) are included in the authorization request to Google
- [ ] Verify existing DCR registration flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth provider scope configuration to properly apply enabled scopes during provider initialization, ensuring correct scope settings are propagated throughout the authentication system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->