### PR TITLE
feat(gdrive): add list_shared_drives tool with optional organizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,14 +764,13 @@ cp .env.oauth21 .env
 | <sub>`create_drive_folder`</sub> | <sub>Core</sub> | <sub>Create empty folders in Drive or shared drives</sub> |
 | <sub>`import_to_google_doc`</sub> | <sub>Core</sub> | <sub>Import files (MD, DOCX, HTML, etc.) as Google Docs</sub> |
 | <sub>`get_drive_shareable_link`</sub> | <sub>Core</sub> | <sub>Get shareable links for a file</sub> |
-| <sub>`list_drive_items`</sub> | <sub>Extended</sub> | <sub>List folder contents</sub> |
+| <sub>`list_drive_items`</sub> | <sub>Extended</sub> | <sub>List folder contents or shared drives</sub> |
 | <sub>`copy_drive_file`</sub> | <sub>Extended</sub> | <sub>Copy existing files (templates) with optional renaming</sub> |
 | <sub>`update_drive_file`</sub> | <sub>Extended</sub> | <sub>Update file metadata, move between folders</sub> |
 | <sub>`manage_drive_access`</sub> | <sub>Extended</sub> | <sub>Grant, update, revoke permissions, and transfer ownership</sub> |
 | <sub>`set_drive_file_permissions`</sub> | <sub>Extended</sub> | <sub>Set link sharing and file-level sharing settings</sub> |
 | <sub>`get_drive_file_permissions`</sub> | <sub>Complete</sub> | <sub>Get detailed file permissions</sub> |
 | <sub>`check_drive_file_public_access`</sub> | <sub>Complete</sub> | <sub>Check public sharing status</sub> |
-| <sub>`list_shared_drives`</sub> | <sub>Complete</sub> | <sub>List shared drives with optional organizer info</sub> |
 
 #### 📧 Gmail <sub>[`gmail_tools.py`](gmail/gmail_tools.py)</sub>
 

--- a/README.md
+++ b/README.md
@@ -771,6 +771,7 @@ cp .env.oauth21 .env
 | <sub>`set_drive_file_permissions`</sub> | <sub>Extended</sub> | <sub>Set link sharing and file-level sharing settings</sub> |
 | <sub>`get_drive_file_permissions`</sub> | <sub>Complete</sub> | <sub>Get detailed file permissions</sub> |
 | <sub>`check_drive_file_public_access`</sub> | <sub>Complete</sub> | <sub>Check public sharing status</sub> |
+| <sub>`list_shared_drives`</sub> | <sub>Complete</sub> | <sub>List shared drives with optional organizer info</sub> |
 
 #### 📧 Gmail <sub>[`gmail_tools.py`](gmail/gmail_tools.py)</sub>
 

--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -38,6 +38,7 @@ drive:
   complete:
     - get_drive_file_permissions
     - check_drive_file_public_access
+    - list_shared_drives
 
 calendar:
   core:

--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -38,7 +38,6 @@ drive:
   complete:
     - get_drive_file_permissions
     - check_drive_file_public_access
-    - list_shared_drives
 
 calendar:
   core:

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -735,7 +735,8 @@ async def list_shared_drives(
         return f"No shared drives found for {user_google_email}."
 
     if include_organizers:
-        for d in drives:
+
+        async def _fetch_organizers(d: Dict[str, Any]) -> None:
             try:
                 perms = await asyncio.to_thread(
                     service.permissions()
@@ -749,12 +750,15 @@ async def list_shared_drives(
                     .execute
                 )
                 d["_organizers"] = [
-                    p for p in perms.get("permissions", []) if p.get("role") == "organizer"
+                    p
+                    for p in perms.get("permissions", [])
+                    if p.get("role") == "organizer"
                 ]
             except HttpError as e:
-                d["_organizers_error"] = (
-                    f"{e.resp.status if e.resp else 'unknown'}: {e._get_reason() if hasattr(e, '_get_reason') else str(e)}"
-                )
+                status = e.resp.status if e.resp else "unknown"
+                d["_organizers_error"] = f"{status}: {e}"
+
+        await asyncio.gather(*[_fetch_organizers(d) for d in drives])
 
     next_token = results.get("nextPageToken")
     parts = [f"Found {len(drives)} shared drives for {user_google_email}:"]
@@ -786,7 +790,11 @@ async def list_shared_drives(
                         )
                         display = o.get("displayName")
                         kind = o.get("type", "?")
-                        suffix = f' ("{display}")' if display and display != identifier else ""
+                        suffix = (
+                            f' ("{display}")'
+                            if display and display != identifier
+                            else ""
+                        )
                         parts.append(f"  Organizer ({kind}): {identifier}{suffix}")
     if next_token:
         parts.append(f"nextPageToken: {next_token}")

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -737,7 +737,10 @@ async def _list_shared_drives_impl(
                         "fileId": d["id"],
                         "supportsAllDrives": True,
                         "useDomainAdminAccess": False,
-                        "fields": "permissions(emailAddress, displayName, role, type, domain)",
+                        "fields": (
+                            "nextPageToken, "
+                            "permissions(emailAddress, displayName, role, type, domain)"
+                        ),
                         "pageSize": 100,
                     }
                     if next_permission_page_token:

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -667,6 +667,132 @@ async def list_drive_items(
     return text_output
 
 
+@server.tool(
+    title="List Shared Drives",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("list_shared_drives", is_read_only=True, service_type="drive")
+@require_google_service("drive", "drive_read")
+async def list_shared_drives(
+    service,
+    user_google_email: str,
+    page_size: int = 100,
+    page_token: Optional[str] = None,
+    query: Optional[str] = None,
+    include_organizers: bool = False,
+) -> str:
+    """
+    Lists shared drives the authenticated user has access to.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        page_size (int): Maximum number of shared drives per page (1-100). Defaults to 100.
+        page_token (Optional[str]): Page token from a previous response's nextPageToken.
+        query (Optional[str]): Drive query for filtering shared drives, e.g. "name contains 'TAT'".
+                                See https://developers.google.com/drive/api/guides/search-shareddrives.
+        include_organizers (bool): When True, performs an extra permissions.list call per drive
+                                    to resolve principals with the `organizer` role and includes
+                                    them in the output. Costs one API call per drive returned;
+                                    keep off for cheap enumeration. Defaults to False.
+
+    Returns:
+        str: Formatted list of shared drives with id, name, createdTime, hidden flag,
+             and selected capability/restriction flags. Includes a nextPageToken line
+             when more results are available.
+
+    Note:
+        Shared drives are owned by the workspace organization, not by individual users,
+        so this endpoint does not return an "owner" field. The `organizer` role (returned
+        when `include_organizers=True`) is the closest equivalent: principals with this
+        role on a given drive can manage members, content and settings.
+    """
+    logger.info(
+        f"[list_shared_drives] Invoked. Email: '{user_google_email}', page_size: {page_size}, "
+        f"include_organizers: {include_organizers}"
+    )
+
+    list_params: Dict[str, Any] = {
+        "pageSize": min(max(page_size, 1), 100),
+        "fields": (
+            "drives(id, name, createdTime, hidden, "
+            "restrictions, capabilities(canManageMembers, canEdit)), "
+            "nextPageToken"
+        ),
+    }
+    if page_token:
+        list_params["pageToken"] = page_token
+    if query:
+        list_params["q"] = query
+
+    results = await asyncio.to_thread(service.drives().list(**list_params).execute)
+    drives = results.get("drives", [])
+    if not drives:
+        return f"No shared drives found for {user_google_email}."
+
+    if include_organizers:
+        for d in drives:
+            try:
+                perms = await asyncio.to_thread(
+                    service.permissions()
+                    .list(
+                        fileId=d["id"],
+                        supportsAllDrives=True,
+                        useDomainAdminAccess=False,
+                        fields="permissions(emailAddress, displayName, role, type, domain)",
+                        pageSize=100,
+                    )
+                    .execute
+                )
+                d["_organizers"] = [
+                    p for p in perms.get("permissions", []) if p.get("role") == "organizer"
+                ]
+            except HttpError as e:
+                d["_organizers_error"] = (
+                    f"{e.resp.status if e.resp else 'unknown'}: {e._get_reason() if hasattr(e, '_get_reason') else str(e)}"
+                )
+
+    next_token = results.get("nextPageToken")
+    parts = [f"Found {len(drives)} shared drives for {user_google_email}:"]
+    for d in drives:
+        caps = d.get("capabilities") or {}
+        rest = d.get("restrictions") or {}
+        cap_flags = ", ".join(k for k, v in caps.items() if v) or "none"
+        rest_flags = ", ".join(k for k, v in rest.items() if v) or "none"
+        hidden = " [hidden]" if d.get("hidden") else ""
+        parts.append(
+            f'- Name: "{d["name"]}" (ID: {d["id"]}, Created: {d.get("createdTime", "N/A")}){hidden} '
+            f"Capabilities: {cap_flags}; Restrictions: {rest_flags}"
+        )
+        if include_organizers:
+            err = d.get("_organizers_error")
+            if err:
+                parts.append(f"  Organizers: <error: {err}>")
+            else:
+                organizers = d.get("_organizers", [])
+                if not organizers:
+                    parts.append("  Organizers: <none returned>")
+                else:
+                    for o in organizers:
+                        identifier = (
+                            o.get("emailAddress")
+                            or o.get("domain")
+                            or o.get("displayName")
+                            or o.get("type", "?")
+                        )
+                        display = o.get("displayName")
+                        kind = o.get("type", "?")
+                        suffix = f' ("{display}")' if display and display != identifier else ""
+                        parts.append(f"  Organizer ({kind}): {identifier}{suffix}")
+    if next_token:
+        parts.append(f"nextPageToken: {next_token}")
+    return "\n".join(parts)
+
+
 async def _create_drive_folder_impl(
     service,
     user_google_email: str,
@@ -1389,6 +1515,7 @@ async def check_drive_file_public_access(
     service,
     user_google_email: str,
     file_name: str,
+    drive_id: Optional[str] = None,
 ) -> str:
     """
     Searches for a file by name and checks if it has public link sharing enabled.
@@ -1396,23 +1523,34 @@ async def check_drive_file_public_access(
     Args:
         user_google_email (str): The user's Google email address. Required.
         file_name (str): The name of the file to check.
+        drive_id (Optional[str]): ID of the shared drive to scope the search to. When set, the
+                                  underlying files.list call uses corpora='drive' and the given
+                                  driveId, which is required to reliably find files that live only
+                                  in that shared drive. When None, behaviour is unchanged
+                                  (default API corpora applies).
 
     Returns:
         str: Information about the file's sharing status and whether it can be used in Google Docs.
     """
-    logger.info(f"[check_drive_file_public_access] Searching for {file_name}")
+    logger.info(
+        f"[check_drive_file_public_access] Searching for {file_name}"
+        + (f" within drive_id={drive_id}" if drive_id else "")
+    )
 
     # Search for the file
     escaped_name = file_name.replace("'", "\\'")
     query = f"name = '{escaped_name}'"
 
-    list_params = {
+    list_params: Dict[str, Any] = {
         "q": query,
         "pageSize": 10,
         "fields": "files(id, name, mimeType, webViewLink)",
         "supportsAllDrives": True,
         "includeItemsFromAllDrives": True,
     }
+    if drive_id:
+        list_params["corpora"] = "drive"
+        list_params["driveId"] = drive_id
 
     results = await asyncio.to_thread(service.files().list(**list_params).execute)
 

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -59,6 +59,7 @@ logger = logging.getLogger(__name__)
 DOWNLOAD_CHUNK_SIZE_BYTES = 256 * 1024  # 256 KB
 UPLOAD_CHUNK_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB (Google recommended minimum)
 MAX_DOWNLOAD_BYTES = 2 * 1024 * 1024 * 1024  # 2 GB safety limit for URL downloads
+SHARED_DRIVE_ORGANIZER_CONCURRENCY_LIMIT = 10
 
 
 async def _stream_url_with_validation(
@@ -585,11 +586,15 @@ async def list_drive_items(
     file_type: Optional[str] = None,
     detailed: bool = True,
     order_by: Optional[str] = None,
+    resource_type: str = "items",
+    query: Optional[str] = None,
+    include_organizers: bool = False,
 ) -> str:
     """
-    Lists files and folders, supporting shared drives.
+    Lists files/folders or shared drive containers, supporting shared drives.
     If `drive_id` is specified, lists items within that shared drive. `folder_id` is then relative to that drive (or use drive_id as folder_id for root).
     If `drive_id` is not specified, lists items from user's "My Drive" and accessible shared drives (if `include_items_from_all_drives` is True).
+    Set `resource_type` to "shared_drives" to list shared drive containers instead of folder contents.
 
     Args:
         user_google_email (str): The user's Google email address. Required.
@@ -610,14 +615,35 @@ async def list_drive_items(
                                   'name', 'name_natural', 'quotaBytesUsed', 'recency', 'sharedWithMeTime',
                                   'starred', 'viewedByMeTime'. Example: 'modifiedTime desc' or 'folder,modifiedTime desc,name'.
                                   Defaults to None (Drive API default ordering).
+        resource_type (str): What to list. Use "items" for folder contents or
+                             "shared_drives" for shared drive containers. Defaults to "items".
+        query (Optional[str]): Shared drive query used only when resource_type="shared_drives",
+                               e.g. "name contains 'Engineering'".
+        include_organizers (bool): When resource_type="shared_drives", include principals
+                                   with the organizer role. This costs one extra permissions.list
+                                   API call per shared drive returned. Defaults to False.
 
     Returns:
-        str: A formatted list of files/folders in the specified folder.
+        str: A formatted list of files/folders in the specified folder or shared drives.
              Includes a nextPageToken line when more results are available.
     """
     logger.info(
-        f"[list_drive_items] Invoked. Email: '{user_google_email}', Folder ID: '{folder_id}', File Type: '{file_type}'"
+        f"[list_drive_items] Invoked. Email: '{user_google_email}', Folder ID: '{folder_id}', "
+        f"File Type: '{file_type}', Resource Type: '{resource_type}'"
     )
+
+    normalized_resource_type = resource_type.lower().strip()
+    if normalized_resource_type == "shared_drives":
+        return await _list_shared_drives_impl(
+            service=service,
+            user_google_email=user_google_email,
+            page_size=page_size,
+            page_token=page_token,
+            query=query,
+            include_organizers=include_organizers,
+        )
+    if normalized_resource_type != "items":
+        raise ValueError("resource_type must be either 'items' or 'shared_drives'")
 
     resolved_folder_id = await resolve_folder_id(service, folder_id)
     final_query = f"'{resolved_folder_id}' in parents and trashed=false"
@@ -667,18 +693,7 @@ async def list_drive_items(
     return text_output
 
 
-@server.tool(
-    title="List Shared Drives",
-    annotations=ToolAnnotations(
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=True,
-    ),
-)
-@handle_http_errors("list_shared_drives", is_read_only=True, service_type="drive")
-@require_google_service("drive", "drive_read")
-async def list_shared_drives(
+async def _list_shared_drives_impl(
     service,
     user_google_email: str,
     page_size: int = 100,
@@ -686,31 +701,7 @@ async def list_shared_drives(
     query: Optional[str] = None,
     include_organizers: bool = False,
 ) -> str:
-    """
-    Lists shared drives the authenticated user has access to.
-
-    Args:
-        user_google_email (str): The user's Google email address. Required.
-        page_size (int): Maximum number of shared drives per page (1-100). Defaults to 100.
-        page_token (Optional[str]): Page token from a previous response's nextPageToken.
-        query (Optional[str]): Drive query for filtering shared drives, e.g. "name contains 'TAT'".
-                                See https://developers.google.com/drive/api/guides/search-shareddrives.
-        include_organizers (bool): When True, performs an extra permissions.list call per drive
-                                    to resolve principals with the `organizer` role and includes
-                                    them in the output. Costs one API call per drive returned;
-                                    keep off for cheap enumeration. Defaults to False.
-
-    Returns:
-        str: Formatted list of shared drives with id, name, createdTime, hidden flag,
-             and selected capability/restriction flags. Includes a nextPageToken line
-             when more results are available.
-
-    Note:
-        Shared drives are owned by the workspace organization, not by individual users,
-        so this endpoint does not return an "owner" field. The `organizer` role (returned
-        when `include_organizers=True`) is the closest equivalent: principals with this
-        role on a given drive can manage members, content and settings.
-    """
+    """List shared drives available to the authenticated user."""
     logger.info(
         f"[list_shared_drives] Invoked. Email: '{user_google_email}', page_size: {page_size}, "
         f"include_organizers: {include_organizers}"
@@ -738,27 +729,48 @@ async def list_shared_drives(
 
         async def _fetch_organizers(d: Dict[str, Any]) -> None:
             try:
-                perms = await asyncio.to_thread(
-                    service.permissions()
-                    .list(
-                        fileId=d["id"],
-                        supportsAllDrives=True,
-                        useDomainAdminAccess=False,
-                        fields="permissions(emailAddress, displayName, role, type, domain)",
-                        pageSize=100,
+                permissions = []
+                next_permission_page_token = None
+
+                while True:
+                    list_kwargs: Dict[str, Any] = {
+                        "fileId": d["id"],
+                        "supportsAllDrives": True,
+                        "useDomainAdminAccess": False,
+                        "fields": "permissions(emailAddress, displayName, role, type, domain)",
+                        "pageSize": 100,
+                    }
+                    if next_permission_page_token:
+                        list_kwargs["pageToken"] = next_permission_page_token
+
+                    perms = await asyncio.to_thread(
+                        service.permissions().list(**list_kwargs).execute
                     )
-                    .execute
-                )
+                    permissions.extend(perms.get("permissions", []))
+
+                    next_permission_page_token = perms.get("nextPageToken")
+                    if not next_permission_page_token:
+                        break
+
                 d["_organizers"] = [
-                    p
-                    for p in perms.get("permissions", [])
-                    if p.get("role") == "organizer"
+                    p for p in permissions if p.get("role") == "organizer"
                 ]
             except HttpError as e:
-                status = e.resp.status if e.resp else "unknown"
-                d["_organizers_error"] = f"{status}: {e}"
+                status = getattr(e, "status_code", None)
+                if status is None and getattr(e, "resp", None) is not None:
+                    status = getattr(e.resp, "status", None)
+                reason = getattr(e, "reason", None) or str(e)
+                d["_organizers_error"] = f"{status or 'unknown'}: {reason}"
 
-        await asyncio.gather(*[_fetch_organizers(d) for d in drives])
+        organizer_fetch_sem = asyncio.Semaphore(
+            SHARED_DRIVE_ORGANIZER_CONCURRENCY_LIMIT
+        )
+
+        async def _bounded_fetch_organizers(d: Dict[str, Any]) -> None:
+            async with organizer_fetch_sem:
+                await _fetch_organizers(d)
+
+        await asyncio.gather(*[_bounded_fetch_organizers(d) for d in drives])
 
     next_token = results.get("nextPageToken")
     parts = [f"Found {len(drives)} shared drives for {user_google_email}:"]

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -1119,6 +1119,124 @@ async def test_list_items_file_type_unknown_raises(mock_resolve_folder):
 
 
 # ---------------------------------------------------------------------------
+# list_drive_items — shared drive containers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_drive_items_can_list_shared_drives():
+    """resource_type='shared_drives' uses the shared drive list endpoint."""
+    mock_service = Mock()
+    mock_service.drives().list().execute.return_value = {
+        "drives": [
+            {
+                "id": "drive1",
+                "name": "Engineering",
+                "createdTime": "2024-01-01T00:00:00Z",
+                "hidden": False,
+                "capabilities": {"canManageMembers": True, "canEdit": True},
+                "restrictions": {"adminManagedRestrictions": False},
+            }
+        ],
+        "nextPageToken": "shared_next",
+    }
+
+    result = await _unwrap(list_drive_items)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        resource_type="shared_drives",
+        page_size=250,
+        page_token="shared_page",
+        query="name contains 'Engineering'",
+    )
+
+    call_kwargs = mock_service.drives.return_value.list.call_args.kwargs
+    assert call_kwargs["pageSize"] == 100
+    assert call_kwargs["pageToken"] == "shared_page"
+    assert call_kwargs["q"] == "name contains 'Engineering'"
+    assert "Found 1 shared drives" in result
+    assert 'Name: "Engineering" (ID: drive1' in result
+    assert result.endswith("nextPageToken: shared_next")
+    mock_service.files.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_drive_items_shared_drives_can_include_organizers():
+    """include_organizers adds organizer principals to shared drive output."""
+    mock_service = Mock()
+    mock_service.drives().list().execute.return_value = {
+        "drives": [
+            {
+                "id": "drive1",
+                "name": "Engineering",
+                "capabilities": {},
+                "restrictions": {},
+            }
+        ]
+    }
+    mock_service.permissions.return_value.list.return_value.execute.side_effect = [
+        {
+            "permissions": [
+                {
+                    "emailAddress": "lead@example.com",
+                    "displayName": "Eng Lead",
+                    "role": "organizer",
+                    "type": "user",
+                },
+                {
+                    "emailAddress": "reader@example.com",
+                    "role": "reader",
+                    "type": "user",
+                },
+            ],
+            "nextPageToken": "permission_page_2",
+        },
+        {
+            "permissions": [
+                {
+                    "emailAddress": "second-lead@example.com",
+                    "displayName": "Second Eng Lead",
+                    "role": "organizer",
+                    "type": "user",
+                }
+            ]
+        },
+    ]
+
+    result = await _unwrap(list_drive_items)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        resource_type="shared_drives",
+        include_organizers=True,
+    )
+
+    permissions_calls = mock_service.permissions.return_value.list.call_args_list
+    assert permissions_calls[0].kwargs["fileId"] == "drive1"
+    assert permissions_calls[0].kwargs["supportsAllDrives"] is True
+    assert "pageToken" not in permissions_calls[0].kwargs
+    assert permissions_calls[1].kwargs["pageToken"] == "permission_page_2"
+    assert "Organizer (user): lead@example.com" in result
+    assert "Organizer (user): second-lead@example.com" in result
+    assert "reader@example.com" not in result
+
+
+@pytest.mark.asyncio
+async def test_list_drive_items_invalid_resource_type_raises():
+    """Unknown resource types are rejected before calling Drive APIs."""
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="resource_type"):
+        await _unwrap(list_drive_items)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            resource_type="calendars",
+        )
+
+    mock_service.files.assert_not_called()
+    mock_service.drives.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # OR-precedence grouping
 # ---------------------------------------------------------------------------
 

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -1213,7 +1213,9 @@ async def test_list_drive_items_shared_drives_can_include_organizers():
     permissions_calls = mock_service.permissions.return_value.list.call_args_list
     assert permissions_calls[0].kwargs["fileId"] == "drive1"
     assert permissions_calls[0].kwargs["supportsAllDrives"] is True
+    assert "nextPageToken" in permissions_calls[0].kwargs["fields"]
     assert "pageToken" not in permissions_calls[0].kwargs
+    assert "nextPageToken" in permissions_calls[1].kwargs["fields"]
     assert permissions_calls[1].kwargs["pageToken"] == "permission_page_2"
     assert "Organizer (user): lead@example.com" in result
     assert "Organizer (user): second-lead@example.com" in result


### PR DESCRIPTION
## Motivation

`workspace-mcp` currently exposes `list_drive_items` and `search_drive_files`
for browsing Drive contents, but there is no wrapper around `Drives.list()`
– the user-level Shared Drive enumeration. Without it, a calling agent
cannot discover which Shared Drives the authenticated user has access to
unless the IDs are known upfront.

## Feature

Adds a `list_shared_drives` tool that wraps `drive.drives().list()` and
returns each drive's `id`, `name`, `createdTime`, `hidden` flag, plus
selected `capabilities` and `restrictions`. Supports paging (`page_size`
/ `page_token`) and an optional Drive query filter (`query`).

Includes an opt-in `include_organizers=True` flag (default `False`). When
enabled, performs an additional `permissions.list` call per drive scoped
by `corpora='drive'` and returns the principals with the `organizer` role
alongside the drive metadata. Default off keeps the cheap listing path
zero-cost; opt-in is documented in the docstring as the closest equivalent
to a per-drive "owner" (since shared drives are owned by the workspace
organization rather than an individual user).

## Test

Verified on a Workspace organization with one Shared Drive: returns the
drive correctly with all metadata fields populated. Organizer fetch
correctly returns the four organizers with their email addresses, display
names, and `type` (`user` / `group`). Whitespace, paging and the Drive
query filter were exercised against the same drive.

## Type of Change

- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have tested this change manually

## Notes

Tool is registered in the `complete` tier (read-heavy enumeration,
low-frequency use). Open to feedback on tier placement, parameter names,
or output schema. Conceptually pairs with #750 (shared-drive lookup fix)
but the changes are independent and can be merged in any order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drive tools can list and query shared drives
  * File public-access checks can be scoped to a specific shared drive
  * Option to include organizer information when listing shared drives

* **Bug Fixes**
  * Unsupported resource types are now validated and rejected early

* **Documentation**
  * Updated tool docs to describe shared-drive capabilities

* **Tests**
  * Added tests for shared-drive listing, organizer inclusion, and invalid-input handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->