### PR TITLE
fix(auth): release googleapiclient Resource cycles to prevent OOM

### DIFF
--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -1,3 +1,4 @@
+import gc
 import inspect
 import json
 import logging
@@ -792,6 +793,10 @@ def require_google_service(
             finally:
                 if service:
                     service.close()
+                # googleapiclient's Resource tree holds circular refs that
+                # service.close() doesn't break. Without this sweep, memory
+                # grows on every call.
+                gc.collect()
 
         # Set the wrapper's signature to the one without 'service'
         wrapper.__signature__ = wrapper_sig


### PR DESCRIPTION
Runs a garbage collection pass in require_google_service's finally block, right after service.close(). googleapiclient's Resource objects reference each other in a loop that close() doesn't break, so without an explicit collection the memory from each call piles up until the memory runs out.

## Verification
- Local reproduction at 384Mi memory limit: previously OOM'd on `modify_sheet_values` around call 7.
  With this change, RSS plateaus at ~216 MB across 24+ tool calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved memory management efficiency in the authentication service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->