### PR TITLE
fix(auth): retry legacy OAuth callback without PKCE when Google rejects verifier

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -677,20 +677,13 @@ def handle_auth_callback(
             flow.fetch_token(authorization_response=authorization_response)
             credentials = flow.credentials
         except Exception as exc:
-            if not _is_pkce_verifier_not_needed_error(exc):
-                raise
-
-            logger.warning(
-                "OAuth token exchange rejected PKCE verifier; retrying callback without PKCE."
-            )
-            fallback_flow = create_oauth_flow(
-                scopes=scopes,
-                redirect_uri=redirect_uri,
-                state=state,
-                autogenerate_code_verifier=False,
-            )
-            fallback_flow.fetch_token(authorization_response=authorization_response)
-            credentials = fallback_flow.credentials
+            if _is_pkce_verifier_not_needed_error(exc):
+                logger.error(
+                    "OAuth token exchange rejected PKCE verifier. "
+                    "The authorization code has been consumed and cannot be reused. "
+                    "Please restart the authentication flow from the beginning."
+                )
+            raise
         logger.info("Successfully exchanged authorization code for tokens.")
 
         # Handle partial OAuth grants: if the user declined some scopes on

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -338,6 +338,16 @@ def create_oauth_flow(
     return flow
 
 
+def _is_pkce_verifier_not_needed_error(error: Exception) -> bool:
+    """Detect Google's legacy desktop-client response when PKCE is unnecessary."""
+    message = str(error).lower()
+    return (
+        "invalid_grant" in message
+        and "code_verifier" in message
+        and "not needed" in message
+    )
+
+
 def _determine_oauth_prompt(
     user_google_email: Optional[str],
     required_scopes: List[str],
@@ -651,8 +661,24 @@ def handle_auth_callback(
 
         # Exchange the authorization code for credentials
         # Note: fetch_token will use the redirect_uri configured in the flow
-        flow.fetch_token(authorization_response=authorization_response)
-        credentials = flow.credentials
+        try:
+            flow.fetch_token(authorization_response=authorization_response)
+            credentials = flow.credentials
+        except Exception as exc:
+            if not _is_pkce_verifier_not_needed_error(exc):
+                raise
+
+            logger.warning(
+                "OAuth token exchange rejected PKCE verifier; retrying callback without PKCE."
+            )
+            fallback_flow = create_oauth_flow(
+                scopes=scopes,
+                redirect_uri=redirect_uri,
+                state=state,
+                autogenerate_code_verifier=False,
+            )
+            fallback_flow.fetch_token(authorization_response=authorization_response)
+            credentials = fallback_flow.credentials
         logger.info("Successfully exchanged authorization code for tokens.")
 
         # Handle partial OAuth grants: if the user declined some scopes on

--- a/tests/auth/test_google_auth_callback_refresh_token.py
+++ b/tests/auth/test_google_auth_callback_refresh_token.py
@@ -1,3 +1,4 @@
+import pytest
 from google.oauth2.credentials import Credentials
 
 from auth.google_auth import handle_auth_callback
@@ -19,7 +20,7 @@ class _DummyOAuthStore:
     def validate_and_consume_oauth_state(self, state, session_id=None):  # noqa: ARG002
         return {"session_id": session_id, "code_verifier": "verifier"}
 
-    def consume_latest_oauth_state(self):
+    def consume_latest_oauth_state(self, initiating_session_id=None):  # noqa: ARG002
         return {"session_id": None, "code_verifier": "verifier"}
 
     def get_credentials_by_mcp_session(self, mcp_session_id):  # noqa: ARG002
@@ -131,28 +132,23 @@ def test_callback_prefers_session_refresh_token_over_credential_store(monkeypatc
     assert oauth_store.stored_refresh_token == "session-refresh-token"
 
 
-def test_callback_retries_without_pkce_when_google_rejects_verifier(monkeypatch):
-    callback_credentials = _make_credentials(refresh_token="fresh-refresh-token")
+def test_callback_raises_when_google_rejects_pkce_verifier(monkeypatch):
+    """Test that PKCE verifier rejection raises exception with clear error message.
+
+    OAuth authorization codes are single-use, so retry is not possible.
+    The auth flow must be restarted from the beginning.
+    """
     oauth_store = _DummyOAuthStore(session_credentials=None)
     credential_store = _DummyCredentialStore(existing_credentials=None)
-    create_flow_calls = []
 
-    class _RetryingFlow:
-        def __init__(self, credentials, should_fail):
-            self.credentials = credentials
-            self._should_fail = should_fail
-
+    class _FailingFlow:
         def fetch_token(self, authorization_response):  # noqa: ARG002
-            if self._should_fail:
-                raise Exception(
-                    "(invalid_grant) code_verifier or verifier is not needed."
-                )
-            return None
+            raise Exception(
+                "(invalid_grant) code_verifier or verifier is not needed."
+            )
 
-    def _fake_create_oauth_flow(**kwargs):
-        create_flow_calls.append(kwargs)
-        should_fail = kwargs.get("code_verifier") == "verifier"
-        return _RetryingFlow(callback_credentials, should_fail=should_fail)
+    def _fake_create_oauth_flow(**kwargs):  # noqa: ARG001
+        return _FailingFlow()
 
     monkeypatch.setattr("auth.google_auth.create_oauth_flow", _fake_create_oauth_flow)
     monkeypatch.setattr(
@@ -161,24 +157,13 @@ def test_callback_retries_without_pkce_when_google_rejects_verifier(monkeypatch)
     monkeypatch.setattr(
         "auth.google_auth.get_credential_store", lambda: credential_store
     )
-    monkeypatch.setattr(
-        "auth.google_auth.get_user_info",
-        lambda credentials: {"email": "user@gmail.com"},  # noqa: ARG005
-    )
-    monkeypatch.setattr(
-        "auth.google_auth.save_credentials_to_session", lambda *args: None
-    )
     monkeypatch.setattr("auth.google_auth.is_stateless_mode", lambda: False)
 
-    _email, credentials = handle_auth_callback(
-        scopes=["scope.a"],
-        authorization_response="http://localhost/callback?code=code123",
-        redirect_uri="http://localhost/callback",
-        session_id=None,
-    )
-
-    assert credentials.refresh_token == "fresh-refresh-token"
-    assert create_flow_calls[0]["code_verifier"] == "verifier"
-    assert create_flow_calls[0]["autogenerate_code_verifier"] is False
-    assert "code_verifier" not in create_flow_calls[1]
-    assert create_flow_calls[1]["autogenerate_code_verifier"] is False
+    # Verify the exception is raised
+    with pytest.raises(Exception, match="code_verifier or verifier is not needed"):
+        handle_auth_callback(
+            scopes=["scope.a"],
+            authorization_response="http://localhost/callback?state=abc123&code=code123",
+            redirect_uri="http://localhost/callback",
+            session_id="session-1",
+        )

--- a/tests/auth/test_google_auth_callback_refresh_token.py
+++ b/tests/auth/test_google_auth_callback_refresh_token.py
@@ -19,6 +19,9 @@ class _DummyOAuthStore:
     def validate_and_consume_oauth_state(self, state, session_id=None):  # noqa: ARG002
         return {"session_id": session_id, "code_verifier": "verifier"}
 
+    def consume_latest_oauth_state(self):
+        return {"session_id": None, "code_verifier": "verifier"}
+
     def get_credentials_by_mcp_session(self, mcp_session_id):  # noqa: ARG002
         return self._session_credentials
 
@@ -126,3 +129,56 @@ def test_callback_prefers_session_refresh_token_over_credential_store(monkeypatc
     assert credentials.refresh_token == "session-refresh-token"
     assert credential_store.saved_credentials.refresh_token == "session-refresh-token"
     assert oauth_store.stored_refresh_token == "session-refresh-token"
+
+
+def test_callback_retries_without_pkce_when_google_rejects_verifier(monkeypatch):
+    callback_credentials = _make_credentials(refresh_token="fresh-refresh-token")
+    oauth_store = _DummyOAuthStore(session_credentials=None)
+    credential_store = _DummyCredentialStore(existing_credentials=None)
+    create_flow_calls = []
+
+    class _RetryingFlow:
+        def __init__(self, credentials, should_fail):
+            self.credentials = credentials
+            self._should_fail = should_fail
+
+        def fetch_token(self, authorization_response):  # noqa: ARG002
+            if self._should_fail:
+                raise Exception(
+                    "(invalid_grant) code_verifier or verifier is not needed."
+                )
+            return None
+
+    def _fake_create_oauth_flow(**kwargs):
+        create_flow_calls.append(kwargs)
+        should_fail = kwargs.get("code_verifier") == "verifier"
+        return _RetryingFlow(callback_credentials, should_fail=should_fail)
+
+    monkeypatch.setattr("auth.google_auth.create_oauth_flow", _fake_create_oauth_flow)
+    monkeypatch.setattr(
+        "auth.google_auth.get_oauth21_session_store", lambda: oauth_store
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_credential_store", lambda: credential_store
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_user_info",
+        lambda credentials: {"email": "user@gmail.com"},  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.save_credentials_to_session", lambda *args: None
+    )
+    monkeypatch.setattr("auth.google_auth.is_stateless_mode", lambda: False)
+
+    _email, credentials = handle_auth_callback(
+        scopes=["scope.a"],
+        authorization_response="http://localhost/callback?code=code123",
+        redirect_uri="http://localhost/callback",
+        session_id=None,
+    )
+
+    assert credentials.refresh_token == "fresh-refresh-token"
+    assert create_flow_calls[0]["code_verifier"] == "verifier"
+    assert create_flow_calls[0]["autogenerate_code_verifier"] is False
+    assert "code_verifier" not in create_flow_calls[1]
+    assert create_flow_calls[1]["autogenerate_code_verifier"] is False


### PR DESCRIPTION
Summary:
This fixes a legacy OAuth callback edge case in the single-user / legacy auth path.

In some re-auth flows, Google redirects back without a `state` parameter. The existing fallback recovers the stored PKCE verifier and retries token exchange with that verifier, but Google can reject the exchange with:

`(invalid_grant) code_verifier or verifier is not needed.`

This patch keeps the existing behavior, but if that exact verifier-rejected error occurs, it retries the token exchange once without PKCE instead of failing the auth flow.

Changes:
- add `_is_pkce_verifier_not_needed_error()` helper
- in `handle_auth_callback()`, retry `fetch_token()` once without `code_verifier` when Google returns the specific `invalid_grant` verifier-not-needed error
- add a regression test covering the missing-state fallback + verifier-rejected path

Why:
This was reproduced locally against a streamable-http + `--single-user` deployment using Desktop OAuth credentials. The first callback failed with the verifier-not-needed error; after applying this retry logic, auth completed successfully.

Validation:
- `.venv/bin/python -m pytest tests/auth/test_google_auth_pkce.py tests/auth/test_google_auth_callback_refresh_token.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and logging for a specific Google OAuth token-exchange error to make failures clearer during sign-in callbacks.

* **Tests**
  * Added a test to ensure the sign-in callback surfaces the specific OAuth error case and updated test helpers to support the new scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->