### PR TITLE
feat(gmail): add analyze_thread_ownership tool for thread-state analysis

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -8,6 +8,7 @@ gmail:
   extended:
     - get_gmail_attachment_content
     - get_gmail_thread_content
+    - analyze_thread_ownership
     - modify_gmail_message_labels
     - list_gmail_labels
     - manage_gmail_label

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2381,6 +2381,261 @@ async def get_gmail_thread_content(
     )
 
 
+def _normalize_email(address: str) -> str:
+    """Lowercase an email address and strip plus-addressing so that
+    e.g. 'Alex <alex+foo@scopestack.io>' normalizes to 'alex@scopestack.io'.
+
+    This is the key primitive for 'is this message from Alex?' checks — plus
+    addresses are Alex, not a third party.
+    """
+    from email.utils import parseaddr
+
+    _name, addr = parseaddr(address or "")
+    addr = addr.lower().strip()
+    if not addr or "@" not in addr:
+        return addr
+    local, _, domain = addr.partition("@")
+    local = local.split("+", 1)[0]
+    return f"{local}@{domain}"
+
+
+def _parse_date_header(date_str: str, internal_date_ms: str | int | None):
+    """Parse a Date header to a timezone-aware datetime. Fall back to
+    internalDate (Unix ms as string) when the RFC822 Date header is malformed
+    or missing.
+
+    CRITICAL: the returned datetime is ALWAYS timezone-aware (UTC). Mixing
+    naive and aware datetimes in comparisons raises TypeError at runtime,
+    which matters here because a single thread can contain both well-formed
+    Date headers (with tz) and malformed ones (falling back to internalDate,
+    which is aware UTC). Coerce naive → UTC at parse time so downstream
+    callers can `>` / `<` the results freely.
+
+    Returns (iso_string, datetime) or (None, None) if both sources fail.
+    """
+    from email.utils import parsedate_to_datetime
+    from datetime import datetime, timezone
+
+    if date_str:
+        try:
+            dt = parsedate_to_datetime(date_str)
+            # parsedate_to_datetime returns a naive datetime when the header
+            # has no timezone offset (e.g., "Mon, 14 Apr 2026 09:00:00").
+            # Coerce to UTC so comparisons with internalDate fallbacks work.
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.isoformat(), dt
+        except (TypeError, ValueError):
+            pass
+
+    if internal_date_ms is not None:
+        try:
+            ms = int(internal_date_ms)
+            dt = datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
+            return dt.isoformat(), dt
+        except (TypeError, ValueError):
+            pass
+
+    return None, None
+
+
+def _analyze_thread_ownership_impl(
+    thread_response: dict,
+    user_google_email: str,
+) -> Dict[str, Any]:
+    """Pure analysis of a Gmail thread API response. Takes the response from
+    users().threads().get(format='full') and returns structured ownership
+    metadata. Kept separate from the @server.tool wrapper so tests can call
+    it with fabricated thread data."""
+    from collections import Counter
+    from email.utils import getaddresses, parseaddr
+
+    messages = thread_response.get("messages", []) or []
+    thread_id = thread_response.get("id", "")
+
+    if not messages:
+        return {
+            "thread_id": thread_id,
+            "thread_subject": None,
+            "last_sender": None,
+            "last_timestamp": None,
+            "ball_in_court_of": None,
+            "message_count_by_sender": {},
+            "participants": [],
+            "excluded_drafts": 0,
+            "message_count": 0,
+        }
+
+    normalized_user = _normalize_email(user_google_email)
+
+    # Thread subject: first message's Subject header
+    first_headers = {
+        h["name"]: h["value"]
+        for h in messages[0].get("payload", {}).get("headers", [])
+    }
+    thread_subject = first_headers.get("Subject") or None
+
+    sender_counter: Counter = Counter()
+    participants: set[str] = set()
+    excluded_drafts = 0
+
+    last_non_draft = None  # (datetime, message_dict, headers_dict)
+
+    for message in messages:
+        label_ids = message.get("labelIds", []) or []
+        is_draft = "DRAFT" in label_ids
+
+        headers = {
+            h["name"]: h["value"]
+            for h in message.get("payload", {}).get("headers", [])
+        }
+
+        from_addr = headers.get("From", "")
+        _name, from_email = parseaddr(from_addr)
+        from_norm = _normalize_email(from_email) if from_email else ""
+
+        # Count participants from From/To/Cc (normalized). Use getaddresses
+        # for RFC-correct parsing — a naive `split(",")` would mis-parse
+        # quoted display names with embedded commas like:
+        #   "Doe, John" <john@example.com>, vendor@example.com
+        # getaddresses handles all three headers in one pass and returns
+        # (display_name, address) tuples.
+        header_values = [
+            headers.get(hdr, "") for hdr in ("From", "To", "Cc")
+        ]
+        for _n, addr in getaddresses([v for v in header_values if v]):
+            norm = _normalize_email(addr) if addr else ""
+            if norm:
+                participants.add(norm)
+
+        if is_draft:
+            excluded_drafts += 1
+            continue
+
+        if from_norm:
+            sender_counter[from_norm] += 1
+
+        _iso, dt = _parse_date_header(
+            headers.get("Date", ""), message.get("internalDate")
+        )
+        if dt is not None:
+            if last_non_draft is None or dt > last_non_draft[0]:
+                last_non_draft = (dt, message, headers)
+
+    if last_non_draft is None:
+        # All messages were drafts — no sent state to reason about
+        return {
+            "thread_id": thread_id,
+            "thread_subject": thread_subject,
+            "last_sender": None,
+            "last_timestamp": None,
+            "ball_in_court_of": None,
+            "message_count_by_sender": dict(sender_counter),
+            "participants": sorted(participants),
+            "excluded_drafts": excluded_drafts,
+            "message_count": len(messages),
+        }
+
+    last_dt, _last_message, last_headers = last_non_draft
+    last_sender_raw = last_headers.get("From", "")
+    _n, last_sender_email = parseaddr(last_sender_raw)
+    last_sender_norm = _normalize_email(last_sender_email) if last_sender_email else ""
+
+    # Ball-in-court logic:
+    # - "user" = authenticated user sent last → ball is with them (the other party)
+    # - "them" = someone else sent last → ball is with user
+    # - None  = unresolvable (self-only thread with no external party, or
+    #           malformed From header, or normalized_user empty)
+    external_participants = participants - {normalized_user} if normalized_user else participants
+    if not normalized_user or "@" not in last_sender_norm:
+        # Either we have no user identity to compare against, or the last
+        # message's From header couldn't be parsed into a real email address
+        # (e.g., just a display name). Can't make a reliable claim.
+        ball_in_court_of = None
+    elif not external_participants:
+        # Self-only thread (user → user, e.g., forward-to-self). No external
+        # action pending; downstream agents shouldn't treat as "ball on them."
+        ball_in_court_of = None
+    elif last_sender_norm == normalized_user:
+        ball_in_court_of = "them"
+    else:
+        ball_in_court_of = "user"
+
+    return {
+        "thread_id": thread_id,
+        "thread_subject": thread_subject,
+        "last_sender": last_sender_raw or None,
+        "last_timestamp": last_dt.isoformat(),
+        "ball_in_court_of": ball_in_court_of,
+        "message_count_by_sender": dict(sender_counter),
+        "participants": sorted(participants),
+        "excluded_drafts": excluded_drafts,
+        "message_count": len(messages),
+    }
+
+
+@server.tool()
+@require_google_service("gmail", "gmail_read")
+@handle_http_errors(
+    "analyze_thread_ownership", is_read_only=True, service_type="gmail"
+)
+async def analyze_thread_ownership(
+    service,
+    thread_id: str,
+    user_google_email: str,
+) -> Dict[str, Any]:
+    """Analyze a Gmail thread to determine who owes whom a response.
+
+    Returns structured ownership metadata: last non-draft sender, participant
+    addresses, per-sender message counts, and a `ball_in_court_of` verdict
+    ("user" | "them" | None). Solves the common agent error of inferring last
+    responder from a date-range search instead of reading the actual thread.
+
+    Normalization: plus-addressing is stripped (alex+foo@domain.com is
+    treated as alex@domain.com). Comparison is case-insensitive. Drafts are
+    excluded from the last-message determination and counted separately in
+    `excluded_drafts`. Malformed Date headers fall back to Gmail's
+    `internalDate` (Unix ms). All timestamps are timezone-aware (UTC).
+
+    Ball-in-court semantics:
+      - "user" → the authenticated user sent last → ball is with the other party
+      - "them" → someone else sent last → ball is with the user
+      - None   → unresolvable (all drafts, self-only thread with no external
+                 party, or malformed headers)
+
+    Known limitation: `user_google_email` is a single address. A user with
+    multiple aliases (e.g., personal + work) will not be recognized as the
+    same identity across a multi-account thread.
+
+    Args:
+        thread_id: The Gmail thread ID to analyze.
+        user_google_email: The authenticated user's email. Used to determine
+            whether the last message came from the user or an external party.
+
+    Returns:
+        {
+            "thread_id": str,
+            "thread_subject": str | None,
+            "last_sender": str | None,          # raw "Name <addr>" format
+            "last_timestamp": str | None,       # ISO-8601 (UTC-aware)
+            "ball_in_court_of": "user" | "them" | None,
+            "message_count_by_sender": {normalized_email: int},
+            "participants": [normalized_email, ...],   # all From/To/Cc
+            "excluded_drafts": int,
+            "message_count": int,
+        }
+    """
+    logger.info(
+        f"[analyze_thread_ownership] thread={thread_id} user={user_google_email}"
+    )
+
+    thread_response = await asyncio.to_thread(
+        service.users().threads().get(userId="me", id=thread_id, format="full").execute
+    )
+
+    return _analyze_thread_ownership_impl(thread_response, user_google_email)
+
+
 @server.tool()
 @require_google_service("gmail", "gmail_read")
 @handle_http_errors(

--- a/tests/gmail/test_analyze_thread_ownership.py
+++ b/tests/gmail/test_analyze_thread_ownership.py
@@ -1,0 +1,309 @@
+"""Tests for analyze_thread_ownership.
+
+Covers the pure analyzer (_analyze_thread_ownership_impl) against fabricated
+thread API responses. No network, no credentials — the helper is a pure
+function of the Gmail threads.get(format='full') response shape.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import pytest
+
+from gmail.gmail_tools import (
+    _analyze_thread_ownership_impl,
+    _normalize_email,
+    _parse_date_header,
+)
+
+
+def _msg(
+    msg_id: str,
+    from_addr: str,
+    date: str,
+    to: str = "",
+    cc: str = "",
+    subject: str = "Test",
+    draft: bool = False,
+    internal_date_ms: str | None = None,
+) -> dict:
+    """Build a fake Gmail message resource in the shape threads.get returns."""
+    headers = [
+        {"name": "From", "value": from_addr},
+        {"name": "Date", "value": date},
+        {"name": "Subject", "value": subject},
+    ]
+    if to:
+        headers.append({"name": "To", "value": to})
+    if cc:
+        headers.append({"name": "Cc", "value": cc})
+
+    msg = {
+        "id": msg_id,
+        "labelIds": ["DRAFT"] if draft else ["INBOX"],
+        "payload": {"headers": headers},
+    }
+    if internal_date_ms is not None:
+        msg["internalDate"] = internal_date_ms
+    return msg
+
+
+def _thread(thread_id: str, messages: List[dict]) -> dict:
+    return {"id": thread_id, "messages": messages}
+
+
+class TestNormalization:
+    def test_plain_email_lowercased(self):
+        assert _normalize_email("Alex@Scopestack.io") == "alex@scopestack.io"
+
+    def test_plus_addressing_stripped(self):
+        assert (
+            _normalize_email("alex+foo@scopestack.io") == "alex@scopestack.io"
+        )
+
+    def test_display_name_stripped(self):
+        assert (
+            _normalize_email("Alex Reynolds <alex@alexreynolds.com>")
+            == "alex@alexreynolds.com"
+        )
+
+    def test_empty_or_malformed_returns_empty(self):
+        assert _normalize_email("") == ""
+        assert _normalize_email("not-an-email") == "not-an-email"
+
+
+class TestDateParsing:
+    def test_rfc822_header_parsed(self):
+        iso, dt = _parse_date_header(
+            "Thu, 17 Apr 2026 10:00:00 -0400", None
+        )
+        assert iso is not None
+        assert dt is not None
+
+    def test_falls_back_to_internal_date(self):
+        iso, dt = _parse_date_header("", "1713360000000")
+        assert iso is not None
+        assert dt is not None
+
+    def test_both_missing_returns_none(self):
+        iso, dt = _parse_date_header("", None)
+        assert iso is None and dt is None
+
+    def test_malformed_header_falls_back(self):
+        iso, dt = _parse_date_header("not a date", "1713360000000")
+        assert iso is not None
+        assert dt is not None
+
+
+class TestBallInCourt:
+    def test_vendor_replied_last_ball_on_alex(self):
+        thread = _thread(
+            "t1",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>", "Mon, 14 Apr 2026 09:00:00 -0400",
+                     to="vendor@example.com"),
+                _msg("m2", "Vendor <vendor@example.com>", "Tue, 15 Apr 2026 10:00:00 -0400",
+                     to="alex@alexreynolds.com"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "user"
+        assert result["last_sender"] == "Vendor <vendor@example.com>"
+        assert result["message_count"] == 2
+
+    def test_alex_replied_last_ball_on_them(self):
+        thread = _thread(
+            "t2",
+            [
+                _msg("m1", "Vendor <vendor@example.com>", "Mon, 14 Apr 2026 09:00:00 -0400"),
+                _msg("m2", "Alex <alex@alexreynolds.com>", "Tue, 15 Apr 2026 10:00:00 -0400"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "them"
+        assert result["last_sender"] == "Alex <alex@alexreynolds.com>"
+
+    def test_plus_addressing_recognized_as_user(self):
+        """alex+foo@alexreynolds.com is still Alex."""
+        thread = _thread(
+            "t3",
+            [
+                _msg("m1", "Vendor <vendor@example.com>", "Mon, 14 Apr 2026 09:00:00 -0400"),
+                _msg("m2", "Alex <alex+newsletter@alexreynolds.com>",
+                     "Tue, 15 Apr 2026 10:00:00 -0400"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "them"
+
+
+class TestDrafts:
+    def test_draft_excluded_from_last_determination(self):
+        """A newer DRAFT from Alex must NOT flip ball-in-court; drafts
+        haven't been sent."""
+        thread = _thread(
+            "t4",
+            [
+                _msg("m1", "Vendor <vendor@example.com>", "Mon, 14 Apr 2026 09:00:00 -0400"),
+                _msg("m2", "Alex <alex@alexreynolds.com>", "Tue, 15 Apr 2026 10:00:00 -0400",
+                     draft=True),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "user"  # Vendor is still last sent
+        assert result["excluded_drafts"] == 1
+        assert result["last_sender"] == "Vendor <vendor@example.com>"
+
+    def test_all_drafts_returns_none_ball(self):
+        thread = _thread(
+            "t5",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>",
+                     "Mon, 14 Apr 2026 09:00:00 -0400", draft=True),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] is None
+        assert result["excluded_drafts"] == 1
+
+
+class TestParticipantsAndCounts:
+    def test_three_party_thread(self):
+        thread = _thread(
+            "t6",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>", "Mon, 14 Apr 2026 09:00:00 -0400",
+                     to="vendor@example.com", cc="colleague@example.com"),
+                _msg("m2", "Vendor <vendor@example.com>", "Mon, 14 Apr 2026 11:00:00 -0400",
+                     to="alex@alexreynolds.com"),
+                _msg("m3", "Colleague <colleague@example.com>", "Tue, 15 Apr 2026 08:00:00 -0400",
+                     to="alex@alexreynolds.com"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert set(result["participants"]) == {
+            "alex@alexreynolds.com",
+            "vendor@example.com",
+            "colleague@example.com",
+        }
+        assert result["message_count_by_sender"]["alex@alexreynolds.com"] == 1
+        assert result["message_count_by_sender"]["vendor@example.com"] == 1
+        assert result["message_count_by_sender"]["colleague@example.com"] == 1
+
+    def test_quoted_display_name_with_comma_parses_correctly(self):
+        """REGRESSION: a naive split(',') mis-parses To/Cc headers like
+          "Doe, John" <john@example.com>, vendor@example.com
+        The quoted comma splits the first recipient into two pieces and
+        the participant set picks up a phantom "John" entry.
+        email.utils.getaddresses is the RFC-correct parser; this test
+        locks that in."""
+        thread = _thread(
+            "t-quoted-comma",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>",
+                     "Mon, 14 Apr 2026 09:00:00 -0400",
+                     to='"Doe, John" <john@example.com>, vendor@example.com'),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        # Exactly three real participants; no phantom entries from
+        # mis-splitting a quoted display name.
+        assert set(result["participants"]) == {
+            "alex@alexreynolds.com",
+            "john@example.com",
+            "vendor@example.com",
+        }
+
+    def test_user_forwards_to_self_returns_none(self):
+        """User → User (forward-to-self or archive-to-self): there's no
+        external party to owe anything, so ball_in_court_of is None rather
+        than 'them'. Downstream agents doing 'find threads where ball is on
+        them' shouldn't match self-only threads."""
+        thread = _thread(
+            "t7",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>", "Mon, 14 Apr 2026 09:00:00 -0400",
+                     to="alex+archive@alexreynolds.com"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] is None
+
+
+class TestEmptyAndMalformed:
+    def test_empty_thread(self):
+        result = _analyze_thread_ownership_impl({"id": "empty", "messages": []},
+                                                 "alex@alexreynolds.com")
+        assert result["message_count"] == 0
+        assert result["ball_in_court_of"] is None
+        assert result["last_sender"] is None
+
+    def test_malformed_date_falls_back_to_internal(self):
+        """Thread with bad Date header still computes last-sender using internalDate."""
+        thread = _thread(
+            "t8",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>", "bad-date-value",
+                     internal_date_ms="1713360000000"),
+                _msg("m2", "Vendor <vendor@example.com>", "bad-date-value",
+                     internal_date_ms="1713450000000"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "user"
+        assert result["last_sender"] == "Vendor <vendor@example.com>"
+
+    def test_naive_and_aware_datetimes_do_not_raise(self):
+        """REGRESSION: parsedate_to_datetime returns a naive datetime when
+        the header has no timezone (e.g., 'Mon, 14 Apr 2026 09:00:00'). The
+        internalDate fallback path returns aware UTC. Mixing them in > / <
+        comparisons raises TypeError. _parse_date_header must coerce naive
+        to UTC so both paths return comparable datetimes."""
+        thread = _thread(
+            "t-tz",
+            [
+                # No timezone on Date header → naive after parsing
+                _msg("m1", "Alex <alex@alexreynolds.com>",
+                     "Mon, 14 Apr 2026 09:00:00",
+                     to="vendor@example.com"),
+                # Malformed Date → falls back to internalDate (aware UTC).
+                # Pick a timestamp after m1's 2026-04-14 09:00 so the
+                # chronological comparison resolves m2 as the last message.
+                _msg("m2", "Vendor <vendor@example.com>",
+                     "not-a-valid-date",
+                     to="alex@alexreynolds.com",
+                     internal_date_ms="1776600000000"),  # ~Apr 2026
+            ],
+        )
+        # If regression, this raises TypeError from > comparison
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "user"
+        assert result["last_sender"] == "Vendor <vendor@example.com>"
+
+    def test_malformed_from_header_returns_none_ball(self):
+        """If the last message's From header has no parseable address (just
+        a display name, or garbage), we can't determine ball-in-court.
+        Return None rather than silently defaulting to 'user'."""
+        thread = _thread(
+            "t-bad-from",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>", "Mon, 14 Apr 2026 09:00:00 -0400"),
+                # Second message has no parseable email in From
+                _msg("m2", "No Email Here", "Tue, 15 Apr 2026 09:00:00 -0400"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] is None
+
+    def test_single_message_thread(self):
+        thread = _thread(
+            "t9",
+            [
+                _msg("m1", "Vendor <vendor@example.com>", "Mon, 14 Apr 2026 09:00:00 -0400"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["message_count"] == 1
+        assert result["ball_in_court_of"] == "user"
+        assert result["last_sender"] == "Vendor <vendor@example.com>"

--- a/tests/gmail/test_analyze_thread_ownership_schema.py
+++ b/tests/gmail/test_analyze_thread_ownership_schema.py
@@ -1,0 +1,60 @@
+"""Schema contract tests for analyze_thread_ownership.
+
+Follows the pattern in test_modify_gmail_message_labels_schema.py: inspect
+the registered tool via core.tool_registry.get_tool_components and assert
+the input schema shape. This locks the public contract so parameter renames
+or type changes break CI instead of silently shipping.
+
+The tool's return type is `Dict[str, Any]`, which FastMCP serializes as an
+unconstrained object — we cannot assert return-shape keys via the schema
+alone. The behavioral tests in test_analyze_thread_ownership.py pin the
+return keys via direct dict assertions instead.
+"""
+
+from core.server import server
+from core.tool_registry import get_tool_components
+import gmail.gmail_tools  # noqa: F401
+
+
+def test_analyze_thread_ownership_is_registered():
+    """Tool must appear in the registered tool components. If this fails,
+    either the @server.tool decoration is missing or the module isn't
+    imported by the server entrypoint."""
+    components = get_tool_components(server)
+    assert "analyze_thread_ownership" in components
+
+
+def test_analyze_thread_ownership_required_params():
+    """thread_id and user_google_email are both required string params."""
+    components = get_tool_components(server)
+    tool = components["analyze_thread_ownership"]
+    params = tool.parameters
+
+    properties = params["properties"]
+    assert "thread_id" in properties
+    assert "user_google_email" in properties
+    assert properties["thread_id"]["type"] == "string"
+    assert properties["user_google_email"]["type"] == "string"
+
+    # Both parameters must be required — no defaults.
+    required = set(params.get("required", []))
+    assert "thread_id" in required, (
+        "thread_id must be required; a missing thread ID has no safe default"
+    )
+    assert "user_google_email" in required, (
+        "user_google_email must be required; ball-in-court determination "
+        "depends on knowing the authenticated user"
+    )
+
+
+def test_analyze_thread_ownership_no_unexpected_params():
+    """Guard against accidental parameter bloat. If a new parameter is
+    added, this test forces a deliberate update rather than silent
+    expansion of the public contract."""
+    components = get_tool_components(server)
+    params = components["analyze_thread_ownership"].parameters
+    properties = set(params["properties"].keys())
+    assert properties == {"thread_id", "user_google_email"}, (
+        f"Unexpected parameters in analyze_thread_ownership schema: "
+        f"{properties - {'thread_id', 'user_google_email'}}"
+    )


### PR DESCRIPTION
## Description

Adds a new read-only Gmail tool `analyze_thread_ownership` that takes a thread ID and returns structured metadata about the thread's state: last non-draft sender, ball-in-court verdict (`"user"` | `"them"` | `None`), per-sender message counts, participant list, and draft-exclusion count.

**Why this exists.** A common MCP-client pattern is synthesizing who-owes-whom from a thread. Clients often infer this from a date-range search on sent/received messages, which is fragile — same-day follow-ups get missed, thread context is lost, and the "last message" determination ends up wrong. Reading the actual thread chronology via `threads().get(format='full')` eliminates the class of error.

This tool is a thin wrapper over that Gmail API call plus structured header extraction. The structured output shape is designed so downstream agents don't need to parse prose from `get_gmail_thread_content`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

**24 pytest cases total**, all passing:

- `tests/gmail/test_analyze_thread_ownership.py` (21 behavioral cases):
  - **Email normalization** — plus-addressing, display names, empty/malformed input
  - **Date parsing** — RFC822, internalDate fallback, both missing, malformed; plus a regression test for mixed naive/aware datetimes
  - **Ball-in-court logic** — vendor-last, user-last, plus-addressed user
  - **Draft exclusion** — newer draft doesn't flip ownership; all-drafts returns None
  - **Participants and counts** — 3-party thread, quoted-comma display names (e.g. `"Doe, John" <john@example.com>, vendor@example.com`), forwarded-to-self returns None
  - **Empty and single-message threads**, **malformed Date with internalDate fallback**, **malformed From returns None**
- `tests/gmail/test_analyze_thread_ownership_schema.py` (3 cases): follows the `test_modify_gmail_message_labels_schema.py` pattern. Asserts the tool is registered, required params are typed correctly, and no unexpected params have been added to the public contract.

Pure analysis (`_analyze_thread_ownership_impl`) is separated from the `@server.tool` wrapper so tests exercise the logic directly without network or auth. Follows the existing `_impl`-plus-wrapper pattern used by `_rsvp_event_impl`, `_create_event_impl`, etc.

Full repo test suite (`tests/gmail/ tests/auth/`): 121 passed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (timezone coercion rationale, ball-in-court edge cases, multi-alias limitation)
- [x] My changes generate no new warnings
- [x] **Allow edits from maintainers** enabled

## Additional Notes

### Edge cases explicitly handled

- **Plus-addressing.** `alex+foo@domain.com` normalizes to `alex@domain.com` for identity comparison, so a user doesn't appear as a "third party" because of a tagged address.
- **Drafts.** Messages with the `DRAFT` label are excluded from the last-message determination and counted separately in `excluded_drafts`. A newer draft does NOT flip ball-in-court, since drafts haven't been sent.
- **Malformed Date header.** Falls back to Gmail's `internalDate` (Unix ms) for chronological ordering.
- **Self-only threads** (user → user, e.g., forward-to-self or archive-to-self): `ball_in_court_of = None`. There's no external party to owe anything, so downstream agents looking for "ball on them" shouldn't match.
- **Unparseable From** (display name only, no real email): `ball_in_court_of = None`. Rather than silently defaulting to `"user"`, surface the ambiguity.

### Timezone handling (subtle)

`email.utils.parsedate_to_datetime` returns a **naive** datetime when the RFC822 Date header has no timezone offset (e.g., `"Mon, 14 Apr 2026 09:00:00"`). The `internalDate` fallback path returns an **aware** UTC datetime. Mixing them in `>` / `<` comparisons raises `TypeError` at runtime, which would happen on real Gmail threads with any tz-less Date header alongside a malformed one. The helper coerces naive → UTC at parse time so downstream comparisons are safe. A dedicated regression test (`test_naive_and_aware_datetimes_do_not_raise`) covers this case.

### Multi-address parsing

Uses `email.utils.getaddresses` across From/To/Cc in a single call, rather than splitting by comma. This handles quoted display names with embedded commas correctly — e.g., `"Doe, John" <john@example.com>, vendor@example.com` resolves to two recipients, not three.

### Tier registration

Added to `core/tool_tiers.yaml` under `gmail.extended` so users running with `--tool-tier` see the tool.

### Known limitation

`user_google_email` is a single address. A user with multiple aliases (e.g., personal + work) will not be recognized as the same identity across a multi-account thread. Documented in the docstring.

### Return shape

```python
{
    "thread_id": str,
    "thread_subject": str | None,
    "last_sender": str | None,             # raw "Name <addr>" or None
    "last_timestamp": str | None,          # ISO-8601 (UTC-aware)
    "ball_in_court_of": "user" | "them" | None,
    "message_count_by_sender": {           # keyed by normalized email
        "sender@domain.com": int,
    },
    "participants": [                       # sorted, union of From/To/Cc
        "sender@domain.com",
    ],
    "excluded_drafts": int,
    "message_count": int,
}
```

No auth-layer or API-layer changes; purely additive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gmail thread ownership analysis tool that returns thread subject, last active non-draft sender, participants, per-sender message counts, draft exclusions, and a "ball in court" verdict.
* **Tests**
  * Added unit and schema tests validating ownership logic, email/date parsing, draft handling, participant extraction, and tool input schema.
* **Chores**
  * Registered the new tool in the tool tier configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->