### PR TITLE
enh: Greater DWD Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ uv run main.py --transport streamable-http --tools gmail drive calendar
 | **🔧 Service Account** | | |
 | `GOOGLE_SERVICE_ACCOUNT_KEY_FILE` | | Path to service account JSON key file (domain-wide delegation) |
 | `GOOGLE_SERVICE_ACCOUNT_KEY_JSON` | | Inline service account JSON key (alternative to file) |
+| `DWD_ALLOW_REQUEST_IMPERSONATION` | `false` | When `true`, caller-supplied `user_google_email` drives DWD impersonation |
+| `DWD_ALLOWED_DOMAINS` | | Comma-separated domain allowlist for per-request impersonation (optional) |
 | **🔍 Custom Search** | | |
 | `GOOGLE_PSE_API_KEY` | | API key for Programmable Search Engine |
 | `GOOGLE_PSE_ENGINE_ID` | | Search Engine ID for PSE |
@@ -1281,8 +1283,22 @@ uv run main.py
 **Key Behaviors:**
 - The OAuth callback server is not started (no interactive auth needed)
 - Credentials directory permission checks are skipped
-- **All operations impersonate the configured `USER_GOOGLE_EMAIL`** — any email addresses supplied in tool calls (e.g., `user_email` parameters) are ignored. This differs from OAuth modes where each user authenticates separately.
+- By default, **all operations impersonate the configured `USER_GOOGLE_EMAIL`** — any email addresses supplied in tool calls are ignored. See *Per-Request Impersonation* below to change this.
 - The service account key is validated at startup (checks for required fields and correct type)
+
+**Per-Request Impersonation (opt-in):**
+
+When `DWD_ALLOW_REQUEST_IMPERSONATION=true`, the caller-supplied `user_google_email` on each tool call is used as the DWD impersonation subject instead of the static `USER_GOOGLE_EMAIL`. This lets a single server instance act on behalf of multiple domain users.
+
+```bash
+export DWD_ALLOW_REQUEST_IMPERSONATION=true
+# Optional: restrict which domains may be impersonated
+export DWD_ALLOWED_DOMAINS="corp.com,subsidiary.io"
+```
+
+- `USER_GOOGLE_EMAIL` is still required and serves as the fallback when no caller email is provided.
+- If `DWD_ALLOWED_DOMAINS` is set, only emails whose domain appears in the comma-separated list are accepted; all others raise an authentication error.
+- If `DWD_ALLOWED_DOMAINS` is unset, any email accepted by the service account's delegation scope is allowed.
 
 ### VS Code MCP Client Support
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,6 @@ uv run main.py --transport streamable-http --tools gmail drive calendar
 | **🔧 Service Account** | | |
 | `GOOGLE_SERVICE_ACCOUNT_KEY_FILE` | | Path to service account JSON key file (domain-wide delegation) |
 | `GOOGLE_SERVICE_ACCOUNT_KEY_JSON` | | Inline service account JSON key (alternative to file) |
-| `DWD_ALLOW_REQUEST_IMPERSONATION` | `false` | When `true`, caller-supplied `user_google_email` drives DWD impersonation |
 | `DWD_ALLOWED_DOMAINS` | | Comma-separated domain allowlist for per-request impersonation (optional) |
 | **🔍 Custom Search** | | |
 | `GOOGLE_PSE_API_KEY` | | API key for Programmable Search Engine |
@@ -1283,20 +1282,19 @@ uv run main.py
 **Key Behaviors:**
 - The OAuth callback server is not started (no interactive auth needed)
 - Credentials directory permission checks are skipped
-- By default, **all operations impersonate the configured `USER_GOOGLE_EMAIL`** — any email addresses supplied in tool calls are ignored. See *Per-Request Impersonation* below to change this.
+- When a tool call supplies `user_google_email`, service account mode uses that email as the domain-wide delegation impersonation subject.
+- `USER_GOOGLE_EMAIL` is still required and serves as the fallback when no caller email is provided.
 - The service account key is validated at startup (checks for required fields and correct type)
 
-**Per-Request Impersonation (opt-in):**
+**Per-Request Impersonation:**
 
-When `DWD_ALLOW_REQUEST_IMPERSONATION=true`, the caller-supplied `user_google_email` on each tool call is used as the DWD impersonation subject instead of the static `USER_GOOGLE_EMAIL`. This lets a single server instance act on behalf of multiple domain users.
+The caller-supplied `user_google_email` on each tool call is used as the DWD impersonation subject instead of the static `USER_GOOGLE_EMAIL`. This lets a single server instance act on behalf of multiple domain users.
 
 ```bash
-export DWD_ALLOW_REQUEST_IMPERSONATION=true
 # Optional: restrict which domains may be impersonated
 export DWD_ALLOWED_DOMAINS="corp.com,subsidiary.io"
 ```
 
-- `USER_GOOGLE_EMAIL` is still required and serves as the fallback when no caller email is provided.
 - If `DWD_ALLOWED_DOMAINS` is set, only emails whose domain appears in the comma-separated list are accepted; all others raise an authentication error.
 - If `DWD_ALLOWED_DOMAINS` is unset, any email accepted by the service account's delegation scope is allowed.
 

--- a/auth/oauth_config.py
+++ b/auth/oauth_config.py
@@ -82,11 +82,7 @@ class OAuthConfig:
                 "but not MCP_ENABLE_OAUTH21=true."
             )
 
-        # Per-request impersonation for domain-wide delegation
-        self.dwd_allow_request_impersonation = (
-            self.service_account_enabled
-            and os.getenv("DWD_ALLOW_REQUEST_IMPERSONATION", "false").lower() == "true"
-        )
+        # Optional per-request impersonation domain allowlist for service accounts.
         _raw_domains = os.getenv("DWD_ALLOWED_DOMAINS", "")
         self.dwd_allowed_domains: List[str] = (
             [d.strip().lower() for d in _raw_domains.split(",") if d.strip()]
@@ -314,15 +310,6 @@ class OAuthConfig:
         """
         return self.service_account_enabled
 
-    def is_dwd_request_impersonation_enabled(self) -> bool:
-        """
-        Check if per-request user impersonation is enabled for DWD mode.
-
-        Returns:
-            True if caller-supplied user_google_email should drive impersonation
-        """
-        return self.dwd_allow_request_impersonation
-
     def detect_oauth_version(self, request_params: Dict[str, Any]) -> str:
         """
         Detect OAuth version based on request parameters.
@@ -506,8 +493,3 @@ def is_external_oauth21_provider() -> bool:
 def is_service_account_enabled() -> bool:
     """Check if service account (domain-wide delegation) mode is enabled."""
     return get_oauth_config().is_service_account_enabled()
-
-
-def is_dwd_request_impersonation_enabled() -> bool:
-    """Check if per-request DWD impersonation is enabled."""
-    return get_oauth_config().is_dwd_request_impersonation_enabled()

--- a/auth/oauth_config.py
+++ b/auth/oauth_config.py
@@ -81,6 +81,18 @@ class OAuthConfig:
                 "Set GOOGLE_SERVICE_ACCOUNT_KEY_FILE or GOOGLE_SERVICE_ACCOUNT_KEY_JSON, "
                 "but not MCP_ENABLE_OAUTH21=true."
             )
+
+        # Per-request impersonation for domain-wide delegation
+        self.dwd_allow_request_impersonation = (
+            self.service_account_enabled
+            and os.getenv("DWD_ALLOW_REQUEST_IMPERSONATION", "false").lower() == "true"
+        )
+        _raw_domains = os.getenv("DWD_ALLOWED_DOMAINS", "")
+        self.dwd_allowed_domains: List[str] = (
+            [d.strip().lower() for d in _raw_domains.split(",") if d.strip()]
+            if self.service_account_enabled and _raw_domains
+            else []
+        )
         # Transport mode (will be set at runtime)
         self._transport_mode = "stdio"  # Default
 
@@ -302,6 +314,15 @@ class OAuthConfig:
         """
         return self.service_account_enabled
 
+    def is_dwd_request_impersonation_enabled(self) -> bool:
+        """
+        Check if per-request user impersonation is enabled for DWD mode.
+
+        Returns:
+            True if caller-supplied user_google_email should drive impersonation
+        """
+        return self.dwd_allow_request_impersonation
+
     def detect_oauth_version(self, request_params: Dict[str, Any]) -> str:
         """
         Detect OAuth version based on request parameters.
@@ -485,3 +506,8 @@ def is_external_oauth21_provider() -> bool:
 def is_service_account_enabled() -> bool:
     """Check if service account (domain-wide delegation) mode is enabled."""
     return get_oauth_config().is_service_account_enabled()
+
+
+def is_dwd_request_impersonation_enabled() -> bool:
+    """Check if per-request DWD impersonation is enabled."""
+    return get_oauth_config().is_dwd_request_impersonation_enabled()

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -25,6 +25,7 @@ from auth.oauth_config import (
     get_oauth_config,
     is_external_oauth21_provider,
     is_service_account_enabled,
+    is_dwd_request_impersonation_enabled,
 )
 from core.context import set_fastmcp_session_id
 from auth.scopes import (
@@ -252,6 +253,18 @@ def _get_service_account_credentials(
         ) from e
 
 
+def _validate_dwd_domain(email: str, config) -> None:
+    """Raise if email's domain is not in the configured allowlist (when set)."""
+    if not config.dwd_allowed_domains:
+        return
+    domain = email.rsplit("@", 1)[-1].lower()
+    if domain not in config.dwd_allowed_domains:
+        raise GoogleAuthenticationError(
+            f"Domain '{domain}' is not in DWD_ALLOWED_DOMAINS. "
+            f"Allowed: {', '.join(config.dwd_allowed_domains)}"
+        )
+
+
 async def _authenticate_service(
     use_oauth21: bool,
     service_name: str,
@@ -274,19 +287,27 @@ async def _authenticate_service(
             raise GoogleAuthenticationError(
                 "Service account mode requires USER_GOOGLE_EMAIL to be configured."
             )
-        if user_google_email != canonical_email:
-            logger.warning(
-                f"[{tool_name}] Service account: ignoring caller-supplied email "
-                f"'{user_google_email}', using configured USER_GOOGLE_EMAIL "
-                f"'{canonical_email}'"
-            )
-        credentials = _get_service_account_credentials(resolved_scopes, canonical_email)
+
+        config = get_oauth_config()
+        if config.dwd_allow_request_impersonation and user_google_email:
+            _validate_dwd_domain(user_google_email, config)
+            target_email = user_google_email
+        else:
+            if user_google_email and user_google_email != canonical_email:
+                logger.warning(
+                    f"[{tool_name}] Service account: ignoring caller-supplied email "
+                    f"'{user_google_email}', using configured USER_GOOGLE_EMAIL "
+                    f"'{canonical_email}'"
+                )
+            target_email = canonical_email
+
+        credentials = _get_service_account_credentials(resolved_scopes, target_email)
         service = build(service_name, service_version, credentials=credentials)
         logger.info(
             f"[{tool_name}] Authenticated {service_name} for "
-            f"{canonical_email} via service-account"
+            f"{target_email} via service-account"
         )
-        return service, canonical_email
+        return service, target_email
 
     if use_oauth21:
         logger.debug(f"[{tool_name}] Using OAuth 2.1 flow")

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -25,7 +25,6 @@ from auth.oauth_config import (
     get_oauth_config,
     is_external_oauth21_provider,
     is_service_account_enabled,
-    is_dwd_request_impersonation_enabled,
 )
 from core.context import set_fastmcp_session_id
 from auth.scopes import (
@@ -289,16 +288,10 @@ async def _authenticate_service(
             )
 
         config = get_oauth_config()
-        if config.dwd_allow_request_impersonation and user_google_email:
+        if user_google_email:
             _validate_dwd_domain(user_google_email, config)
             target_email = user_google_email
         else:
-            if user_google_email and user_google_email != canonical_email:
-                logger.warning(
-                    f"[{tool_name}] Service account: ignoring caller-supplied email "
-                    f"'{user_google_email}', using configured USER_GOOGLE_EMAIL "
-                    f"'{canonical_email}'"
-                )
             target_email = canonical_email
 
         credentials = _get_service_account_credentials(resolved_scopes, target_email)

--- a/tests/core/test_user_google_email_defaults.py
+++ b/tests/core/test_user_google_email_defaults.py
@@ -137,7 +137,7 @@ def test_get_service_account_credentials_raises_without_key_source(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_authenticate_service_account_uses_runtime_configured_user(monkeypatch):
+async def test_authenticate_service_account_uses_caller_email(monkeypatch):
     monkeypatch.setattr(service_decorator, "_ENV_USER_EMAIL", None)
     monkeypatch.setenv("USER_GOOGLE_EMAIL", "configured@example.com")
     monkeypatch.setattr(service_decorator, "is_service_account_enabled", lambda: True)
@@ -176,10 +176,10 @@ async def test_authenticate_service_account_uses_runtime_configured_user(monkeyp
     )
 
     assert service is fake_service
-    assert actual_user == "configured@example.com"
+    assert actual_user == "caller@example.com"
     assert captured == {
         "scopes": ["scope-a"],
-        "subject": "configured@example.com",
+        "subject": "caller@example.com",
         "service_name": "gmail",
         "service_version": "v1",
         "credentials": fake_credentials,
@@ -213,7 +213,7 @@ async def test_authenticate_service_account_raises_without_configured_user(
 # --- DWD per-request impersonation tests ---
 
 
-def _patch_service_account(monkeypatch, *, impersonation=False, allowed_domains=""):
+def _patch_service_account(monkeypatch, *, allowed_domains=""):
     """Common monkeypatching for DWD impersonation tests."""
     monkeypatch.setattr(service_decorator, "_ENV_USER_EMAIL", None)
     monkeypatch.setenv("USER_GOOGLE_EMAIL", "canonical@corp.com")
@@ -222,7 +222,6 @@ def _patch_service_account(monkeypatch, *, impersonation=False, allowed_domains=
     config = SimpleNamespace(
         service_account_key_file="/fake/key.json",
         service_account_key_json=None,
-        dwd_allow_request_impersonation=impersonation,
         dwd_allowed_domains=(
             [d.strip().lower() for d in allowed_domains.split(",") if d.strip()]
             if allowed_domains
@@ -253,7 +252,7 @@ def _patch_service_account(monkeypatch, *, impersonation=False, allowed_domains=
 
 @pytest.mark.asyncio
 async def test_dwd_request_impersonation_uses_caller_email(monkeypatch):
-    captured, fake_service = _patch_service_account(monkeypatch, impersonation=True)
+    captured, fake_service = _patch_service_account(monkeypatch)
 
     service, actual_user = await service_decorator._authenticate_service(
         use_oauth21=False,
@@ -273,7 +272,7 @@ async def test_dwd_request_impersonation_uses_caller_email(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_dwd_request_impersonation_falls_back_to_canonical(monkeypatch):
-    captured, fake_service = _patch_service_account(monkeypatch, impersonation=True)
+    captured, fake_service = _patch_service_account(monkeypatch)
 
     service, actual_user = await service_decorator._authenticate_service(
         use_oauth21=False,
@@ -293,7 +292,7 @@ async def test_dwd_request_impersonation_falls_back_to_canonical(monkeypatch):
 @pytest.mark.asyncio
 async def test_dwd_request_impersonation_domain_allowlist_passes(monkeypatch):
     captured, _ = _patch_service_account(
-        monkeypatch, impersonation=True, allowed_domains="corp.com,partner.io"
+        monkeypatch, allowed_domains="corp.com,partner.io"
     )
 
     _, actual_user = await service_decorator._authenticate_service(
@@ -313,7 +312,7 @@ async def test_dwd_request_impersonation_domain_allowlist_passes(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_dwd_request_impersonation_domain_allowlist_rejects(monkeypatch):
-    _patch_service_account(monkeypatch, impersonation=True, allowed_domains="corp.com")
+    _patch_service_account(monkeypatch, allowed_domains="corp.com")
 
     with pytest.raises(
         service_decorator.GoogleAuthenticationError,
@@ -329,22 +328,3 @@ async def test_dwd_request_impersonation_domain_allowlist_rejects(monkeypatch):
             mcp_session_id=None,
             authenticated_user=None,
         )
-
-
-@pytest.mark.asyncio
-async def test_dwd_request_impersonation_disabled_ignores_caller(monkeypatch):
-    captured, _ = _patch_service_account(monkeypatch, impersonation=False)
-
-    _, actual_user = await service_decorator._authenticate_service(
-        use_oauth21=False,
-        service_name="gmail",
-        service_version="v1",
-        tool_name="t",
-        user_google_email="other@corp.com",
-        resolved_scopes=["scope-a"],
-        mcp_session_id=None,
-        authenticated_user=None,
-    )
-
-    assert actual_user == "canonical@corp.com"
-    assert captured["subject"] == "canonical@corp.com"

--- a/tests/core/test_user_google_email_defaults.py
+++ b/tests/core/test_user_google_email_defaults.py
@@ -208,3 +208,143 @@ async def test_authenticate_service_account_raises_without_configured_user(
             mcp_session_id=None,
             authenticated_user=None,
         )
+
+
+# --- DWD per-request impersonation tests ---
+
+
+def _patch_service_account(monkeypatch, *, impersonation=False, allowed_domains=""):
+    """Common monkeypatching for DWD impersonation tests."""
+    monkeypatch.setattr(service_decorator, "_ENV_USER_EMAIL", None)
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "canonical@corp.com")
+    monkeypatch.setattr(service_decorator, "is_service_account_enabled", lambda: True)
+
+    config = SimpleNamespace(
+        service_account_key_file="/fake/key.json",
+        service_account_key_json=None,
+        dwd_allow_request_impersonation=impersonation,
+        dwd_allowed_domains=(
+            [d.strip().lower() for d in allowed_domains.split(",") if d.strip()]
+            if allowed_domains
+            else []
+        ),
+    )
+    monkeypatch.setattr(service_decorator, "get_oauth_config", lambda: config)
+
+    captured = {}
+    fake_service = object()
+    fake_credentials = object()
+
+    def fake_get_creds(scopes, subject):
+        captured["subject"] = subject
+        return fake_credentials
+
+    def fake_build(service_name, service_version, credentials):
+        return fake_service
+
+    monkeypatch.setattr(
+        service_decorator,
+        "_get_service_account_credentials",
+        fake_get_creds,
+    )
+    monkeypatch.setattr(service_decorator, "build", fake_build)
+    return captured, fake_service
+
+
+@pytest.mark.asyncio
+async def test_dwd_request_impersonation_uses_caller_email(monkeypatch):
+    captured, fake_service = _patch_service_account(monkeypatch, impersonation=True)
+
+    service, actual_user = await service_decorator._authenticate_service(
+        use_oauth21=False,
+        service_name="gmail",
+        service_version="v1",
+        tool_name="t",
+        user_google_email="other@corp.com",
+        resolved_scopes=["scope-a"],
+        mcp_session_id=None,
+        authenticated_user=None,
+    )
+
+    assert service is fake_service
+    assert actual_user == "other@corp.com"
+    assert captured["subject"] == "other@corp.com"
+
+
+@pytest.mark.asyncio
+async def test_dwd_request_impersonation_falls_back_to_canonical(monkeypatch):
+    captured, fake_service = _patch_service_account(monkeypatch, impersonation=True)
+
+    service, actual_user = await service_decorator._authenticate_service(
+        use_oauth21=False,
+        service_name="gmail",
+        service_version="v1",
+        tool_name="t",
+        user_google_email="",
+        resolved_scopes=["scope-a"],
+        mcp_session_id=None,
+        authenticated_user=None,
+    )
+
+    assert actual_user == "canonical@corp.com"
+    assert captured["subject"] == "canonical@corp.com"
+
+
+@pytest.mark.asyncio
+async def test_dwd_request_impersonation_domain_allowlist_passes(monkeypatch):
+    captured, _ = _patch_service_account(
+        monkeypatch, impersonation=True, allowed_domains="corp.com,partner.io"
+    )
+
+    _, actual_user = await service_decorator._authenticate_service(
+        use_oauth21=False,
+        service_name="gmail",
+        service_version="v1",
+        tool_name="t",
+        user_google_email="alice@partner.io",
+        resolved_scopes=["scope-a"],
+        mcp_session_id=None,
+        authenticated_user=None,
+    )
+
+    assert actual_user == "alice@partner.io"
+    assert captured["subject"] == "alice@partner.io"
+
+
+@pytest.mark.asyncio
+async def test_dwd_request_impersonation_domain_allowlist_rejects(monkeypatch):
+    _patch_service_account(monkeypatch, impersonation=True, allowed_domains="corp.com")
+
+    with pytest.raises(
+        service_decorator.GoogleAuthenticationError,
+        match="not in DWD_ALLOWED_DOMAINS",
+    ):
+        await service_decorator._authenticate_service(
+            use_oauth21=False,
+            service_name="gmail",
+            service_version="v1",
+            tool_name="t",
+            user_google_email="evil@external.com",
+            resolved_scopes=["scope-a"],
+            mcp_session_id=None,
+            authenticated_user=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_dwd_request_impersonation_disabled_ignores_caller(monkeypatch):
+    captured, _ = _patch_service_account(monkeypatch, impersonation=False)
+
+    _, actual_user = await service_decorator._authenticate_service(
+        use_oauth21=False,
+        service_name="gmail",
+        service_version="v1",
+        tool_name="t",
+        user_google_email="other@corp.com",
+        resolved_scopes=["scope-a"],
+        mcp_session_id=None,
+        authenticated_user=None,
+    )
+
+    assert actual_user == "canonical@corp.com"
+    assert captured["subject"] == "canonical@corp.com"


### PR DESCRIPTION
Close #743 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service account mode now supports per-request impersonation using caller-supplied email instead of only using the configured default
  * Added `DWD_ALLOWED_DOMAINS` environment variable to enforce domain-based access control for impersonation

* **Documentation**
  * Updated Service Account Mode behavior documentation with impersonation details and domain allowlist information

* **Tests**
  * Added comprehensive test coverage for per-request impersonation, domain validation, and fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->