### PR TITLE
feat: add WORKSPACE_MCP_ALLOWED_CLIENT_REDIRECT_URIS config

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ uv run main.py --transport streamable-http --tools gmail drive calendar
 | `OAUTH_ALLOWED_ORIGINS` | | Comma-separated additional CORS origins |
 | `WORKSPACE_MCP_OAUTH_PROXY_STORAGE_BACKEND` | | `memory`, `disk`, or `valkey` — see [storage backends](#oauth-proxy-storage-backends) |
 | `FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY` | | Custom encryption key for OAuth proxy storage; required for public OAuth 2.1 clients when `GOOGLE_OAUTH_CLIENT_SECRET` is omitted |
+| `WORKSPACE_MCP_ALLOWED_CLIENT_REDIRECT_URIS` | | Comma-separated allowlist of redirect URIs that dynamically-registered OAuth clients may use. Default is unset (any URI permitted, per DCR). Supports FastMCP's glob patterns (`*`, `*.example.com`) |
 | **🔧 Service Account** | | |
 | `GOOGLE_SERVICE_ACCOUNT_KEY_FILE` | | Path to service account JSON key file (domain-wide delegation) |
 | `GOOGLE_SERVICE_ACCOUNT_KEY_JSON` | | Inline service account JSON key (alternative to file) |
@@ -1065,6 +1066,20 @@ FastMCP ships a native `GoogleProvider` that we now rely on directly. It solves 
 2.  **CORS & Browser Compatibility**: The provider includes an OAuth proxy that serves all discovery, authorization, and token endpoints with proper CORS headers. We no longer maintain custom `/oauth2/*` routes—the provider handles the upstream exchanges securely and advertises the correct metadata to clients.
 
 The result is a leaner server that still enables any OAuth 2.1 compliant client (including browser-based ones) to authenticate through Google without bespoke code.
+
+**Restricting DCR client redirect URIs:**
+
+By default, any client going through Dynamic Client Registration can declare any `redirect_uri`. For publicly-exposed deployments, this is a phishing vector — an attacker can register a client with a `redirect_uri` they control and harvest authorization codes from tricked users. Set `WORKSPACE_MCP_ALLOWED_CLIENT_REDIRECT_URIS` to a comma-separated allowlist of permitted URIs:
+
+```bash
+# Public deployment — restrict to Claude's hosted OAuth callbacks
+export WORKSPACE_MCP_ALLOWED_CLIENT_REDIRECT_URIS="https://claude.ai/api/mcp/auth_callback,https://claude.com/api/mcp/auth_callback"
+
+# Add Claude Code CLI (loopback redirects on ephemeral ports)
+export WORKSPACE_MCP_ALLOWED_CLIENT_REDIRECT_URIS="https://claude.ai/api/mcp/auth_callback,https://claude.com/api/mcp/auth_callback,http://localhost:*/callback,http://127.0.0.1:*/callback"
+```
+
+Patterns use FastMCP's matcher: `*` wildcards any port or path component; `*.example.com` matches subdomains. Leaving the variable unset preserves the default DCR behaviour (any URI accepted), which is appropriate for local development but unsafe for public deployments.
 
 </details>
 

--- a/core/server.py
+++ b/core/server.py
@@ -169,6 +169,25 @@ def _parse_bool_env(value: str) -> bool:
     return value.lower() in ("1", "true", "yes", "on")
 
 
+def _parse_allowed_redirect_uris(value: Optional[str]) -> Optional[List[str]]:
+    """Parse a comma-separated list of OAuth client redirect URIs.
+
+    Returns a list of non-empty, trimmed URIs, or None when the input is
+    empty/None. Returning None preserves FastMCP's default behaviour of
+    accepting any client-supplied redirect URI during DCR — callers that
+    want to lock down registration must supply a non-empty list.
+
+    Patterns supported by FastMCP's matcher (see
+    ``fastmcp.server.auth.redirect_validation``) include ``*`` for port
+    and path globs (e.g. ``http://localhost:*/callback``) and ``*.example.com``
+    for subdomain wildcards.
+    """
+    if not value:
+        return None
+    uris = [u.strip() for u in value.split(",") if u.strip()]
+    return uris or None
+
+
 def set_transport_mode(mode: str):
     """Sets the transport mode for the server."""
     _set_transport_mode(mode)
@@ -477,6 +496,14 @@ def configure_server_for_http():
                 )
             else:
                 # Standard OAuth 2.1 mode: use FastMCP's GoogleProvider
+                allowed_client_redirect_uris = _parse_allowed_redirect_uris(
+                    os.getenv("WORKSPACE_MCP_ALLOWED_CLIENT_REDIRECT_URIS")
+                )
+                if allowed_client_redirect_uris:
+                    logger.info(
+                        "OAuth 2.1: restricting DCR client redirect URIs to allowlist: %s",
+                        allowed_client_redirect_uris,
+                    )
                 provider = GoogleProvider(
                     client_id=config.client_id,
                     client_secret=config.client_secret,
@@ -486,6 +513,7 @@ def configure_server_for_http():
                     valid_scopes=provider_valid_scopes,
                     client_storage=client_storage,
                     jwt_signing_key=jwt_signing_key,
+                    allowed_client_redirect_uris=allowed_client_redirect_uris,
                 )
                 if provider.client_registration_options is not None:
                     # Keep protocol-level auth limited to base identity scopes, but

--- a/tests/core/test_allowed_redirect_uris.py
+++ b/tests/core/test_allowed_redirect_uris.py
@@ -1,0 +1,65 @@
+"""Tests for _parse_allowed_redirect_uris in core/server.py.
+
+Covers parsing of WORKSPACE_MCP_ALLOWED_CLIENT_REDIRECT_URIS into the
+list[str] | None shape that FastMCP's GoogleProvider expects.
+"""
+
+from core.server import _parse_allowed_redirect_uris
+
+
+class TestParseAllowedRedirectUris:
+    def test_none_returns_none(self):
+        assert _parse_allowed_redirect_uris(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _parse_allowed_redirect_uris("") is None
+
+    def test_whitespace_only_returns_none(self):
+        assert _parse_allowed_redirect_uris("   ") is None
+
+    def test_single_uri(self):
+        assert _parse_allowed_redirect_uris(
+            "https://claude.ai/api/mcp/auth_callback"
+        ) == ["https://claude.ai/api/mcp/auth_callback"]
+
+    def test_multiple_uris_comma_separated(self):
+        result = _parse_allowed_redirect_uris(
+            "https://claude.ai/api/mcp/auth_callback,"
+            "https://claude.com/api/mcp/auth_callback"
+        )
+        assert result == [
+            "https://claude.ai/api/mcp/auth_callback",
+            "https://claude.com/api/mcp/auth_callback",
+        ]
+
+    def test_whitespace_around_entries_is_stripped(self):
+        result = _parse_allowed_redirect_uris(
+            "  https://a.example/callback  ,  https://b.example/callback  "
+        )
+        assert result == [
+            "https://a.example/callback",
+            "https://b.example/callback",
+        ]
+
+    def test_empty_entries_are_filtered(self):
+        # Trailing comma or double comma should not produce empty strings
+        result = _parse_allowed_redirect_uris(
+            "https://a.example/callback,,https://b.example/callback,"
+        )
+        assert result == [
+            "https://a.example/callback",
+            "https://b.example/callback",
+        ]
+
+    def test_only_commas_returns_none(self):
+        assert _parse_allowed_redirect_uris(",,,") is None
+
+    def test_wildcard_patterns_preserved(self):
+        """Patterns pass through unchanged — FastMCP's matcher interprets them."""
+        result = _parse_allowed_redirect_uris(
+            "http://localhost:*/callback,http://127.0.0.1:*/callback"
+        )
+        assert result == [
+            "http://localhost:*/callback",
+            "http://127.0.0.1:*/callback",
+        ]


### PR DESCRIPTION
## Summary

Adds an env var allowlist wired through to FastMCP's \`GoogleProvider.allowed_client_redirect_uris\`, letting operators restrict the redirect URIs that dynamically-registered OAuth clients may use.

## Motivation

By default, FastMCP's DCR accepts any client-declared \`redirect_uri\` (the parameter defaults to \`None\`, meaning "allow any" for DCR compatibility). For publicly-exposed deployments this is a phishing vector — an attacker can DCR-register a client with a \`redirect_uri\` they control and harvest authorization codes from tricked users.

Operators of public endpoints can now opt into a strict allowlist:

\`\`\`bash
# Restrict to Claude's hosted OAuth callbacks
export WORKSPACE_MCP_ALLOWED_CLIENT_REDIRECT_URIS="https://claude.ai/api/mcp/auth_callback,https://claude.com/api/mcp/auth_callback"
\`\`\`

## Design

- Preserves upstream default: when the env var is unset (or empty), \`None\` is passed through, matching current behaviour exactly
- Format: comma-separated list; whitespace around entries is trimmed; empty entries are filtered (so trailing commas are fine)
- Supports FastMCP's matcher patterns (e.g. \`http://localhost:*/callback\`, \`*.example.com\`) unchanged — the helper does no validation beyond splitting
- Only applies to the standard \`GoogleProvider\` branch. The external-OAuth branch does not expose DCR endpoints and doesn't need this configuration

## Test plan

- [x] 9 unit tests for the parsing helper: \`None\`/empty/whitespace-only → \`None\`; single URI; multiple URIs; whitespace trimming; empty-entry filtering; only-commas edge case; wildcard patterns preserved
- [x] Full existing tests/auth and tests/core suites unchanged and passing (98 tests)
- [x] \`ruff check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to restrict dynamically-registered OAuth client redirect URIs to an allowlist.
  * Supports glob pattern matching for flexible URI control.

* **Documentation**
  * Added guidance documenting the new redirect URI allowlist configuration with deployment examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->