### PR TITLE
fix: set SO_REUSEADDR on port probes to match uvicorn's actual bind

### DIFF
--- a/main.py
+++ b/main.py
@@ -747,9 +747,15 @@ def main():
             )
 
         if args.transport == "streamable-http":
-            # Check port availability before starting HTTP server
+            # Check port availability before starting HTTP server.
+            # SO_REUSEADDR matches what asyncio's loop.create_server()
+            # (called by uvicorn under server.run()) does automatically
+            # on Unix; without it this probe is strictly stricter than
+            # the real bind that follows and fails on lingering
+            # TIME_WAIT sockets that uvicorn would happily rebind over.
             try:
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                     s.bind((host, port))
             except OSError as e:
                 safe_print(f"Socket error: {e}")
@@ -778,7 +784,11 @@ def main():
                     """Run stdio and HTTP transports concurrently."""
                     http_available = True
                     try:
+                        # See note above on the streamable-http probe — match
+                        # asyncio/uvicorn's SO_REUSEADDR behavior so a quick
+                        # restart isn't blocked by lingering TIME_WAIT sockets.
                         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                             s.bind((http_host, http_port))
                     except OSError:
                         logger.warning(


### PR DESCRIPTION
## Description

The pre-flight `socket.bind()` probe used to gate `streamable-http` startup creates a vanilla socket without `SO_REUSEADDR`, so on macOS it fails as soon as there are lingering `TIME_WAIT` sockets on port 8000 from a previous run's MCP traffic. The process exits with `❌ Port 8000 is already in use` before `uvicorn` ever runs.

But the real bind that follows goes through `uvicorn.Server` → `loop.create_server()`, and per the [asyncio docs](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.create_server) `reuse_address` defaults to `True` on Unix. The probe is strictly stricter than the bind it's supposed to protect — in practice uvicorn would happily rebind the port if we let it.

This PR sets `SO_REUSEADDR` on both probes (the streamable-http main listener at `main.py:749` and the dual-transport workspace-cli sidecar at `main.py:780`) so they match the behavior of the asyncio bind that follows. No change to the actual runtime semantics — same listener, same port, same process — just removes a false-negative from the probe.

Fixes the EADDRINUSE-on-quick-restart symptom I reported at the end of #667. The orphan-process / hardcoded-port design concerns raised in that issue remain a separate (larger) cleanup that this PR doesn't try to address.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

**Manual test (macOS, Apple Silicon, Python 3.13):**

1. Start with `uvx workspace-mcp --transport streamable-http --tool-tier core` — server binds 8000, accept some MCP traffic to populate established connections.
2. SIGTERM the process. Logs show clean uvicorn shutdown (`Application shutdown complete. Finished server process [N]`).
3. Immediately re-run the same `uvx workspace-mcp ...` command.

Before this PR: second run reliably exits with `Socket error: [Errno 48] Address already in use ❌ Port 8000 is already in use`.
After this PR: second run binds port 8000 successfully and serves MCP requests as expected.

I did not add an automated test because the failure window depends on `TIME_WAIT` timing, which is hard to assert deterministically in CI. Happy to add one (e.g., a unit test that asserts `setsockopt` was called) if you'd prefer.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of HTTP sidecar startup by enhancing port availability detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->