### PR TITLE
feat: inject quotaUser for per-user quota attribution

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -1195,7 +1195,10 @@ async def get_authenticated_google_service(
         raise GoogleAuthenticationError(auth_response)
 
     try:
+        from auth.service_decorator import _inject_quota_user
+
         service = build(service_name, version, credentials=credentials)
+        service = _inject_quota_user(service, user_google_email)
         log_user_email = user_google_email
 
         # Try to get email from credentials if needed for validation

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -2,6 +2,7 @@ import inspect
 import json
 import logging
 import os
+import urllib.parse
 
 import re
 from functools import wraps
@@ -246,6 +247,31 @@ def _get_service_account_credentials(
         ) from e
 
 
+def _inject_quota_user(service, user_email):
+    """Inject quotaUser on every Google API request for per-user quota attribution.
+
+    Google attributes quota to the project's global bucket by default. Passing
+    quotaUser=<email> shifts attribution to a per-user bucket, preventing
+    multi-tenant deployments from hitting the global 429 ceiling.
+
+    See: https://cloud.google.com/apis/docs/capping-api-usage#quotauser
+    Portions derived from Mail-0/Zero (https://github.com/Mail-0/Zero) —
+    Copyright (c) 2025 Zero Email, MIT License
+    (apps/server/src/lib/driver/google.ts:579-581)
+    """
+    if not user_email:
+        return service
+    original_request = service._http.request
+    quoted_email = urllib.parse.quote(user_email)
+
+    def _quota_request(uri, *args, **kwargs):
+        sep = "&" if "?" in uri else "?"
+        return original_request(f"{uri}{sep}quotaUser={quoted_email}", *args, **kwargs)
+
+    service._http.request = _quota_request
+    return service
+
+
 async def _authenticate_service(
     use_oauth21: bool,
     service_name: str,
@@ -276,9 +302,10 @@ async def _authenticate_service(
             )
         credentials = _get_service_account_credentials(resolved_scopes, canonical_email)
         service = build(service_name, service_version, credentials=credentials)
+        service = _inject_quota_user(service, canonical_email)
         logger.info(
             f"[{tool_name}] Authenticated {service_name} for "
-            f"{canonical_email} via service-account"
+            f"{canonical_email} via service-account (quotaUser={canonical_email})"
         )
         return service, canonical_email
 
@@ -361,9 +388,10 @@ async def get_authenticated_google_service_oauth21(
             )
 
         service = build(service_name, version, credentials=credentials)
+        service = _inject_quota_user(service, resolved_email)
         logger.info(
             f"[{tool_name}] Authenticated {service_name} for "
-            f"{resolved_email} via oauth2.1"
+            f"{resolved_email} via oauth2.1 (quotaUser={resolved_email})"
         )
         return service, resolved_email
 
@@ -394,9 +422,10 @@ async def get_authenticated_google_service_oauth21(
         )
 
     service = build(service_name, version, credentials=credentials)
+    service = _inject_quota_user(service, user_google_email)
     logger.info(
         f"[{tool_name}] Authenticated {service_name} for "
-        f"{user_google_email} via oauth2.1"
+        f"{user_google_email} via oauth2.1 (quotaUser={user_google_email})"
     )
 
     return service, user_google_email


### PR DESCRIPTION
## Summary

Pass `quotaUser=<user-email>` on every Google API call so Google attributes quota to the per-user bucket instead of the project's global bucket.

Without this, multi-tenant deployments through one OAuth client share a single global quota and hit 429s earlier than necessary. This is a [documented Google recommendation](https://cloud.google.com/apis/docs/capping-api-usage#quotauser) for multi-tenant integrators.

## Changes

- Added `_inject_quota_user()` helper in `auth/service_decorator.py` that wraps the HTTP transport to append `quotaUser` to every request URL
- Applied at all 4 `build()` call sites: service account, OAuth 2.1 (2 paths), and OAuth 2.0
- Zero behavioral change for single-user deployments (quotaUser is ignored when there's only one user)

## Attribution

Portions derived from [Mail-0/Zero](https://github.com/Mail-0/Zero) — Copyright (c) 2025 Zero Email, MIT License  
Original TypeScript source: `apps/server/src/lib/driver/google.ts:579-581` (`getQuotaUser()`)

## Testing

- No breaking changes to existing API surface
- `quotaUser` is a standard Google API parameter — no additional scopes required
- Verified: parameter is URL-encoded to handle special characters in email addresses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced API request handling to properly associate requests with individual users for improved quota tracking and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->