### PR TITLE
Add optional email allowlist for OAuth callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist/
 
 # ---- Environments & tooling -------------------------------------------
 .env
+.env*
 .venv/
 venv/
 .idea/

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -727,10 +727,10 @@ async def handle_auth_callback(
             }
             if user_google_email.lower() not in allowed_emails:
                 logger.warning(
-                    f"Rejecting OAuth callback: {user_google_email} not in WORKSPACE_MCP_ALLOWED_EMAILS"
+                    "Rejecting OAuth callback: authenticated email not in WORKSPACE_MCP_ALLOWED_EMAILS"
                 )
                 raise PermissionError(
-                    f"Access denied: {user_google_email} is not authorized to use this server."
+                    "Access denied: this account is not authorized to use this server."
                 )
 
         stateless_mode = is_stateless_mode()

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -720,6 +720,19 @@ async def handle_auth_callback(
         user_google_email = user_info["email"]
         logger.info(f"Identified user_google_email: {user_google_email}")
 
+        allowed_emails_raw = os.getenv("WORKSPACE_MCP_ALLOWED_EMAILS", "").strip()
+        if allowed_emails_raw:
+            allowed_emails = {
+                e.strip().lower() for e in allowed_emails_raw.split(",") if e.strip()
+            }
+            if user_google_email.lower() not in allowed_emails:
+                logger.warning(
+                    f"Rejecting OAuth callback: {user_google_email} not in WORKSPACE_MCP_ALLOWED_EMAILS"
+                )
+                raise PermissionError(
+                    f"Access denied: {user_google_email} is not authorized to use this server."
+                )
+
         stateless_mode = is_stateless_mode()
         credential_store = None
         if not stateless_mode:


### PR DESCRIPTION
## Summary

- Adds an optional `WORKSPACE_MCP_ALLOWED_EMAILS` env var (comma-separated) that restricts which Google accounts can complete the OAuth callback.
- When the verified email returned by Google is not in the allowlist, the callback raises `PermissionError` before any credentials are stored.
- When the env var is unset or empty, behavior is unchanged — fully backward compatible.

## Why

After publishing the OAuth consent screen to "In production" (so refresh tokens last beyond 7 days), any Google account can complete the OAuth flow against the deployment. For self-hosted or small-team deployments this is undesirable — operators want to publish the consent screen but still restrict who can actually use the server. A simple env-var allowlist is the lowest-friction way to do this without requiring IAP or a separate auth proxy.

## Behavior

- `WORKSPACE_MCP_ALLOWED_EMAILS` unset/empty → no allowlist enforced (current behavior).
- Set to `alice@example.com,bob@example.com` → only those emails can authenticate; others get a `PermissionError` surfaced via the existing callback error handler.
- Comparison is case-insensitive and trims whitespace around each entry.

## Test plan

- [ ] Deploy without the env var; confirm OAuth flow still works.
- [ ] Set `WORKSPACE_MCP_ALLOWED_EMAILS` to your own email; confirm OAuth flow still works.
- [ ] Attempt the OAuth flow from a Google account not in the list; confirm it is rejected and no credential file is written.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional email allowlist for Google sign-in: when configured, only addresses in the allowlist can complete OAuth sign-in; blocked attempts are logged and prevented.

* **Chores**
  * Git ignore updated to exclude any files beginning with ".env" to better protect environment and secret configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->