### PR TITLE
feat: add GCSCredentialStore backend with optional CMEK enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1471,11 +1471,11 @@ export WORKSPACE_MCP_GCS_REQUIRE_CMEK="true"                # optional; see belo
 
 By default GCS encrypts objects with Google-managed keys. For customer-managed encryption, set a default KMS key on the bucket (e.g. via Terraform's `google_storage_bucket.encryption.default_kms_key_name`). All credentials written to the bucket will inherit the key transparently — no application-level key to manage.
 
-To guard against accidentally deploying against a bucket without CMEK, set `WORKSPACE_MCP_GCS_REQUIRE_CMEK=true`. The store will verify the bucket has a default KMS key at startup and refuse to initialise otherwise.
+To guard against accidentally deploying against a bucket without CMEK, set `WORKSPACE_MCP_GCS_REQUIRE_CMEK=true`. The store will verify the bucket has a default KMS key at startup and refuse to initialise otherwise. Note that this check reads bucket metadata, so the runtime service account additionally needs `storage.buckets.get` (provided by `roles/storage.legacyBucketReader` or `roles/storage.admin`) — `roles/storage.objectUser` alone only covers object operations.
 
 **Usage Example:**
 ```python
-from auth.credential_store import get_credential_store
+from auth.credential_store import get_credential_store, LocalDirectoryCredentialStore
 
 # Get the global credential store instance
 store = get_credential_store()
@@ -1486,8 +1486,11 @@ store.store_credential("user@example.com", credentials)
 # Retrieve credentials
 creds = store.get_credential("user@example.com")
 
-# List all users with stored credentials
-users = store.list_users()
+# List all users with stored credentials (local_directory backend only;
+# GCSCredentialStore intentionally does not support enumeration — use the
+# upstream identity provider to enumerate users instead).
+if isinstance(store, LocalDirectoryCredentialStore):
+    users = store.list_users()
 ```
 
 The credential store automatically handles credential serialization, expiry parsing, and provides error handling for storage operations.

--- a/README.md
+++ b/README.md
@@ -253,6 +253,13 @@ uv run main.py --transport streamable-http --tools gmail drive calendar
 | `OAUTH_ALLOWED_ORIGINS` | | Comma-separated additional CORS origins |
 | `WORKSPACE_MCP_OAUTH_PROXY_STORAGE_BACKEND` | | `memory`, `disk`, or `valkey` — see [storage backends](#oauth-proxy-storage-backends) |
 | `FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY` | | Custom encryption key for OAuth proxy storage; required for public OAuth 2.1 clients when `GOOGLE_OAUTH_CLIENT_SECRET` is omitted |
+| **🗄️ Credential Store** | | |
+| `WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND` | | `local_directory` (default) or `gcs` — see [credential store system](#credential-store-system) |
+| `WORKSPACE_MCP_CREDENTIALS_DIR` | | Directory for the `local_directory` backend |
+| `GOOGLE_MCP_CREDENTIALS_DIR` | | Backward-compatible alias for `WORKSPACE_MCP_CREDENTIALS_DIR` |
+| `WORKSPACE_MCP_GCS_BUCKET` | | **Required when backend is `gcs`** — GCS bucket name |
+| `WORKSPACE_MCP_GCS_PREFIX` | | Optional object-name prefix for the `gcs` backend |
+| `WORKSPACE_MCP_GCS_REQUIRE_CMEK` | | `true` to require a bucket default KMS key at startup (fails fast if unset) |
 | **🔧 Service Account** | | |
 | `GOOGLE_SERVICE_ACCOUNT_KEY_FILE` | | Path to service account JSON key file (domain-wide delegation) |
 | `GOOGLE_SERVICE_ACCOUNT_KEY_JSON` | | Inline service account JSON key (alternative to file) |
@@ -1471,7 +1478,7 @@ export WORKSPACE_MCP_GCS_REQUIRE_CMEK="true"                # optional; see belo
 
 By default GCS encrypts objects with Google-managed keys. For customer-managed encryption, set a default KMS key on the bucket (e.g. via Terraform's `google_storage_bucket.encryption.default_kms_key_name`). All credentials written to the bucket will inherit the key transparently — no application-level key to manage.
 
-To guard against accidentally deploying against a bucket without CMEK, set `WORKSPACE_MCP_GCS_REQUIRE_CMEK=true`. The store will verify the bucket has a default KMS key at startup and refuse to initialise otherwise. Note that this check reads bucket metadata, so the runtime service account additionally needs `storage.buckets.get` (provided by `roles/storage.legacyBucketReader` or `roles/storage.admin`) — `roles/storage.objectUser` alone only covers object operations.
+To guard against accidentally deploying against a bucket without CMEK, set `WORKSPACE_MCP_GCS_REQUIRE_CMEK=true`. The store will verify the bucket has a default KMS key at startup and refuse to initialise otherwise. Note that this check reads bucket metadata, so the runtime service account additionally needs `storage.buckets.get` — grant `roles/storage.bucketViewer` on the bucket (or a custom role containing `storage.buckets.get`) in addition to the object-level role. `roles/storage.objectUser` alone covers only object operations.
 
 **Usage Example:**
 ```python

--- a/README.md
+++ b/README.md
@@ -1433,25 +1433,45 @@ async def your_new_tool(service, param1: str, param2: int = 10):
 
 ### Credential Store System
 
-The server includes an abstract credential store API and a default backend for managing Google OAuth
-credentials with support for multiple storage backends:
+The server includes an abstract credential store API with pluggable backends for managing Google OAuth credentials:
 
 **Features:**
 - **Abstract Interface**: `CredentialStore` base class defines standard operations (get, store, delete, list users)
-- **Local File Storage**: `LocalDirectoryCredentialStore` implementation stores credentials as JSON files
-- **Configurable Storage**: Environment variable `GOOGLE_MCP_CREDENTIALS_DIR` sets storage location
+- **Local File Storage**: `LocalDirectoryCredentialStore` — plaintext JSON files protected by filesystem permissions (0o600 / 0o700)
+- **GCS-Backed Storage**: `GCSCredentialStore` — stores each user's credentials as an object in a Google Cloud Storage bucket. Supports atomic read-modify-write via generation preconditions, first-class Cloud IAM / Audit Logs integration, and transparent bucket-level CMEK encryption at rest
+- **Configurable Storage**: Environment variables select backend and location
 - **Multi-User Support**: Store and manage credentials for multiple Google accounts
-- **Automatic Directory Creation**: Storage directory is created automatically if it doesn't exist
+- **Automatic Directory Creation**: Storage directory is created automatically if it doesn't exist (local backend)
 
 **Configuration:**
 ```bash
-# Optional: Set custom credentials directory
+# Select backend (default: local_directory). Supported: local_directory, gcs
+export WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND="gcs"
+
+# --- local_directory options ---
+export WORKSPACE_MCP_CREDENTIALS_DIR="/path/to/credentials"
+# Backward-compatible alias:
 export GOOGLE_MCP_CREDENTIALS_DIR="/path/to/credentials"
 
-# Default locations (if GOOGLE_MCP_CREDENTIALS_DIR not set):
+# Default directory locations (if no directory env var is set):
 # - ~/.google_workspace_mcp/credentials (if home directory accessible)
 # - ./.credentials (fallback)
+
+# --- gcs options ---
+export WORKSPACE_MCP_GCS_BUCKET="my-workspace-mcp-tokens"   # required
+export WORKSPACE_MCP_GCS_PREFIX="credentials/"              # optional
+export WORKSPACE_MCP_GCS_REQUIRE_CMEK="true"                # optional; see below
 ```
+
+**Backend selection:**
+- `local_directory` (default): Plaintext JSON records. Suitable for local development and single-user stdio mode.
+- `gcs`: Stores credentials as objects in a GCS bucket using the JSON API. Authenticates via Application Default Credentials — on Cloud Run this means the runtime service account needs `roles/storage.objectUser` (or equivalent) on the bucket. Does not support `list_users()` — designed for multi-user OAuth 2.1 mode where users are looked up individually by email.
+
+**CMEK enforcement (gcs backend):**
+
+By default GCS encrypts objects with Google-managed keys. For customer-managed encryption, set a default KMS key on the bucket (e.g. via Terraform's `google_storage_bucket.encryption.default_kms_key_name`). All credentials written to the bucket will inherit the key transparently — no application-level key to manage.
+
+To guard against accidentally deploying against a bucket without CMEK, set `WORKSPACE_MCP_GCS_REQUIRE_CMEK=true`. The store will verify the bucket has a default KMS key at startup and refuse to initialise otherwise.
 
 **Usage Example:**
 ```python

--- a/auth/credential_store.py
+++ b/auth/credential_store.py
@@ -397,12 +397,12 @@ class GCSCredentialStore(CredentialStore):
         for attempt in range(3):
             blob = self._bucket.blob(self._blob_name(user_email))
             try:
-                blob.reload()
-                generation = blob.generation
-            except NotFound:
-                generation = 0  # must-not-exist precondition
+                try:
+                    blob.reload()
+                    generation = blob.generation
+                except NotFound:
+                    generation = 0  # must-not-exist precondition
 
-            try:
                 blob.upload_from_string(
                     payload,
                     content_type="application/json",
@@ -454,9 +454,32 @@ class GCSCredentialStore(CredentialStore):
         )
 
 
-def _parse_bool_env(value: str) -> bool:
-    """Parse a truthy env var value; defaults to False."""
-    return value.strip().lower() in ("1", "true", "yes", "on")
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"", "0", "false", "no", "off"})
+
+
+def _parse_bool_env(value: Optional[str]) -> bool:
+    """Parse a boolean env var value, failing loudly on anything unrecognised.
+
+    Accepts (case-insensitive, whitespace-trimmed):
+        true:  ``1``, ``true``, ``yes``, ``on``
+        false: ``0``, ``false``, ``no``, ``off``, empty string, None
+
+    Raises ValueError for any other input. The strict parsing matters for
+    security-relevant flags (e.g. ``WORKSPACE_MCP_GCS_REQUIRE_CMEK``) where
+    a typo like ``"treu"`` would otherwise silently disable the flag.
+    """
+    if value is None:
+        return False
+    normalised = value.strip().lower()
+    if normalised in _TRUE_VALUES:
+        return True
+    if normalised in _FALSE_VALUES:
+        return False
+    raise ValueError(
+        f"Invalid boolean env var value: {value!r}. "
+        f"Expected one of: {sorted(_TRUE_VALUES | _FALSE_VALUES - {''})}"
+    )
 
 
 # Global credential store instance

--- a/auth/credential_store.py
+++ b/auth/credential_store.py
@@ -381,8 +381,15 @@ class GCSCredentialStore(CredentialStore):
         )
 
     def store_credential(self, user_email: str, credentials: Credentials) -> bool:
-        """Serialize and upload credentials, using generation preconditions
-        to guarantee atomic read-modify-write under concurrent writers."""
+        """Serialize and upload credentials using a generation precondition.
+
+        Fails fast on concurrent writes (HTTP 412). We deliberately do NOT
+        retry: the payload we hold reflects the *pre-race* state, so
+        retrying with a fresh generation but the same payload would
+        overwrite a racing writer's updates. Returning False signals the
+        caller to abandon this attempt; the next credential refresh will
+        read the latest state and try again.
+        """
         creds_data = {
             "token": credentials.token,
             "refresh_token": credentials.refresh_token,
@@ -394,36 +401,30 @@ class GCSCredentialStore(CredentialStore):
         }
         payload = json.dumps(creds_data).encode()
 
-        for attempt in range(3):
-            blob = self._bucket.blob(self._blob_name(user_email))
+        blob = self._bucket.blob(self._blob_name(user_email))
+        try:
             try:
-                try:
-                    blob.reload()
-                    generation = blob.generation
-                except NotFound:
-                    generation = 0  # must-not-exist precondition
+                blob.reload()
+                generation = blob.generation
+            except NotFound:
+                generation = 0  # must-not-exist precondition
 
-                blob.upload_from_string(
-                    payload,
-                    content_type="application/json",
-                    if_generation_match=generation,
-                )
-                logger.info(f"Stored credentials for {user_email}")
-                return True
-            except PreconditionFailed:
-                logger.info(
-                    f"Concurrent write detected for {user_email}; "
-                    f"retrying (attempt {attempt + 1}/3)"
-                )
-                continue
-            except Exception as e:
-                logger.error(f"Error storing credentials for {user_email}: {e}")
-                return False
-
-        logger.error(
-            f"Failed to store credentials for {user_email} after 3 attempts"
-        )
-        return False
+            blob.upload_from_string(
+                payload,
+                content_type="application/json",
+                if_generation_match=generation,
+            )
+            logger.info(f"Stored credentials for {user_email}")
+            return True
+        except PreconditionFailed:
+            logger.warning(
+                f"Concurrent write detected for {user_email}; "
+                f"abandoning this write so next refresh can merge current state"
+            )
+            return False
+        except Exception as e:
+            logger.error(f"Error storing credentials for {user_email}: {e}")
+            return False
 
     def delete_credential(self, user_email: str) -> bool:
         """Delete a user's credentials object; idempotent."""
@@ -496,11 +497,19 @@ def get_credential_store() -> CredentialStore:
     global _credential_store
 
     if _credential_store is None:
-        backend = os.getenv("WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND", "").lower()
+        backend = (
+            os.getenv("WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND", "").strip().lower()
+            or "local_directory"
+        )
         if backend == "gcs":
             _credential_store = GCSCredentialStore()
-        else:
+        elif backend == "local_directory":
             _credential_store = LocalDirectoryCredentialStore()
+        else:
+            raise ValueError(
+                f"Unsupported WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND: {backend!r}. "
+                f"Expected 'local_directory' or 'gcs'."
+            )
         logger.info(f"Initialized credential store: {type(_credential_store).__name__}")
 
     return _credential_store

--- a/auth/credential_store.py
+++ b/auth/credential_store.py
@@ -12,6 +12,8 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Optional, List
 from datetime import datetime
+from google.cloud import storage
+from google.cloud.exceptions import NotFound, PreconditionFailed
 from google.oauth2.credentials import Credentials
 
 logger = logging.getLogger(__name__)
@@ -249,6 +251,214 @@ class LocalDirectoryCredentialStore(CredentialStore):
         return sorted(users)
 
 
+class GCSCredentialStore(CredentialStore):
+    """Credential store backed directly by a Google Cloud Storage bucket.
+
+    Uses the GCS JSON API (not a gcsfuse mount) which provides:
+    - Atomic read-modify-write via generation preconditions (prevents lost
+      updates on concurrent token rotation).
+    - First-class integration with Cloud IAM, Cloud Audit Logs, and VPC-SC.
+    - Transparent bucket-level CMEK encryption at rest (no app-level key).
+
+    Confidentiality at rest is delegated to the bucket's encryption
+    configuration:
+    - Default: Google-managed encryption (always on, zero configuration).
+    - CMEK: Set the bucket's default_kms_key_name (e.g. via Terraform).
+      Every object inherits the key; no per-request configuration needed.
+
+    To guard against accidentally deploying against a bucket without CMEK,
+    set ``WORKSPACE_MCP_GCS_REQUIRE_CMEK=true``. The store will fail at
+    startup if the bucket has no default KMS key configured.
+
+    This backend does not support ``list_users()`` — it is designed for
+    multi-user OAuth 2.1 mode where users are looked up by email.
+
+    Configuration (env vars):
+        WORKSPACE_MCP_GCS_BUCKET         — bucket name (required)
+        WORKSPACE_MCP_GCS_PREFIX         — object prefix, default empty
+        WORKSPACE_MCP_GCS_REQUIRE_CMEK   — "true"/"1" to enforce CMEK
+    """
+
+    FILE_EXTENSION = ".json"
+
+    def __init__(
+        self,
+        bucket_name: Optional[str] = None,
+        prefix: Optional[str] = None,
+        require_cmek: Optional[bool] = None,
+    ):
+        bucket_name = bucket_name or os.getenv("WORKSPACE_MCP_GCS_BUCKET")
+        if not bucket_name:
+            raise ValueError(
+                "GCSCredentialStore requires a bucket name; "
+                "pass bucket_name or set WORKSPACE_MCP_GCS_BUCKET"
+            )
+        self.bucket_name = bucket_name
+
+        prefix = prefix if prefix is not None else os.getenv(
+            "WORKSPACE_MCP_GCS_PREFIX", ""
+        )
+        self.prefix = prefix.strip("/")
+        if self.prefix:
+            self.prefix += "/"
+
+        if require_cmek is None:
+            require_cmek = _parse_bool_env(
+                os.getenv("WORKSPACE_MCP_GCS_REQUIRE_CMEK", "")
+            )
+
+        self._client = storage.Client()
+        self._bucket = self._client.bucket(bucket_name)
+
+        if require_cmek:
+            self._verify_cmek()
+
+        logger.info(
+            f"GCSCredentialStore initialized with bucket={bucket_name}, "
+            f"prefix={self.prefix!r}, require_cmek={require_cmek}"
+        )
+
+    def _verify_cmek(self) -> None:
+        """Fetch bucket metadata and assert a default KMS key is configured.
+
+        Raises ValueError if the bucket exists but has no default_kms_key_name.
+        Raises the underlying google exception if the bucket does not exist.
+        """
+        self._bucket.reload()
+        if not self._bucket.default_kms_key_name:
+            raise ValueError(
+                f"GCSCredentialStore: bucket {self.bucket_name!r} has no "
+                f"default KMS key configured, but "
+                f"WORKSPACE_MCP_GCS_REQUIRE_CMEK is set. Either configure "
+                f"bucket.default_kms_key_name (e.g. via Terraform) or unset "
+                f"the requirement flag."
+            )
+        logger.info(
+            f"GCSCredentialStore: verified CMEK on bucket "
+            f"{self.bucket_name!r} (key={self._bucket.default_kms_key_name})"
+        )
+
+    def _blob_name(self, user_email: str) -> str:
+        """Construct the object key for a user, sanitising email for safety."""
+        safe_email = re.sub(r"[^a-zA-Z0-9@._-]", "_", user_email)
+        return f"{self.prefix}{safe_email}{self.FILE_EXTENSION}"
+
+    def get_credential(self, user_email: str) -> Optional[Credentials]:
+        """Download and deserialize credentials for a user."""
+        blob = self._bucket.blob(self._blob_name(user_email))
+        try:
+            raw = blob.download_as_bytes()
+        except NotFound:
+            logger.debug(f"No credentials object for {user_email}")
+            return None
+        except Exception as e:
+            logger.error(f"Error downloading credentials for {user_email}: {e}")
+            return None
+
+        try:
+            creds_data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            logger.error(f"Error parsing credentials for {user_email}: {e}")
+            return None
+
+        expiry = None
+        if creds_data.get("expiry"):
+            try:
+                expiry = datetime.fromisoformat(creds_data["expiry"])
+                if expiry.tzinfo is not None:
+                    expiry = expiry.replace(tzinfo=None)
+            except (ValueError, TypeError) as e:
+                logger.warning(f"Could not parse expiry for {user_email}: {e}")
+
+        return Credentials(
+            token=creds_data.get("token"),
+            refresh_token=creds_data.get("refresh_token"),
+            token_uri=creds_data.get("token_uri"),
+            client_id=creds_data.get("client_id"),
+            client_secret=creds_data.get("client_secret"),
+            scopes=creds_data.get("scopes"),
+            expiry=expiry,
+        )
+
+    def store_credential(self, user_email: str, credentials: Credentials) -> bool:
+        """Serialize and upload credentials, using generation preconditions
+        to guarantee atomic read-modify-write under concurrent writers."""
+        creds_data = {
+            "token": credentials.token,
+            "refresh_token": credentials.refresh_token,
+            "token_uri": credentials.token_uri,
+            "client_id": credentials.client_id,
+            "client_secret": credentials.client_secret,
+            "scopes": credentials.scopes,
+            "expiry": credentials.expiry.isoformat() if credentials.expiry else None,
+        }
+        payload = json.dumps(creds_data).encode()
+
+        for attempt in range(3):
+            blob = self._bucket.blob(self._blob_name(user_email))
+            try:
+                blob.reload()
+                generation = blob.generation
+            except NotFound:
+                generation = 0  # must-not-exist precondition
+
+            try:
+                blob.upload_from_string(
+                    payload,
+                    content_type="application/json",
+                    if_generation_match=generation,
+                )
+                logger.info(f"Stored credentials for {user_email}")
+                return True
+            except PreconditionFailed:
+                logger.info(
+                    f"Concurrent write detected for {user_email}; "
+                    f"retrying (attempt {attempt + 1}/3)"
+                )
+                continue
+            except Exception as e:
+                logger.error(f"Error storing credentials for {user_email}: {e}")
+                return False
+
+        logger.error(
+            f"Failed to store credentials for {user_email} after 3 attempts"
+        )
+        return False
+
+    def delete_credential(self, user_email: str) -> bool:
+        """Delete a user's credentials object; idempotent."""
+        blob = self._bucket.blob(self._blob_name(user_email))
+        try:
+            blob.delete()
+            logger.info(f"Deleted credentials for {user_email}")
+            return True
+        except NotFound:
+            return True
+        except Exception as e:
+            logger.error(f"Error deleting credentials for {user_email}: {e}")
+            return False
+
+    def list_users(self) -> List[str]:
+        """Not supported by this backend.
+
+        Designed for multi-user OAuth 2.1 mode where users are looked up
+        individually by email. Enumerating all users requires a bucket LIST
+        which is semantically wrong for that flow. Use
+        ``LocalDirectoryCredentialStore`` if you need single-user mode.
+        """
+        raise NotImplementedError(
+            "GCSCredentialStore does not support listing users. "
+            "This backend is designed for multi-user OAuth 2.1 mode where "
+            "users are looked up individually by email. Use "
+            "LocalDirectoryCredentialStore if you need single-user mode."
+        )
+
+
+def _parse_bool_env(value: str) -> bool:
+    """Parse a truthy env var value; defaults to False."""
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
 # Global credential store instance
 _credential_store: Optional[CredentialStore] = None
 
@@ -263,9 +473,11 @@ def get_credential_store() -> CredentialStore:
     global _credential_store
 
     if _credential_store is None:
-        # always use LocalJsonCredentialStore as the default
-        # Future enhancement: support other backends via environment variables
-        _credential_store = LocalDirectoryCredentialStore()
+        backend = os.getenv("WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND", "").lower()
+        if backend == "gcs":
+            _credential_store = GCSCredentialStore()
+        else:
+            _credential_store = LocalDirectoryCredentialStore()
         logger.info(f"Initialized credential store: {type(_credential_store).__name__}")
 
     return _credential_store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
  "google-api-python-client>=2.168.0",
  "google-auth-httplib2>=0.2.0",
  "google-auth-oauthlib>=1.2.2",
+ "google-cloud-storage>=2.18.0",
  "httpx>=0.28.1",
  "py-key-value-aio>=0.3.0",
  "pyjwt>=2.12.0",

--- a/tests/auth/test_gcs_credential_store.py
+++ b/tests/auth/test_gcs_credential_store.py
@@ -16,6 +16,7 @@ from auth import credential_store as cs_module
 from auth.credential_store import (
     GCSCredentialStore,
     LocalDirectoryCredentialStore,
+    _parse_bool_env,
     get_credential_store,
 )
 
@@ -163,6 +164,18 @@ class TestAtomicWrite:
         assert cred_store.store_credential("user@example.com", mock_creds) is False
         assert blob.upload_from_string.call_count == 3
 
+    def test_reload_non_notfound_error_returns_false(
+        self, cred_store, mock_storage_client, mock_creds
+    ):
+        """Permission / network / quota errors from reload() must not propagate."""
+        blob = MagicMock()
+        blob.reload.side_effect = Exception("permission denied")
+        mock_storage_client.blob.return_value = blob
+
+        # Should return False (error path), not raise
+        assert cred_store.store_credential("user@example.com", mock_creds) is False
+        blob.upload_from_string.assert_not_called()
+
 
 class TestCMEKVerification:
     """WORKSPACE_MCP_GCS_REQUIRE_CMEK gates on bucket.default_kms_key_name."""
@@ -272,3 +285,24 @@ class TestBackendSelection:
         monkeypatch.setenv("WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND", "gibberish")
         monkeypatch.setenv("WORKSPACE_MCP_CREDENTIALS_DIR", str(tmp_path))
         assert isinstance(get_credential_store(), LocalDirectoryCredentialStore)
+
+
+class TestParseBoolEnv:
+    """The strict bool parser used for security-relevant flags.
+
+    Fails loud on unrecognised input to prevent typos silently disabling
+    a flag like WORKSPACE_MCP_GCS_REQUIRE_CMEK.
+    """
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " true ", "Yes"])
+    def test_truthy_values(self, value):
+        assert _parse_bool_env(value) is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "off", "", " ", None])
+    def test_falsy_values(self, value):
+        assert _parse_bool_env(value) is False
+
+    @pytest.mark.parametrize("value", ["treu", "ye", "maybe", "2", "enabled"])
+    def test_unrecognised_values_raise(self, value):
+        with pytest.raises(ValueError, match="Invalid boolean env var"):
+            _parse_bool_env(value)

--- a/tests/auth/test_gcs_credential_store.py
+++ b/tests/auth/test_gcs_credential_store.py
@@ -121,7 +121,7 @@ class TestRoundTrip:
 
 
 class TestAtomicWrite:
-    """Store path must use generation preconditions and retry on contention."""
+    """Store path must use generation preconditions and fail closed on contention."""
 
     def test_existing_blob_uses_current_generation(
         self, cred_store, mock_storage_client, mock_creds
@@ -135,34 +135,20 @@ class TestAtomicWrite:
         _, kwargs = blob.upload_from_string.call_args
         assert kwargs["if_generation_match"] == 12345
 
-    def test_precondition_failed_triggers_retry(
+    def test_precondition_failed_returns_false_without_retry(
         self, cred_store, mock_storage_client, mock_creds
     ):
-        """First upload hits PreconditionFailed; second succeeds."""
+        """On 412 (concurrent writer), fail fast rather than overwrite with
+        stale payload. Caller must re-read and re-derive for the next write."""
         blob = MagicMock()
         blob.reload.return_value = None
         blob.generation = 1
-        blob.upload_from_string.side_effect = [
-            PreconditionFailed("racing writer"),
-            None,  # succeed on retry
-        ]
-        mock_storage_client.blob.return_value = blob
-
-        assert cred_store.store_credential("user@example.com", mock_creds) is True
-        assert blob.upload_from_string.call_count == 2
-
-    def test_persistent_precondition_failed_returns_false(
-        self, cred_store, mock_storage_client, mock_creds
-    ):
-        """Three consecutive 412s give up."""
-        blob = MagicMock()
-        blob.reload.return_value = None
-        blob.generation = 1
-        blob.upload_from_string.side_effect = PreconditionFailed("persistent race")
+        blob.upload_from_string.side_effect = PreconditionFailed("racing writer")
         mock_storage_client.blob.return_value = blob
 
         assert cred_store.store_credential("user@example.com", mock_creds) is False
-        assert blob.upload_from_string.call_count == 3
+        # Exactly one upload attempt — no retry with the same (potentially stale) payload
+        assert blob.upload_from_string.call_count == 1
 
     def test_reload_non_notfound_error_returns_false(
         self, cred_store, mock_storage_client, mock_creds
@@ -281,10 +267,25 @@ class TestBackendSelection:
         monkeypatch.delenv("WORKSPACE_MCP_GCS_REQUIRE_CMEK", raising=False)
         assert isinstance(get_credential_store(), GCSCredentialStore)
 
-    def test_unknown_backend_falls_back_to_local(self, monkeypatch, tmp_path):
+    def test_unknown_backend_raises(self, monkeypatch, tmp_path):
+        """Typos/invalid values must not silently fall back — they raise."""
         monkeypatch.setenv("WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND", "gibberish")
         monkeypatch.setenv("WORKSPACE_MCP_CREDENTIALS_DIR", str(tmp_path))
+        with pytest.raises(ValueError, match="Unsupported.*BACKEND"):
+            get_credential_store()
+
+    def test_empty_backend_uses_local_directory(self, monkeypatch, tmp_path):
+        """Empty env var defaults to local_directory."""
+        monkeypatch.setenv("WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND", "")
+        monkeypatch.setenv("WORKSPACE_MCP_CREDENTIALS_DIR", str(tmp_path))
         assert isinstance(get_credential_store(), LocalDirectoryCredentialStore)
+
+    def test_whitespace_around_backend_is_stripped(self, monkeypatch, mock_storage_client):
+        """Trailing whitespace on the env var doesn't cause a misclassification."""
+        monkeypatch.setenv("WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND", "  gcs  ")
+        monkeypatch.setenv("WORKSPACE_MCP_GCS_BUCKET", "test-bucket")
+        monkeypatch.delenv("WORKSPACE_MCP_GCS_REQUIRE_CMEK", raising=False)
+        assert isinstance(get_credential_store(), GCSCredentialStore)
 
 
 class TestParseBoolEnv:

--- a/tests/auth/test_gcs_credential_store.py
+++ b/tests/auth/test_gcs_credential_store.py
@@ -1,0 +1,274 @@
+"""Tests for GCSCredentialStore.
+
+Covers round-trip, path sanitisation, CMEK verification flag, atomic
+read-modify-write retry, backend selection, and dependency error handling.
+
+GCS is mocked at the client level — these tests do not hit real GCS.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.cloud.exceptions import NotFound, PreconditionFailed
+
+from auth import credential_store as cs_module
+from auth.credential_store import (
+    GCSCredentialStore,
+    LocalDirectoryCredentialStore,
+    get_credential_store,
+)
+
+
+@pytest.fixture
+def mock_storage_client():
+    """Patch google.cloud.storage.Client; yield the bucket mock for configuration."""
+    with patch("google.cloud.storage.Client") as client_cls:
+        bucket = MagicMock(name="bucket")
+        client_cls.return_value.bucket.return_value = bucket
+        # Default: CMEK not configured (None). Tests that need it set it explicitly.
+        bucket.default_kms_key_name = None
+        yield bucket
+
+
+@pytest.fixture
+def cred_store(mock_storage_client):
+    """A GCSCredentialStore wired up to the mocked bucket."""
+    return GCSCredentialStore(bucket_name="test-bucket")
+
+
+@pytest.fixture
+def mock_creds():
+    creds = MagicMock()
+    creds.token = "access_token_value"
+    creds.refresh_token = "refresh_token_value"
+    creds.token_uri = "https://oauth2.googleapis.com/token"
+    creds.client_id = "client_id_value"
+    creds.client_secret = "client_secret_value"
+    creds.scopes = ["openid", "email"]
+    creds.expiry = None
+    return creds
+
+
+def _serialized_payload(creds) -> bytes:
+    """The bytes GCSCredentialStore would upload for this credential."""
+    return json.dumps(
+        {
+            "token": creds.token,
+            "refresh_token": creds.refresh_token,
+            "token_uri": creds.token_uri,
+            "client_id": creds.client_id,
+            "client_secret": creds.client_secret,
+            "scopes": creds.scopes,
+            "expiry": None,
+        }
+    ).encode()
+
+
+class TestRoundTrip:
+    """store/get/delete round-trip correctness against the mocked bucket."""
+
+    def test_get_missing_user_returns_none(self, cred_store, mock_storage_client):
+        blob = MagicMock()
+        blob.download_as_bytes.side_effect = NotFound("gone")
+        mock_storage_client.blob.return_value = blob
+
+        assert cred_store.get_credential("nobody@example.com") is None
+
+    def test_get_returns_credentials(self, cred_store, mock_storage_client, mock_creds):
+        blob = MagicMock()
+        blob.download_as_bytes.return_value = _serialized_payload(mock_creds)
+        mock_storage_client.blob.return_value = blob
+
+        loaded = cred_store.get_credential("user@example.com")
+        assert loaded is not None
+        assert loaded.token == "access_token_value"
+        assert loaded.refresh_token == "refresh_token_value"
+        assert loaded.scopes == ["openid", "email"]
+
+    def test_store_uploads_serialized_payload(
+        self, cred_store, mock_storage_client, mock_creds
+    ):
+        blob = MagicMock()
+        blob.reload.side_effect = NotFound("new blob")
+        mock_storage_client.blob.return_value = blob
+
+        assert cred_store.store_credential("user@example.com", mock_creds) is True
+
+        blob.upload_from_string.assert_called_once()
+        args, kwargs = blob.upload_from_string.call_args
+        assert args[0] == _serialized_payload(mock_creds)
+        assert kwargs["content_type"] == "application/json"
+        # New blob → generation 0 precondition
+        assert kwargs["if_generation_match"] == 0
+
+    def test_delete_removes_blob(self, cred_store, mock_storage_client):
+        blob = MagicMock()
+        mock_storage_client.blob.return_value = blob
+
+        assert cred_store.delete_credential("user@example.com") is True
+        blob.delete.assert_called_once()
+
+    def test_delete_missing_user_is_idempotent(
+        self, cred_store, mock_storage_client
+    ):
+        blob = MagicMock()
+        blob.delete.side_effect = NotFound("already gone")
+        mock_storage_client.blob.return_value = blob
+
+        assert cred_store.delete_credential("nobody@example.com") is True
+
+
+class TestAtomicWrite:
+    """Store path must use generation preconditions and retry on contention."""
+
+    def test_existing_blob_uses_current_generation(
+        self, cred_store, mock_storage_client, mock_creds
+    ):
+        blob = MagicMock()
+        blob.reload.return_value = None
+        blob.generation = 12345
+        mock_storage_client.blob.return_value = blob
+
+        assert cred_store.store_credential("user@example.com", mock_creds) is True
+        _, kwargs = blob.upload_from_string.call_args
+        assert kwargs["if_generation_match"] == 12345
+
+    def test_precondition_failed_triggers_retry(
+        self, cred_store, mock_storage_client, mock_creds
+    ):
+        """First upload hits PreconditionFailed; second succeeds."""
+        blob = MagicMock()
+        blob.reload.return_value = None
+        blob.generation = 1
+        blob.upload_from_string.side_effect = [
+            PreconditionFailed("racing writer"),
+            None,  # succeed on retry
+        ]
+        mock_storage_client.blob.return_value = blob
+
+        assert cred_store.store_credential("user@example.com", mock_creds) is True
+        assert blob.upload_from_string.call_count == 2
+
+    def test_persistent_precondition_failed_returns_false(
+        self, cred_store, mock_storage_client, mock_creds
+    ):
+        """Three consecutive 412s give up."""
+        blob = MagicMock()
+        blob.reload.return_value = None
+        blob.generation = 1
+        blob.upload_from_string.side_effect = PreconditionFailed("persistent race")
+        mock_storage_client.blob.return_value = blob
+
+        assert cred_store.store_credential("user@example.com", mock_creds) is False
+        assert blob.upload_from_string.call_count == 3
+
+
+class TestCMEKVerification:
+    """WORKSPACE_MCP_GCS_REQUIRE_CMEK gates on bucket.default_kms_key_name."""
+
+    def test_require_cmek_passes_when_key_is_set(self, mock_storage_client):
+        mock_storage_client.default_kms_key_name = (
+            "projects/p/locations/l/keyRings/r/cryptoKeys/k"
+        )
+        # Should not raise
+        GCSCredentialStore(bucket_name="b", require_cmek=True)
+        mock_storage_client.reload.assert_called_once()
+
+    def test_require_cmek_raises_when_key_is_missing(self, mock_storage_client):
+        mock_storage_client.default_kms_key_name = None
+        with pytest.raises(ValueError, match="no default KMS key"):
+            GCSCredentialStore(bucket_name="b", require_cmek=True)
+
+    def test_require_cmek_raises_when_key_is_empty_string(self, mock_storage_client):
+        mock_storage_client.default_kms_key_name = ""
+        with pytest.raises(ValueError, match="no default KMS key"):
+            GCSCredentialStore(bucket_name="b", require_cmek=True)
+
+    def test_no_flag_does_not_call_reload(self, mock_storage_client):
+        # When require_cmek is False, we should not pay for bucket metadata fetch
+        GCSCredentialStore(bucket_name="b", require_cmek=False)
+        mock_storage_client.reload.assert_not_called()
+
+    def test_env_var_truthy_enables_cmek_check(self, mock_storage_client, monkeypatch):
+        monkeypatch.setenv("WORKSPACE_MCP_GCS_REQUIRE_CMEK", "true")
+        mock_storage_client.default_kms_key_name = None
+        with pytest.raises(ValueError, match="no default KMS key"):
+            GCSCredentialStore(bucket_name="b")
+
+    def test_env_var_falsy_skips_cmek_check(self, mock_storage_client, monkeypatch):
+        monkeypatch.setenv("WORKSPACE_MCP_GCS_REQUIRE_CMEK", "false")
+        mock_storage_client.default_kms_key_name = None
+        # Should not raise
+        GCSCredentialStore(bucket_name="b")
+
+
+class TestConfiguration:
+    """Bucket and prefix configuration via arg or env var."""
+
+    def test_missing_bucket_raises(self, mock_storage_client, monkeypatch):
+        monkeypatch.delenv("WORKSPACE_MCP_GCS_BUCKET", raising=False)
+        with pytest.raises(ValueError, match="bucket name"):
+            GCSCredentialStore()
+
+    def test_env_bucket_used(self, mock_storage_client, monkeypatch):
+        monkeypatch.setenv("WORKSPACE_MCP_GCS_BUCKET", "from-env")
+        store = GCSCredentialStore()
+        assert store.bucket_name == "from-env"
+
+    def test_prefix_applied_to_blob_names(self, mock_storage_client):
+        store = GCSCredentialStore(bucket_name="b", prefix="creds")
+        assert store._blob_name("a@example.com") == "creds/a@example.com.json"
+
+    def test_prefix_trailing_slash_normalised(self, mock_storage_client):
+        store = GCSCredentialStore(bucket_name="b", prefix="creds/")
+        assert store._blob_name("a@example.com") == "creds/a@example.com.json"
+
+    def test_empty_prefix_produces_flat_names(self, mock_storage_client):
+        store = GCSCredentialStore(bucket_name="b", prefix="")
+        assert store._blob_name("a@example.com") == "a@example.com.json"
+
+
+class TestPathSanitisation:
+    """Email sanitisation prevents weird object names / injection."""
+
+    def test_traversal_chars_sanitised(self, cred_store):
+        assert (
+            cred_store._blob_name("../../etc/evil@gmail.com")
+            == ".._.._etc_evil@gmail.com.json"
+        )
+
+    def test_slash_sanitised(self, cred_store):
+        assert (
+            cred_store._blob_name("user/admin@gmail.com")
+            == "user_admin@gmail.com.json"
+        )
+
+    def test_normal_email_unchanged(self, cred_store):
+        assert cred_store._blob_name("alice@example.com") == "alice@example.com.json"
+
+
+class TestBackendSelection:
+    """get_credential_store() dispatches on WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_singleton(self):
+        cs_module._credential_store = None
+        yield
+        cs_module._credential_store = None
+
+    def test_default_backend_is_local_directory(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND", raising=False)
+        monkeypatch.setenv("WORKSPACE_MCP_CREDENTIALS_DIR", str(tmp_path))
+        assert isinstance(get_credential_store(), LocalDirectoryCredentialStore)
+
+    def test_gcs_backend_selected(self, monkeypatch, mock_storage_client):
+        monkeypatch.setenv("WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND", "gcs")
+        monkeypatch.setenv("WORKSPACE_MCP_GCS_BUCKET", "test-bucket")
+        monkeypatch.delenv("WORKSPACE_MCP_GCS_REQUIRE_CMEK", raising=False)
+        assert isinstance(get_credential_store(), GCSCredentialStore)
+
+    def test_unknown_backend_falls_back_to_local(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND", "gibberish")
+        monkeypatch.setenv("WORKSPACE_MCP_CREDENTIALS_DIR", str(tmp_path))
+        assert isinstance(get_credential_store(), LocalDirectoryCredentialStore)


### PR DESCRIPTION
## Summary

- Adds a new `GCSCredentialStore` backend, selectable via `WORKSPACE_MCP_CREDENTIAL_STORE_BACKEND=gcs`, which stores each user's credentials as an object in a Google Cloud Storage bucket via the JSON API
- Supports atomic read-modify-write via generation preconditions (`ifGenerationMatch`), preventing lost updates when two workers rotate the same user's refresh token concurrently
- Adds optional `WORKSPACE_MCP_GCS_REQUIRE_CMEK=true` flag that verifies the bucket has a default KMS key configured at startup and fails fast otherwise
- Preserves `LocalDirectoryCredentialStore` as the default; new backend is strictly opt-in

## Motivation

For remote MCP deployments on GCP (Cloud Run and similar), storing credentials in a bucket gives:

- Durable storage that survives container restarts without a mounted filesystem
- Native integration with Cloud IAM, Cloud Audit Logs, and VPC-SC
- Transparent bucket-level CMEK encryption at rest — no application-level key to manage or rotate
- Atomic RMW semantics that gcsfuse cannot provide

## Design notes

- `list_users()` raises `NotImplementedError` — this backend is designed for multi-user OAuth 2.1 mode where users are looked up individually by email; enumerating a bucket is semantically wrong for that flow (and expensive on large buckets). Single-user mode users should stay on `LocalDirectoryCredentialStore`.
- `google-cloud-storage` is added as a default dependency rather than an optional extra. The primary deployment target for a GCS-backed store is the project's Docker image; requiring users to rebuild with an extra would be friction for the main intended use case. Happy to move to an extra if you'd prefer.
- Uses Application Default Credentials — on Cloud Run this means the runtime service account needs `roles/storage.objectUser` (or equivalent) on the bucket.

## Test plan

- [x] 25 new unit tests with mocked \`google.cloud.storage.Client\` cover: round-trip get/store/delete, atomic RMW using current generation, retry on \`PreconditionFailed\`, give-up after persistent contention, CMEK verification pass/fail (including empty-string KMS key edge case), bucket + prefix config via arg or env var, path sanitisation of user emails, and backend selection via env var
- [x] All 10 existing credential-store security tests unchanged and passing
- [x] \`ruff check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Google Cloud Storage credential backend selectable via environment configuration, with optional CMEK enforcement; GCS backend does not support user listing.

* **Documentation**
  * Expanded credential store docs: backend selection, local vs GCS behaviors, configuration examples, and CMEK guidance; example clarifies listing is local-only.

* **Tests**
  * Added comprehensive tests covering the GCS backend and environment parsing.

* **Chores**
  * Added Google Cloud Storage client dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->