### PR TITLE
Relax MCP protocol auth scope requirements

### DIFF
--- a/auth/scopes.py
+++ b/auth/scopes.py
@@ -131,6 +131,9 @@ def has_required_scopes(available_scopes, required_scopes):
 # Base OAuth scopes required for user identification
 BASE_SCOPES = [USERINFO_EMAIL_SCOPE, USERINFO_PROFILE_SCOPE, OPENID_SCOPE]
 
+# Minimal scopes required to accept an MCP bearer token at the protocol layer.
+PROTOCOL_AUTH_SCOPES = [USERINFO_EMAIL_SCOPE, OPENID_SCOPE]
+
 # Service-specific scope groups
 DOCS_SCOPES = [
     DOCS_READONLY_SCOPE,

--- a/core/server.py
+++ b/core/server.py
@@ -25,7 +25,7 @@ from auth.oauth_responses import (
     create_server_error_response,
 )
 from auth.auth_info_middleware import AuthInfoMiddleware
-from auth.scopes import BASE_SCOPES, SCOPES, get_current_scopes  # noqa
+from auth.scopes import PROTOCOL_AUTH_SCOPES, SCOPES, get_current_scopes  # noqa
 from core.config import (
     USER_GOOGLE_EMAIL,
     get_transport_mode,
@@ -258,7 +258,7 @@ def configure_server_for_http():
             from fastmcp.server.auth.jwt_issuer import derive_jwt_key
 
             provider_valid_scopes: List[str] = sorted(get_current_scopes())
-            provider_required_scopes: List[str] = sorted(BASE_SCOPES)
+            provider_required_scopes: List[str] = sorted(PROTOCOL_AUTH_SCOPES)
 
             client_storage = None
             jwt_signing_key_override = (

--- a/tests/core/test_http_oauth_scope_config.py
+++ b/tests/core/test_http_oauth_scope_config.py
@@ -5,7 +5,7 @@ import pytest
 import core.server as server_module
 
 
-def test_configure_server_for_http_uses_base_required_scopes(monkeypatch):
+def test_configure_server_for_http_uses_protocol_auth_required_scopes(monkeypatch):
     captured = {}
 
     class FakeGoogleProvider:
@@ -50,7 +50,7 @@ def test_configure_server_for_http_uses_base_required_scopes(monkeypatch):
 
     server_module.configure_server_for_http()
 
-    assert captured["required_scopes"] == sorted(server_module.BASE_SCOPES)
+    assert captured["required_scopes"] == sorted(server_module.PROTOCOL_AUTH_SCOPES)
     assert captured["valid_scopes"] == sorted(server_module.get_current_scopes())
     assert (
         server_module.server.auth.client_registration_options.default_scopes


### PR DESCRIPTION
## Summary
- add a separate minimal protocol auth scope list for MCP bearer-token validation
- require only user identity scopes needed to accept the token (`userinfo.email` and `openid`)
- keep advertised/default valid scopes unchanged, so clients can still request `userinfo.profile` and all tool scopes

## Why
A token minted for a limited Workspace grant, for example `openid userinfo.email calendar.readonly`, can be fresh and otherwise valid but still fail `/api/mcp` validation if `GoogleProvider.required_scopes` also requires `userinfo.profile`. That turns a missing optional identity profile grant into a generic `401 invalid_token`.

## Tests
- `uv run ruff check .`
- `uv run pytest tests/core/test_http_oauth_scope_config.py tests/test_scopes.py -q` (`35 passed, 1 warning`)
- Full-suite note: `uv run pytest -q` currently stops on missing optional GCS dependency; `uv run --extra gcs pytest -q` runs the suite but reports two unrelated failures in `tests/auth/test_oauth_callback_server.py` and `tests/gdocs/test_insert_doc_tab_response.py` outside this patch area.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced OAuth authentication scope configuration to improve protocol-layer bearer token acceptance. Updated scope definitions provide better control over authentication request handling and security while maintaining full compatibility with existing authentication workflows.

* **Tests**
  * Updated authentication configuration tests to validate scope requirements and ensure correct configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->