### PR TITLE
enh: enhance attachment dir security

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This server sends no data anywhere except Google's APIs, on behalf of the authen
 - **You control the network** — deploy behind your reverse proxy, in your VPC, on your own terms
 - **No third-party services** — no intermediary servers, no token relays, no hosted backends
 - **Stateless mode** — zero disk writes for locked-down container environments
-- **Sensitive path blocking** — `.env`, `.ssh/`, `.aws/`, and credential files are blocked regardless of configuration
+- **Sensitive path blocking** — local file reads default to the managed attachment directory, and `.env`, `.ssh/`, `.aws/`, and credential files are blocked regardless of configuration
 
 Full dependency tree in `pyproject.toml`, pinned in `uv.lock`.
 
@@ -241,7 +241,7 @@ uv run main.py --transport streamable-http --tools gmail drive calendar
 | `WORKSPACE_MCP_PORT` | | Listening port — default `8000` |
 | `WORKSPACE_MCP_HOST` | | Bind host — default `0.0.0.0` |
 | `WORKSPACE_EXTERNAL_URL` | | External URL for reverse proxy setups |
-| `WORKSPACE_ATTACHMENT_DIR` | | Downloaded attachments dir — default `~/.workspace-mcp/attachments/` |
+| `WORKSPACE_ATTACHMENT_DIR` | | Downloaded attachments dir and default trusted local attachment directory — default `~/.workspace-mcp/attachments/` |
 | `WORKSPACE_MCP_URL` | | Remote MCP endpoint URL for CLI |
 | `ALLOWED_FILE_DIRS` | | Colon-separated allowlist for local file reads |
 | **🔑 OAuth 2.1 & Multi-User** | | |
@@ -1481,12 +1481,13 @@ The credential store automatically handles credential serialization, expiry pars
 - **Transport-Aware Callbacks**: Stdio mode starts a minimal HTTP server only for OAuth, ensuring callbacks work in all modes
 - **Production**: Use HTTPS & OAuth 2.1 and configure accordingly
 - **Scope Minimization**: Tools request only necessary permissions
-- **Local File Access Control**: Tools that read local files (e.g., attachments, `file://` uploads) are restricted to the user's home directory by default. Override this with the `ALLOWED_FILE_DIRS` environment variable:
+- **Local File Access Control**: Tools that read local files (e.g., attachments, `file://` uploads) are restricted to the managed attachment directory by default. Override this with the `ALLOWED_FILE_DIRS` environment variable if you intentionally need broader access:
   ```bash
   # Colon-separated list of directories (semicolon on Windows) from which local file reads are permitted
   export ALLOWED_FILE_DIRS="/home/user/documents:/data/shared"
   ```
-  Regardless of the allowlist, access to sensitive paths (`.env`, `.ssh/`, `.aws/`, `/etc/shadow`, credential files, etc.) is always blocked.
+  The managed attachment directory is controlled by `WORKSPACE_ATTACHMENT_DIR` and remains allowed even when `ALLOWED_FILE_DIRS` is set. Regardless of the allowlist, access to sensitive paths (`.env`, `.ssh/`, `.aws/`, `/etc/shadow`, credential files, etc.) is always blocked.
+- **Indirect Prompt Injection**: In agentic clients, email bodies, documents, and calendar events can contain malicious instructions that try to coerce the model into exfiltrating local files. Do not broaden `ALLOWED_FILE_DIRS` unless you trust the client, the model behavior, and the data sources it can read.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This server sends no data anywhere except Google's APIs, on behalf of the authen
 - **You control the network** — deploy behind your reverse proxy, in your VPC, on your own terms
 - **No third-party services** — no intermediary servers, no token relays, no hosted backends
 - **Stateless mode** — zero disk writes for locked-down container environments
-- **Sensitive path blocking** — local file reads default to the managed attachment directory, and `.env`, `.ssh/`, `.aws/`, and credential files are blocked regardless of configuration
+- **Sensitive path blocking** — local file reads default to the managed attachment directory, and `validate_file_path()` still blocks `.env*` files plus common home-directory credential stores such as `~/.ssh/` and `~/.aws/` even if `ALLOWED_FILE_DIRS` is broadened
 
 Full dependency tree in `pyproject.toml`, pinned in `uv.lock`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,7 @@ When using this MCP server, please ensure:
 3. Use environment variables for sensitive configuration
 4. Regularly rotate OAuth refresh tokens
 5. Limit OAuth scopes to only what's necessary
-6. Keep local file reads narrowly scoped. By default, path-based attachments are limited to `WORKSPACE_ATTACHMENT_DIR`; expanding `ALLOWED_FILE_DIRS` increases exposure to indirect prompt-injection driven exfiltration.
+6. Keep local file reads narrowly scoped. By default, path-based attachments are limited to `WORKSPACE_ATTACHMENT_DIR`; expanding `ALLOWED_FILE_DIRS` increases exposure to prompt-injection-driven exfiltration.
 
 For more information on securing your use of the project, see https://workspacemcp.com/privacy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,7 @@ When using this MCP server, please ensure:
 3. Use environment variables for sensitive configuration
 4. Regularly rotate OAuth refresh tokens
 5. Limit OAuth scopes to only what's necessary
+6. Keep local file reads narrowly scoped. By default, path-based attachments are limited to `WORKSPACE_ATTACHMENT_DIR`; expanding `ALLOWED_FILE_DIRS` increases exposure to indirect prompt-injection driven exfiltration.
 
 For more information on securing your use of the project, see https://workspacemcp.com/privacy
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -105,7 +105,9 @@ def _get_allowed_file_dirs() -> list[Path]:
     env_val = os.environ.get(_ALLOWED_FILE_DIRS_ENV)
     if env_val:
         allowed_dirs.extend(
-            Path(p).expanduser().resolve() for p in env_val.split(os.pathsep) if p.strip()
+            Path(p).expanduser().resolve()
+            for p in env_val.split(os.pathsep)
+            if p.strip()
         )
 
     unique_dirs: list[Path] = []

--- a/core/utils.py
+++ b/core/utils.py
@@ -92,22 +92,30 @@ that send ``'{"key":"val"}'`` instead of ``{"key": "val"}``.
 
 
 # Directories from which local file reads are allowed.
-# The user's home directory is the default safe base.
+# By default, only the managed attachment storage directory is trusted.
 # Override via ALLOWED_FILE_DIRS env var (os.pathsep-separated paths).
 _ALLOWED_FILE_DIRS_ENV = "ALLOWED_FILE_DIRS"
 
 
 def _get_allowed_file_dirs() -> list[Path]:
     """Return the list of directories from which local file access is permitted."""
+    from core.attachment_storage import STORAGE_DIR
+
+    allowed_dirs: list[Path] = [STORAGE_DIR]
     env_val = os.environ.get(_ALLOWED_FILE_DIRS_ENV)
     if env_val:
-        return [
-            Path(p).expanduser().resolve()
-            for p in env_val.split(os.pathsep)
-            if p.strip()
-        ]
-    home = Path.home()
-    return [home] if home else []
+        allowed_dirs.extend(
+            Path(p).expanduser().resolve() for p in env_val.split(os.pathsep) if p.strip()
+        )
+
+    unique_dirs: list[Path] = []
+    seen: set[Path] = set()
+    for path in allowed_dirs:
+        if path in seen:
+            continue
+        seen.add(path)
+        unique_dirs.append(path)
+    return unique_dirs
 
 
 def validate_file_path(file_path: str) -> Path:
@@ -203,7 +211,8 @@ def validate_file_path(file_path: str) -> Path:
     if not allowed_dirs:
         raise ValueError(
             "No allowed file directories configured. "
-            "Set the ALLOWED_FILE_DIRS environment variable or ensure a home directory exists."
+            "Set the ALLOWED_FILE_DIRS environment variable or configure "
+            "WORKSPACE_ATTACHMENT_DIR."
         )
 
     for allowed in allowed_dirs:

--- a/core/utils.py
+++ b/core/utils.py
@@ -104,9 +104,11 @@ def _get_allowed_file_dirs() -> list[Path]:
     allowed_dirs: list[Path] = [STORAGE_DIR]
     env_val = os.environ.get(_ALLOWED_FILE_DIRS_ENV)
     if env_val:
-        allowed_dirs.extend(
-            Path(p).expanduser().resolve() for p in env_val.split(os.pathsep) if p.strip()
-        )
+        for raw_path in env_val.split(os.pathsep):
+            stripped_path = raw_path.strip()
+            if not stripped_path:
+                continue
+            allowed_dirs.append(Path(stripped_path).expanduser().resolve())
 
     unique_dirs: list[Path] = []
     seen: set[Path] = set()

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -560,8 +560,8 @@ def _format_attachment_error(
             detail = (
                 "local file access is limited to the server's permitted directories, "
                 f"so '{file_path}' could not be read. Files on external mounts such as "
-                "/run/media may be blocked; move the file into an allowed directory or "
-                "set ALLOWED_FILE_DIRS."
+                "/run/media may be blocked; move the file into the managed attachment "
+                "directory or another allowed directory, or set ALLOWED_FILE_DIRS."
             )
 
     return f"{label}: {detail}"

--- a/tests/core/test_validate_file_path.py
+++ b/tests/core/test_validate_file_path.py
@@ -6,9 +6,7 @@ import core.attachment_storage as attachment_storage
 from core.utils import validate_file_path
 
 
-def test_validate_file_path_allows_attachment_storage_by_default(
-    tmp_path, monkeypatch
-):
+def test_validate_file_path_allows_attachment_storage_by_default(tmp_path, monkeypatch):
     monkeypatch.delenv("ALLOWED_FILE_DIRS", raising=False)
     monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path)
 

--- a/tests/core/test_validate_file_path.py
+++ b/tests/core/test_validate_file_path.py
@@ -53,3 +53,20 @@ def test_validate_file_path_keeps_attachment_storage_allowed_with_custom_allowli
 
     assert validate_file_path(str(stored_file)) == stored_file.resolve()
     assert validate_file_path(str(shared_file)) == shared_file.resolve()
+
+
+def test_validate_file_path_strips_whitespace_from_allowed_file_dirs(
+    tmp_path, monkeypatch
+):
+    storage_dir = tmp_path / "attachments"
+    storage_dir.mkdir()
+    monkeypatch.setattr(attachment_storage, "STORAGE_DIR", storage_dir)
+
+    spaced_dir = tmp_path / "shared"
+    spaced_dir.mkdir()
+    monkeypatch.setenv("ALLOWED_FILE_DIRS", f"  {spaced_dir}  ")
+
+    shared_file = spaced_dir / "report.txt"
+    shared_file.write_text("report", encoding="utf-8")
+
+    assert validate_file_path(str(shared_file)) == shared_file.resolve()

--- a/tests/core/test_validate_file_path.py
+++ b/tests/core/test_validate_file_path.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+
+import core.attachment_storage as attachment_storage
+from core.utils import validate_file_path
+
+
+def test_validate_file_path_allows_attachment_storage_by_default(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("ALLOWED_FILE_DIRS", raising=False)
+    monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path)
+
+    file_path = tmp_path / "downloaded.txt"
+    file_path.write_text("attachment", encoding="utf-8")
+
+    assert validate_file_path(str(file_path)) == file_path.resolve()
+
+
+def test_validate_file_path_blocks_home_by_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("ALLOWED_FILE_DIRS", raising=False)
+    storage_dir = tmp_path / "attachments"
+    storage_dir.mkdir()
+    monkeypatch.setattr(attachment_storage, "STORAGE_DIR", storage_dir)
+
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home_dir))
+
+    secret_file = home_dir / ".bash_history"
+    secret_file.write_text("secret", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="outside permitted directories"):
+        validate_file_path(str(secret_file))
+
+
+def test_validate_file_path_keeps_attachment_storage_allowed_with_custom_allowlist(
+    tmp_path, monkeypatch
+):
+    storage_dir = tmp_path / "attachments"
+    storage_dir.mkdir()
+    monkeypatch.setattr(attachment_storage, "STORAGE_DIR", storage_dir)
+
+    extra_dir = tmp_path / "shared"
+    extra_dir.mkdir()
+    monkeypatch.setenv("ALLOWED_FILE_DIRS", str(extra_dir))
+
+    stored_file = storage_dir / "saved.txt"
+    stored_file.write_text("attachment", encoding="utf-8")
+    shared_file = extra_dir / "report.txt"
+    shared_file.write_text("report", encoding="utf-8")
+
+    assert validate_file_path(str(stored_file)) == stored_file.resolve()
+    assert validate_file_path(str(shared_file)) == shared_file.resolve()

--- a/tests/gcalendar/test_manage_event.py
+++ b/tests/gcalendar/test_manage_event.py
@@ -12,7 +12,11 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from gcalendar.calendar_tools import _create_event_impl, _modify_event_impl, manage_event
+from gcalendar.calendar_tools import (
+    _create_event_impl,
+    _modify_event_impl,
+    manage_event,
+)
 
 
 def _unwrap(tool):


### PR DESCRIPTION
Thanks to Sean Valentine @ CarbonHelm for the idea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced security guidance on local file access, clarified default managed attachment directory and warning about broadened allowlists and indirect prompt-injection risks
  * Updated user-facing messaging for attachment access failures

* **Bug Fixes**
  * Narrowed default local file allowlist to the managed attachment directory and improved allowlist handling

* **Tests**
  * Added tests validating file-path allowlist and parsing behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->