### PR TITLE
fix: add apps script scopes for execution

### DIFF
--- a/auth/scopes.py
+++ b/auth/scopes.py
@@ -80,6 +80,10 @@ SCRIPT_DEPLOYMENTS_READONLY_SCOPE = (
 )
 SCRIPT_PROCESSES_READONLY_SCOPE = "https://www.googleapis.com/auth/script.processes"
 SCRIPT_METRICS_SCOPE = "https://www.googleapis.com/auth/script.metrics"
+SCRIPT_EXTERNAL_REQUEST_SCOPE = (
+    "https://www.googleapis.com/auth/script.external_request"
+)
+SCRIPT_SCRIPTAPP_SCOPE = "https://www.googleapis.com/auth/script.scriptapp"
 
 # Google scope hierarchy: broader scopes that implicitly cover narrower ones.
 # See https://developers.google.com/gmail/api/auth/scopes,
@@ -185,6 +189,8 @@ SCRIPT_SCOPES = [
     SCRIPT_DEPLOYMENTS_READONLY_SCOPE,
     SCRIPT_PROCESSES_READONLY_SCOPE,  # Required for list_script_processes
     SCRIPT_METRICS_SCOPE,  # Required for get_script_metrics
+    SCRIPT_EXTERNAL_REQUEST_SCOPE,  # Required for scripts.run (execution API)
+    SCRIPT_SCRIPTAPP_SCOPE,  # Required for scripts.run (execution API)
     DRIVE_FILE_SCOPE,  # Required for list/delete script projects (uses Drive API)
 ]
 

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -63,6 +63,7 @@ from auth.scopes import (
     SCRIPT_DEPLOYMENTS_SCOPE,
     SCRIPT_DEPLOYMENTS_READONLY_SCOPE,
     SCRIPT_EXTERNAL_REQUEST_SCOPE,
+    SCRIPT_SCRIPTAPP_SCOPE,
     has_required_scopes,
 )
 
@@ -579,6 +580,7 @@ SCOPE_GROUPS = {
     "script_deployments": SCRIPT_DEPLOYMENTS_SCOPE,
     "script_deployments_readonly": SCRIPT_DEPLOYMENTS_READONLY_SCOPE,
     "script_run": SCRIPT_EXTERNAL_REQUEST_SCOPE,
+    "script_scriptapp": SCRIPT_SCRIPTAPP_SCOPE,
 }
 
 

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -62,6 +62,7 @@ from auth.scopes import (
     SCRIPT_PROJECTS_READONLY_SCOPE,
     SCRIPT_DEPLOYMENTS_SCOPE,
     SCRIPT_DEPLOYMENTS_READONLY_SCOPE,
+    SCRIPT_EXTERNAL_REQUEST_SCOPE,
     has_required_scopes,
 )
 
@@ -577,6 +578,7 @@ SCOPE_GROUPS = {
     "script_projects": SCRIPT_PROJECTS_SCOPE,
     "script_deployments": SCRIPT_DEPLOYMENTS_SCOPE,
     "script_deployments_readonly": SCRIPT_DEPLOYMENTS_READONLY_SCOPE,
+    "script_run": SCRIPT_EXTERNAL_REQUEST_SCOPE,
 }
 
 

--- a/gappsscript/README.md
+++ b/gappsscript/README.md
@@ -154,6 +154,8 @@ https://www.googleapis.com/auth/script.deployments
 https://www.googleapis.com/auth/script.deployments.readonly
 https://www.googleapis.com/auth/script.processes
 https://www.googleapis.com/auth/script.metrics
+https://www.googleapis.com/auth/script.external_request
+https://www.googleapis.com/auth/script.scriptapp
 https://www.googleapis.com/auth/drive.file
 ```
 

--- a/gappsscript/apps_script_tools.py
+++ b/gappsscript/apps_script_tools.py
@@ -432,7 +432,7 @@ async def _run_script_function_impl(
     ),
 )
 @handle_http_errors("run_script_function", service_type="script")
-@require_google_service("script", "script_projects")
+@require_google_service("script", "script_run")
 async def run_script_function(
     service: Any,
     user_google_email: str,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Apps Script authentication: two additional OAuth scopes are now recognized, enabling broader script operations and external requests.

* **Behavior Change**
  * Script execution tooling now uses a more specific Apps Script permission grouping for authorization checks, affecting how script-run permissions are enforced.

* **Documentation**
  * README updated to list the newly recognized Apps Script OAuth scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->