### PR TITLE
feat(gmail): add get_gmail_label_stats tool for unread/total message counts

### DIFF
--- a/.github/workflows/check-maintainer-edits.yml
+++ b/.github/workflows/check-maintainer-edits.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check-maintainer-edits:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.fork == true || github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
       - name: Check if maintainer edits are enabled
@@ -45,7 +45,7 @@ jobs:
 
   check-maintainer-edits-internal:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.fork == false && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Skip check for internal PRs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+    - name: Install locked test dependencies
+      run: uv sync --group test --frozen
+    - name: Run pytest
+      run: uv run pytest

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2574,6 +2574,63 @@ async def list_gmail_labels(service, user_google_email: str) -> str:
 
 
 @server.tool()
+@handle_http_errors("get_gmail_label_stats", is_read_only=True, service_type="gmail")
+@require_google_service("gmail", "gmail_read")
+async def get_gmail_label_stats(
+    service,
+    user_google_email: str,
+    label_id: Annotated[
+        str,
+        Field(
+            description="The Gmail label ID to get stats for (e.g. 'INBOX', 'UNREAD', "
+            "'STARRED', 'SENT', 'DRAFT', 'SPAM', 'TRASH', or a custom label ID). "
+            "Defaults to 'INBOX'."
+        ),
+    ] = "INBOX",
+) -> str:
+    """
+    Returns message and thread counts for a Gmail label.
+
+    Provides messagesTotal, messagesUnread, threadsTotal, and threadsUnread
+    in a single API call — much faster than paginating through search results
+    to count unread messages.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        label_id (str): The Gmail label ID. Defaults to 'INBOX'.
+
+    Returns:
+        str: Formatted label statistics including message and thread counts.
+    """
+    logger.info(
+        f"[get_gmail_label_stats] Invoked. Email: '{user_google_email}', "
+        f"label_id: '{label_id}'"
+    )
+
+    response = await asyncio.to_thread(
+        service.users().labels().get(userId="me", id=label_id).execute
+    )
+
+    name = response.get("name", label_id)
+    label_type = response.get("type", "unknown")
+    messages_total = response.get("messagesTotal", 0)
+    messages_unread = response.get("messagesUnread", 0)
+    threads_total = response.get("threadsTotal", 0)
+    threads_unread = response.get("threadsUnread", 0)
+
+    lines = [
+        f"📊 Label stats for '{name}' (ID: {label_id}, type: {label_type}):",
+        "",
+        f"  Messages total:  {messages_total}",
+        f"  Messages unread: {messages_unread}",
+        f"  Threads total:   {threads_total}",
+        f"  Threads unread:  {threads_unread}",
+    ]
+
+    return "\n".join(lines)
+
+
+@server.tool()
 @handle_http_errors("manage_gmail_label", service_type="gmail")
 @require_google_service("gmail", GMAIL_LABELS_SCOPE)
 async def manage_gmail_label(

--- a/tests/gmail/test_get_gmail_label_stats.py
+++ b/tests/gmail/test_get_gmail_label_stats.py
@@ -1,0 +1,122 @@
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gmail.gmail_tools import get_gmail_label_stats
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _mock_service(label_response: dict) -> Mock:
+    """Build a mock Gmail service that returns the given label response."""
+    service = Mock()
+    service.users.return_value.labels.return_value.get.return_value.execute.return_value = (
+        label_response
+    )
+    return service
+
+
+@pytest.mark.asyncio
+async def test_inbox_default():
+    """Default label_id='INBOX' returns formatted stats."""
+    response = {
+        "id": "INBOX",
+        "name": "INBOX",
+        "type": "system",
+        "messagesTotal": 1234,
+        "messagesUnread": 56,
+        "threadsTotal": 800,
+        "threadsUnread": 30,
+    }
+    service = _mock_service(response)
+    fn = _unwrap(get_gmail_label_stats)
+
+    result = await fn(service, user_google_email="test@example.com")
+
+    assert "INBOX" in result
+    assert "1234" in result
+    assert "56" in result
+    assert "800" in result
+    assert "30" in result
+    service.users().labels().get.assert_called_once_with(userId="me", id="INBOX")
+
+
+@pytest.mark.asyncio
+async def test_custom_label_id():
+    """Passing a custom label_id calls the API with that ID."""
+    response = {
+        "id": "Label_42",
+        "name": "Projects",
+        "type": "user",
+        "messagesTotal": 10,
+        "messagesUnread": 3,
+        "threadsTotal": 7,
+        "threadsUnread": 2,
+    }
+    service = _mock_service(response)
+    fn = _unwrap(get_gmail_label_stats)
+
+    result = await fn(
+        service, user_google_email="test@example.com", label_id="Label_42"
+    )
+
+    assert "Projects" in result
+    assert "Label_42" in result
+    assert "user" in result
+    assert "10" in result
+    assert "3" in result
+    service.users().labels().get.assert_called_once_with(userId="me", id="Label_42")
+
+
+@pytest.mark.asyncio
+async def test_zero_counts():
+    """Labels with zero messages/threads are handled gracefully."""
+    response = {
+        "id": "TRASH",
+        "name": "TRASH",
+        "type": "system",
+        "messagesTotal": 0,
+        "messagesUnread": 0,
+        "threadsTotal": 0,
+        "threadsUnread": 0,
+    }
+    service = _mock_service(response)
+    fn = _unwrap(get_gmail_label_stats)
+
+    result = await fn(service, user_google_email="test@example.com", label_id="TRASH")
+
+    assert "TRASH" in result
+    assert "Messages total:  0" in result
+    assert "Threads total:   0" in result
+
+
+@pytest.mark.asyncio
+async def test_missing_optional_fields():
+    """When API response omits count fields, defaults to 0."""
+    response = {
+        "id": "STARRED",
+        "name": "STARRED",
+        "type": "system",
+    }
+    service = _mock_service(response)
+    fn = _unwrap(get_gmail_label_stats)
+
+    result = await fn(
+        service, user_google_email="test@example.com", label_id="STARRED"
+    )
+
+    assert "STARRED" in result
+    assert "Messages total:  0" in result
+    assert "Messages unread: 0" in result
+    assert "Threads total:   0" in result
+    assert "Threads unread:  0" in result

--- a/tests/gmail/test_get_gmail_label_stats.py
+++ b/tests/gmail/test_get_gmail_label_stats.py
@@ -20,9 +20,7 @@ def _unwrap(tool):
 def _mock_service(label_response: dict) -> Mock:
     """Build a mock Gmail service that returns the given label response."""
     service = Mock()
-    service.users.return_value.labels.return_value.get.return_value.execute.return_value = (
-        label_response
-    )
+    service.users.return_value.labels.return_value.get.return_value.execute.return_value = label_response
     return service
 
 
@@ -111,9 +109,7 @@ async def test_missing_optional_fields():
     service = _mock_service(response)
     fn = _unwrap(get_gmail_label_stats)
 
-    result = await fn(
-        service, user_google_email="test@example.com", label_id="STARRED"
-    )
+    result = await fn(service, user_google_email="test@example.com", label_id="STARRED")
 
     assert "STARRED" in result
     assert "Messages total:  0" in result


### PR DESCRIPTION
## Summary

Add a `get_gmail_label_stats` MCP tool that returns message and thread counts for a Gmail label using the `labels.get` endpoint.

## Motivation

Currently, the only way to get unread message counts is to paginate through `search_gmail_messages` with `is:unread` — which is slow and token-heavy for accounts with many messages. The Gmail API's `labels.get` endpoint returns `messagesTotal`, `messagesUnread`, `threadsTotal`, and `threadsUnread` in a single API call.

## What changed

- **gmail/gmail_tools.py**: Added `get_gmail_label_stats` tool (placed after `list_gmail_labels`). Accepts an optional `label_id` parameter (defaults to `INBOX`), calls `service.users().labels().get()`, and returns formatted stats.
- **tests/gmail/test_get_gmail_label_stats.py**: 4 unit tests covering default inbox, custom label ID, zero counts, and missing optional fields.

## Implementation details

- Follows the existing tool pattern: `@server.tool()` / `@handle_http_errors` / `@require_google_service`
- Uses `gmail_read` scope (read-only, no extra permissions needed)
- Tested live against a real Gmail account — API response matches expected format

## Example output

```
📊 Label stats for 'INBOX' (ID: INBOX, type: system):

  Messages total:  1234
  Messages unread: 56
  Threads total:   800
  Threads unread:  30
```

## Gmail API Reference

- [users.labels.get](https://developers.google.com/gmail/api/reference/rest/v1/users.labels/get)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a Gmail label statistics tool that reports label details, total and unread messages, and total and unread threads for any label. It defaults to the Inbox when no label is specified.

## Tests
- Added comprehensive coverage for default and custom labels, zero-count labels, and labels with missing count information.

## Chores
- Added automated testing for pull requests and updates to the main branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->