### PR TITLE
feat(sheets): add delete_sheet_rows and move_sheet_rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,7 @@ Saved files expire after 1 hour and are cleaned up automatically.
 | <sub>`format_sheet_range`</sub> | <sub>Extended</sub> | <sub>Apply colors, number formats, text wrapping, alignment, bold/italic, font size</sub> |
 | <sub>`list_sheet_tables`</sub> | <sub>Extended</sub> | <sub>List structured tables with IDs, names, ranges, and columns</sub> |
 | <sub>`create_sheet`</sub> | <sub>Complete</sub> | <sub>Add sheets to existing files</sub> |
+| <sub>`move_sheet_rows`</sub> | <sub>Complete</sub> | <sub>Move rows between sheets within a spreadsheet</sub> |
 | <sub>`append_table_rows`</sub> | <sub>Complete</sub> | <sub>Append rows to a structured table, auto-extending the table range</sub> |
 | <sub>`list_spreadsheet_comments`</sub> | <sub>Complete</sub> | <sub>List all spreadsheet comments</sub> |
 | <sub>`manage_spreadsheet_comment`</sub> | <sub>Complete</sub> | <sub>Create, reply to, or resolve comments</sub> |

--- a/README_NEW.md
+++ b/README_NEW.md
@@ -129,6 +129,7 @@ export OAUTHLIB_INSECURE_TRANSPORT=1  # Development only
 | `get_spreadsheet_info` | Extended | Get metadata, sheets, conditional formats |
 | `format_sheet_range` | Extended | Apply colors, number formats, text wrapping, alignment, bold/italic, font size |
 | `create_sheet` | Complete | Add sheets to existing spreadsheets |
+| `move_sheet_rows` | Complete | Move rows between sheets within a spreadsheet |
 | `list_spreadsheet_comments` | Complete | List all spreadsheet comments |
 | `manage_spreadsheet_comment` | Complete | Create, reply to, or resolve comments |
 | `manage_conditional_formatting` | Complete | Add, update, or delete conditional formatting rules |

--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -89,6 +89,7 @@ sheets:
     - create_sheet
     - append_table_rows
     - resize_sheet_dimensions
+    - move_sheet_rows
     - list_spreadsheet_comments
     - manage_spreadsheet_comment
     - manage_conditional_formatting

--- a/gsheets/__init__.py
+++ b/gsheets/__init__.py
@@ -13,7 +13,6 @@ from .sheets_tools import (
     create_sheet,
     list_sheet_tables,
     append_table_rows,
-    delete_sheet_rows,
     move_sheet_rows,
 )
 
@@ -26,6 +25,5 @@ __all__ = [
     "create_sheet",
     "list_sheet_tables",
     "append_table_rows",
-    "delete_sheet_rows",
     "move_sheet_rows",
 ]

--- a/gsheets/__init__.py
+++ b/gsheets/__init__.py
@@ -13,6 +13,8 @@ from .sheets_tools import (
     create_sheet,
     list_sheet_tables,
     append_table_rows,
+    delete_sheet_rows,
+    move_sheet_rows,
 )
 
 __all__ = [
@@ -24,4 +26,6 @@ __all__ = [
     "create_sheet",
     "list_sheet_tables",
     "append_table_rows",
+    "delete_sheet_rows",
+    "move_sheet_rows",
 ]

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -2206,10 +2206,15 @@ async def move_sheet_rows(
     dst_values = await asyncio.to_thread(
         service.spreadsheets()
         .values()
-        .get(spreadsheetId=spreadsheet_id, range=f"'{safe_destination}'")
+        .get(
+            spreadsheetId=spreadsheet_id,
+            range=f"'{safe_destination}'!A:A",
+            majorDimension="COLUMNS",
+        )
         .execute
     )
-    dst_data_rows = len(dst_values.get("values", []))
+    dst_columns = dst_values.get("values", [])
+    dst_data_rows = len(dst_columns[0]) if dst_columns else 0
 
     num_rows = end_row - start_row + 1
     paste_start = dst_data_rows

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -1500,6 +1500,7 @@ async def _resize_sheet_dimensions_impl(
     insert_columns: Optional[int] = None,
     insert_columns_at: Optional[str] = None,
     delete_rows: Optional[Union[str, List[int]]] = None,
+    delete_row_range: Optional[str] = None,
     delete_columns: Optional[Union[str, List[str]]] = None,
 ) -> dict:
     """Internal implementation for resize_sheet_dimensions.
@@ -1527,6 +1528,9 @@ async def _resize_sheet_dimensions_impl(
         insert_columns: Number of columns to insert.
         insert_columns_at: Column letter to insert before (e.g. "C"). Appends to end if omitted.
         delete_rows: List of 1-based row numbers to delete.
+        delete_row_range: Contiguous range of rows to delete, as "start:end"
+            (1-based, inclusive). Example: "5:10". More efficient than
+            delete_rows for large contiguous ranges.
         delete_columns: List of column letters to delete.
 
     Returns:
@@ -1547,6 +1551,7 @@ async def _resize_sheet_dimensions_impl(
             insert_rows is not None,
             insert_columns is not None,
             delete_rows,
+            delete_row_range,
             delete_columns,
         ]
     )
@@ -1556,7 +1561,7 @@ async def _resize_sheet_dimensions_impl(
             "auto_resize_columns, auto_resize_rows, frozen_row_count, "
             "frozen_column_count, hide_columns, unhide_columns, "
             "hide_rows, unhide_rows, insert_rows, insert_columns, "
-            "delete_rows, or delete_columns."
+            "delete_rows, delete_row_range, or delete_columns."
         )
 
     # Parse JSON string parameters
@@ -1915,6 +1920,45 @@ async def _resize_sheet_dimensions_impl(
             )
         applied_parts.append(f"deleted rows: {', '.join(str(r) for r in delete_rows)}")
 
+    # Build delete row range request (contiguous range, single API call)
+    if delete_row_range:
+        if isinstance(delete_row_range, str) and ":" in delete_row_range:
+            parts = delete_row_range.split(":", 1)
+            try:
+                range_start = int(parts[0])
+                range_end = int(parts[1])
+            except ValueError as exc:
+                raise UserInputError(
+                    f"Invalid delete_row_range format: '{delete_row_range}'. "
+                    f"Expected 'start:end' with integer row numbers."
+                ) from exc
+        else:
+            raise UserInputError(
+                f"delete_row_range must be a 'start:end' string (e.g. '5:10'), "
+                f"got: '{delete_row_range}'."
+            )
+        if range_start < 1 or range_end < range_start:
+            raise UserInputError(
+                f"Invalid row range: start={range_start}, end={range_end}. "
+                f"Rows are 1-based and end must be >= start."
+            )
+        requests.append(
+            {
+                "deleteDimension": {
+                    "range": {
+                        "sheetId": sheet_id,
+                        "dimension": "ROWS",
+                        "startIndex": range_start - 1,
+                        "endIndex": range_end,
+                    }
+                }
+            }
+        )
+        num_range_deleted = range_end - range_start + 1
+        applied_parts.append(
+            f"deleted row range {range_start}-{range_end} ({num_range_deleted} row(s))"
+        )
+
     # Build delete column requests (process in reverse to keep indices stable)
     if delete_columns:
         if not isinstance(delete_columns, list):
@@ -1982,6 +2026,7 @@ async def resize_sheet_dimensions(
     insert_columns: Optional[int] = None,
     insert_columns_at: Optional[str] = None,
     delete_rows: Optional[Union[str, List[int]]] = None,
+    delete_row_range: Optional[str] = None,
     delete_columns: Optional[Union[str, List[str]]] = None,
 ) -> str:
     """
@@ -2023,7 +2068,11 @@ async def resize_sheet_dimensions(
         insert_columns_at (Optional[str]): Column letter to insert before
             (e.g. "C"). Appends to the end if omitted.
         delete_rows (Optional[Union[str, List[int]]]): List of 1-based row
-            numbers to delete. Example: [5, 6].
+            numbers to delete. Example: [5, 6]. Best for non-contiguous rows.
+        delete_row_range (Optional[str]): Contiguous range of rows to delete,
+            as "start:end" (1-based, inclusive). Example: "5:10" deletes rows
+            5 through 10. More efficient than delete_rows for large contiguous
+            ranges.
         delete_columns (Optional[Union[str, List[str]]]): List of column
             letters to delete. Example: ["E", "F"].
 
@@ -2055,6 +2104,7 @@ async def resize_sheet_dimensions(
         insert_columns=insert_columns,
         insert_columns_at=insert_columns_at,
         delete_rows=delete_rows,
+        delete_row_range=delete_row_range,
         delete_columns=delete_columns,
     )
 
@@ -2062,93 +2112,6 @@ async def resize_sheet_dimensions(
         f"Applied dimension changes in spreadsheet {result['spreadsheet_id']} "
         f"for {user_google_email}: {result['summary']}."
     )
-
-
-@server.tool()
-@handle_http_errors("delete_sheet_rows", service_type="sheets")
-@require_google_service("sheets", "sheets_write")
-async def delete_sheet_rows(
-    service,
-    user_google_email: str,
-    spreadsheet_id: str,
-    sheet_name: str,
-    start_row: int,
-    end_row: int,
-) -> str:
-    """
-    Deletes a contiguous range of rows from a sheet. Row numbers are 1-based
-    (matching what you see in the spreadsheet UI). Both start_row and end_row
-    are inclusive.
-
-    For deleting non-contiguous rows, use resize_sheet_dimensions with the
-    delete_rows parameter instead.
-
-    Args:
-        user_google_email (str): The user's Google email address. Required.
-        spreadsheet_id (str): The ID of the spreadsheet. Required.
-        sheet_name (str): The name of the sheet. Required.
-        start_row (int): First row to delete (1-based, inclusive). Required.
-        end_row (int): Last row to delete (1-based, inclusive). Required.
-
-    Returns:
-        str: Confirmation message with the number of rows deleted.
-    """
-    logger.info(
-        f"[delete_sheet_rows] Invoked. Email: '{user_google_email}', "
-        f"Spreadsheet: {spreadsheet_id}, Sheet: {sheet_name}, "
-        f"Rows: {start_row}-{end_row}"
-    )
-
-    if start_row < 1 or end_row < start_row:
-        raise UserInputError(
-            f"Invalid row range: start_row={start_row}, end_row={end_row}. "
-            f"Rows are 1-based and end_row must be >= start_row."
-        )
-
-    spreadsheet = await asyncio.to_thread(
-        service.spreadsheets()
-        .get(
-            spreadsheetId=spreadsheet_id,
-            fields="sheets(properties(sheetId,title))",
-        )
-        .execute
-    )
-
-    sheet = _select_sheet(spreadsheet.get("sheets", []), sheet_name)
-    sheet_id = sheet["properties"]["sheetId"]
-
-    request_body = {
-        "requests": [
-            {
-                "deleteDimension": {
-                    "range": {
-                        "sheetId": sheet_id,
-                        "dimension": "ROWS",
-                        "startIndex": start_row - 1,
-                        "endIndex": end_row,
-                    }
-                }
-            }
-        ]
-    }
-
-    await asyncio.to_thread(
-        service.spreadsheets()
-        .batchUpdate(spreadsheetId=spreadsheet_id, body=request_body)
-        .execute
-    )
-
-    num_deleted = end_row - start_row + 1
-    text_output = (
-        f"Successfully deleted {num_deleted} row(s) ({start_row}-{end_row}) "
-        f"from sheet '{sheet_name}' in spreadsheet {spreadsheet_id} "
-        f"for {user_google_email}."
-    )
-
-    logger.info(
-        f"[delete_sheet_rows] Deleted {num_deleted} rows for {user_google_email}"
-    )
-    return text_output
 
 
 @server.tool()
@@ -2165,10 +2128,11 @@ async def move_sheet_rows(
 ) -> str:
     """
     Moves rows from one sheet to another within the same spreadsheet. The move
-    is performed atomically in a single batchUpdate (copyPaste followed by
-    deleteDimension), so either both operations succeed or neither does — no
-    risk of duplicated data on partial failure. Formulas, data types, and
-    formatting are preserved (unlike a values.get/append round-trip).
+    is performed in a single batchUpdate (copyPaste followed by
+    deleteDimension). Note: batchUpdate executes requests sequentially but does
+    not roll back on partial failure — if the copy succeeds but the delete
+    fails, rows may be duplicated. Formulas, data types, and formatting are
+    preserved (unlike a values.get/append round-trip).
     Row numbers are 1-based (matching the spreadsheet UI).
 
     Args:
@@ -2210,37 +2174,64 @@ async def move_sheet_rows(
     dst = _select_sheet(sheets, destination_sheet)
     src_id = src["properties"]["sheetId"]
     dst_id = dst["properties"]["sheetId"]
-    dst_row_count = dst["properties"].get("gridProperties", {}).get("rowCount", 0)
+    dst_grid_rows = dst["properties"].get("gridProperties", {}).get("rowCount", 0)
+
+    # Find the last row with actual data in the destination sheet.
+    # gridProperties.rowCount is the allocated grid size (e.g. 1000 for a new
+    # sheet), not the count of rows containing data.
+    dst_values = await asyncio.to_thread(
+        service.spreadsheets()
+        .values()
+        .get(spreadsheetId=spreadsheet_id, range=f"'{destination_sheet}'")
+        .execute
+    )
+    dst_data_rows = len(dst_values.get("values", []))
 
     num_rows = end_row - start_row + 1
+    paste_start = dst_data_rows
 
-    requests = [
-        {
-            "copyPaste": {
-                "source": {
-                    "sheetId": src_id,
-                    "startRowIndex": start_row - 1,
-                    "endRowIndex": end_row,
-                },
-                "destination": {
+    # If pasting beyond the current grid, expand the destination sheet first.
+    requests = []
+    if paste_start + num_rows > dst_grid_rows:
+        requests.append(
+            {
+                "appendDimension": {
                     "sheetId": dst_id,
-                    "startRowIndex": dst_row_count,
-                    "endRowIndex": dst_row_count + num_rows,
-                },
-                "pasteType": "PASTE_NORMAL",
-            }
-        },
-        {
-            "deleteDimension": {
-                "range": {
-                    "sheetId": src_id,
                     "dimension": "ROWS",
-                    "startIndex": start_row - 1,
-                    "endIndex": end_row,
+                    "length": (paste_start + num_rows) - dst_grid_rows,
                 }
             }
-        },
-    ]
+        )
+
+    requests.extend(
+        [
+            {
+                "copyPaste": {
+                    "source": {
+                        "sheetId": src_id,
+                        "startRowIndex": start_row - 1,
+                        "endRowIndex": end_row,
+                    },
+                    "destination": {
+                        "sheetId": dst_id,
+                        "startRowIndex": paste_start,
+                        "endRowIndex": paste_start + num_rows,
+                    },
+                    "pasteType": "PASTE_NORMAL",
+                }
+            },
+            {
+                "deleteDimension": {
+                    "range": {
+                        "sheetId": src_id,
+                        "dimension": "ROWS",
+                        "startIndex": start_row - 1,
+                        "endIndex": end_row,
+                    }
+                }
+            },
+        ]
+    )
 
     await asyncio.to_thread(
         service.spreadsheets()

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -2201,20 +2201,20 @@ async def move_sheet_rows(
 
     # Find the last row with actual data in the destination sheet.
     # gridProperties.rowCount is the allocated grid size (e.g. 1000 for a new
-    # sheet), not the count of rows containing data.
+    # sheet), not the count of rows containing data.  Fetch all columns so the
+    # append position reflects any non-empty cell, not just column A.
     safe_destination = destination_sheet.replace("'", "''")
     dst_values = await asyncio.to_thread(
         service.spreadsheets()
         .values()
         .get(
             spreadsheetId=spreadsheet_id,
-            range=f"'{safe_destination}'!A:A",
-            majorDimension="COLUMNS",
+            range=f"'{safe_destination}'",
+            majorDimension="ROWS",
         )
         .execute
     )
-    dst_columns = dst_values.get("values", [])
-    dst_data_rows = len(dst_columns[0]) if dst_columns else 0
+    dst_data_rows = len(dst_values.get("values", []))
 
     num_rows = end_row - start_row + 1
     paste_start = dst_data_rows

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -1888,6 +1888,14 @@ async def _resize_sheet_dimensions_impl(
             )
             applied_parts.append(f"appended {insert_columns} column(s)")
 
+    # Reject mixing delete_rows and delete_row_range — their interleaved
+    # deleteDimension requests shift indices unpredictably.
+    if delete_rows and delete_row_range:
+        raise UserInputError(
+            "delete_rows and delete_row_range cannot be used together. "
+            "Specify one or the other."
+        )
+
     # Build delete row requests (process in reverse to keep indices stable)
     if delete_rows:
         if not isinstance(delete_rows, list):
@@ -2176,13 +2184,29 @@ async def move_sheet_rows(
     dst_id = dst["properties"]["sheetId"]
     dst_grid_rows = dst["properties"].get("gridProperties", {}).get("rowCount", 0)
 
+    # Validate that the source row block actually contains data.
+    safe_source = source_sheet.replace("'", "''")
+    src_range = f"'{safe_source}'!{start_row}:{end_row}"
+    src_values = await asyncio.to_thread(
+        service.spreadsheets()
+        .values()
+        .get(spreadsheetId=spreadsheet_id, range=src_range)
+        .execute
+    )
+    if not src_values.get("values"):
+        raise UserInputError(
+            f"Source range '{source_sheet}' rows {start_row}-{end_row} "
+            f"contains no data. Nothing to move."
+        )
+
     # Find the last row with actual data in the destination sheet.
     # gridProperties.rowCount is the allocated grid size (e.g. 1000 for a new
     # sheet), not the count of rows containing data.
+    safe_destination = destination_sheet.replace("'", "''")
     dst_values = await asyncio.to_thread(
         service.spreadsheets()
         .values()
-        .get(spreadsheetId=spreadsheet_id, range=f"'{destination_sheet}'")
+        .get(spreadsheetId=spreadsheet_id, range=f"'{safe_destination}'")
         .execute
     )
     dst_data_rows = len(dst_values.get("values", []))

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -2064,6 +2064,207 @@ async def resize_sheet_dimensions(
     )
 
 
+@server.tool()
+@handle_http_errors("delete_sheet_rows", service_type="sheets")
+@require_google_service("sheets", "sheets_write")
+async def delete_sheet_rows(
+    service,
+    user_google_email: str,
+    spreadsheet_id: str,
+    sheet_name: str,
+    start_row: int,
+    end_row: int,
+) -> str:
+    """
+    Deletes a contiguous range of rows from a sheet. Row numbers are 1-based
+    (matching what you see in the spreadsheet UI). Both start_row and end_row
+    are inclusive.
+
+    For deleting non-contiguous rows, use resize_sheet_dimensions with the
+    delete_rows parameter instead.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        spreadsheet_id (str): The ID of the spreadsheet. Required.
+        sheet_name (str): The name of the sheet. Required.
+        start_row (int): First row to delete (1-based, inclusive). Required.
+        end_row (int): Last row to delete (1-based, inclusive). Required.
+
+    Returns:
+        str: Confirmation message with the number of rows deleted.
+    """
+    logger.info(
+        f"[delete_sheet_rows] Invoked. Email: '{user_google_email}', "
+        f"Spreadsheet: {spreadsheet_id}, Sheet: {sheet_name}, "
+        f"Rows: {start_row}-{end_row}"
+    )
+
+    if start_row < 1 or end_row < start_row:
+        raise UserInputError(
+            f"Invalid row range: start_row={start_row}, end_row={end_row}. "
+            f"Rows are 1-based and end_row must be >= start_row."
+        )
+
+    spreadsheet = await asyncio.to_thread(
+        service.spreadsheets()
+        .get(
+            spreadsheetId=spreadsheet_id,
+            fields="sheets(properties(sheetId,title))",
+        )
+        .execute
+    )
+
+    sheet = _select_sheet(spreadsheet.get("sheets", []), sheet_name)
+    sheet_id = sheet["properties"]["sheetId"]
+
+    request_body = {
+        "requests": [
+            {
+                "deleteDimension": {
+                    "range": {
+                        "sheetId": sheet_id,
+                        "dimension": "ROWS",
+                        "startIndex": start_row - 1,
+                        "endIndex": end_row,
+                    }
+                }
+            }
+        ]
+    }
+
+    await asyncio.to_thread(
+        service.spreadsheets()
+        .batchUpdate(spreadsheetId=spreadsheet_id, body=request_body)
+        .execute
+    )
+
+    num_deleted = end_row - start_row + 1
+    text_output = (
+        f"Successfully deleted {num_deleted} row(s) ({start_row}-{end_row}) "
+        f"from sheet '{sheet_name}' in spreadsheet {spreadsheet_id} "
+        f"for {user_google_email}."
+    )
+
+    logger.info(
+        f"[delete_sheet_rows] Deleted {num_deleted} rows for {user_google_email}"
+    )
+    return text_output
+
+
+@server.tool()
+@handle_http_errors("move_sheet_rows", service_type="sheets")
+@require_google_service("sheets", "sheets_write")
+async def move_sheet_rows(
+    service,
+    user_google_email: str,
+    spreadsheet_id: str,
+    source_sheet: str,
+    start_row: int,
+    end_row: int,
+    destination_sheet: str,
+) -> str:
+    """
+    Moves rows from one sheet to another within the same spreadsheet. Reads the
+    row data from the source sheet, appends it to the destination sheet, then
+    deletes the original rows. Row numbers are 1-based (matching the spreadsheet UI).
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        spreadsheet_id (str): The ID of the spreadsheet. Required.
+        source_sheet (str): Name of the sheet to move rows from. Required.
+        start_row (int): First row to move (1-based, inclusive). Required.
+        end_row (int): Last row to move (1-based, inclusive). Required.
+        destination_sheet (str): Name of the sheet to move rows to. Required.
+
+    Returns:
+        str: Confirmation message with the number of rows moved.
+    """
+    logger.info(
+        f"[move_sheet_rows] Invoked. Email: '{user_google_email}', "
+        f"Spreadsheet: {spreadsheet_id}, "
+        f"From: {source_sheet}!{start_row}-{end_row}, To: {destination_sheet}"
+    )
+
+    if start_row < 1 or end_row < start_row:
+        raise UserInputError(
+            f"Invalid row range: start_row={start_row}, end_row={end_row}. "
+            f"Rows are 1-based and end_row must be >= start_row."
+        )
+
+    if source_sheet == destination_sheet:
+        raise UserInputError("source_sheet and destination_sheet must be different.")
+
+    source_range = f"'{source_sheet}'!{start_row}:{end_row}"
+    result = await asyncio.to_thread(
+        service.spreadsheets()
+        .values()
+        .get(spreadsheetId=spreadsheet_id, range=source_range)
+        .execute
+    )
+
+    values = result.get("values", [])
+    if not values:
+        raise UserInputError(
+            f"No data found in {source_sheet} rows {start_row}-{end_row}."
+        )
+
+    dest_range = f"'{destination_sheet}'!A1"
+    await asyncio.to_thread(
+        service.spreadsheets()
+        .values()
+        .append(
+            spreadsheetId=spreadsheet_id,
+            range=dest_range,
+            valueInputOption="RAW",
+            body={"values": values},
+        )
+        .execute
+    )
+
+    spreadsheet = await asyncio.to_thread(
+        service.spreadsheets()
+        .get(
+            spreadsheetId=spreadsheet_id,
+            fields="sheets(properties(sheetId,title))",
+        )
+        .execute
+    )
+
+    sheet = _select_sheet(spreadsheet.get("sheets", []), source_sheet)
+    sheet_id = sheet["properties"]["sheetId"]
+
+    delete_body = {
+        "requests": [
+            {
+                "deleteDimension": {
+                    "range": {
+                        "sheetId": sheet_id,
+                        "dimension": "ROWS",
+                        "startIndex": start_row - 1,
+                        "endIndex": end_row,
+                    }
+                }
+            }
+        ]
+    }
+
+    await asyncio.to_thread(
+        service.spreadsheets()
+        .batchUpdate(spreadsheetId=spreadsheet_id, body=delete_body)
+        .execute
+    )
+
+    num_moved = len(values)
+    text_output = (
+        f"Successfully moved {num_moved} row(s) from '{source_sheet}' "
+        f"(rows {start_row}-{end_row}) to '{destination_sheet}' "
+        f"in spreadsheet {spreadsheet_id} for {user_google_email}."
+    )
+
+    logger.info(f"[move_sheet_rows] Moved {num_moved} rows for {user_google_email}")
+    return text_output
+
+
 # Create comment management tools for sheets
 _comment_tools = create_comment_tools("spreadsheet", "spreadsheet_id")
 

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -2164,9 +2164,12 @@ async def move_sheet_rows(
     destination_sheet: str,
 ) -> str:
     """
-    Moves rows from one sheet to another within the same spreadsheet. Reads the
-    row data from the source sheet, appends it to the destination sheet, then
-    deletes the original rows. Row numbers are 1-based (matching the spreadsheet UI).
+    Moves rows from one sheet to another within the same spreadsheet. The move
+    is performed atomically in a single batchUpdate (copyPaste followed by
+    deleteDimension), so either both operations succeed or neither does — no
+    risk of duplicated data on partial failure. Formulas, data types, and
+    formatting are preserved (unlike a values.get/append round-trip).
+    Row numbers are 1-based (matching the spreadsheet UI).
 
     Args:
         user_google_email (str): The user's Google email address. Required.
@@ -2194,74 +2197,64 @@ async def move_sheet_rows(
     if source_sheet == destination_sheet:
         raise UserInputError("source_sheet and destination_sheet must be different.")
 
-    source_range = f"'{source_sheet}'!{start_row}:{end_row}"
-    result = await asyncio.to_thread(
-        service.spreadsheets()
-        .values()
-        .get(spreadsheetId=spreadsheet_id, range=source_range)
-        .execute
-    )
-
-    values = result.get("values", [])
-    if not values:
-        raise UserInputError(
-            f"No data found in {source_sheet} rows {start_row}-{end_row}."
-        )
-
-    dest_range = f"'{destination_sheet}'!A1"
-    await asyncio.to_thread(
-        service.spreadsheets()
-        .values()
-        .append(
-            spreadsheetId=spreadsheet_id,
-            range=dest_range,
-            valueInputOption="RAW",
-            body={"values": values},
-        )
-        .execute
-    )
-
     spreadsheet = await asyncio.to_thread(
         service.spreadsheets()
         .get(
             spreadsheetId=spreadsheet_id,
-            fields="sheets(properties(sheetId,title))",
+            fields="sheets(properties(sheetId,title,gridProperties))",
         )
         .execute
     )
+    sheets = spreadsheet.get("sheets", [])
+    src = _select_sheet(sheets, source_sheet)
+    dst = _select_sheet(sheets, destination_sheet)
+    src_id = src["properties"]["sheetId"]
+    dst_id = dst["properties"]["sheetId"]
+    dst_row_count = dst["properties"].get("gridProperties", {}).get("rowCount", 0)
 
-    sheet = _select_sheet(spreadsheet.get("sheets", []), source_sheet)
-    sheet_id = sheet["properties"]["sheetId"]
+    num_rows = end_row - start_row + 1
 
-    delete_body = {
-        "requests": [
-            {
-                "deleteDimension": {
-                    "range": {
-                        "sheetId": sheet_id,
-                        "dimension": "ROWS",
-                        "startIndex": start_row - 1,
-                        "endIndex": end_row,
-                    }
+    requests = [
+        {
+            "copyPaste": {
+                "source": {
+                    "sheetId": src_id,
+                    "startRowIndex": start_row - 1,
+                    "endRowIndex": end_row,
+                },
+                "destination": {
+                    "sheetId": dst_id,
+                    "startRowIndex": dst_row_count,
+                    "endRowIndex": dst_row_count + num_rows,
+                },
+                "pasteType": "PASTE_NORMAL",
+            }
+        },
+        {
+            "deleteDimension": {
+                "range": {
+                    "sheetId": src_id,
+                    "dimension": "ROWS",
+                    "startIndex": start_row - 1,
+                    "endIndex": end_row,
                 }
             }
-        ]
-    }
+        },
+    ]
 
     await asyncio.to_thread(
         service.spreadsheets()
-        .batchUpdate(spreadsheetId=spreadsheet_id, body=delete_body)
+        .batchUpdate(spreadsheetId=spreadsheet_id, body={"requests": requests})
         .execute
     )
 
-    num_moved = len(values)
     text_output = (
-        f"Successfully moved {num_moved} row(s) from '{source_sheet}' "
+        f"Successfully moved {num_rows} row(s) from '{source_sheet}' "
         f"(rows {start_row}-{end_row}) to '{destination_sheet}' "
         f"in spreadsheet {spreadsheet_id} for {user_google_email}."
     )
 
-    logger.info(f"[move_sheet_rows] Moved {num_moved} rows for {user_google_email}")
+    logger.info(f"[move_sheet_rows] Moved {num_rows} rows for {user_google_email}")
     return text_output
 
 

--- a/skills/managing-google-workspace/SKILL.md
+++ b/skills/managing-google-workspace/SKILL.md
@@ -153,6 +153,7 @@ For parameters: [references/docs.md](references/docs.md)
 | Get spreadsheet info | `get_spreadsheet_info` |
 | Create spreadsheet | `create_spreadsheet` |
 | Create sheet (tab) | `create_sheet` |
+| Move rows between sheets | `move_sheet_rows` |
 | List spreadsheets | `list_spreadsheets` |
 | Comments | `manage_spreadsheet_comment` / `list_spreadsheet_comments` |
 

--- a/skills/managing-google-workspace/references/sheets.md
+++ b/skills/managing-google-workspace/references/sheets.md
@@ -5,7 +5,7 @@ MCP tools for reading, writing, formatting, and managing Google Sheets. All tool
 ## Contents
 - Search & Info: list_spreadsheets, get_spreadsheet_info
 - Read & Write: read_sheet_values, modify_sheet_values
-- Create: create_spreadsheet, create_sheet
+- Create: create_spreadsheet, create_sheet, move_sheet_rows
 - Formatting: format_sheet_range, manage_conditional_formatting
 - Comments: list_spreadsheet_comments, manage_spreadsheet_comment
 - Tips
@@ -78,6 +78,18 @@ Add a new sheet (tab) to an existing spreadsheet.
 | user_google_email | string | yes | | |
 | spreadsheet_id | string | yes | | |
 | sheet_name | string | yes | | |
+
+### move_sheet_rows
+Move rows from one sheet to another within the same spreadsheet. Preserves formulas, data types, and formatting.
+
+| Parameter | Type | Required | Default | Notes |
+|-----------|------|----------|---------|-------|
+| user_google_email | string | yes | | |
+| spreadsheet_id | string | yes | | |
+| source_sheet | string | yes | | Name of the sheet to move rows from |
+| start_row | integer | yes | | First row to move (1-based, inclusive) |
+| end_row | integer | yes | | Last row to move (1-based, inclusive) |
+| destination_sheet | string | yes | | Name of the sheet to move rows to |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds two row-management tools to `gsheets/sheets_tools.py`, complementing the recently-merged `resize_sheet_dimensions` (#???) and table tools (#643):

- **`delete_sheet_rows`** — deletes a contiguous range of rows by 1-based `start_row`/`end_row` (inclusive). Useful when you want to drop a block of rows by range (e.g. clear rows 100-500) without enumerating each row number. For non-contiguous deletes, `resize_sheet_dimensions` with `delete_rows: [...]` remains the right tool.
- **`move_sheet_rows`** — copies a contiguous row range from one sheet to another within the same spreadsheet, then deletes the source rows. Useful for archiving (move closed/processed rows to an archive tab), routing (move rows matching a condition to a downstream-processing tab), or splitting tabs.

## Implementation notes

Both tools follow the existing patterns in `sheets_tools.py`:
- 1-based row numbers matching the spreadsheet UI
- `asyncio.to_thread` for blocking API calls
- `UserInputError` for invalid input (start_row < 1, end_row < start_row, source == destination for move)
- Reuses the existing `_select_sheet` helper from `sheets_helpers.py`
- Decorated with `@server.tool()`, `@handle_http_errors`, `@require_google_service("sheets", "sheets_write")`
- Exports added to `gsheets/__init__.py`

## Test plan

- [ ] Manual: delete contiguous rows 5-10 in a test sheet, confirm the rows are removed and remaining rows shift up
- [ ] Manual: move rows from `SheetA!2:5` to `SheetB`, confirm appended at the end of SheetB and removed from SheetA
- [ ] Manual: invalid input (start_row=0, end_row<start_row, same source/destination) returns `UserInputError`
- [ ] Manual: move from a sheet with no data in the requested range returns `UserInputError`
- [ ] `uvx ruff check gsheets/` passes
- [ ] `uvx ruff format --check gsheets/` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete rows by specifying a contiguous row range (start:end).
  * Move rows between sheets with optional destination expansion and a summary of rows moved.
  * Exposed the row-moving capability for public use.

* **Bug Fixes / Validation**
  * Added input validation and clearer error messages for range formats and ordering.
  * Prevents combining overlapping delete options and disallows invalid/empty moves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->