### PR TITLE
claude cowork patch

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -64,6 +64,14 @@ that send ``'["value"]'`` instead of ``["value"]``.
 """
 
 
+DictList = Annotated[List[dict], BeforeValidator(_coerce_json_str_to_list)]
+"""``List[dict]`` that also accepts a JSON-encoded string of an array.
+
+Use in tool signatures instead of ``List[dict]`` to work around MCP clients
+that send ``'[{"key":"val"}]'`` instead of ``[{"key":"val"}]``.
+"""
+
+
 def _coerce_json_str_to_dict(v: Any) -> Any:
     """Coerce a JSON-encoded string to a dict.
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -64,7 +64,7 @@ that send ``'["value"]'`` instead of ``["value"]``.
 """
 
 
-DictList = Annotated[List[dict], BeforeValidator(_coerce_json_str_to_list)]
+DictList = Annotated[List[dict[str, Any]], BeforeValidator(_coerce_json_str_to_list)]
 """``List[dict]`` that also accepts a JSON-encoded string of an array.
 
 Use in tool signatures instead of ``List[dict]`` to work around MCP clients

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -28,6 +28,7 @@ from core.utils import (
     UserInputError,
     StringList,
     JsonDict,
+    DictList,
 )
 from core.server import server
 from auth.scopes import (
@@ -1534,7 +1535,7 @@ async def send_gmail_message(
         ),
     ] = None,
     attachments: Annotated[
-        Optional[List[Dict[str, str]]],
+        Optional[DictList],
         Field(
             description='Optional list of attachments. Each can have: "path" (file path, auto-encodes), OR "content" (standard base64, not urlsafe) + "filename". Optional "mime_type". Example: [{"path": "/path/to/file.pdf"}] or [{"filename": "doc.pdf", "content": "base64data", "mime_type": "application/pdf"}]',
         ),
@@ -1741,7 +1742,7 @@ async def draft_gmail_message(
         ),
     ] = None,
     attachments: Annotated[
-        Optional[List[Dict[str, str]]],
+        Optional[DictList],
         Field(
             description="Optional list of attachments. Each can have: 'path' (file path, auto-encodes), OR 'content' (standard base64, not urlsafe) + 'filename'. Optional 'mime_type' (auto-detected from path if not provided).",
         ),


### PR DESCRIPTION
Closes #689 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Gmail send and draft message tools now accept attachment data either as native list structures or as JSON-encoded strings.
  * This makes adding files to emails more flexible and robust across varied input formats, reducing errors when attachments are provided from different sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->