### PR TITLE
enh: preflight validator for slides batch 

### DIFF
--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -13,10 +13,85 @@ from mcp.types import ToolAnnotations
 
 from auth.service_decorator import require_google_service
 from core.server import server
-from core.utils import handle_http_errors
+from core.utils import UserInputError, handle_http_errors
 from core.comments import create_comment_tools
 
 logger = logging.getLogger(__name__)
+
+
+def _get_request_payload(request: Dict[str, Any], request_type: str) -> Dict[str, Any]:
+    payload = request.get(request_type)
+    return payload if isinstance(payload, dict) else {}
+
+
+def _find_insert_text_targets(
+    requests: List[Dict[str, Any]],
+) -> List[tuple[int, str]]:
+    targets = []
+    for index, request in enumerate(requests):
+        if not isinstance(request, dict):
+            continue
+        object_id = _get_request_payload(request, "insertText").get("objectId")
+        if isinstance(object_id, str) and object_id:
+            targets.append((index, object_id))
+    return targets
+
+
+def _find_created_slide_ids(requests: List[Dict[str, Any]]) -> set[str]:
+    slide_ids = set()
+    for request in requests:
+        if not isinstance(request, dict):
+            continue
+        object_id = _get_request_payload(request, "createSlide").get("objectId")
+        if isinstance(object_id, str) and object_id:
+            slide_ids.add(object_id)
+    return slide_ids
+
+
+async def _get_presentation_slide_ids(service, presentation_id: str) -> set[str]:
+    result = await asyncio.to_thread(
+        service.presentations()
+        .get(presentationId=presentation_id, fields="slides(objectId)")
+        .execute
+    )
+    return {
+        slide["objectId"]
+        for slide in result.get("slides", [])
+        if isinstance(slide.get("objectId"), str)
+    }
+
+
+async def _validate_insert_text_targets(
+    service, presentation_id: str, requests: List[Dict[str, Any]]
+) -> None:
+    insert_text_targets = _find_insert_text_targets(requests)
+    if not insert_text_targets:
+        return
+
+    slide_ids = _find_created_slide_ids(requests)
+    slide_ids.update(await _get_presentation_slide_ids(service, presentation_id))
+
+    invalid_targets = [
+        (index, object_id)
+        for index, object_id in insert_text_targets
+        if object_id in slide_ids
+    ]
+    if not invalid_targets:
+        return
+
+    invalid_refs = ", ".join(
+        f"requests[{index}].insertText.objectId='{object_id}'"
+        for index, object_id in invalid_targets
+    )
+    raise UserInputError(
+        "Invalid Slides batch update request: "
+        f"{invalid_refs} targets a slide/page object. The Slides API only allows "
+        "insertText on text-capable shapes or table cells. Create a text box or "
+        "shape first with createShape, set elementProperties.pageObjectId to the "
+        "slide ID, then insertText into the new shape objectId. For existing "
+        "content, call get_page and use a Shape or Table element ID, not the "
+        "Page ID."
+    )
 
 
 @server.tool(
@@ -185,6 +260,13 @@ async def batch_update_presentation(
     """
     Apply batch updates to a Google Slides presentation.
 
+    Important:
+        insertText.objectId must be a text-capable shape or table object ID,
+        not a slide/page object ID. To add text to a slide, create a text box
+        or shape first with createShape, set elementProperties.pageObjectId to
+        the slide ID, and then insertText into that shape objectId. To edit
+        existing text, call get_page and use a Shape or Table element ID.
+
     Args:
         user_google_email (str): The user's Google email address. Required.
         presentation_id (str): The ID of the presentation to update.
@@ -196,6 +278,8 @@ async def batch_update_presentation(
     logger.info(
         f"[batch_update_presentation] Invoked. Email: '{user_google_email}', ID: '{presentation_id}', Requests: {len(requests)}"
     )
+
+    await _validate_insert_text_targets(service, presentation_id, requests)
 
     body = {"requests": requests}
 

--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -55,17 +55,21 @@ async def _get_presentation_slide_ids(service, presentation_id: str) -> set[str]
             presentationId=presentation_id,
             fields=(
                 "slides(objectId),masters(objectId),"
-                "layouts(objectId),notesMasters(objectId)"
+                "layouts(objectId),notesMaster(objectId)"
             ),
         )
         .execute
     )
-    return {
+    page_ids = {
         page["objectId"]
-        for page_type in ("slides", "masters", "layouts", "notesMasters")
+        for page_type in ("slides", "masters", "layouts")
         for page in result.get(page_type, [])
         if isinstance(page.get("objectId"), str)
     }
+    notes_master = result.get("notesMaster")
+    if isinstance(notes_master, dict) and isinstance(notes_master.get("objectId"), str):
+        page_ids.add(notes_master["objectId"])
+    return page_ids
 
 
 async def _validate_insert_text_targets(

--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -51,13 +51,20 @@ def _find_created_slide_ids(requests: List[Dict[str, Any]]) -> set[str]:
 async def _get_presentation_slide_ids(service, presentation_id: str) -> set[str]:
     result = await asyncio.to_thread(
         service.presentations()
-        .get(presentationId=presentation_id, fields="slides(objectId)")
+        .get(
+            presentationId=presentation_id,
+            fields=(
+                "slides(objectId),masters(objectId),"
+                "layouts(objectId),notesMasters(objectId)"
+            ),
+        )
         .execute
     )
     return {
-        slide["objectId"]
-        for slide in result.get("slides", [])
-        if isinstance(slide.get("objectId"), str)
+        page["objectId"]
+        for page_type in ("slides", "masters", "layouts", "notesMasters")
+        for page in result.get(page_type, [])
+        if isinstance(page.get("objectId"), str)
     }
 
 

--- a/skills/managing-google-workspace/references/slides.md
+++ b/skills/managing-google-workspace/references/slides.md
@@ -116,6 +116,8 @@ Create, reply to, or resolve a comment.
 
 **Object IDs**: Every slide and element has a unique `objectId`. Use `get_presentation` to discover slide IDs and `get_page` to discover element IDs within a slide. You can assign custom object IDs when creating elements (useful for referencing them in subsequent requests within the same batch).
 
+**Adding text**: `insertText.objectId` must be a text-capable shape or table object ID, not the slide/page ID. To place new text on a slide, create a text box or shape first with `createShape` and `elementProperties.pageObjectId` set to the slide ID, then call `insertText` using the new shape `objectId`.
+
 **Coordinate system**: Positions and sizes use EMU (English Metric Units). 1 inch = 914400 EMU. Standard slide dimensions are 10 inches wide (9144000 EMU) by 5.625 inches tall (5143500 EMU).
 
 **Batch ordering**: Requests in a batch execute sequentially. Earlier requests can create elements that later requests reference by object ID. If a request fails, subsequent requests in the batch are skipped.

--- a/tests/test_slides_tools.py
+++ b/tests/test_slides_tools.py
@@ -58,7 +58,7 @@ async def test_batch_update_rejects_insert_text_targeting_other_page_ids():
             "slides": [{"objectId": "slide_1"}],
             "masters": [{"objectId": "master_1"}],
             "layouts": [{"objectId": "layout_1"}],
-            "notesMasters": [{"objectId": "notes_master_1"}],
+            "notesMaster": {"objectId": "notes_master_1"},
         }
     )
 
@@ -99,8 +99,7 @@ async def test_batch_update_rejects_insert_text_targeting_other_page_ids():
     presentations.get.assert_called_once_with(
         presentationId="presentation-1",
         fields=(
-            "slides(objectId),masters(objectId),"
-            "layouts(objectId),notesMasters(objectId)"
+            "slides(objectId),masters(objectId),layouts(objectId),notesMaster(objectId)"
         ),
     )
     presentations.batchUpdate.assert_not_called()

--- a/tests/test_slides_tools.py
+++ b/tests/test_slides_tools.py
@@ -1,0 +1,118 @@
+from unittest.mock import Mock
+
+import pytest
+
+from core.utils import UserInputError
+from gslides.slides_tools import batch_update_presentation
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _build_slides_service(presentation=None, batch_update_response=None):
+    service = Mock()
+    presentations = service.presentations.return_value
+    presentations.get.return_value.execute.return_value = presentation or {
+        "slides": [{"objectId": "p"}]
+    }
+    presentations.batchUpdate.return_value.execute.return_value = (
+        batch_update_response or {"replies": []}
+    )
+    return service, presentations
+
+
+@pytest.mark.asyncio
+async def test_batch_update_rejects_insert_text_targeting_slide_id():
+    service, presentations = _build_slides_service()
+
+    with pytest.raises(UserInputError) as exc_info:
+        await _unwrap(batch_update_presentation)(
+            service=service,
+            user_google_email="user@example.com",
+            presentation_id="presentation-1",
+            requests=[
+                {
+                    "insertText": {
+                        "objectId": "p",
+                        "insertionIndex": 0,
+                        "text": "Title",
+                    }
+                }
+            ],
+        )
+
+    assert "requests[0].insertText.objectId='p'" in str(exc_info.value)
+    assert "createShape" in str(exc_info.value)
+    presentations.batchUpdate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_batch_update_allows_insert_text_targeting_created_shape():
+    service, presentations = _build_slides_service(
+        batch_update_response={
+            "replies": [
+                {},
+                {"createShape": {"objectId": "title_box"}},
+                {},
+            ]
+        }
+    )
+    requests = [
+        {"createSlide": {"objectId": "slide_2"}},
+        {
+            "createShape": {
+                "objectId": "title_box",
+                "shapeType": "TEXT_BOX",
+                "elementProperties": {"pageObjectId": "slide_2"},
+            }
+        },
+        {
+            "insertText": {
+                "objectId": "title_box",
+                "insertionIndex": 0,
+                "text": "Title",
+            }
+        },
+    ]
+
+    result = await _unwrap(batch_update_presentation)(
+        service=service,
+        user_google_email="user@example.com",
+        presentation_id="presentation-1",
+        requests=requests,
+    )
+
+    call_kwargs = presentations.batchUpdate.call_args.kwargs
+    assert call_kwargs["body"] == {"requests": requests}
+    assert "Batch Update Completed" in result
+    assert "Created shape with ID title_box" in result
+
+
+@pytest.mark.asyncio
+async def test_batch_update_rejects_insert_text_targeting_new_slide_id():
+    service, presentations = _build_slides_service(presentation={"slides": []})
+
+    with pytest.raises(UserInputError) as exc_info:
+        await _unwrap(batch_update_presentation)(
+            service=service,
+            user_google_email="user@example.com",
+            presentation_id="presentation-1",
+            requests=[
+                {"createSlide": {"objectId": "slide_2"}},
+                {
+                    "insertText": {
+                        "objectId": "slide_2",
+                        "insertionIndex": 0,
+                        "text": "Title",
+                    }
+                },
+            ],
+        )
+
+    assert "requests[1].insertText.objectId='slide_2'" in str(exc_info.value)
+    presentations.batchUpdate.assert_not_called()

--- a/tests/test_slides_tools.py
+++ b/tests/test_slides_tools.py
@@ -52,6 +52,61 @@ async def test_batch_update_rejects_insert_text_targeting_slide_id():
 
 
 @pytest.mark.asyncio
+async def test_batch_update_rejects_insert_text_targeting_other_page_ids():
+    service, presentations = _build_slides_service(
+        presentation={
+            "slides": [{"objectId": "slide_1"}],
+            "masters": [{"objectId": "master_1"}],
+            "layouts": [{"objectId": "layout_1"}],
+            "notesMasters": [{"objectId": "notes_master_1"}],
+        }
+    )
+
+    with pytest.raises(UserInputError) as exc_info:
+        await _unwrap(batch_update_presentation)(
+            service=service,
+            user_google_email="user@example.com",
+            presentation_id="presentation-1",
+            requests=[
+                {
+                    "insertText": {
+                        "objectId": "master_1",
+                        "insertionIndex": 0,
+                        "text": "Title",
+                    }
+                },
+                {
+                    "insertText": {
+                        "objectId": "layout_1",
+                        "insertionIndex": 0,
+                        "text": "Title",
+                    }
+                },
+                {
+                    "insertText": {
+                        "objectId": "notes_master_1",
+                        "insertionIndex": 0,
+                        "text": "Title",
+                    }
+                },
+            ],
+        )
+
+    message = str(exc_info.value)
+    assert "requests[0].insertText.objectId='master_1'" in message
+    assert "requests[1].insertText.objectId='layout_1'" in message
+    assert "requests[2].insertText.objectId='notes_master_1'" in message
+    presentations.get.assert_called_once_with(
+        presentationId="presentation-1",
+        fields=(
+            "slides(objectId),masters(objectId),"
+            "layouts(objectId),notesMasters(objectId)"
+        ),
+    )
+    presentations.batchUpdate.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_batch_update_allows_insert_text_targeting_created_shape():
     service, presentations = _build_slides_service(
         batch_update_response={


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batch updates now validate text-insert targets and block attempts to insert text into slide/page IDs, returning clearer, actionable errors.

* **Documentation**
  * Added guidance: create a text-capable shape or table cell on a slide first, then insert text using that element’s object ID.

* **Tests**
  * Added automated tests covering validation and batch-update behaviors for various insert-text scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->