### PR TITLE
fix: cwe77 ruff GitHub 5c87

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -10,23 +10,6 @@ permissions:
   contents: read
 
 jobs:
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
-      with:
-        python-version: '3.11'
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-    - name: Validate
-      # Use `uvx` so we run ruff in an isolated environment without invoking
-      # the project's build backend or executing pyproject.toml hooks. This
-      # keeps the validation step safe to run on untrusted fork PR code.
-      run: |
-        uvx ruff check
-        uvx ruff format --check
-
   autofix:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
@@ -56,3 +39,23 @@ jobs:
         git add -A
         git commit -m "style: auto-fix ruff lint and format"
         git push
+
+  ruff:
+    if: always() && github.event_name == 'pull_request'
+    needs: [autofix]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+    - name: Validate
+      # Use `uvx` so we run ruff in an isolated environment without invoking
+      # the project's build backend or executing pyproject.toml hooks. This
+      # keeps the validation step safe to run on untrusted fork PR code.
+      # For same-repo PRs, this runs after autofix commits any formatting fixes.
+      run: |
+        uvx ruff check
+        uvx ruff format --check

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   autofix:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -41,7 +41,7 @@ jobs:
         git push
 
   ruff:
-    if: always() && github.event_name == 'pull_request'
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'push')
     needs: [autofix]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -19,12 +19,13 @@ jobs:
         python-version: '3.11'
     - name: Install uv
       uses: astral-sh/setup-uv@v7
-    - name: Install dependencies
-      run: uv sync
     - name: Validate
+      # Use `uvx` so we run ruff in an isolated environment without invoking
+      # the project's build backend or executing pyproject.toml hooks. This
+      # keeps the validation step safe to run on untrusted fork PR code.
       run: |
-        uv run ruff check
-        uv run ruff format --check
+        uvx ruff check
+        uvx ruff format --check
 
   autofix:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
@@ -41,12 +42,12 @@ jobs:
         python-version: '3.11'
     - name: Install uv
       uses: astral-sh/setup-uv@v7
-    - name: Install dependencies
-      run: uv sync
     - name: Auto-fix ruff lint and format
+      # Same-repo only (guarded by job `if`), so we still avoid `uv sync`
+      # to keep behaviour consistent and minimise blast radius.
       run: |
-        uv run ruff check --fix
-        uv run ruff format
+        uvx ruff check --fix
+        uvx ruff format
     - name: Commit and push fixes
       run: |
         git diff --quiet && exit 0

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,16 +7,34 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
-        ref: ${{ github.event.pull_request.head.ref || github.ref }}
-        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+        python-version: '3.11'
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+    - name: Install dependencies
+      run: uv sync
+    - name: Validate
+      run: |
+        uv run ruff check
+        uv run ruff format --check
+
+  autofix:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/setup-python@v6
       with:
@@ -26,12 +44,10 @@ jobs:
     - name: Install dependencies
       run: uv sync
     - name: Auto-fix ruff lint and format
-      if: github.event_name == 'pull_request'
       run: |
         uv run ruff check --fix
         uv run ruff format
     - name: Commit and push fixes
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       run: |
         git diff --quiet && exit 0
         git config user.name "github-actions[bot]"
@@ -39,7 +55,3 @@ jobs:
         git add -A
         git commit -m "style: auto-fix ruff lint and format"
         git push
-    - name: Validate
-      run: |
-        uv run ruff check
-        uv run ruff format --check

--- a/tests/test_cwe77_ruff_workflow.py
+++ b/tests/test_cwe77_ruff_workflow.py
@@ -66,6 +66,40 @@ def _workflow_has_write_permission(wf: Dict[str, Any]) -> bool:
     return False
 
 
+def _is_same_repo_guard(expr: str) -> bool:
+    """Return True only for exact same-repository pull request guards."""
+    normalized: str = " ".join(expr.split())
+    if normalized.startswith("${{") and normalized.endswith("}}"):
+        normalized = " ".join(normalized[3:-2].split())
+
+    same_repo_expressions = {
+        "github.event.pull_request.head.repo.full_name == github.repository",
+        "github.repository == github.event.pull_request.head.repo.full_name",
+    }
+    return normalized in same_repo_expressions
+
+
+def test_same_repo_guard_matcher_is_strict() -> None:
+    """Same-repo guards must be exact, not broad substring matches."""
+    assert _is_same_repo_guard(
+        "github.event.pull_request.head.repo.full_name == github.repository"
+    )
+    assert _is_same_repo_guard(
+        "github.repository == github.event.pull_request.head.repo.full_name"
+    )
+    assert _is_same_repo_guard(
+        "${{ github.event.pull_request.head.repo.full_name   ==   github.repository }}"
+    )
+
+    assert not _is_same_repo_guard(
+        "github.event_name == 'pull_request' && "
+        "github.event.pull_request.head.repo.full_name == github.repository"
+    )
+    assert not _is_same_repo_guard(
+        "github.event.pull_request.head.repo.full_name == 'attacker/repo'"
+    )
+
+
 def test_no_fork_repo_checkout() -> None:
     """Checkout step must NOT reference github.event.pull_request.head.repo.full_name
     as the repository parameter, which would check out attacker-controlled fork code."""
@@ -82,7 +116,7 @@ def test_no_fork_repo_checkout() -> None:
 
                 # Must NOT reference the fork's repo
                 assert "pull_request.head.repo" not in repo_param, (
-                    f"Job \'{job_name}\' checkout uses fork repository: {repo_param}. "
+                    f"Job '{job_name}' checkout uses fork repository: {repo_param}. "
                     "This allows attacker-controlled code execution."
                 )
 
@@ -98,10 +132,7 @@ def test_uv_sync_not_on_fork_prs() -> None:
     jobs: Dict[str, Any] = wf.get("jobs", {})
     for job_name, job in jobs.items():
         job_if: str = str(job.get("if", ""))
-        job_is_fork_guarded: bool = (
-            "head.repo.full_name == github.repository" in job_if
-            or "head.repo.full_name ==" in job_if
-        )
+        job_is_fork_guarded: bool = _is_same_repo_guard(job_if)
 
         steps = job.get("steps", [])
         for step in steps:
@@ -110,13 +141,10 @@ def test_uv_sync_not_on_fork_prs() -> None:
                 continue
 
             step_if: str = str(step.get("if", ""))
-            step_is_fork_guarded: bool = (
-                "head.repo.full_name == github.repository" in step_if
-                or "head.repo.full_name ==" in step_if
-            )
+            step_is_fork_guarded: bool = _is_same_repo_guard(step_if)
 
             assert job_is_fork_guarded or step_is_fork_guarded, (
-                f"Job \'{job_name}\' runs a project-aware install "
+                f"Job '{job_name}' runs a project-aware install "
                 f"({run_cmd.strip().splitlines()[0]!r}) without a fork guard "
                 "on either the job or the step. Attacker-controlled "
                 "pyproject.toml/build hooks could execute on fork PRs."
@@ -139,10 +167,7 @@ def test_no_write_permissions_or_fork_guarded() -> None:
             continue
 
         job_if: str = str(job.get("if", ""))
-        job_is_fork_guarded: bool = (
-            "head.repo.full_name == github.repository" in job_if
-            or "head.repo.full_name ==" in job_if
-        )
+        job_is_fork_guarded: bool = _is_same_repo_guard(job_if)
 
         steps = job.get("steps", [])
         for step in steps:
@@ -151,23 +176,43 @@ def test_no_write_permissions_or_fork_guarded() -> None:
                 with_params: Dict[str, Any] = step.get("with", {})
                 repo_param: str = str(with_params.get("repository", ""))
                 assert "pull_request.head.repo" not in repo_param, (
-                    f"Job \'{job_name}\' has write permissions AND checks out fork code. "
+                    f"Job '{job_name}' has write permissions AND checks out fork code. "
                     "This is a critical security issue (CWE-77)."
                 )
 
         assert job_is_fork_guarded, (
-            f"Job \'{job_name}\' has write permissions but lacks a same-repo "
+            f"Job '{job_name}' has write permissions but lacks a same-repo "
             "`if` guard. Add `if: github.event.pull_request.head.repo.full_name "
             "== github.repository` (or equivalent) to prevent fork PRs from "
             "running with elevated permissions."
         )
 
 
+def test_push_trigger_runs_ruff_validation() -> None:
+    """If the workflow listens for pushes to main, the validation job must run."""
+    wf, _raw = load_workflow(WORKFLOW_PATH)
+
+    workflow_on: Any = wf.get("on", wf.get(True, {}))
+    push_event: Any = (
+        workflow_on.get("push", {}) if isinstance(workflow_on, dict) else {}
+    )
+    push_branches: Any = (
+        push_event.get("branches", []) if isinstance(push_event, dict) else []
+    )
+    assert "main" in push_branches
+
+    ruff_job: Dict[str, Any] = wf.get("jobs", {}).get("ruff", {})
+    ruff_if: str = " ".join(str(ruff_job.get("if", "")).split())
+    assert "github.event_name == 'push'" in ruff_if
+
+
 if __name__ == "__main__":
     tests = [
+        test_same_repo_guard_matcher_is_strict,
         test_no_fork_repo_checkout,
         test_uv_sync_not_on_fork_prs,
         test_no_write_permissions_or_fork_guarded,
+        test_push_trigger_runs_ruff_validation,
     ]
 
     failed = 0

--- a/tests/test_cwe77_ruff_workflow.py
+++ b/tests/test_cwe77_ruff_workflow.py
@@ -9,106 +9,158 @@ pyproject.toml or inject malicious ruff plugins to achieve code execution
 with the workflow's contents:write GITHUB_TOKEN.
 
 The fix: remove the explicit repository/ref override so `actions/checkout`
-uses the default merge commit ref (github.sha) for pull_request events.
+uses the default merge commit ref (github.sha) for pull_request events,
+and avoid project-aware installers (`uv sync`, `pip install .`) on the
+fork-facing validation job so attacker-controlled build hooks cannot run.
 """
 
-import sys
+from __future__ import annotations
+
 import os
+import sys
+from typing import Any, Dict, Tuple
+
 import yaml
 
 # Resolve the repo root (one level up from tests/)
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-WORKFLOW_PATH = os.path.join(REPO_ROOT, ".github", "workflows", "ruff.yml")
+REPO_ROOT: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOW_PATH: str = os.path.join(REPO_ROOT, ".github", "workflows", "ruff.yml")
+
+# Commands that resolve and execute the project's own build backend /
+# pyproject.toml hooks. These must NOT run on untrusted fork PR code.
+PROJECT_INSTALL_COMMANDS: Tuple[str, ...] = (
+    "uv sync",
+    "uv pip install -e",
+    "uv pip install .",
+    "pip install -e",
+    "pip install .",
+    "poetry install",
+)
 
 
-
-def load_workflow(path):
+def load_workflow(path: str) -> Tuple[Dict[str, Any], str]:
+    """Load a workflow file and return (parsed_yaml, raw_text)."""
     with open(path, "r") as f:
-        return yaml.safe_load(f), f.read()
+        raw: str = f.read()
+    parsed: Dict[str, Any] = yaml.safe_load(raw)
+    return parsed, raw
 
 
-def test_no_fork_repo_checkout():
+def _job_has_write_permission(job: Dict[str, Any]) -> bool:
+    """Return True if a job grants any write-scoped permission."""
+    perms: Any = job.get("permissions", {})
+    if isinstance(perms, str):
+        return perms == "write-all"
+    if isinstance(perms, dict):
+        return any(v == "write" for v in perms.values())
+    return False
+
+
+def _workflow_has_write_permission(wf: Dict[str, Any]) -> bool:
+    """Return True if the top-level workflow grants any write-scoped permission."""
+    perms: Any = wf.get("permissions", {})
+    if isinstance(perms, str):
+        return perms == "write-all"
+    if isinstance(perms, dict):
+        return any(v == "write" for v in perms.values())
+    return False
+
+
+def test_no_fork_repo_checkout() -> None:
     """Checkout step must NOT reference github.event.pull_request.head.repo.full_name
     as the repository parameter, which would check out attacker-controlled fork code."""
-    wf, raw = load_workflow(WORKFLOW_PATH)
+    wf, _raw = load_workflow(WORKFLOW_PATH)
 
-    jobs = wf.get("jobs", {})
+    jobs: Dict[str, Any] = wf.get("jobs", {})
     for job_name, job in jobs.items():
         steps = job.get("steps", [])
         for step in steps:
-            uses = step.get("uses", "")
+            uses: str = step.get("uses", "")
             if "actions/checkout" in uses:
-                with_params = step.get("with", {})
-                repo_param = str(with_params.get("repository", ""))
+                with_params: Dict[str, Any] = step.get("with", {})
+                repo_param: str = str(with_params.get("repository", ""))
 
                 # Must NOT reference the fork's repo
                 assert "pull_request.head.repo" not in repo_param, (
-                    f"Job '{job_name}' checkout uses fork repository: {repo_param}. "
+                    f"Job \'{job_name}\' checkout uses fork repository: {repo_param}. "
                     "This allows attacker-controlled code execution."
                 )
 
 
-def test_uv_sync_not_on_fork_prs():
-    """uv sync (which installs from pyproject.toml) should not run on fork PRs,
-    or the checkout should not contain fork code."""
-    wf, raw = load_workflow(WORKFLOW_PATH)
+def test_uv_sync_not_on_fork_prs() -> None:
+    """Any project-aware install step (uv sync, pip install ., etc.) must
+    either be absent from fork-reachable jobs or guarded by a fork check on
+    the step itself. We assert directly on the install step rather than on
+    the checkout to catch unguarded installs even when the checkout looks
+    safe."""
+    wf, _raw = load_workflow(WORKFLOW_PATH)
 
-    jobs = wf.get("jobs", {})
+    jobs: Dict[str, Any] = wf.get("jobs", {})
     for job_name, job in jobs.items():
-        steps = job.get("steps", [])
+        job_if: str = str(job.get("if", ""))
+        job_is_fork_guarded: bool = (
+            "head.repo.full_name == github.repository" in job_if
+            or "head.repo.full_name ==" in job_if
+        )
 
-        # Check if checkout references fork repo
-        checkout_uses_fork = False
-        for step in steps:
-            uses = step.get("uses", "")
-            if "actions/checkout" in uses:
-                with_params = step.get("with", {})
-                repo_param = str(with_params.get("repository", ""))
-                if "pull_request.head.repo" in repo_param:
-                    checkout_uses_fork = True
-
-        if checkout_uses_fork:
-            # If checking out fork code, uv sync must be guarded
-            for step in steps:
-                run_cmd = str(step.get("run", ""))
-                if "uv sync" in run_cmd:
-                    step_if = str(step.get("if", ""))
-                    assert "head.repo.full_name == github.repository" in step_if or \
-                           "head.repo.full_name ==" in step_if, (
-                        f"Job '{job_name}' runs 'uv sync' on fork checkout without fork guard. "
-                        "Attacker's pyproject.toml will be installed."
-                    )
-
-
-def test_no_write_permissions_or_fork_guarded():
-    """If the workflow has write permissions, it must not execute fork code,
-    or execution steps must be guarded against fork PRs."""
-    wf, raw = load_workflow(WORKFLOW_PATH)
-
-    # Check top-level permissions
-    perms = wf.get("permissions", {})
-    has_write = False
-    if isinstance(perms, str):
-        has_write = perms == "write-all"
-    elif isinstance(perms, dict):
-        has_write = any(v == "write" for v in perms.values())
-
-    if not has_write:
-        return  # No write permissions, lower risk
-
-    # If write permissions exist, checkout must not use fork repo
-    jobs = wf.get("jobs", {})
-    for job_name, job in jobs.items():
         steps = job.get("steps", [])
         for step in steps:
-            uses = step.get("uses", "")
+            run_cmd: str = str(step.get("run", ""))
+            if not any(cmd in run_cmd for cmd in PROJECT_INSTALL_COMMANDS):
+                continue
+
+            step_if: str = str(step.get("if", ""))
+            step_is_fork_guarded: bool = (
+                "head.repo.full_name == github.repository" in step_if
+                or "head.repo.full_name ==" in step_if
+            )
+
+            assert job_is_fork_guarded or step_is_fork_guarded, (
+                f"Job \'{job_name}\' runs a project-aware install "
+                f"({run_cmd.strip().splitlines()[0]!r}) without a fork guard "
+                "on either the job or the step. Attacker-controlled "
+                "pyproject.toml/build hooks could execute on fork PRs."
+            )
+
+
+def test_no_write_permissions_or_fork_guarded() -> None:
+    """If any job (or the workflow) grants write permissions, that job must
+    not execute fork code: checkout must not point at the fork repo and the
+    job must be guarded by a same-repo `if` condition."""
+    wf, _raw = load_workflow(WORKFLOW_PATH)
+
+    workflow_has_write: bool = _workflow_has_write_permission(wf)
+    jobs: Dict[str, Any] = wf.get("jobs", {})
+
+    for job_name, job in jobs.items():
+        job_has_write: bool = _job_has_write_permission(job)
+        has_write: bool = workflow_has_write or job_has_write
+        if not has_write:
+            continue
+
+        job_if: str = str(job.get("if", ""))
+        job_is_fork_guarded: bool = (
+            "head.repo.full_name == github.repository" in job_if
+            or "head.repo.full_name ==" in job_if
+        )
+
+        steps = job.get("steps", [])
+        for step in steps:
+            uses: str = step.get("uses", "")
             if "actions/checkout" in uses:
-                with_params = step.get("with", {})
-                repo_param = str(with_params.get("repository", ""))
+                with_params: Dict[str, Any] = step.get("with", {})
+                repo_param: str = str(with_params.get("repository", ""))
                 assert "pull_request.head.repo" not in repo_param, (
-                    f"Job '{job_name}' has write permissions AND checks out fork code. "
+                    f"Job \'{job_name}\' has write permissions AND checks out fork code. "
                     "This is a critical security issue (CWE-77)."
                 )
+
+        assert job_is_fork_guarded, (
+            f"Job \'{job_name}\' has write permissions but lacks a same-repo "
+            "`if` guard. Add `if: github.event.pull_request.head.repo.full_name "
+            "== github.repository` (or equivalent) to prevent fork PRs from "
+            "running with elevated permissions."
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_cwe77_ruff_workflow.py
+++ b/tests/test_cwe77_ruff_workflow.py
@@ -82,7 +82,7 @@ def test_no_fork_repo_checkout() -> None:
 
                 # Must NOT reference the fork's repo
                 assert "pull_request.head.repo" not in repo_param, (
-                    f"Job \'{job_name}\' checkout uses fork repository: {repo_param}. "
+                    f"Job '{job_name}' checkout uses fork repository: {repo_param}. "
                     "This allows attacker-controlled code execution."
                 )
 
@@ -116,7 +116,7 @@ def test_uv_sync_not_on_fork_prs() -> None:
             )
 
             assert job_is_fork_guarded or step_is_fork_guarded, (
-                f"Job \'{job_name}\' runs a project-aware install "
+                f"Job '{job_name}' runs a project-aware install "
                 f"({run_cmd.strip().splitlines()[0]!r}) without a fork guard "
                 "on either the job or the step. Attacker-controlled "
                 "pyproject.toml/build hooks could execute on fork PRs."
@@ -151,12 +151,12 @@ def test_no_write_permissions_or_fork_guarded() -> None:
                 with_params: Dict[str, Any] = step.get("with", {})
                 repo_param: str = str(with_params.get("repository", ""))
                 assert "pull_request.head.repo" not in repo_param, (
-                    f"Job \'{job_name}\' has write permissions AND checks out fork code. "
+                    f"Job '{job_name}' has write permissions AND checks out fork code. "
                     "This is a critical security issue (CWE-77)."
                 )
 
         assert job_is_fork_guarded, (
-            f"Job \'{job_name}\' has write permissions but lacks a same-repo "
+            f"Job '{job_name}' has write permissions but lacks a same-repo "
             "`if` guard. Add `if: github.event.pull_request.head.repo.full_name "
             "== github.repository` (or equivalent) to prevent fork PRs from "
             "running with elevated permissions."

--- a/tests/test_cwe77_ruff_workflow.py
+++ b/tests/test_cwe77_ruff_workflow.py
@@ -17,6 +17,7 @@ fork-facing validation job so attacker-controlled build hooks cannot run.
 from __future__ import annotations
 
 import os
+import re
 import sys
 from typing import Any, Dict, Tuple
 
@@ -28,13 +29,17 @@ WORKFLOW_PATH: str = os.path.join(REPO_ROOT, ".github", "workflows", "ruff.yml")
 
 # Commands that resolve and execute the project's own build backend /
 # pyproject.toml hooks. These must NOT run on untrusted fork PR code.
-PROJECT_INSTALL_COMMANDS: Tuple[str, ...] = (
-    "uv sync",
-    "uv pip install -e",
-    "uv pip install .",
-    "pip install -e",
-    "pip install .",
-    "poetry install",
+PROJECT_INSTALL_COMMANDS: Tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?:^|[\s;&|])uv\s+sync(?:$|[\s;&|])"),
+    re.compile(
+        r"(?:^|[\s;&|])uv\s+pip\s+install\b[^\n;&|]*?"
+        r"(?:\s\.|(?:-e\s+\.|--editable(?:=|\s+)\.))(?=$|[\s;&|])"
+    ),
+    re.compile(
+        r"(?:^|[\s;&|])(?:python\s+-m\s+)?pip3?\s+install\b[^\n;&|]*?"
+        r"(?:\s\.|(?:-e\s+\.|--editable(?:=|\s+)\.))(?=$|[\s;&|])"
+    ),
+    re.compile(r"(?:^|[\s;&|])poetry\s+install(?:$|[\s;&|])"),
 )
 
 
@@ -79,6 +84,11 @@ def _is_same_repo_guard(expr: str) -> bool:
     return normalized in same_repo_expressions
 
 
+def _runs_project_install(run_cmd: str) -> bool:
+    """Return True when a shell command installs the local project."""
+    return any(pattern.search(run_cmd) for pattern in PROJECT_INSTALL_COMMANDS)
+
+
 def test_same_repo_guard_matcher_is_strict() -> None:
     """Same-repo guards must be exact, not broad substring matches."""
     assert _is_same_repo_guard(
@@ -98,6 +108,20 @@ def test_same_repo_guard_matcher_is_strict() -> None:
     assert not _is_same_repo_guard(
         "github.event.pull_request.head.repo.full_name == 'attacker/repo'"
     )
+
+
+def test_project_install_matcher_detects_common_variants() -> None:
+    """Project install detection must catch common pip and uv variants."""
+    assert _runs_project_install("python -m pip install .")
+    assert _runs_project_install("pip3 install .")
+    assert _runs_project_install("uv pip install --editable .")
+    assert _runs_project_install("uv pip install --editable=.")
+    assert _runs_project_install("pip install -e .")
+    assert _runs_project_install("uv sync")
+    assert _runs_project_install("poetry install")
+
+    assert not _runs_project_install("python -m pip install -r requirements.txt")
+    assert not _runs_project_install("pip3 install ruff")
 
 
 def test_no_fork_repo_checkout() -> None:
@@ -137,7 +161,7 @@ def test_uv_sync_not_on_fork_prs() -> None:
         steps = job.get("steps", [])
         for step in steps:
             run_cmd: str = str(step.get("run", ""))
-            if not any(cmd in run_cmd for cmd in PROJECT_INSTALL_COMMANDS):
+            if not _runs_project_install(run_cmd):
                 continue
 
             step_if: str = str(step.get("if", ""))
@@ -199,7 +223,7 @@ def test_push_trigger_runs_ruff_validation() -> None:
     push_branches: Any = (
         push_event.get("branches", []) if isinstance(push_event, dict) else []
     )
-    assert "main" in push_branches
+    assert not push_branches or "main" in push_branches
 
     ruff_job: Dict[str, Any] = wf.get("jobs", {}).get("ruff", {})
     ruff_if: str = " ".join(str(ruff_job.get("if", "")).split())
@@ -209,6 +233,7 @@ def test_push_trigger_runs_ruff_validation() -> None:
 if __name__ == "__main__":
     tests = [
         test_same_repo_guard_matcher_is_strict,
+        test_project_install_matcher_detects_common_variants,
         test_no_fork_repo_checkout,
         test_uv_sync_not_on_fork_prs,
         test_no_write_permissions_or_fork_guarded,

--- a/tests/test_cwe77_ruff_workflow.py
+++ b/tests/test_cwe77_ruff_workflow.py
@@ -1,0 +1,138 @@
+"""
+Test that the ruff.yml GitHub Actions workflow does NOT check out
+attacker-controlled code from fork PRs (CWE-77).
+
+The vulnerability: the workflow uses pull_request trigger with
+  repository: ${{ github.event.pull_request.head.repo.full_name }}
+which checks out the fork's code directly. An attacker can poison
+pyproject.toml or inject malicious ruff plugins to achieve code execution
+with the workflow's contents:write GITHUB_TOKEN.
+
+The fix: remove the explicit repository/ref override so `actions/checkout`
+uses the default merge commit ref (github.sha) for pull_request events.
+"""
+
+import sys
+import os
+import yaml
+
+# Resolve the repo root (one level up from tests/)
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOW_PATH = os.path.join(REPO_ROOT, ".github", "workflows", "ruff.yml")
+
+
+
+def load_workflow(path):
+    with open(path, "r") as f:
+        return yaml.safe_load(f), f.read()
+
+
+def test_no_fork_repo_checkout():
+    """Checkout step must NOT reference github.event.pull_request.head.repo.full_name
+    as the repository parameter, which would check out attacker-controlled fork code."""
+    wf, raw = load_workflow(WORKFLOW_PATH)
+
+    jobs = wf.get("jobs", {})
+    for job_name, job in jobs.items():
+        steps = job.get("steps", [])
+        for step in steps:
+            uses = step.get("uses", "")
+            if "actions/checkout" in uses:
+                with_params = step.get("with", {})
+                repo_param = str(with_params.get("repository", ""))
+
+                # Must NOT reference the fork's repo
+                assert "pull_request.head.repo" not in repo_param, (
+                    f"Job '{job_name}' checkout uses fork repository: {repo_param}. "
+                    "This allows attacker-controlled code execution."
+                )
+
+
+def test_uv_sync_not_on_fork_prs():
+    """uv sync (which installs from pyproject.toml) should not run on fork PRs,
+    or the checkout should not contain fork code."""
+    wf, raw = load_workflow(WORKFLOW_PATH)
+
+    jobs = wf.get("jobs", {})
+    for job_name, job in jobs.items():
+        steps = job.get("steps", [])
+
+        # Check if checkout references fork repo
+        checkout_uses_fork = False
+        for step in steps:
+            uses = step.get("uses", "")
+            if "actions/checkout" in uses:
+                with_params = step.get("with", {})
+                repo_param = str(with_params.get("repository", ""))
+                if "pull_request.head.repo" in repo_param:
+                    checkout_uses_fork = True
+
+        if checkout_uses_fork:
+            # If checking out fork code, uv sync must be guarded
+            for step in steps:
+                run_cmd = str(step.get("run", ""))
+                if "uv sync" in run_cmd:
+                    step_if = str(step.get("if", ""))
+                    assert "head.repo.full_name == github.repository" in step_if or \
+                           "head.repo.full_name ==" in step_if, (
+                        f"Job '{job_name}' runs 'uv sync' on fork checkout without fork guard. "
+                        "Attacker's pyproject.toml will be installed."
+                    )
+
+
+def test_no_write_permissions_or_fork_guarded():
+    """If the workflow has write permissions, it must not execute fork code,
+    or execution steps must be guarded against fork PRs."""
+    wf, raw = load_workflow(WORKFLOW_PATH)
+
+    # Check top-level permissions
+    perms = wf.get("permissions", {})
+    has_write = False
+    if isinstance(perms, str):
+        has_write = perms == "write-all"
+    elif isinstance(perms, dict):
+        has_write = any(v == "write" for v in perms.values())
+
+    if not has_write:
+        return  # No write permissions, lower risk
+
+    # If write permissions exist, checkout must not use fork repo
+    jobs = wf.get("jobs", {})
+    for job_name, job in jobs.items():
+        steps = job.get("steps", [])
+        for step in steps:
+            uses = step.get("uses", "")
+            if "actions/checkout" in uses:
+                with_params = step.get("with", {})
+                repo_param = str(with_params.get("repository", ""))
+                assert "pull_request.head.repo" not in repo_param, (
+                    f"Job '{job_name}' has write permissions AND checks out fork code. "
+                    "This is a critical security issue (CWE-77)."
+                )
+
+
+if __name__ == "__main__":
+    tests = [
+        test_no_fork_repo_checkout,
+        test_uv_sync_not_on_fork_prs,
+        test_no_write_permissions_or_fork_guarded,
+    ]
+
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f"  PASS: {test.__name__}")
+        except AssertionError as e:
+            print(f"  FAIL: {test.__name__}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR: {test.__name__}: {e}")
+            failed += 1
+
+    if failed:
+        print(f"\n{failed} test(s) failed")
+        sys.exit(1)
+    else:
+        print("\nAll tests passed")
+        sys.exit(0)


### PR DESCRIPTION
Authored by @sebastiondev 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  - Top-level workflow now read-only; write permission limited to an auto-fix job for same-repo PRs
  - Prevents checking out forked PR code and requires same-repo guards for steps that install project code

* **New Features**
  - Auto-fix job runs fixes and pushes changes for same-repo PRs

* **Tests**
  - Added tests enforcing same-repo guards, no fork checkouts, guarded install steps, and push-trigger validation

* **Chores**
  - Split autofix and validation into separate jobs; validation runs for both push and PR events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->