### PR TITLE
feat(gmail): expose attachment metadata in batch and thread handlers

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -1550,11 +1550,23 @@ async def get_gmail_messages_content_batch(
                         )
                         body_label = "BODY"
 
+                    attachments = _extract_attachments(payload)
+
                     msg_output = "\n".join(
                         _format_message_header_lines(headers, message_id=mid)
                     )
                     msg_output += f"\nWeb Link: {_generate_gmail_web_url(mid)}\n"
                     msg_output += f"\n--- {body_label} ---\n{body_data}\n"
+
+                    if attachments:
+                        msg_output += "\n--- ATTACHMENTS ---\n"
+                        for i, att in enumerate(attachments, 1):
+                            size_kb = att["size"] / 1024
+                            msg_output += (
+                                f"{i}. {att['filename']} ({att['mimeType']}, {size_kb:.1f} KB)\n"
+                                f"   Attachment ID: {att['attachmentId']}\n"
+                                f"   Use get_gmail_attachment_content(message_id='{mid}', attachment_id='{att['attachmentId']}') to download\n"
+                            )
 
                     output_messages.append(msg_output)
 
@@ -2255,9 +2267,10 @@ def _format_thread_content(
 
     # Process each message in the thread
     for i, message in enumerate(messages, 1):
+        payload = message.get("payload", {})
         # Extract headers
         headers = {
-            h["name"]: h["value"] for h in message.get("payload", {}).get("headers", [])
+            h["name"]: h["value"] for h in payload.get("headers", [])
         }
 
         sender = headers.get("From", "(unknown sender)")
@@ -2274,7 +2287,6 @@ def _format_thread_content(
             body_label = "RAW MIME"
         else:
             # Extract both text and HTML bodies
-            payload = message.get("payload", {})
             bodies = _extract_message_bodies(payload)
             text_body = bodies.get("text", "")
             html_body = bodies.get("html", "")
@@ -2284,6 +2296,10 @@ def _format_thread_content(
                 text_body, html_body, body_format=body_format
             )
             body_label = "BODY"
+
+        # Extract attachment metadata for this message
+        attachments = _extract_attachments(payload)
+        message_id = message.get("id", "")
 
         # Add message to content
         content_lines.extend(
@@ -2316,6 +2332,17 @@ def _format_thread_content(
             )
         else:
             content_lines.extend(["", body_data, ""])
+
+        if attachments:
+            content_lines.append("--- ATTACHMENTS ---")
+            for j, att in enumerate(attachments, 1):
+                size_kb = att["size"] / 1024
+                content_lines.append(
+                    f"{j}. {att['filename']} ({att['mimeType']}, {size_kb:.1f} KB)\n"
+                    f"   Attachment ID: {att['attachmentId']}\n"
+                    f"   Use get_gmail_attachment_content(message_id='{message_id}', attachment_id='{att['attachmentId']}') to download"
+                )
+            content_lines.append("")
 
     return "\n".join(content_lines)
 


### PR DESCRIPTION
## Summary

Extends the existing attachment-metadata display (already present in `get_gmail_message_content`) to two more handlers that currently omit it:

- **`get_gmail_messages_content_batch`** (full / plain / html body formats): emits an `--- ATTACHMENTS ---` block per message when attachments are present.
- **`_format_thread_content`** (used by `get_gmail_thread_content` and `get_gmail_threads_content_batch`): same block emitted per message inside the thread.

Reuses the existing `_extract_attachments(payload)` helper — no new logic, no new dependencies.

## Why

The single-message handler already surfaces `filename`, `mimeType`, `size` and `attachmentId` plus a copy-paste suggestion for `get_gmail_attachment_content`. When a consumer fetches messages via the batch or thread handlers, the same payload already contains the attachment metadata, but the output silently drops it — forcing a second roundtrip to the single-message handler just to discover attachment IDs.

This closes the gap so batch/thread outputs are self-sufficient for downstream attachment workflows.

## Change shape

Purely additive:

- No handler signature change.
- Existing output fields (Subject, From, Web Link, body, etc.) unchanged.
- The `--- ATTACHMENTS ---` section is only emitted when `_extract_attachments` returns a non-empty list — zero visible change on messages without attachments.
- Small local refactor in `_format_thread_content`: `payload = message.get("payload", {})` lifted to the top of the per-message loop so it is available in both `raw` and non-`raw` `body_format` branches (required so `_extract_attachments(payload)` works in both).

Diff size: **+29 / -2** lines in one file.

## Test plan

- [x] `python3 -c \"import ast; ast.parse(open('gmail/gmail_tools.py').read())\"` syntax check
- [x] Rebased cleanly onto current `main` (v1.19.0 line)
- [ ] Manual: `get_gmail_messages_content_batch(message_ids=[msg-with-attachment], body_format=\"plain\")` → ATTACHMENTS block appears and IDs resolve via `get_gmail_attachment_content`
- [ ] Manual: `get_gmail_thread_content(thread_id=thread-with-attachment)` → same, per message
- [ ] Regression: both handlers on messages **without** attachments → no ATTACHMENTS block emitted (existing output unchanged)
- [ ] Regression: `get_gmail_messages_content_batch` with `body_format=\"raw\"` and `format=\"metadata\"` → no unintended change

Happy to add unit tests if you'd like — wanted to send the shape first in case you prefer a different approach (e.g. returning a structured object instead of extending the string).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Attachment metadata now displays in messages and threads, showing filename, MIME type, file size (in KB), and attachment ID. This provides improved visibility of attached files and facilitates better management and retrieval of email attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->