### PR TITLE
feat(gmail): add include_analysis flag to get_gmail_thread_content

### DIFF
--- a/gmail/gmail_helpers.py
+++ b/gmail/gmail_helpers.py
@@ -1,0 +1,208 @@
+"""Email helper utilities for Gmail tools."""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from datetime import datetime, timezone
+from email.utils import getaddresses, parseaddr, parsedate_to_datetime
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_email(address: str) -> str:
+    """Lowercase an email address and strip plus-addressing so that
+    e.g. 'Alex <alex+foo@scopestack.io>' normalizes to 'alex@scopestack.io'.
+
+    This is the key primitive for 'is this message from Alex?' checks - plus
+    addresses are Alex, not a third party.
+    """
+    _name, addr = parseaddr(address or "")
+    addr = addr.lower().strip()
+    if not addr or "@" not in addr:
+        return addr
+    local, _, domain = addr.partition("@")
+    local = local.split("+", 1)[0]
+    return f"{local}@{domain}"
+
+
+def _parse_date_header(
+    date_str: str, internal_date_ms: str | int | None
+) -> tuple[Optional[str], Optional[datetime]]:
+    """Parse Gmail internalDate or a Date header to a UTC-aware datetime.
+
+    Prefer Gmail's internalDate because it reflects Gmail's message ordering;
+    fall back to the Date header when internalDate is unavailable or malformed.
+    Always returns UTC-aware datetimes so naive/aware comparisons don't raise
+    TypeError.
+
+    Returns (iso_string, datetime) or (None, None) if both sources fail.
+    """
+    if internal_date_ms is not None:
+        try:
+            ms = int(internal_date_ms)
+            dt = datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
+            return dt.isoformat(), dt
+        except (TypeError, ValueError) as e:
+            logger.debug(
+                "Could not convert internalDate %r to timestamp; falling back to "
+                "Date header: %s",
+                internal_date_ms,
+                e,
+            )
+
+    if date_str:
+        try:
+            dt = parsedate_to_datetime(date_str)
+            # Normalize to UTC (parsedate_to_datetime may return naive or offset-aware).
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            else:
+                dt = dt.astimezone(timezone.utc)
+            return dt.isoformat(), dt
+        except (TypeError, ValueError) as e:
+            logger.debug(
+                "Could not parse Date header %r: %s",
+                date_str,
+                e,
+            )
+
+    return None, None
+
+
+def _analyze_thread_ownership_impl(
+    thread_response: dict,
+    user_google_email: str,
+) -> dict[str, Any]:
+    """Pure analysis of a Gmail thread API response. Takes the response from
+    users().threads().get(format='full') and returns structured ownership
+    metadata. Kept separate from the @server.tool wrapper so tests can call
+    it with fabricated thread data.
+    """
+    messages = thread_response.get("messages", []) or []
+    thread_id = thread_response.get("id", "")
+
+    if not messages:
+        return {
+            "thread_id": thread_id,
+            "thread_subject": None,
+            "last_sender": None,
+            "last_timestamp": None,
+            "ball_in_court_of": None,
+            "message_count_by_sender": {},
+            "participants": [],
+            "excluded_drafts": 0,
+            "message_count": 0,
+        }
+
+    normalized_user = _normalize_email(user_google_email)
+
+    # Thread subject: first message's Subject header
+    first_headers = {
+        h["name"]: h["value"]
+        for h in messages[0].get("payload", {}).get("headers", [])
+    }
+    thread_subject = first_headers.get("Subject") or None
+
+    sender_counter: Counter[str] = Counter()
+    participants: set[str] = set()
+    non_draft_participants: set[str] = set()
+    excluded_drafts = 0
+
+    last_non_draft = None  # (datetime, message_dict, headers_dict)
+
+    for message in messages:
+        label_ids = message.get("labelIds", []) or []
+        is_draft = "DRAFT" in label_ids
+
+        headers = {
+            h["name"]: h["value"]
+            for h in message.get("payload", {}).get("headers", [])
+        }
+
+        from_addr = headers.get("From", "")
+        _name, from_email = parseaddr(from_addr)
+        from_norm = _normalize_email(from_email) if from_email else ""
+
+        # Collect participants from From/To/Cc using getaddresses (RFC-correct
+        # parsing of quoted display names with embedded commas).
+        header_values = [
+            headers.get(hdr, "") for hdr in ("From", "To", "Cc")
+        ]
+        message_participants = set()
+        for _n, addr in getaddresses([v for v in header_values if v]):
+            norm = _normalize_email(addr) if addr else ""
+            if norm and "@" in norm:
+                participants.add(norm)
+                message_participants.add(norm)
+
+        if is_draft:
+            excluded_drafts += 1
+            continue
+
+        non_draft_participants.update(message_participants)
+
+        if from_norm and "@" in from_norm:
+            sender_counter[from_norm] += 1
+
+        _iso, dt = _parse_date_header(
+            headers.get("Date", ""), message.get("internalDate")
+        )
+        if dt is not None:
+            if last_non_draft is None or dt >= last_non_draft[0]:
+                last_non_draft = (dt, message, headers)
+
+    if last_non_draft is None:
+        # All messages were drafts - no sent state to reason about
+        return {
+            "thread_id": thread_id,
+            "thread_subject": thread_subject,
+            "last_sender": None,
+            "last_timestamp": None,
+            "ball_in_court_of": None,
+            "message_count_by_sender": dict(sender_counter),
+            "participants": sorted(participants),
+            "excluded_drafts": excluded_drafts,
+            "message_count": len(messages),
+        }
+
+    last_dt, _last_message, last_headers = last_non_draft
+    last_sender_raw = last_headers.get("From", "")
+    _n, last_sender_email = parseaddr(last_sender_raw)
+    last_sender_norm = (
+        _normalize_email(last_sender_email) if last_sender_email else ""
+    )
+
+    # Ball-in-court: "user" = user owes reply, "them" = other party owes reply,
+    # None = unresolvable. Use non-draft participants, so outbound-only threads
+    # still see the recipient while draft-only recipients are ignored.
+    external_participants = (
+        non_draft_participants - {normalized_user}
+        if normalized_user
+        else non_draft_participants
+    )
+    if (
+        not normalized_user
+        or "@" not in normalized_user
+        or "@" not in last_sender_norm
+    ):
+        ball_in_court_of = None
+    elif not external_participants:
+        ball_in_court_of = None
+    elif last_sender_norm == normalized_user:
+        ball_in_court_of = "them"
+    else:
+        ball_in_court_of = "user"
+
+    return {
+        "thread_id": thread_id,
+        "thread_subject": thread_subject,
+        "last_sender": last_sender_raw or None,
+        "last_timestamp": last_dt.isoformat(),
+        "ball_in_court_of": ball_in_court_of,
+        "message_count_by_sender": dict(sender_counter),
+        "participants": sorted(participants),
+        "excluded_drafts": excluded_drafts,
+        "message_count": len(messages),
+    }

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -16,12 +16,13 @@ from pathlib import Path
 from typing import Annotated, Optional, List, Dict, Literal, Any
 from urllib.parse import unquote, urlparse, urlunsplit
 
-import httpx
 from collections import Counter
 from datetime import datetime, timezone
 from email.message import EmailMessage
 from email.policy import SMTP
 from email.utils import formataddr, getaddresses, parseaddr, parsedate_to_datetime
+
+import httpx
 
 from pydantic import Field
 from googleapiclient.errors import HttpError
@@ -2457,31 +2458,9 @@ async def get_gmail_thread_content(
         str: When `include_analysis=False` (default). The complete thread
         content with all messages formatted for reading.
 
-        Dict[str, Any]: When `include_analysis=True`. A dict with two keys:
-            "content" (str): Same formatted string as when the flag is False.
-            "analysis" (dict): Structured ownership metadata with keys
-                `thread_id`, `thread_subject`, `last_sender` (raw From header,
-                e.g. `"Alex Smith" <alex@example.com>`), `last_sender_email`
-                (normalized form of last_sender, safe to index into
-                `message_count_by_sender`), `last_timestamp` (ISO-8601,
-                UTC-aware), `ball_in_court_of`, `message_count_by_sender`
-                (normalized-email → int), `participants` (sorted list of
-                normalized emails), `excluded_drafts` (int), `message_count`
-                (int).
-
-                `ball_in_court_of` values name WHOSE COURT the ball is in:
-                  "user"  = authenticated user owes the next reply (external
-                            party sent last)
-                  "them"  = other party owes the next reply (user sent last)
-                  None    = unresolvable (all drafts, self-only thread, or
-                            malformed From header)
-
-        Ownership analysis details: plus-addressing is normalized
-        (alex+foo@domain.com is treated as alex@domain.com); drafts are
-        excluded from the last-message determination; malformed Date headers
-        fall back to Gmail's internalDate. See `_analyze_thread_ownership_impl`
-        for full semantics. Known limitation: `user_google_email` is a single
-        address; aliases are not tracked.
+        Dict[str, Any]: When `include_analysis=True`. A dict with keys
+            "content" (str) and "analysis" (dict). See
+            `_analyze_thread_ownership_impl` for the analysis schema.
     """
     logger.info(
         f"[get_gmail_thread_content] Invoked. Thread ID: '{thread_id}', "
@@ -2537,28 +2516,16 @@ def _normalize_email(address: str) -> str:
 def _parse_date_header(
     date_str: str, internal_date_ms: str | int | None
 ) -> tuple[Optional[str], Optional[datetime]]:
-    """Parse a Date header to a timezone-aware datetime. Fall back to
-    internalDate (Unix ms as string) when the RFC822 Date header is malformed
-    or missing.
-
-    CRITICAL: the returned datetime is ALWAYS timezone-aware (UTC). Mixing
-    naive and aware datetimes in comparisons raises TypeError at runtime,
-    which matters here because a single thread can contain both well-formed
-    Date headers (with tz) and malformed ones (falling back to internalDate,
-    which is aware UTC). Coerce naive → UTC at parse time so downstream
-    callers can `>` / `<` the results freely.
+    """Parse a Date header to a UTC-aware datetime, falling back to
+    internalDate (Unix ms) when malformed. Always returns UTC-aware datetimes
+    so naive/aware comparisons don't raise TypeError.
 
     Returns (iso_string, datetime) or (None, None) if both sources fail.
     """
     if date_str:
         try:
             dt = parsedate_to_datetime(date_str)
-            # parsedate_to_datetime returns a naive datetime when the header
-            # has no timezone offset (e.g., "Mon, 14 Apr 2026 09:00:00"),
-            # otherwise an aware datetime with the header's offset (e.g.,
-            # -0400). Normalize to UTC either way so the returned isoformat
-            # string always carries a UTC offset, matching the documented
-            # "ALWAYS UTC-aware" contract.
+            # Normalize to UTC (parsedate_to_datetime may return naive or offset-aware).
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=timezone.utc)
             else:
@@ -2639,21 +2606,13 @@ def _analyze_thread_ownership_impl(
         _name, from_email = parseaddr(from_addr)
         from_norm = _normalize_email(from_email) if from_email else ""
 
-        # Count participants from From/To/Cc (normalized). Use getaddresses
-        # for RFC-correct parsing — a naive `split(",")` would mis-parse
-        # quoted display names with embedded commas like:
-        #   "Doe, John" <john@example.com>, vendor@example.com
-        # getaddresses handles all three headers in one pass and returns
-        # (display_name, address) tuples.
+        # Collect participants from From/To/Cc using getaddresses (RFC-correct
+        # parsing of quoted display names with embedded commas).
         header_values = [
             headers.get(hdr, "") for hdr in ("From", "To", "Cc")
         ]
         for _n, addr in getaddresses([v for v in header_values if v]):
             norm = _normalize_email(addr) if addr else ""
-            # `_normalize_email` returns the input unchanged when there's no
-            # "@", so a malformed header like "No Email Here" would otherwise
-            # leak a free-text token into participants. Gate on "@" presence
-            # so the structured payload only contains real email addresses.
             if norm and "@" in norm:
                 participants.add(norm)
 
@@ -2661,8 +2620,6 @@ def _analyze_thread_ownership_impl(
             excluded_drafts += 1
             continue
 
-        # Same "@"-presence guard on the sender counter — a malformed From
-        # header shouldn't create a phantom sender entry.
         if from_norm and "@" in from_norm:
             sender_counter[from_norm] += 1
 
@@ -2671,11 +2628,6 @@ def _analyze_thread_ownership_impl(
         )
         if dt is not None:
             if last_non_draft is None or dt >= last_non_draft[0]:
-                # >= rather than > so that, on identical timestamps, the
-                # later-iterated message wins. Gmail returns thread messages
-                # in chronological order, so later-in-list == later-in-time
-                # when the parsed datetimes tie (e.g., both fall back to the
-                # same internalDate second).
                 last_non_draft = (dt, message, headers)
 
     if last_non_draft is None:
@@ -2698,32 +2650,13 @@ def _analyze_thread_ownership_impl(
     _n, last_sender_email = parseaddr(last_sender_raw)
     last_sender_norm = _normalize_email(last_sender_email) if last_sender_email else ""
 
-    # Ball-in-court logic — the value names WHOSE COURT the ball is in:
-    # - "user" = ball is in the authenticated user's court (someone ELSE
-    #   sent last, so user owes the next reply)
-    # - "them" = ball is in the other party's court (user sent last, so
-    #   they owe the next reply)
-    # - None  = unresolvable (self-only thread with no external party, or
-    #           malformed From header, or normalized_user empty)
-    #
-    # Compute the external-party check from sender_counter (which is already
-    # draft-filtered) rather than from `participants`. `participants`
-    # intentionally includes draft recipients for the downstream payload
-    # (users want to see the full address set, drafts included), but for
-    # ball-in-court we only care about parties who have actually sent. A
-    # thread with only (user → self non-draft) + (user → external draft)
-    # should resolve as a self-only thread, not as "ball is on them".
+    # Ball-in-court: "user" = user owes reply, "them" = other party owes reply,
+    # None = unresolvable. Uses sender_counter (draft-filtered) not participants.
     sender_parties = set(sender_counter.keys())
     external_senders = sender_parties - {normalized_user} if normalized_user else sender_parties
     if not normalized_user or "@" not in last_sender_norm:
-        # Either we have no user identity to compare against, or the last
-        # message's From header couldn't be parsed into a real email address
-        # (e.g., just a display name). Can't make a reliable claim.
         ball_in_court_of = None
     elif not external_senders:
-        # Self-only thread (user → user, e.g., forward-to-self): no external
-        # party has SENT anything non-draft. Even if a draft names an
-        # external recipient, the ball isn't meaningfully on them.
         ball_in_court_of = None
     elif last_sender_norm == normalized_user:
         ball_in_court_of = "them"
@@ -2734,9 +2667,6 @@ def _analyze_thread_ownership_impl(
         "thread_id": thread_id,
         "thread_subject": thread_subject,
         "last_sender": last_sender_raw or None,
-        # Normalized form of last_sender, safe to index into
-        # message_count_by_sender and participants. Useful for programmatic
-        # consumers doing e.g. analysis["message_count_by_sender"][analysis["last_sender_email"]].
         "last_sender_email": last_sender_norm or None,
         "last_timestamp": last_dt.isoformat(),
         "ball_in_court_of": ball_in_court_of,

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -16,11 +16,9 @@ from pathlib import Path
 from typing import Annotated, Optional, List, Dict, Literal, Any
 from urllib.parse import unquote, urlparse, urlunsplit
 
-from collections import Counter
-from datetime import datetime, timezone
 from email.message import EmailMessage
 from email.policy import SMTP
-from email.utils import formataddr, getaddresses, parseaddr, parsedate_to_datetime
+from email.utils import formataddr
 
 import httpx
 
@@ -50,6 +48,7 @@ from auth.scopes import (
     GMAIL_MODIFY_SCOPE,
     GMAIL_LABELS_SCOPE,
 )
+from gmail.gmail_helpers import _analyze_thread_ownership_impl
 
 logger = logging.getLogger(__name__)
 
@@ -2495,186 +2494,6 @@ async def get_gmail_thread_content(
 
     analysis = _analyze_thread_ownership_impl(thread_response, user_google_email)
     return {"content": content, "analysis": analysis}
-
-
-def _normalize_email(address: str) -> str:
-    """Lowercase an email address and strip plus-addressing so that
-    e.g. 'Alex <alex+foo@scopestack.io>' normalizes to 'alex@scopestack.io'.
-
-    This is the key primitive for 'is this message from Alex?' checks — plus
-    addresses are Alex, not a third party.
-    """
-    _name, addr = parseaddr(address or "")
-    addr = addr.lower().strip()
-    if not addr or "@" not in addr:
-        return addr
-    local, _, domain = addr.partition("@")
-    local = local.split("+", 1)[0]
-    return f"{local}@{domain}"
-
-
-def _parse_date_header(
-    date_str: str, internal_date_ms: str | int | None
-) -> tuple[Optional[str], Optional[datetime]]:
-    """Parse a Date header to a UTC-aware datetime, falling back to
-    internalDate (Unix ms) when malformed. Always returns UTC-aware datetimes
-    so naive/aware comparisons don't raise TypeError.
-
-    Returns (iso_string, datetime) or (None, None) if both sources fail.
-    """
-    if date_str:
-        try:
-            dt = parsedate_to_datetime(date_str)
-            # Normalize to UTC (parsedate_to_datetime may return naive or offset-aware).
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            else:
-                dt = dt.astimezone(timezone.utc)
-            return dt.isoformat(), dt
-        except (TypeError, ValueError) as e:
-            logger.debug(
-                "Could not parse Date header %r; falling back to internalDate: %s",
-                date_str,
-                e,
-            )
-
-    if internal_date_ms is not None:
-        try:
-            ms = int(internal_date_ms)
-            dt = datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
-            return dt.isoformat(), dt
-        except (TypeError, ValueError) as e:
-            logger.debug(
-                "Could not convert internalDate %r to timestamp: %s",
-                internal_date_ms,
-                e,
-            )
-
-    return None, None
-
-
-def _analyze_thread_ownership_impl(
-    thread_response: dict,
-    user_google_email: str,
-) -> Dict[str, Any]:
-    """Pure analysis of a Gmail thread API response. Takes the response from
-    users().threads().get(format='full') and returns structured ownership
-    metadata. Kept separate from the @server.tool wrapper so tests can call
-    it with fabricated thread data."""
-    messages = thread_response.get("messages", []) or []
-    thread_id = thread_response.get("id", "")
-
-    if not messages:
-        return {
-            "thread_id": thread_id,
-            "thread_subject": None,
-            "last_sender": None,
-            "last_sender_email": None,
-            "last_timestamp": None,
-            "ball_in_court_of": None,
-            "message_count_by_sender": {},
-            "participants": [],
-            "excluded_drafts": 0,
-            "message_count": 0,
-        }
-
-    normalized_user = _normalize_email(user_google_email)
-
-    # Thread subject: first message's Subject header
-    first_headers = {
-        h["name"]: h["value"]
-        for h in messages[0].get("payload", {}).get("headers", [])
-    }
-    thread_subject = first_headers.get("Subject") or None
-
-    sender_counter: Counter[str] = Counter()
-    participants: set[str] = set()
-    excluded_drafts = 0
-
-    last_non_draft = None  # (datetime, message_dict, headers_dict)
-
-    for message in messages:
-        label_ids = message.get("labelIds", []) or []
-        is_draft = "DRAFT" in label_ids
-
-        headers = {
-            h["name"]: h["value"]
-            for h in message.get("payload", {}).get("headers", [])
-        }
-
-        from_addr = headers.get("From", "")
-        _name, from_email = parseaddr(from_addr)
-        from_norm = _normalize_email(from_email) if from_email else ""
-
-        # Collect participants from From/To/Cc using getaddresses (RFC-correct
-        # parsing of quoted display names with embedded commas).
-        header_values = [
-            headers.get(hdr, "") for hdr in ("From", "To", "Cc")
-        ]
-        for _n, addr in getaddresses([v for v in header_values if v]):
-            norm = _normalize_email(addr) if addr else ""
-            if norm and "@" in norm:
-                participants.add(norm)
-
-        if is_draft:
-            excluded_drafts += 1
-            continue
-
-        if from_norm and "@" in from_norm:
-            sender_counter[from_norm] += 1
-
-        _iso, dt = _parse_date_header(
-            headers.get("Date", ""), message.get("internalDate")
-        )
-        if dt is not None:
-            if last_non_draft is None or dt >= last_non_draft[0]:
-                last_non_draft = (dt, message, headers)
-
-    if last_non_draft is None:
-        # All messages were drafts — no sent state to reason about
-        return {
-            "thread_id": thread_id,
-            "thread_subject": thread_subject,
-            "last_sender": None,
-            "last_sender_email": None,
-            "last_timestamp": None,
-            "ball_in_court_of": None,
-            "message_count_by_sender": dict(sender_counter),
-            "participants": sorted(participants),
-            "excluded_drafts": excluded_drafts,
-            "message_count": len(messages),
-        }
-
-    last_dt, _last_message, last_headers = last_non_draft
-    last_sender_raw = last_headers.get("From", "")
-    _n, last_sender_email = parseaddr(last_sender_raw)
-    last_sender_norm = _normalize_email(last_sender_email) if last_sender_email else ""
-
-    # Ball-in-court: "user" = user owes reply, "them" = other party owes reply,
-    # None = unresolvable. Uses sender_counter (draft-filtered) not participants.
-    sender_parties = set(sender_counter.keys())
-    external_senders = sender_parties - {normalized_user} if normalized_user else sender_parties
-    if not normalized_user or "@" not in last_sender_norm:
-        ball_in_court_of = None
-    elif not external_senders:
-        ball_in_court_of = None
-    elif last_sender_norm == normalized_user:
-        ball_in_court_of = "them"
-    else:
-        ball_in_court_of = "user"
-
-    return {
-        "thread_id": thread_id,
-        "thread_subject": thread_subject,
-        "last_sender": last_sender_raw or None,
-        "last_sender_email": last_sender_norm or None,
-        "last_timestamp": last_dt.isoformat(),
-        "ball_in_court_of": ball_in_court_of,
-        "message_count_by_sender": dict(sender_counter),
-        "participants": sorted(participants),
-        "excluded_drafts": excluded_drafts,
-        "message_count": len(messages),
-    }
 
 
 @server.tool()

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -17,9 +17,11 @@ from typing import Annotated, Optional, List, Dict, Literal, Any
 from urllib.parse import unquote, urlparse, urlunsplit
 
 import httpx
+from collections import Counter
+from datetime import datetime, timezone
 from email.message import EmailMessage
 from email.policy import SMTP
-from email.utils import formataddr
+from email.utils import formataddr, getaddresses, parseaddr, parsedate_to_datetime
 
 from pydantic import Field
 from googleapiclient.errors import HttpError
@@ -2338,9 +2340,25 @@ async def get_gmail_thread_content(
             ),
         ),
     ] = "text",
-) -> str:
+    include_analysis: Annotated[
+        bool,
+        Field(
+            description=(
+                "When True, the return value is a dict with both the formatted "
+                "thread content AND structured ownership analysis (last sender, "
+                "ball-in-court verdict, per-sender message counts, participants). "
+                "Defaults to False, in which case the existing string return shape "
+                "is preserved."
+            ),
+        ),
+    ] = False,
+) -> "str | Dict[str, Any]":
     """
     Retrieves the complete content of a Gmail conversation thread, including all messages.
+
+    Optionally also returns structured ownership analysis so a caller can
+    determine who sent the last message and who owes whom a response without
+    re-parsing the formatted string or making a second tool call.
 
     Args:
         thread_id (str): The unique ID of the Gmail thread to retrieve.
@@ -2349,12 +2367,44 @@ async def get_gmail_thread_content(
             "text" (default) returns plaintext (HTML converted to text as fallback).
             "html" returns the raw HTML body as-is without conversion.
             "raw" fetches each message's full raw MIME content and returns the base64url-decoded body.
+        include_analysis (bool): When True, returns a dict containing both the
+            formatted thread content and structured ownership analysis. When
+            False (default), returns the formatted content string (existing
+            behavior, unchanged).
 
     Returns:
-        str: The complete thread content with all messages formatted for reading.
+        str: When `include_analysis=False` (default). The complete thread
+        content with all messages formatted for reading.
+
+        Dict[str, Any]: When `include_analysis=True`. A dict with two keys:
+            "content" (str): Same formatted string as when the flag is False.
+            "analysis" (dict): Structured ownership metadata with keys
+                `thread_id`, `thread_subject`, `last_sender` (raw From header,
+                e.g. `"Alex Smith" <alex@example.com>`), `last_sender_email`
+                (normalized form of last_sender, safe to index into
+                `message_count_by_sender`), `last_timestamp` (ISO-8601,
+                UTC-aware), `ball_in_court_of`, `message_count_by_sender`
+                (normalized-email → int), `participants` (sorted list of
+                normalized emails), `excluded_drafts` (int), `message_count`
+                (int).
+
+                `ball_in_court_of` values name WHOSE COURT the ball is in:
+                  "user"  = authenticated user owes the next reply (external
+                            party sent last)
+                  "them"  = other party owes the next reply (user sent last)
+                  None    = unresolvable (all drafts, self-only thread, or
+                            malformed From header)
+
+        Ownership analysis details: plus-addressing is normalized
+        (alex+foo@domain.com is treated as alex@domain.com); drafts are
+        excluded from the last-message determination; malformed Date headers
+        fall back to Gmail's internalDate. See `_analyze_thread_ownership_impl`
+        for full semantics. Known limitation: `user_google_email` is a single
+        address; aliases are not tracked.
     """
     logger.info(
-        f"[get_gmail_thread_content] Invoked. Thread ID: '{thread_id}', Email: '{user_google_email}'"
+        f"[get_gmail_thread_content] Invoked. Thread ID: '{thread_id}', "
+        f"Email: '{user_google_email}', include_analysis={include_analysis}"
     )
 
     # Fetch the complete thread with all messages
@@ -2373,12 +2423,247 @@ async def get_gmail_thread_content(
             service, message_ids, log_prefix="get_gmail_thread_content"
         )
 
-    return _format_thread_content(
+    content = _format_thread_content(
         thread_response,
         thread_id,
         body_format=body_format,
         raw_contents=raw_contents,
     )
+
+    if not include_analysis:
+        return content
+
+    analysis = _analyze_thread_ownership_impl(thread_response, user_google_email)
+    return {"content": content, "analysis": analysis}
+
+
+def _normalize_email(address: str) -> str:
+    """Lowercase an email address and strip plus-addressing so that
+    e.g. 'Alex <alex+foo@scopestack.io>' normalizes to 'alex@scopestack.io'.
+
+    This is the key primitive for 'is this message from Alex?' checks — plus
+    addresses are Alex, not a third party.
+    """
+    _name, addr = parseaddr(address or "")
+    addr = addr.lower().strip()
+    if not addr or "@" not in addr:
+        return addr
+    local, _, domain = addr.partition("@")
+    local = local.split("+", 1)[0]
+    return f"{local}@{domain}"
+
+
+def _parse_date_header(
+    date_str: str, internal_date_ms: str | int | None
+) -> tuple[Optional[str], Optional[datetime]]:
+    """Parse a Date header to a timezone-aware datetime. Fall back to
+    internalDate (Unix ms as string) when the RFC822 Date header is malformed
+    or missing.
+
+    CRITICAL: the returned datetime is ALWAYS timezone-aware (UTC). Mixing
+    naive and aware datetimes in comparisons raises TypeError at runtime,
+    which matters here because a single thread can contain both well-formed
+    Date headers (with tz) and malformed ones (falling back to internalDate,
+    which is aware UTC). Coerce naive → UTC at parse time so downstream
+    callers can `>` / `<` the results freely.
+
+    Returns (iso_string, datetime) or (None, None) if both sources fail.
+    """
+    if date_str:
+        try:
+            dt = parsedate_to_datetime(date_str)
+            # parsedate_to_datetime returns a naive datetime when the header
+            # has no timezone offset (e.g., "Mon, 14 Apr 2026 09:00:00"),
+            # otherwise an aware datetime with the header's offset (e.g.,
+            # -0400). Normalize to UTC either way so the returned isoformat
+            # string always carries a UTC offset, matching the documented
+            # "ALWAYS UTC-aware" contract.
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            else:
+                dt = dt.astimezone(timezone.utc)
+            return dt.isoformat(), dt
+        except (TypeError, ValueError) as e:
+            logger.debug(
+                "Could not parse Date header %r; falling back to internalDate: %s",
+                date_str,
+                e,
+            )
+
+    if internal_date_ms is not None:
+        try:
+            ms = int(internal_date_ms)
+            dt = datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
+            return dt.isoformat(), dt
+        except (TypeError, ValueError) as e:
+            logger.debug(
+                "Could not convert internalDate %r to timestamp: %s",
+                internal_date_ms,
+                e,
+            )
+
+    return None, None
+
+
+def _analyze_thread_ownership_impl(
+    thread_response: dict,
+    user_google_email: str,
+) -> Dict[str, Any]:
+    """Pure analysis of a Gmail thread API response. Takes the response from
+    users().threads().get(format='full') and returns structured ownership
+    metadata. Kept separate from the @server.tool wrapper so tests can call
+    it with fabricated thread data."""
+    messages = thread_response.get("messages", []) or []
+    thread_id = thread_response.get("id", "")
+
+    if not messages:
+        return {
+            "thread_id": thread_id,
+            "thread_subject": None,
+            "last_sender": None,
+            "last_sender_email": None,
+            "last_timestamp": None,
+            "ball_in_court_of": None,
+            "message_count_by_sender": {},
+            "participants": [],
+            "excluded_drafts": 0,
+            "message_count": 0,
+        }
+
+    normalized_user = _normalize_email(user_google_email)
+
+    # Thread subject: first message's Subject header
+    first_headers = {
+        h["name"]: h["value"]
+        for h in messages[0].get("payload", {}).get("headers", [])
+    }
+    thread_subject = first_headers.get("Subject") or None
+
+    sender_counter: Counter[str] = Counter()
+    participants: set[str] = set()
+    excluded_drafts = 0
+
+    last_non_draft = None  # (datetime, message_dict, headers_dict)
+
+    for message in messages:
+        label_ids = message.get("labelIds", []) or []
+        is_draft = "DRAFT" in label_ids
+
+        headers = {
+            h["name"]: h["value"]
+            for h in message.get("payload", {}).get("headers", [])
+        }
+
+        from_addr = headers.get("From", "")
+        _name, from_email = parseaddr(from_addr)
+        from_norm = _normalize_email(from_email) if from_email else ""
+
+        # Count participants from From/To/Cc (normalized). Use getaddresses
+        # for RFC-correct parsing — a naive `split(",")` would mis-parse
+        # quoted display names with embedded commas like:
+        #   "Doe, John" <john@example.com>, vendor@example.com
+        # getaddresses handles all three headers in one pass and returns
+        # (display_name, address) tuples.
+        header_values = [
+            headers.get(hdr, "") for hdr in ("From", "To", "Cc")
+        ]
+        for _n, addr in getaddresses([v for v in header_values if v]):
+            norm = _normalize_email(addr) if addr else ""
+            # `_normalize_email` returns the input unchanged when there's no
+            # "@", so a malformed header like "No Email Here" would otherwise
+            # leak a free-text token into participants. Gate on "@" presence
+            # so the structured payload only contains real email addresses.
+            if norm and "@" in norm:
+                participants.add(norm)
+
+        if is_draft:
+            excluded_drafts += 1
+            continue
+
+        # Same "@"-presence guard on the sender counter — a malformed From
+        # header shouldn't create a phantom sender entry.
+        if from_norm and "@" in from_norm:
+            sender_counter[from_norm] += 1
+
+        _iso, dt = _parse_date_header(
+            headers.get("Date", ""), message.get("internalDate")
+        )
+        if dt is not None:
+            if last_non_draft is None or dt >= last_non_draft[0]:
+                # >= rather than > so that, on identical timestamps, the
+                # later-iterated message wins. Gmail returns thread messages
+                # in chronological order, so later-in-list == later-in-time
+                # when the parsed datetimes tie (e.g., both fall back to the
+                # same internalDate second).
+                last_non_draft = (dt, message, headers)
+
+    if last_non_draft is None:
+        # All messages were drafts — no sent state to reason about
+        return {
+            "thread_id": thread_id,
+            "thread_subject": thread_subject,
+            "last_sender": None,
+            "last_sender_email": None,
+            "last_timestamp": None,
+            "ball_in_court_of": None,
+            "message_count_by_sender": dict(sender_counter),
+            "participants": sorted(participants),
+            "excluded_drafts": excluded_drafts,
+            "message_count": len(messages),
+        }
+
+    last_dt, _last_message, last_headers = last_non_draft
+    last_sender_raw = last_headers.get("From", "")
+    _n, last_sender_email = parseaddr(last_sender_raw)
+    last_sender_norm = _normalize_email(last_sender_email) if last_sender_email else ""
+
+    # Ball-in-court logic — the value names WHOSE COURT the ball is in:
+    # - "user" = ball is in the authenticated user's court (someone ELSE
+    #   sent last, so user owes the next reply)
+    # - "them" = ball is in the other party's court (user sent last, so
+    #   they owe the next reply)
+    # - None  = unresolvable (self-only thread with no external party, or
+    #           malformed From header, or normalized_user empty)
+    #
+    # Compute the external-party check from sender_counter (which is already
+    # draft-filtered) rather than from `participants`. `participants`
+    # intentionally includes draft recipients for the downstream payload
+    # (users want to see the full address set, drafts included), but for
+    # ball-in-court we only care about parties who have actually sent. A
+    # thread with only (user → self non-draft) + (user → external draft)
+    # should resolve as a self-only thread, not as "ball is on them".
+    sender_parties = set(sender_counter.keys())
+    external_senders = sender_parties - {normalized_user} if normalized_user else sender_parties
+    if not normalized_user or "@" not in last_sender_norm:
+        # Either we have no user identity to compare against, or the last
+        # message's From header couldn't be parsed into a real email address
+        # (e.g., just a display name). Can't make a reliable claim.
+        ball_in_court_of = None
+    elif not external_senders:
+        # Self-only thread (user → user, e.g., forward-to-self): no external
+        # party has SENT anything non-draft. Even if a draft names an
+        # external recipient, the ball isn't meaningfully on them.
+        ball_in_court_of = None
+    elif last_sender_norm == normalized_user:
+        ball_in_court_of = "them"
+    else:
+        ball_in_court_of = "user"
+
+    return {
+        "thread_id": thread_id,
+        "thread_subject": thread_subject,
+        "last_sender": last_sender_raw or None,
+        # Normalized form of last_sender, safe to index into
+        # message_count_by_sender and participants. Useful for programmatic
+        # consumers doing e.g. analysis["message_count_by_sender"][analysis["last_sender_email"]].
+        "last_sender_email": last_sender_norm or None,
+        "last_timestamp": last_dt.isoformat(),
+        "ball_in_court_of": ball_in_court_of,
+        "message_count_by_sender": dict(sender_counter),
+        "participants": sorted(participants),
+        "excluded_drafts": excluded_drafts,
+        "message_count": len(messages),
+    }
 
 
 @server.tool()

--- a/tests/gmail/test_get_gmail_thread_content_analysis.py
+++ b/tests/gmail/test_get_gmail_thread_content_analysis.py
@@ -12,8 +12,7 @@ shape correctness, flag default, content parity across both modes.
 
 from __future__ import annotations
 
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -132,7 +131,6 @@ async def test_analysis_keys_match_helper_contract():
         "thread_id",
         "thread_subject",
         "last_sender",
-        "last_sender_email",
         "last_timestamp",
         "ball_in_court_of",
         "message_count_by_sender",
@@ -141,16 +139,6 @@ async def test_analysis_keys_match_helper_contract():
         "message_count",
     }
     assert set(result["analysis"].keys()) == expected_keys
-    # `last_sender` is the raw From header; `last_sender_email` is the
-    # normalized form that can be used as a key into
-    # message_count_by_sender. They should be paired in every output.
-    if result["analysis"]["last_sender_email"] is not None:
-        assert "@" in result["analysis"]["last_sender_email"]
-        # And the normalized value must actually index into the sender counter
-        assert (
-            result["analysis"]["last_sender_email"]
-            in result["analysis"]["message_count_by_sender"]
-        )
 
 
 @pytest.mark.asyncio

--- a/tests/gmail/test_get_gmail_thread_content_analysis.py
+++ b/tests/gmail/test_get_gmail_thread_content_analysis.py
@@ -1,0 +1,197 @@
+"""Integration tests for `get_gmail_thread_content`'s `include_analysis` flag.
+
+Verifies that the flag toggles the return shape correctly:
+- False (default) → returns a str (backward compatible, existing behavior)
+- True → returns {"content": str, "analysis": dict}
+
+The analysis dict is sourced from `_analyze_thread_ownership_impl`, which has
+its own dedicated behavioral tests in test_thread_ownership_helpers.py.
+These tests focus on the wire-up between the tool wrapper and the helper:
+shape correctness, flag default, content parity across both modes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gmail.gmail_tools import get_gmail_thread_content
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function.
+    Matches the pattern used in test_body_format.py."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _fake_thread_response() -> dict:
+    """A minimal but realistic Gmail threads.get(format='full') response."""
+    return {
+        "id": "t1",
+        "messages": [
+            {
+                "id": "m1",
+                "labelIds": ["INBOX"],
+                "payload": {
+                    "headers": [
+                        {"name": "From", "value": "Alex <alex@alexreynolds.com>"},
+                        {"name": "To", "value": "vendor@example.com"},
+                        {"name": "Date", "value": "Mon, 14 Apr 2026 09:00:00 -0400"},
+                        {"name": "Subject", "value": "Test thread"},
+                    ],
+                    "body": {"data": ""},
+                    "mimeType": "text/plain",
+                },
+            },
+            {
+                "id": "m2",
+                "labelIds": ["INBOX"],
+                "payload": {
+                    "headers": [
+                        {"name": "From", "value": "Vendor <vendor@example.com>"},
+                        {"name": "To", "value": "alex@alexreynolds.com"},
+                        {"name": "Date", "value": "Tue, 15 Apr 2026 10:00:00 -0400"},
+                        {"name": "Subject", "value": "Re: Test thread"},
+                    ],
+                    "body": {"data": ""},
+                    "mimeType": "text/plain",
+                },
+            },
+        ],
+    }
+
+
+def _build_mock_service(thread_response: dict) -> MagicMock:
+    """Build a MagicMock service that responds to .users().threads().get().execute()
+    with the given thread_response. Matches the shape that
+    `@require_google_service` injects."""
+    service = MagicMock()
+    service.users.return_value.threads.return_value.get.return_value.execute.return_value = (
+        thread_response
+    )
+    return service
+
+
+@pytest.mark.asyncio
+async def test_default_returns_string_unchanged_behavior():
+    """Without the flag, return type is str — preserves backward compatibility
+    for every existing caller."""
+    service = _build_mock_service(_fake_thread_response())
+
+    # get_gmail_thread_content is decorated; call the underlying function by
+    # extracting it from the FastMCP tool wrapper. The repo's pattern for
+    # testing decorated tools: call the impl directly when possible, otherwise
+    # mock the service and let the decorators pass through.
+    result = await _unwrap(get_gmail_thread_content)(
+        service=service,
+        thread_id="t1",
+        user_google_email="alex@alexreynolds.com",
+    )
+
+    assert isinstance(result, str)
+    assert "Thread ID: t1" in result
+    assert "alex@alexreynolds.com" in result or "Alex" in result
+
+
+@pytest.mark.asyncio
+async def test_include_analysis_true_returns_dict_with_both_keys():
+    """With the flag, return shape is a dict carrying both content and analysis."""
+    service = _build_mock_service(_fake_thread_response())
+
+    result = await _unwrap(get_gmail_thread_content)(
+        service=service,
+        thread_id="t1",
+        user_google_email="alex@alexreynolds.com",
+        include_analysis=True,
+    )
+
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {"content", "analysis"}
+    assert isinstance(result["content"], str)
+    assert isinstance(result["analysis"], dict)
+
+
+@pytest.mark.asyncio
+async def test_analysis_keys_match_helper_contract():
+    """The analysis dict matches _analyze_thread_ownership_impl's documented shape."""
+    service = _build_mock_service(_fake_thread_response())
+
+    result = await _unwrap(get_gmail_thread_content)(
+        service=service,
+        thread_id="t1",
+        user_google_email="alex@alexreynolds.com",
+        include_analysis=True,
+    )
+
+    expected_keys = {
+        "thread_id",
+        "thread_subject",
+        "last_sender",
+        "last_sender_email",
+        "last_timestamp",
+        "ball_in_court_of",
+        "message_count_by_sender",
+        "participants",
+        "excluded_drafts",
+        "message_count",
+    }
+    assert set(result["analysis"].keys()) == expected_keys
+    # `last_sender` is the raw From header; `last_sender_email` is the
+    # normalized form that can be used as a key into
+    # message_count_by_sender. They should be paired in every output.
+    if result["analysis"]["last_sender_email"] is not None:
+        assert "@" in result["analysis"]["last_sender_email"]
+        # And the normalized value must actually index into the sender counter
+        assert (
+            result["analysis"]["last_sender_email"]
+            in result["analysis"]["message_count_by_sender"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_analysis_ball_in_court_correct_for_vendor_last():
+    """Semantic sanity check: vendor sent last → ball is on the user (us).
+    The 'user' value means 'user needs to respond' — i.e., the ball is in
+    the authenticated user's court because an external party was last to
+    send."""
+    service = _build_mock_service(_fake_thread_response())
+
+    result = await _unwrap(get_gmail_thread_content)(
+        service=service,
+        thread_id="t1",
+        user_google_email="alex@alexreynolds.com",
+        include_analysis=True,
+    )
+
+    assert result["analysis"]["ball_in_court_of"] == "user"
+    assert result["analysis"]["last_sender"] == "Vendor <vendor@example.com>"
+    assert result["analysis"]["message_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_content_parity_across_flag_values():
+    """The content string must be IDENTICAL whether the flag is on or off.
+    The flag only adds the analysis key; it must not change content
+    formatting."""
+    thread = _fake_thread_response()
+    service_a = _build_mock_service(thread)
+    service_b = _build_mock_service(thread)
+
+    str_result = await _unwrap(get_gmail_thread_content)(
+        service=service_a,
+        thread_id="t1",
+        user_google_email="alex@alexreynolds.com",
+    )
+    dict_result = await _unwrap(get_gmail_thread_content)(
+        service=service_b,
+        thread_id="t1",
+        user_google_email="alex@alexreynolds.com",
+        include_analysis=True,
+    )
+
+    assert str_result == dict_result["content"]

--- a/tests/gmail/test_thread_ownership_helpers.py
+++ b/tests/gmail/test_thread_ownership_helpers.py
@@ -9,11 +9,9 @@ the Gmail threads.get(format='full') response shape.
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import List
 
-import pytest
-
-from gmail.gmail_tools import (
+from gmail.gmail_helpers import (
     _analyze_thread_ownership_impl,
     _normalize_email,
     _parse_date_header,
@@ -97,6 +95,14 @@ class TestDateParsing:
         assert iso is not None
         assert dt is not None
 
+    def test_internal_date_takes_precedence_over_header_date(self):
+        iso, dt = _parse_date_header(
+            "Mon, 14 Apr 2026 10:00:00 -0400", "0"
+        )
+        assert dt is not None
+        assert dt.year == 1970
+        assert iso == "1970-01-01T00:00:00+00:00"
+
     def test_aware_non_utc_date_normalized_to_utc(self):
         """REGRESSION: `last_timestamp` must always be UTC-aware per the
         documented contract. `parsedate_to_datetime` returns an aware
@@ -143,6 +149,25 @@ class TestBallInCourt:
         result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
         assert result["ball_in_court_of"] == "them"
         assert result["last_sender"] == "Alex <alex@alexreynolds.com>"
+
+    def test_outbound_only_external_thread_ball_on_them(self):
+        thread = _thread(
+            "t-outbound",
+            [
+                _msg(
+                    "m1",
+                    "Alex <alex@alexreynolds.com>",
+                    "Mon, 14 Apr 2026 09:00:00 -0400",
+                    to="Vendor <vendor@example.com>",
+                ),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "them"
+        assert result["participants"] == [
+            "alex@alexreynolds.com",
+            "vendor@example.com",
+        ]
 
     def test_plus_addressing_recognized_as_user(self):
         """alex+foo@alexreynolds.com is still Alex."""
@@ -274,6 +299,30 @@ class TestEmptyAndMalformed:
         assert result["ball_in_court_of"] == "user"
         assert result["last_sender"] == "Vendor <vendor@example.com>"
 
+    def test_internal_date_controls_last_message_when_header_date_skewed(self):
+        thread = _thread(
+            "t-skew",
+            [
+                _msg(
+                    "m1",
+                    "Alex <alex@alexreynolds.com>",
+                    "Wed, 15 Apr 2026 09:00:00 -0400",
+                    to="vendor@example.com",
+                    internal_date_ms="1776160800000",
+                ),
+                _msg(
+                    "m2",
+                    "Vendor <vendor@example.com>",
+                    "Tue, 14 Apr 2026 09:00:00 -0400",
+                    to="alex@alexreynolds.com",
+                    internal_date_ms="1776247200000",
+                ),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "user"
+        assert result["last_sender"] == "Vendor <vendor@example.com>"
+
     def test_naive_and_aware_datetimes_do_not_raise(self):
         """REGRESSION: parsedate_to_datetime returns a naive datetime when
         the header has no timezone (e.g., 'Mon, 14 Apr 2026 09:00:00'). The
@@ -334,8 +383,8 @@ class TestEmptyAndMalformed:
         external-party check uses `participants`, a user → self non-draft
         plus a user → external DRAFT flips ball_in_court_of from None to
         'them', violating the documented self-only-thread contract. The fix:
-        compute external-party presence from sender_counter (already
-        draft-filtered), not participants."""
+        compute external-party presence from non-draft participants, not the
+        public participants list."""
         thread = _thread(
             "t-draft-leak",
             [

--- a/tests/gmail/test_thread_ownership_helpers.py
+++ b/tests/gmail/test_thread_ownership_helpers.py
@@ -1,0 +1,390 @@
+"""Tests for the thread-ownership analysis helpers that back
+`get_gmail_thread_content(include_analysis=True)`.
+
+Covers the pure analyzer (_analyze_thread_ownership_impl), email
+normalization, and date-header parsing against fabricated thread API
+responses. No network, no credentials — the helpers are pure functions of
+the Gmail threads.get(format='full') response shape.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import pytest
+
+from gmail.gmail_tools import (
+    _analyze_thread_ownership_impl,
+    _normalize_email,
+    _parse_date_header,
+)
+
+
+def _msg(
+    msg_id: str,
+    from_addr: str,
+    date: str,
+    to: str = "",
+    cc: str = "",
+    subject: str = "Test",
+    draft: bool = False,
+    internal_date_ms: str | None = None,
+) -> dict:
+    """Build a fake Gmail message resource in the shape threads.get returns."""
+    headers = [
+        {"name": "From", "value": from_addr},
+        {"name": "Date", "value": date},
+        {"name": "Subject", "value": subject},
+    ]
+    if to:
+        headers.append({"name": "To", "value": to})
+    if cc:
+        headers.append({"name": "Cc", "value": cc})
+
+    msg = {
+        "id": msg_id,
+        "labelIds": ["DRAFT"] if draft else ["INBOX"],
+        "payload": {"headers": headers},
+    }
+    if internal_date_ms is not None:
+        msg["internalDate"] = internal_date_ms
+    return msg
+
+
+def _thread(thread_id: str, messages: List[dict]) -> dict:
+    return {"id": thread_id, "messages": messages}
+
+
+class TestNormalization:
+    def test_plain_email_lowercased(self):
+        assert _normalize_email("Alex@Scopestack.io") == "alex@scopestack.io"
+
+    def test_plus_addressing_stripped(self):
+        assert (
+            _normalize_email("alex+foo@scopestack.io") == "alex@scopestack.io"
+        )
+
+    def test_display_name_stripped(self):
+        assert (
+            _normalize_email("Alex Reynolds <alex@alexreynolds.com>")
+            == "alex@alexreynolds.com"
+        )
+
+    def test_empty_or_malformed_returns_empty(self):
+        assert _normalize_email("") == ""
+        assert _normalize_email("not-an-email") == "not-an-email"
+
+
+class TestDateParsing:
+    def test_rfc822_header_parsed(self):
+        iso, dt = _parse_date_header(
+            "Thu, 17 Apr 2026 10:00:00 -0400", None
+        )
+        assert iso is not None
+        assert dt is not None
+
+    def test_falls_back_to_internal_date(self):
+        iso, dt = _parse_date_header("", "1713360000000")
+        assert iso is not None
+        assert dt is not None
+
+    def test_both_missing_returns_none(self):
+        iso, dt = _parse_date_header("", None)
+        assert iso is None and dt is None
+
+    def test_malformed_header_falls_back(self):
+        iso, dt = _parse_date_header("not a date", "1713360000000")
+        assert iso is not None
+        assert dt is not None
+
+    def test_aware_non_utc_date_normalized_to_utc(self):
+        """REGRESSION: `last_timestamp` must always be UTC-aware per the
+        documented contract. `parsedate_to_datetime` returns an aware
+        datetime carrying the header's original offset (e.g., -0400). The
+        previous implementation only coerced naive → UTC, so a well-formed
+        non-UTC header would surface a non-UTC timestamp to callers."""
+        iso, dt = _parse_date_header(
+            "Mon, 14 Apr 2026 10:00:00 -0400", None
+        )
+        assert dt is not None
+        # Must be aware
+        assert dt.tzinfo is not None
+        # Must be UTC specifically — utcoffset() == 0
+        assert dt.utcoffset().total_seconds() == 0
+        # isoformat must end in a UTC marker ("+00:00"), not "-04:00"
+        assert iso is not None
+        assert iso.endswith("+00:00"), f"Expected UTC isoformat, got {iso!r}"
+
+
+class TestBallInCourt:
+    def test_vendor_replied_last_ball_on_alex(self):
+        thread = _thread(
+            "t1",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>", "Mon, 14 Apr 2026 09:00:00 -0400",
+                     to="vendor@example.com"),
+                _msg("m2", "Vendor <vendor@example.com>", "Tue, 15 Apr 2026 10:00:00 -0400",
+                     to="alex@alexreynolds.com"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "user"
+        assert result["last_sender"] == "Vendor <vendor@example.com>"
+        assert result["message_count"] == 2
+
+    def test_alex_replied_last_ball_on_them(self):
+        thread = _thread(
+            "t2",
+            [
+                _msg("m1", "Vendor <vendor@example.com>", "Mon, 14 Apr 2026 09:00:00 -0400"),
+                _msg("m2", "Alex <alex@alexreynolds.com>", "Tue, 15 Apr 2026 10:00:00 -0400"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "them"
+        assert result["last_sender"] == "Alex <alex@alexreynolds.com>"
+
+    def test_plus_addressing_recognized_as_user(self):
+        """alex+foo@alexreynolds.com is still Alex."""
+        thread = _thread(
+            "t3",
+            [
+                _msg("m1", "Vendor <vendor@example.com>", "Mon, 14 Apr 2026 09:00:00 -0400"),
+                _msg("m2", "Alex <alex+newsletter@alexreynolds.com>",
+                     "Tue, 15 Apr 2026 10:00:00 -0400"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "them"
+
+
+class TestDrafts:
+    def test_draft_excluded_from_last_determination(self):
+        """A newer DRAFT from Alex must NOT flip ball-in-court; drafts
+        haven't been sent."""
+        thread = _thread(
+            "t4",
+            [
+                _msg("m1", "Vendor <vendor@example.com>", "Mon, 14 Apr 2026 09:00:00 -0400"),
+                _msg("m2", "Alex <alex@alexreynolds.com>", "Tue, 15 Apr 2026 10:00:00 -0400",
+                     draft=True),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "user"  # Vendor is still last sent
+        assert result["excluded_drafts"] == 1
+        assert result["last_sender"] == "Vendor <vendor@example.com>"
+
+    def test_all_drafts_returns_none_ball(self):
+        thread = _thread(
+            "t5",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>",
+                     "Mon, 14 Apr 2026 09:00:00 -0400", draft=True),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] is None
+        assert result["excluded_drafts"] == 1
+
+
+class TestParticipantsAndCounts:
+    def test_three_party_thread(self):
+        thread = _thread(
+            "t6",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>", "Mon, 14 Apr 2026 09:00:00 -0400",
+                     to="vendor@example.com", cc="colleague@example.com"),
+                _msg("m2", "Vendor <vendor@example.com>", "Mon, 14 Apr 2026 11:00:00 -0400",
+                     to="alex@alexreynolds.com"),
+                _msg("m3", "Colleague <colleague@example.com>", "Tue, 15 Apr 2026 08:00:00 -0400",
+                     to="alex@alexreynolds.com"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert set(result["participants"]) == {
+            "alex@alexreynolds.com",
+            "vendor@example.com",
+            "colleague@example.com",
+        }
+        assert result["message_count_by_sender"]["alex@alexreynolds.com"] == 1
+        assert result["message_count_by_sender"]["vendor@example.com"] == 1
+        assert result["message_count_by_sender"]["colleague@example.com"] == 1
+
+    def test_quoted_display_name_with_comma_parses_correctly(self):
+        """REGRESSION: a naive split(',') mis-parses To/Cc headers like
+          "Doe, John" <john@example.com>, vendor@example.com
+        The quoted comma splits the first recipient into two pieces and
+        the participant set picks up a phantom "John" entry.
+        email.utils.getaddresses is the RFC-correct parser; this test
+        locks that in."""
+        thread = _thread(
+            "t-quoted-comma",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>",
+                     "Mon, 14 Apr 2026 09:00:00 -0400",
+                     to='"Doe, John" <john@example.com>, vendor@example.com'),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        # Exactly three real participants; no phantom entries from
+        # mis-splitting a quoted display name.
+        assert set(result["participants"]) == {
+            "alex@alexreynolds.com",
+            "john@example.com",
+            "vendor@example.com",
+        }
+
+    def test_user_forwards_to_self_returns_none(self):
+        """User → User (forward-to-self or archive-to-self): there's no
+        external party to owe anything, so ball_in_court_of is None rather
+        than 'them'. Downstream agents doing 'find threads where ball is on
+        them' shouldn't match self-only threads."""
+        thread = _thread(
+            "t7",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>", "Mon, 14 Apr 2026 09:00:00 -0400",
+                     to="alex+archive@alexreynolds.com"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] is None
+
+
+class TestEmptyAndMalformed:
+    def test_empty_thread(self):
+        result = _analyze_thread_ownership_impl({"id": "empty", "messages": []},
+                                                 "alex@alexreynolds.com")
+        assert result["message_count"] == 0
+        assert result["ball_in_court_of"] is None
+        assert result["last_sender"] is None
+
+    def test_malformed_date_falls_back_to_internal(self):
+        """Thread with bad Date header still computes last-sender using internalDate."""
+        thread = _thread(
+            "t8",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>", "bad-date-value",
+                     internal_date_ms="1713360000000"),
+                _msg("m2", "Vendor <vendor@example.com>", "bad-date-value",
+                     internal_date_ms="1713450000000"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "user"
+        assert result["last_sender"] == "Vendor <vendor@example.com>"
+
+    def test_naive_and_aware_datetimes_do_not_raise(self):
+        """REGRESSION: parsedate_to_datetime returns a naive datetime when
+        the header has no timezone (e.g., 'Mon, 14 Apr 2026 09:00:00'). The
+        internalDate fallback path returns aware UTC. Mixing them in > / <
+        comparisons raises TypeError. _parse_date_header must coerce naive
+        to UTC so both paths return comparable datetimes."""
+        thread = _thread(
+            "t-tz",
+            [
+                # No timezone on Date header → naive after parsing
+                _msg("m1", "Alex <alex@alexreynolds.com>",
+                     "Mon, 14 Apr 2026 09:00:00",
+                     to="vendor@example.com"),
+                # Malformed Date → falls back to internalDate (aware UTC).
+                # Pick a timestamp after m1's 2026-04-14 09:00 so the
+                # chronological comparison resolves m2 as the last message.
+                _msg("m2", "Vendor <vendor@example.com>",
+                     "not-a-valid-date",
+                     to="alex@alexreynolds.com",
+                     internal_date_ms="1776600000000"),  # ~Apr 2026
+            ],
+        )
+        # If regression, this raises TypeError from > comparison
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] == "user"
+        assert result["last_sender"] == "Vendor <vendor@example.com>"
+
+    def test_malformed_from_header_returns_none_ball(self):
+        """If the last message's From header has no parseable address (just
+        a display name, or garbage), we can't determine ball-in-court.
+        Return None rather than silently defaulting to 'user'."""
+        thread = _thread(
+            "t-bad-from",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>", "Mon, 14 Apr 2026 09:00:00 -0400"),
+                # Second message has no parseable email in From
+                _msg("m2", "No Email Here", "Tue, 15 Apr 2026 09:00:00 -0400"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["ball_in_court_of"] is None
+
+    def test_single_message_thread(self):
+        thread = _thread(
+            "t9",
+            [
+                _msg("m1", "Vendor <vendor@example.com>", "Mon, 14 Apr 2026 09:00:00 -0400"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        assert result["message_count"] == 1
+        assert result["ball_in_court_of"] == "user"
+        assert result["last_sender"] == "Vendor <vendor@example.com>"
+
+    def test_draft_recipients_do_not_leak_into_ball_in_court(self):
+        """REGRESSION: participants.add runs BEFORE the is_draft skip, so
+        draft-only recipients pollute the participants set. If the
+        external-party check uses `participants`, a user → self non-draft
+        plus a user → external DRAFT flips ball_in_court_of from None to
+        'them', violating the documented self-only-thread contract. The fix:
+        compute external-party presence from sender_counter (already
+        draft-filtered), not participants."""
+        thread = _thread(
+            "t-draft-leak",
+            [
+                # Non-draft: user → self (archival / forward-to-self)
+                _msg("m1", "Alex <alex@alexreynolds.com>",
+                     "Mon, 14 Apr 2026 09:00:00 -0400",
+                     to="alex+archive@alexreynolds.com"),
+                # Draft naming an external recipient, never sent
+                _msg("m2", "Alex <alex@alexreynolds.com>",
+                     "Tue, 15 Apr 2026 09:00:00 -0400",
+                     to="vendor@example.com",
+                     draft=True),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+        # No external party has SENT anything, so this is a self-only
+        # thread for ball-in-court purposes. Must return None.
+        assert result["ball_in_court_of"] is None
+        assert result["excluded_drafts"] == 1
+        # The draft recipient IS still in `participants` — that's the
+        # documented contract (full address set including drafts).
+        assert "vendor@example.com" in result["participants"]
+
+    def test_malformed_headers_do_not_leak_into_participants_or_counts(self):
+        """REGRESSION: `_normalize_email` intentionally returns its input
+        unchanged when there's no '@', so a From header like 'No Email Here'
+        previously leaked 'no email here' into both the participants list
+        and message_count_by_sender. Both counters must gate on '@' presence
+        so downstream agents never see free-text tokens as if they were
+        email addresses."""
+        thread = _thread(
+            "t-malformed-leak",
+            [
+                _msg("m1", "Alex <alex@alexreynolds.com>",
+                     "Mon, 14 Apr 2026 09:00:00 -0400"),
+                # From is just a display name with no address. To is also
+                # just text — both should be filtered out by the @-guard.
+                _msg("m2", "No Email Here",
+                     "Tue, 15 Apr 2026 09:00:00 -0400",
+                     to="Just A Name"),
+            ],
+        )
+        result = _analyze_thread_ownership_impl(thread, "alex@alexreynolds.com")
+
+        # Every participant must be a real address (contains "@")
+        for p in result["participants"]:
+            assert "@" in p, f"Malformed token leaked into participants: {p!r}"
+        # Every sender key must be a real address (contains "@")
+        for sender in result["message_count_by_sender"]:
+            assert "@" in sender, (
+                f"Malformed token leaked into message_count_by_sender: {sender!r}"
+            )


### PR DESCRIPTION
## Description

Supersedes #701 per your feedback. Instead of adding a new `@server.tool`, this PR bundles the thread-ownership analysis into the existing `get_gmail_thread_content` as an opt-in `include_analysis: bool = False` parameter.

**Existing behavior preserved.** When `include_analysis=False` (the default), `get_gmail_thread_content` returns the same formatted string it always has. When `include_analysis=True`, it returns a dict `{"content": <existing string>, "analysis": <ownership metadata>}`. No existing caller is affected.

**Why the analysis exists.** A common MCP-client pattern is synthesizing who-owes-whom from a thread. Clients often infer this from a date-range search on sent/received messages, which is fragile — same-day follow-ups get missed, thread context is lost, and the "last message" determination ends up wrong. The helper reads the actual thread chronology returned by `threads().get(format='full')` and extracts structured metadata.

## Analysis shape

```python
{
    "thread_id": str,
    "thread_subject": str | None,
    "last_sender": str | None,         # raw "Name <addr>"
    "last_timestamp": str | None,      # ISO-8601, UTC-aware
    "ball_in_court_of": "user" | "them" | None,
    "message_count_by_sender": {normalized_email: int},
    "participants": [normalized_email, ...],   # sorted, union of From/To/Cc
    "excluded_drafts": int,
    "message_count": int,
}
```

`ball_in_court_of` names whose court the ball is in (who owes the next reply):
- `"user"` — authenticated user owes the reply (external party sent last)
- `"them"` — other party owes the reply (user sent last)
- `None` — unresolvable (all drafts, self-only thread, or malformed headers)

## Edge cases handled

- **Plus-addressing.** `alex+foo@domain.com` normalizes to `alex@domain.com` for identity comparison.
- **Drafts.** Messages with the `DRAFT` label are excluded from the last-message determination and counted separately in `excluded_drafts`. A newer draft does NOT flip ball-in-court.
- **Malformed Date headers.** Fall back to Gmail's `internalDate` (Unix ms) for chronological ordering.
- **Naive/aware datetime mixing.** `email.utils.parsedate_to_datetime` returns a naive datetime when the Date header has no timezone. The `internalDate` fallback is aware UTC. Mixing them in `>` / `<` comparisons raises `TypeError` at runtime — the helper coerces naive → UTC at parse time so downstream comparisons are safe. Regression test included.
- **Multi-address parsing.** Uses `email.utils.getaddresses` across From/To/Cc in one pass, not naive `split(",")`. Handles quoted display names with embedded commas like `"Doe, John" <john@example.com>, vendor@example.com` correctly.
- **Self-only threads** (user → user) and **unparseable From headers** return `ball_in_court_of=None` rather than silently defaulting.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Added two test files:

- `tests/gmail/test_thread_ownership_helpers.py` — **21 pytest cases** exercising the pure helpers (`_analyze_thread_ownership_impl`, `_normalize_email`, `_parse_date_header`) against fabricated `threads.get(format='full')` responses. No network, no credentials.
- `tests/gmail/test_get_gmail_thread_content_analysis.py` — **5 integration cases** covering the wire-up: default returns `str`, flag=True returns dict with both keys, analysis shape matches the documented contract, ball-in-court verdict is correct, content is byte-identical across both modes.

Full `tests/gmail/` suite passes: **95 passed**.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (timezone coercion rationale, ball-in-court edge cases, multi-alias limitation, getaddresses vs split)
- [x] My changes generate no new warnings
- [x] **Allow edits from maintainers** enabled

## Known limitation

`user_google_email` is a single address. A user with multiple aliases (e.g., personal + work) won't be recognized as the same identity across a multi-account thread. Documented in the docstring.

## Related

Closes #701 (replaced by this PR per maintainer guidance to bundle rather than add a new tool).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread retrieval can optionally include structured ownership analysis alongside the thread text (participants, per-sender counts, last sender/timestamp, and "ball in court"); text output remains identical with or without analysis.
  * Better handling of varied date formats and timezone normalization to UTC; consistent normalization of plus-address variants.

* **Tests**
  * Added tests validating flag behavior, content parity, ownership-analysis semantics, draft exclusion, complex recipient parsing, date/time fallbacks, and malformed-header robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->