### PR TITLE
fix: make label_ids schemas compatible with Moonshot/Kimi strict JSON Schema

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2806,14 +2806,8 @@ async def modify_gmail_message_labels(
     service,
     user_google_email: str,
     message_id: str,
-    add_label_ids: Annotated[
-        Optional[StringList],
-        Field(json_schema_extra={"type": "array", "items": {"type": "string"}}),
-    ] = None,
-    remove_label_ids: Annotated[
-        Optional[StringList],
-        Field(json_schema_extra={"type": "array", "items": {"type": "string"}}),
-    ] = None,
+    add_label_ids: Optional[StringList] = None,
+    remove_label_ids: Optional[StringList] = None,
 ) -> str:
     """
     Adds or removes labels from a Gmail message.
@@ -2864,14 +2858,8 @@ async def batch_modify_gmail_message_labels(
     service,
     user_google_email: str,
     message_ids: StringList,
-    add_label_ids: Annotated[
-        Optional[StringList],
-        Field(json_schema_extra={"type": "array", "items": {"type": "string"}}),
-    ] = None,
-    remove_label_ids: Annotated[
-        Optional[StringList],
-        Field(json_schema_extra={"type": "array", "items": {"type": "string"}}),
-    ] = None,
+    add_label_ids: Optional[StringList] = None,
+    remove_label_ids: Optional[StringList] = None,
 ) -> str:
     """
     Adds or removes labels from multiple Gmail messages in a single batch request.

--- a/tests/gmail/test_modify_gmail_message_labels_schema.py
+++ b/tests/gmail/test_modify_gmail_message_labels_schema.py
@@ -3,23 +3,35 @@ from core.tool_registry import get_tool_components
 import gmail.gmail_tools  # noqa: F401
 
 
-def test_modify_gmail_message_labels_optional_arrays_publish_array_type():
+def _assert_optional_string_array_anyof(field_schema):
+    """Assert that field_schema describes `Optional[List[str]]` in Moonshot-
+    compatible form: an ``anyOf`` with an array-of-strings branch and a null
+    branch, and no redundant parent-level ``type``/``items``.
+    """
+    assert "anyOf" in field_schema
+    assert "type" not in field_schema, (
+        "Parent-level `type` alongside `anyOf` breaks Moonshot/Kimi strict "
+        "JSON Schema validation"
+    )
+    assert "items" not in field_schema
+    assert field_schema["default"] is None
+
+    branches = field_schema["anyOf"]
+    assert {"type": "array", "items": {"type": "string"}} in branches
+    assert {"type": "null"} in branches
+
+
+def test_modify_gmail_message_labels_optional_arrays_publish_anyof_array_null():
     components = get_tool_components(server)
     schema = components["modify_gmail_message_labels"].parameters["properties"]
 
     for field_name in ("add_label_ids", "remove_label_ids"):
-        field_schema = schema[field_name]
-        assert field_schema["type"] == "array"
-        assert field_schema["items"] == {"type": "string"}
-        assert field_schema["default"] is None
+        _assert_optional_string_array_anyof(schema[field_name])
 
 
-def test_batch_modify_gmail_message_labels_optional_arrays_publish_array_type():
+def test_batch_modify_gmail_message_labels_optional_arrays_publish_anyof_array_null():
     components = get_tool_components(server)
     schema = components["batch_modify_gmail_message_labels"].parameters["properties"]
 
     for field_name in ("add_label_ids", "remove_label_ids"):
-        field_schema = schema[field_name]
-        assert field_schema["type"] == "array"
-        assert field_schema["items"] == {"type": "string"}
-        assert field_schema["default"] is None
+        _assert_optional_string_array_anyof(schema[field_name])

--- a/tests/gmail/test_modify_gmail_message_labels_schema.py
+++ b/tests/gmail/test_modify_gmail_message_labels_schema.py
@@ -17,6 +17,7 @@ def _assert_optional_string_array_anyof(field_schema):
     assert field_schema["default"] is None
 
     branches = field_schema["anyOf"]
+    assert len(branches) == 2
     assert {"type": "array", "items": {"type": "string"}} in branches
     assert {"type": "null"} in branches
 


### PR DESCRIPTION
## Problem

When connecting this MCP server to an agent whose LLM is Moonshot/Kimi (e.g. `kimi-k2.6`), the entire tool list is rejected with:

```
Invalid request: tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path 'properties.add_label_ids': when using anyOf, type should be
defined in anyOf items instead of the parent schema>
```

## Root cause

Commit [`PR #613`](https://github.com/taylorwilsdon/google_workspace_mcp/pull/613) (closes #611) added `json_schema_extra={"type": "array", "items": {"type": "string"}}` to the `add_label_ids` / `remove_label_ids` parameters. Because those parameters are declared as `Optional[StringList]`, Pydantic already emits an `anyOf: [{"type":"array","items":{"type":"string"}},{"type":"null"}]` schema. Combining both produces a hybrid schema:

```json
{
  "anyOf": [
    {"type": "array", "items": {"type": "string"}},
    {"type": "null"}
  ],
  "default": null,
  "type": "array",
  "items": {"type": "string"}
}
```

OpenAI and Anthropic tolerate this redundancy; Moonshot/Kimi rejects it because the strict moonshot-flavored schema requires `type` to live **inside** each `anyOf` branch, not on the parent.

## Fix

Remove `json_schema_extra` from the two affected tool signatures. Pydantic then generates the standard Moonshot-compatible form:

```json
{
  "anyOf": [
    {"type": "array", "items": {"type": "string"}},
    {"type": "null"}
  ],
  "default": null
}
```

Affected functions (both in `gmail/gmail_tools.py`):
- `modify_gmail_message_labels`
- `batch_modify_gmail_message_labels`

## Why this is safe

- The `StringList = Annotated[List[str], BeforeValidator(_coerce_json_str_to_list)]` alias (from `core/utils.py`) already provides runtime coercion for MCP clients that serialise arrays as JSON strings — i.e. the original problem that motivated #611 (`'[\"Label_57\"]'` → `[\"Label_57\"]`) is still handled by the `BeforeValidator`, not by `json_schema_extra`.
- The emitted schema now contains `{\"type\": \"array\", \"items\": {\"type\": \"string\"}}` inside the first `anyOf` branch, so clients that rely on `type: array` to pass native lists still see it — just in the correct JSON-Schema location.

## Verification

- Inspected the live MCP `tools/list` output before/after — `anyOf` branches now include `type`, and no duplicate parent-level `type` / `items`.
- Called `list_gmail_labels` and verified Claude Code (Anthropic) still parses the schema and the tool still returns successfully.
- The same server running behind a Moonshot/Kimi-backed agent no longer raises the `anyOf`-location error.

## Compatibility notes

No behavioural change for existing clients; only the JSON-Schema shape changes. `modify_gmail_message_labels` / `batch_modify_gmail_message_labels` still accept:
- `["Label_57"]` (native array)
- `'[\"Label_57\"]'` (JSON-encoded string — via the unchanged `BeforeValidator`)
- `None` / omission (default)

Closes (partially) the integration gap for Moonshot/Kimi-hosted agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified how optional label ID lists are represented for Gmail label-modification tools; behavior and defaults unchanged.
* **Tests**
  * Updated and refactored tests to validate the new schema representation for optional label lists (array of strings or null) and reduced duplicated assertions via a shared helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->