### PR TITLE
single user mode fix

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -947,11 +947,10 @@ def get_credentials(
                 found_user_email = user_google_email
             else:
                 logger.info(
-                    f"[get_credentials] Single-user mode: no credentials for {user_google_email}, falling back to any"
+                    "[get_credentials] Single-user mode: no credentials for requested "
+                    f"user {user_google_email}; not falling back to another user"
                 )
-                credentials, found_user_email = _find_any_credentials(
-                    credentials_base_dir
-                )
+                return None
         else:
             credentials, found_user_email = _find_any_credentials(credentials_base_dir)
         if not credentials:

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -824,7 +824,9 @@ def get_credentials(
     """
     Retrieves stored credentials, prioritizing OAuth 2.1 store, then session, then file. Refreshes if necessary.
     If credentials are loaded from file and a session_id is present, they are cached in the session.
-    In single-user mode, bypasses session mapping and uses any available credentials.
+    In single-user mode, bypasses session mapping. If user_google_email is provided, only credentials
+    for that email are used and the function returns None instead of falling back to any available
+    credentials. If user_google_email is not provided, any available credentials may be used.
 
     Args:
         user_google_email: Optional user's Google email.

--- a/tests/auth/test_google_auth_refresh_persistence.py
+++ b/tests/auth/test_google_auth_refresh_persistence.py
@@ -39,9 +39,11 @@ class _CredentialStore:
     def __init__(self, existing_credentials=None, store_result=True):
         self._existing_credentials = existing_credentials
         self.store_result = store_result
+        self.get_calls = []
         self.store_calls = []
 
-    def get_credential(self, user_email):  # noqa: ARG002
+    def get_credential(self, user_email):
+        self.get_calls.append(user_email)
         return self._existing_credentials
 
     def store_credential(self, user_email, credentials):  # noqa: ARG002
@@ -115,3 +117,31 @@ def test_get_credentials_skips_session_update_when_refresh_persist_fails(monkeyp
     assert oauth_store.store_calls == []
     assert len(session_cache_writes) == 1
     assert session_cache_writes[0][0] == "session-1"
+
+
+def test_get_credentials_single_user_returns_none_for_missing_requested_user(
+    monkeypatch,
+):
+    credential_store = _CredentialStore(existing_credentials=None)
+    fallback_creds = _RefreshableCredentials()
+    fallback_calls = []
+
+    def _unexpected_fallback(credentials_base_dir):  # noqa: ARG001
+        fallback_calls.append(True)
+        return fallback_creds, "other@example.com"
+
+    monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
+    monkeypatch.setattr(
+        "auth.google_auth.get_credential_store", lambda: credential_store
+    )
+    monkeypatch.setattr("auth.google_auth._find_any_credentials", _unexpected_fallback)
+
+    result = get_credentials(
+        user_google_email="missing@example.com",
+        required_scopes=["scope.a"],
+    )
+
+    assert result is None
+    assert credential_store.get_calls == ["missing@example.com"]
+    assert credential_store.store_calls == []
+    assert fallback_calls == []


### PR DESCRIPTION
Closes #718 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now fails immediately when requested user credentials are absent, instead of falling back to other users’ credentials.

* **Tests**
  * Added automated coverage ensuring single-user credential lookups return none when no matching credentials exist and that no fallback path is invoked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->