### PR TITLE
Skip trashed messages in _fetch_thread_reply_context to prevent ghost drafts

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -695,6 +695,13 @@ async def _fetch_thread_reply_context(
 
     message_contexts = []
     for msg in messages:
+        # Skip trashed messages so auto-derived In-Reply-To never points at a
+        # message that Gmail's UI cannot render (e.g., a just-trashed prior
+        # draft on the same thread). Without this filter, draft replies
+        # created after a trash-and-recreate cycle become "ghost drafts":
+        # present in the Drafts folder but invisible in the thread view.
+        if "TRASH" in msg.get("labelIds", []):
+            continue
         payload = msg.get("payload", {})
         headers = _extract_headers(payload, header_names)
         context = {

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -696,10 +696,7 @@ async def _fetch_thread_reply_context(
     message_contexts = []
     for msg in messages:
         # Skip trashed messages so auto-derived In-Reply-To never points at a
-        # message that Gmail's UI cannot render (e.g., a just-trashed prior
-        # draft on the same thread). Without this filter, draft replies
-        # created after a trash-and-recreate cycle become "ghost drafts":
-        # present in the Drafts folder but invisible in the thread view.
+        # message that Gmail's UI cannot render
         if "TRASH" in msg.get("labelIds", []):
             continue
         payload = msg.get("payload", {})


### PR DESCRIPTION
## Problem

`draft_gmail_message` with only `thread_id` (no explicit `in_reply_to` / `references`) auto-derives `In-Reply-To` from the latest message in the thread. `_fetch_thread_reply_context` (`gmail/gmail_tools.py:668`) does not filter messages labeled `TRASH`, so after a trash-and-recreate cycle, the new draft's `In-Reply-To` points to the just-trashed prior draft.

Gmail's web UI orphans drafts whose `In-Reply-To` parent is not visible (trashed) — the draft exists in the Drafts folder and is returned by `users.drafts.list`, but does not render in the thread view. This produces "ghost drafts" that pass existence-based verification but are invisible to the user, with the source email at risk of being archived against an empty reply.

## Repro

1. Create a draft on a thread via `draft_gmail_message(thread_id=...)` (no explicit `in_reply_to`).
2. Trash the draft via `users.messages.modify` adding `TRASH`.
3. Create a second draft on the same thread via `draft_gmail_message(thread_id=...)` (still no explicit `in_reply_to`).
4. The second draft's `In-Reply-To` is set to the trashed draft's RFC `Message-ID`.
5. Open the thread in the Gmail web UI: the second draft is not rendered. Searching `in:drafts` still returns it; `users.messages.get` still returns its content.

## Fix

In `_fetch_thread_reply_context`, skip messages whose `labelIds` contains `TRASH` when building `message_contexts`. The `labelIds` field is already returned by `threads().get(format="metadata")` — no extra API call required.

```python
    message_contexts = []
    for msg in messages:
        if "TRASH" in msg.get("labelIds", []):
            continue
        payload = msg.get("payload", {})
        ...
```

## Notes

- One-line behavioral change plus a comment.
- Affects callers that rely on auto-derivation of `In-Reply-To` after a draft revision via trash-and-recreate. Callers that already pass `in_reply_to` explicitly are unaffected (the explicit value is used regardless).
- I did not see an existing test fixture for `_fetch_thread_reply_context`. Happy to add one (e.g., construct a fake thread with a TRASH-labeled message and assert it is skipped) if you would like.
- Discovered in production on 2026-04-24; bug reproduces deterministically on workspace-mcp 1.20.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gmail thread handling by excluding trashed messages from reply context construction. This prevents trashed messages from influencing reply-chain derivation and target selection, resulting in more accurate reply suggestions and clearer thread behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->