### PR TITLE
feat(calendar): add send_updates to create/update/delete event actions

### DIFF
--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -669,6 +669,7 @@ async def _create_event_impl(
     guests_can_modify: Optional[bool] = None,
     guests_can_invite_others: Optional[bool] = None,
     guests_can_see_other_guests: Optional[bool] = None,
+    send_updates: str = "all",
 ) -> str:
     """Internal implementation for creating a calendar event."""
     logger.info(
@@ -845,6 +846,7 @@ async def _create_event_impl(
                     body=event_body,
                     supportsAttachments=True,
                     conferenceDataVersion=1 if add_google_meet else 0,
+                    sendUpdates=send_updates,
                 )
                 .execute()
             )
@@ -857,6 +859,7 @@ async def _create_event_impl(
                     calendarId=calendar_id,
                     body=event_body,
                     conferenceDataVersion=1 if add_google_meet else 0,
+                    sendUpdates=send_updates,
                 )
                 .execute()
             )
@@ -932,6 +935,7 @@ async def _modify_event_impl(
     guests_can_modify: Optional[bool] = None,
     guests_can_invite_others: Optional[bool] = None,
     guests_can_see_other_guests: Optional[bool] = None,
+    send_updates: str = "all",
 ) -> str:
     """Internal implementation for modifying a calendar event."""
     logger.info(
@@ -1132,6 +1136,7 @@ async def _modify_event_impl(
                 eventId=event_id,
                 body=event_body,
                 conferenceDataVersion=1,
+                sendUpdates=send_updates,
             )
             .execute()
         )
@@ -1164,6 +1169,7 @@ async def _delete_event_impl(
     user_google_email: str,
     event_id: str,
     calendar_id: str = "primary",
+    send_updates: str = "all",
 ) -> str:
     """Internal implementation for deleting a calendar event."""
     logger.info(
@@ -1198,7 +1204,13 @@ async def _delete_event_impl(
     # Proceed with the deletion
     await asyncio.to_thread(
         lambda: (
-            service.events().delete(calendarId=calendar_id, eventId=event_id).execute()
+            service.events()
+            .delete(
+                calendarId=calendar_id,
+                eventId=event_id,
+                sendUpdates=send_updates,
+            )
+            .execute()
         )
     )
 
@@ -1221,12 +1233,6 @@ async def _rsvp_event_impl(
     if response not in valid_responses:
         raise ValueError(
             f"Invalid response '{response}'. Must be one of: {sorted(valid_responses)}"
-        )
-
-    valid_send_updates = {"all", "externalOnly", "none"}
-    if send_updates not in valid_send_updates:
-        raise ValueError(
-            f"Invalid send_updates '{send_updates}'. Must be one of: {sorted(valid_send_updates)}"
         )
 
     existing_event = await asyncio.to_thread(
@@ -1337,12 +1343,20 @@ async def manage_event(
         guests_can_see_other_guests (Optional[bool]): Whether attendees can see other guests.
         response (Optional[str]): RSVP response — "accepted", "declined", "tentative", or "needsAction" (rsvp action only).
         rsvp_comment (Optional[str]): Optional message to include with the RSVP response (rsvp action only).
-        send_updates (Optional[str]): Notification behavior for RSVP — "all" (default), "externalOnly", or "none" (rsvp action only).
+        send_updates (Optional[str]): Notification behavior for create, update, delete, and rsvp — "all" (default), "externalOnly", or "none".
 
     Returns:
         str: Confirmation message with event details.
     """
     action_lower = action.lower().strip()
+
+    if send_updates is not None:
+        valid_send_updates = {"all", "externalOnly", "none"}
+        if send_updates not in valid_send_updates:
+            raise ValueError(
+                f"Invalid send_updates '{send_updates}'. Must be one of: {sorted(valid_send_updates)}"
+            )
+
     if action_lower == "create":
         if not summary or not start_time or not end_time:
             raise ValueError(
@@ -1371,6 +1385,7 @@ async def manage_event(
             guests_can_invite_others=guests_can_invite_others,
             guests_can_see_other_guests=guests_can_see_other_guests,
             recurrence=recurrence,
+            send_updates=send_updates or "all",
         )
     elif action_lower == "update":
         if not event_id:
@@ -1397,6 +1412,7 @@ async def manage_event(
             guests_can_modify=guests_can_modify,
             guests_can_invite_others=guests_can_invite_others,
             guests_can_see_other_guests=guests_can_see_other_guests,
+            send_updates=send_updates or "all",
         )
     elif action_lower == "delete":
         if not event_id:
@@ -1406,6 +1422,7 @@ async def manage_event(
             user_google_email=user_google_email,
             event_id=event_id,
             calendar_id=calendar_id,
+            send_updates=send_updates or "all",
         )
     elif action_lower == "rsvp":
         if not event_id:

--- a/tests/gcalendar/test_manage_event.py
+++ b/tests/gcalendar/test_manage_event.py
@@ -12,7 +12,15 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from gcalendar.calendar_tools import _create_event_impl, _modify_event_impl
+from gcalendar.calendar_tools import _create_event_impl, _modify_event_impl, manage_event
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
 
 
 def _create_mock_service():
@@ -101,3 +109,21 @@ async def test_modify_event_can_update_recurrence():
 
     update_body = mock_service.events().update.call_args[1]["body"]
     assert update_body["recurrence"] == ["RRULE:FREQ=WEEKLY;COUNT=6"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["create", "update", "delete", "rsvp"])
+async def test_manage_event_rejects_invalid_send_updates(action):
+    fn = _unwrap(manage_event)
+    with pytest.raises(ValueError, match="Invalid send_updates 'invalid'"):
+        await fn(
+            service=Mock(),
+            user_google_email="user@example.com",
+            action=action,
+            summary="x",
+            start_time="2026-04-06T09:00:00Z",
+            end_time="2026-04-06T09:15:00Z",
+            event_id="evt123",
+            response="accepted",
+            send_updates="invalid",
+        )

--- a/tests/gcalendar/test_rsvp_event.py
+++ b/tests/gcalendar/test_rsvp_event.py
@@ -104,19 +104,6 @@ async def test_rsvp_invalid_response():
         )
 
 
-@pytest.mark.asyncio
-async def test_rsvp_invalid_send_updates():
-    service = Mock()
-    with pytest.raises(ValueError, match="Invalid send_updates 'invalid'"):
-        await _rsvp_event_impl(
-            service=service,
-            user_google_email="user@example.com",
-            event_id="evt123",
-            response="accepted",
-            send_updates="invalid",
-        )
-
-
 # -- Guard tests --
 
 


### PR DESCRIPTION
### Summary

`manage_event` exposes a `send_updates` parameter, but it's currently wired only for the `rsvp` action. The `create`, `update`, and `delete` actions ignore it, so there's no way to control attendee notifications for those flows.

### Changes

- Threaded `send_updates` through `_create_event_impl`, `_modify_event_impl`, and `_delete_event_impl`, forwarding it to the underlying `events().insert / update / delete` calls.
- Updated the `manage_event` docstring to reflect that `send_updates` now applies to create, update, delete, and rsvp.
- Centralized validation of the `send_updates` value in `manage_event` itself, rather than repeating it in each impl.
- Default remains `"all"` across all four actions, matching the existing `rsvp` behavior.

### Behavior note

Google Calendar's implicit default when `sendUpdates` is omitted is effectively "none". Defaulting to `"all"` here is intentional and consistent with the RSVP path's existing default — the tool's opinion is "notify attendees by default; callers can opt out with `externalOnly` or `none`".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event management now consistently accepts a send_updates option for create, update, delete and RSVP operations.

* **Bug Fixes**
  * Centralized validation for send_updates so invalid values are rejected uniformly across all event actions.

* **Tests**
  * Added coverage ensuring send_updates validation applies to all actions; removed the old RSVP-only validation test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->