### PR TITLE
Fix Google Chat message search stability

### DIFF
--- a/gchat/chat_tools.py
+++ b/gchat/chat_tools.py
@@ -16,7 +16,7 @@ from googleapiclient.errors import HttpError
 # Auth & server utilities
 from auth.service_decorator import require_google_service, require_multiple_services
 from core.server import server
-from core.utils import handle_http_errors
+from core.utils import TransientNetworkError, handle_http_errors
 
 logger = logging.getLogger(__name__)
 
@@ -460,6 +460,11 @@ async def search_messages(
         for batch, had_transient_failure in results:
             messages.extend(batch)
             transient_failures += int(had_transient_failure)
+        if spaces_to_search and transient_failures == len(spaces_to_search):
+            raise TransientNetworkError(
+                "A transient SSL error occurred in 'search_messages' while searching Chat spaces. "
+                "Please try again shortly."
+            )
         context = "all accessible spaces"
 
     # Client-side text filtering (text: operator is not supported by the API)

--- a/gchat/chat_tools.py
+++ b/gchat/chat_tools.py
@@ -16,14 +16,14 @@ from googleapiclient.errors import HttpError
 # Auth & server utilities
 from auth.service_decorator import require_google_service, require_multiple_services
 from core.server import server
-from core.utils import TransientNetworkError, handle_http_errors
+from core.utils import handle_http_errors
 
 logger = logging.getLogger(__name__)
 
 # In-memory cache for user ID → display name (bounded to avoid unbounded growth)
 _SENDER_CACHE_MAX_SIZE = 256
 _sender_name_cache: Dict[str, str] = {}
-_SEARCH_MESSAGES_MAX_CONCURRENT_SPACE_FETCHES = 3
+_SEARCH_MESSAGES_MAX_CONCURRENT_SPACE_FETCHES = 1
 _SEARCH_MESSAGES_SSL_RETRIES = 3
 _SEARCH_MESSAGES_RETRY_BASE_DELAY_SECONDS = 1
 
@@ -384,12 +384,9 @@ async def search_messages(
         f"[search_messages] Email={user_google_email}, Query='{query}', TimeFilter='{time_filter}'"
     )
 
-    # Build API filter string. Keep client-side filtering as a fallback so
-    # result formatting stays consistent even if the backend returns extra rows.
+    # Google Chat messages.list supports time/thread filters, but not full-text
+    # search. Apply only supported API filters, then filter message text below.
     filter_parts = []
-    if query:
-        escaped_query = query.replace("\\", "\\\\").replace('"', '\\"')
-        filter_parts.append(f'text:"{escaped_query}"')
     if time_filter:
         filter_parts.append(time_filter)
     filter_str = " AND ".join(filter_parts) if filter_parts else None
@@ -463,11 +460,6 @@ async def search_messages(
         for batch, had_transient_failure in results:
             messages.extend(batch)
             transient_failures += int(had_transient_failure)
-        if transient_failures and not messages:
-            raise TransientNetworkError(
-                "A transient SSL error occurred in 'search_messages' while searching Chat spaces. "
-                "Please try again shortly."
-            )
         context = "all accessible spaces"
 
     # Client-side text filtering (text: operator is not supported by the API)
@@ -476,19 +468,24 @@ async def search_messages(
         messages = [m for m in messages if query_lower in (m.get("text") or "").lower()]
 
     if not messages:
-        return f"No messages found matching '{search_desc}' in {context}."
+        suffix = (
+            f" Skipped {transient_failures} spaces due to repeated SSL failures."
+            if "transient_failures" in locals() and transient_failures
+            else ""
+        )
+        return f"No messages found matching '{search_desc}' in {context}.{suffix}"
 
-    # Pre-resolve unique senders in parallel
+    # Resolve senders sequentially. The underlying googleapiclient/httplib2
+    # service objects are not safe to fan out heavily and can trigger SSL churn.
     sender_lookup = {}
     for msg in messages:
         s = msg.get("sender", {})
         key = s.get("name", "")
         if key and key not in sender_lookup:
             sender_lookup[key] = s
-    resolved_names = await asyncio.gather(
-        *[_resolve_sender(people_service, s) for s in sender_lookup.values()]
-    )
-    sender_map = dict(zip(sender_lookup.keys(), resolved_names))
+    sender_map = {}
+    for key, sender_obj in sender_lookup.items():
+        sender_map[key] = await _resolve_sender(people_service, sender_obj)
 
     output = [f"Found {len(messages)} messages matching '{search_desc}' in {context}:"]
     for msg in messages:

--- a/tests/gchat/test_chat_tools.py
+++ b/tests/gchat/test_chat_tools.py
@@ -220,7 +220,7 @@ async def test_search_messages_shows_attachment_indicator(mock_resolve):
 @pytest.mark.asyncio
 @patch("gchat.chat_tools._resolve_sender", new_callable=AsyncMock)
 async def test_search_messages_combines_filters_and_uses_page_size(mock_resolve):
-    """Cross-space search should honor page_size and combine query with time_filter."""
+    """Cross-space search should honor page_size and only send supported API filters."""
     mock_resolve.return_value = "Test User"
 
     msg = _make_message(text="Deploy finished")
@@ -247,10 +247,45 @@ async def test_search_messages_combines_filters_and_uses_page_size(mock_resolve)
     assert 'text "deploy" and createTime > "2026-03-18T00:00:00-03:00"' in result
     list_kwargs = chat_service.spaces().messages().list.call_args.kwargs
     assert list_kwargs["pageSize"] == 7
-    assert (
-        list_kwargs["filter"]
-        == 'text:"deploy" AND createTime > "2026-03-18T00:00:00-03:00"'
+    assert list_kwargs["filter"] == 'createTime > "2026-03-18T00:00:00-03:00"'
+
+
+@pytest.mark.asyncio
+@patch("gchat.chat_tools._resolve_sender", new_callable=AsyncMock)
+async def test_search_messages_query_only_filters_client_side_without_api_filter(
+    mock_resolve,
+):
+    """Query-only search should avoid unsupported Chat API text filters."""
+    mock_resolve.return_value = "Test User"
+
+    matching = _make_message(text="Deploy finished")
+    matching["_space_name"] = "General"
+    non_matching = _make_message(text="Lunch plans")
+    non_matching["_space_name"] = "General"
+
+    chat_service = Mock()
+    chat_service.spaces().list().execute.return_value = {
+        "spaces": [{"name": "spaces/S", "displayName": "General"}]
+    }
+    chat_service.spaces().messages().list().execute.return_value = {
+        "messages": [matching, non_matching]
+    }
+    people_service = Mock()
+
+    from gchat.chat_tools import search_messages
+
+    result = await _unwrap(search_messages)(
+        chat_service=chat_service,
+        people_service=people_service,
+        user_google_email="test@example.com",
+        query="deploy",
     )
+
+    assert "Deploy finished" in result
+    assert "Lunch plans" not in result
+    list_kwargs = chat_service.spaces().messages().list.call_args.kwargs
+    assert list_kwargs["pageSize"] == 25
+    assert "filter" not in list_kwargs
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes `search_messages` stability for Google Chat by avoiding API/filter and connection patterns that can trigger repeated SSL failures.

## Root cause

`search_messages` was applying `text:"..."` to the Google Chat `spaces.messages.list` API filter, but Chat message text search is not supported by that filter. The tool already does client-side text filtering later, so this API filter is unnecessary and can make the request path brittle.

The tool also fetched multiple spaces concurrently and resolved senders concurrently using shared googleapiclient/httplib2 service objects. In practice this can create SSL/socket churn; similar Gmail batch code in this repo already avoids that by falling back to sequential processing when needed.

Finally, when SSL failures occurred across space fetches and no messages were returned, the tool raised a fatal transient error. That prevents callers from using otherwise available partial/empty results.

## Changes

- Stop sending unsupported text filters to `spaces.messages.list`; keep text filtering client-side.
- Reduce Chat space fetch concurrency to 1 to avoid sharing the same Google API client across concurrent worker threads.
- Do not throw a fatal `TransientNetworkError` when repeated per-space SSL failures produce no messages; return an empty result with a warning suffix.
- Resolve sender names sequentially to avoid extra People API concurrency on the same client.

## Validation

- `uv run python -m py_compile gchat\chat_tools.py`
- `uv run ruff check gchat\chat_tools.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transient SSL connection failures during searches and enhanced reporting when some spaces are skipped.
  * Refined search behavior so query matching is performed client-side for more consistent results.

* **Performance**
  * Reduced concurrent search processing to prioritize stability and more predictable sender resolution for results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->