### PR TITLE
enh: Missing state fallback for single user stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ export GOOGLE_PSE_ENGINE_ID=\
 
 > **📌 Transport Mode Guidance**: Use **streamable HTTP mode** (`--transport streamable-http`) for all modern MCP clients including Claude Code, VS Code MCP, and MCP Inspector. For Claude Desktop, run an instance and connect via a [Connector](https://workspacemcp.com/quick-start). Stdio mode is a legacy fallback. For deployments, prefer OAuth 2.1 with stateless mode (`MCP_ENABLE_OAUTH21=true`, `WORKSPACE_MCP_STATELESS_MODE=true`) unless you need local attachment or credential storage.
 
-> **OAuth state safety**: Legacy stdio starts a local-only OAuth callback server and may recover a missing Google `state` parameter by consuming the most recent pending local OAuth state. This fallback is intentionally limited to stdio because it can cross session boundaries. Do not enable or emulate this behavior in streamable HTTP, hosted, or multi-user deployments; those modes must require an explicit state match.
+> **OAuth state safety**: Legacy stdio starts a local-only OAuth callback server. In single-user mode only, it may recover a missing Google `state` parameter by consuming the most recent pending local OAuth state. This fallback is intentionally disabled outside single-user mode because it can cross session boundaries. Do not enable or emulate this behavior in streamable HTTP, hosted, or multi-user deployments; those modes must require an explicit state match.
 
 <details open>
 <summary>▶ <b>Launch Commands</b> <sub><sup>← Choose your startup mode</sup></sub></summary>
@@ -978,7 +978,7 @@ See the **[Quick Start Guide](https://workspacemcp.com/quick-start)** for setup 
 
 > **⚠️ Note**: Stdio mode is a legacy fallback for clients that don't support Connectors. Prefer the Connector-based approach above.
 >
-> **OAuth callback caveat**: The legacy stdio callback path includes a local recovery fallback for rare Google redirects that omit the `state` parameter. That recovery can only be safe in a single-user local process; in HTTP or hosted multi-user scenarios it could consume another user's pending OAuth state. There is no environment variable to enable this globally.
+> **OAuth callback caveat**: The legacy stdio callback path includes a local recovery fallback for rare Google redirects that omit the `state` parameter, but only when `--single-user` is active. That recovery can only be safe in a single-user local process; in HTTP or hosted multi-user scenarios it could consume another user's pending OAuth state. There is no environment variable to enable this globally.
 
 1. Open Claude Desktop Settings → Developer → Edit Config
    - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`

--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ export GOOGLE_PSE_ENGINE_ID=\
 
 > **📌 Transport Mode Guidance**: Use **streamable HTTP mode** (`--transport streamable-http`) for all modern MCP clients including Claude Code, VS Code MCP, and MCP Inspector. For Claude Desktop, run an instance and connect via a [Connector](https://workspacemcp.com/quick-start). Stdio mode is a legacy fallback. For deployments, prefer OAuth 2.1 with stateless mode (`MCP_ENABLE_OAUTH21=true`, `WORKSPACE_MCP_STATELESS_MODE=true`) unless you need local attachment or credential storage.
 
+> **OAuth state safety**: Legacy stdio starts a local-only OAuth callback server and may recover a missing Google `state` parameter by consuming the most recent pending local OAuth state. This fallback is intentionally limited to stdio because it can cross session boundaries. Do not enable or emulate this behavior in streamable HTTP, hosted, or multi-user deployments; those modes must require an explicit state match.
+
 <details open>
 <summary>▶ <b>Launch Commands</b> <sub><sup>← Choose your startup mode</sup></sub></summary>
 
@@ -975,6 +977,8 @@ See the **[Quick Start Guide](https://workspacemcp.com/quick-start)** for setup 
 <summary>📝 <b>Legacy: Manual stdio configuration</b> <sub><sup>← For clients without Connector support</sup></sub></summary>
 
 > **⚠️ Note**: Stdio mode is a legacy fallback for clients that don't support Connectors. Prefer the Connector-based approach above.
+>
+> **OAuth callback caveat**: The legacy stdio callback path includes a local recovery fallback for rare Google redirects that omit the `state` parameter. That recovery can only be safe in a single-user local process; in HTTP or hosted multi-user scenarios it could consume another user's pending OAuth state. There is no environment variable to enable this globally.
 
 1. Open Claude Desktop Settings → Developer → Edit Config
    - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -586,6 +586,7 @@ async def handle_auth_callback(
     redirect_uri: str,
     credentials_base_dir: str = DEFAULT_CREDENTIALS_DIR,
     session_id: Optional[str] = None,
+    allow_missing_state_fallback: bool = False,
     client_secrets_path: Optional[
         str
     ] = None,  # Deprecated: kept for backward compatibility
@@ -601,6 +602,9 @@ async def handle_auth_callback(
         redirect_uri: The redirect URI.
         credentials_base_dir: Base directory for credential files.
         session_id: Optional MCP session ID to associate with the credentials.
+        allow_missing_state_fallback: Whether to recover a missing callback state
+            from the most recently stored OAuth state. Only enable for local stdio
+            callbacks where there is no multi-user session context.
         client_secrets_path: (Deprecated) Path to client secrets file. Ignored if environment variables are set.
 
     Returns:
@@ -640,7 +644,7 @@ async def handle_auth_callback(
             state_info = store.validate_and_consume_oauth_state(
                 state, session_id=session_id
             )
-        elif session_id is None:
+        elif allow_missing_state_fallback:
             # stdio mode fallback: state may be absent from Google's redirect
             # (e.g. when prompt=select_account is used with revoked credentials).
             # Use the most recently stored state to recover the PKCE code_verifier.
@@ -648,7 +652,8 @@ async def handle_auth_callback(
                 "OAuth callback missing state parameter; using most recent stored state (stdio fallback)"
             )
             state_info = store.consume_latest_oauth_state(
-                initiating_session_id=session_id
+                initiating_session_id=session_id,
+                allow_any_session=session_id is None,
             )
             if not state_info:
                 raise ValueError(

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -644,16 +644,20 @@ async def handle_auth_callback(
             state_info = store.validate_and_consume_oauth_state(
                 state, session_id=session_id
             )
-        elif allow_missing_state_fallback:
+        elif (
+            allow_missing_state_fallback
+            and os.getenv("MCP_SINGLE_USER_MODE") == "1"
+            and session_id is None
+        ):
             # stdio mode fallback: state may be absent from Google's redirect
             # (e.g. when prompt=select_account is used with revoked credentials).
             # Use the most recently stored state to recover the PKCE code_verifier.
             logger.warning(
-                "OAuth callback missing state parameter; using most recent stored state (stdio fallback)"
+                "OAuth callback missing state parameter; using most recent stored state (single-user stdio fallback)"
             )
             state_info = store.consume_latest_oauth_state(
                 initiating_session_id=session_id,
-                allow_any_session=session_id is None,
+                allow_any_session=True,
             )
             if not state_info:
                 raise ValueError(

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -586,6 +586,7 @@ async def handle_auth_callback(
     redirect_uri: str,
     credentials_base_dir: str = DEFAULT_CREDENTIALS_DIR,
     session_id: Optional[str] = None,
+    *,
     allow_missing_state_fallback: bool = False,
     client_secrets_path: Optional[
         str

--- a/auth/oauth21_session_store.py
+++ b/auth/oauth21_session_store.py
@@ -412,7 +412,7 @@ class OAuth21SessionStore:
             matching_states = [
                 state
                 for state, state_info in oauth_states.items()
-                if state_info.get("session_id") == session_id
+                if session_id is None or state_info.get("session_id") == session_id
             ]
             if not matching_states:
                 return None, False

--- a/auth/oauth21_session_store.py
+++ b/auth/oauth21_session_store.py
@@ -405,6 +405,7 @@ class OAuth21SessionStore:
     def _consume_latest_oauth_state_from_shared_store(
         self,
         session_id: Optional[str] = None,
+        allow_any_session: bool = False,
     ) -> Optional[Tuple[str, Dict[str, Any]]]:
         def mutator(
             oauth_states: Dict[str, Dict[str, Any]],
@@ -412,7 +413,10 @@ class OAuth21SessionStore:
             matching_states = [
                 state
                 for state, state_info in oauth_states.items()
-                if session_id is None or state_info.get("session_id") == session_id
+                if (
+                    (allow_any_session and session_id is None)
+                    or state_info.get("session_id") == session_id
+                )
             ]
             if not matching_states:
                 return None, False
@@ -524,7 +528,9 @@ class OAuth21SessionStore:
             return state_info
 
     def consume_latest_oauth_state(
-        self, initiating_session_id: Optional[str] = None
+        self,
+        initiating_session_id: Optional[str] = None,
+        allow_any_session: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """
         Consume and return the most recently created OAuth state.
@@ -536,6 +542,9 @@ class OAuth21SessionStore:
             initiating_session_id: Optional session identifier that initiated the
                 OAuth flow. When provided, only matching shared-store states are
                 considered during fallback lookup.
+            allow_any_session: When True and no initiating session is available,
+                allow fallback lookup across session-bound states. This is only
+                safe for local stdio OAuth callbacks.
 
         Returns:
             State metadata dict, or None if no states are stored.
@@ -543,7 +552,8 @@ class OAuth21SessionStore:
         with self._lock:
             self._cleanup_expired_oauth_states_locked()
             shared_state = self._consume_latest_oauth_state_from_shared_store(
-                initiating_session_id
+                initiating_session_id,
+                allow_any_session=allow_any_session,
             )
             if not shared_state:
                 self._oauth_states.clear()

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -91,6 +91,7 @@ class MinimalOAuthServer:
                     authorization_response=str(request.url),
                     redirect_uri=redirect_uri,
                     session_id=None,
+                    allow_missing_state_fallback=True,
                 )
 
                 logger.info(

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -8,6 +8,7 @@ In stdio mode: Starts a minimal HTTP server just for OAuth callbacks
 import asyncio
 import errno
 import logging
+import os
 import threading
 import time
 import socket
@@ -91,7 +92,8 @@ class MinimalOAuthServer:
                     authorization_response=str(request.url),
                     redirect_uri=redirect_uri,
                     session_id=None,
-                    allow_missing_state_fallback=True,
+                    allow_missing_state_fallback=os.getenv("MCP_SINGLE_USER_MODE")
+                    == "1",
                 )
 
                 logger.info(

--- a/tests/auth/test_google_auth_callback_refresh_token.py
+++ b/tests/auth/test_google_auth_callback_refresh_token.py
@@ -13,16 +13,26 @@ class _DummyFlow:
 
 
 class _DummyOAuthStore:
-    def __init__(self, session_credentials=None):
+    def __init__(self, session_credentials=None, latest_state_info=None):
         self._session_credentials = session_credentials
+        self._latest_state_info = latest_state_info or {
+            "session_id": None,
+            "code_verifier": "verifier",
+        }
+        self.latest_calls = []
         self.stored_refresh_token = None
         self.store_calls = 0
 
     def validate_and_consume_oauth_state(self, state, session_id=None):  # noqa: ARG002
         return {"session_id": session_id, "code_verifier": "verifier"}
 
-    def consume_latest_oauth_state(self, initiating_session_id=None):  # noqa: ARG002
-        return {"session_id": None, "code_verifier": "verifier"}
+    def consume_latest_oauth_state(
+        self,
+        initiating_session_id=None,
+        allow_any_session=False,
+    ):
+        self.latest_calls.append((initiating_session_id, allow_any_session))
+        return self._latest_state_info
 
     def get_credentials_by_mcp_session(self, mcp_session_id):  # noqa: ARG002
         return self._session_credentials
@@ -55,6 +65,70 @@ def _make_credentials(refresh_token):
         client_secret="client-secret",
         scopes=["scope.a"],
     )
+
+
+@pytest.mark.asyncio
+async def test_callback_missing_state_does_not_use_latest_state_by_default(
+    monkeypatch,
+):
+    oauth_store = _DummyOAuthStore(session_credentials=None)
+
+    monkeypatch.setattr(
+        "auth.google_auth.get_oauth21_session_store", lambda: oauth_store
+    )
+
+    with pytest.raises(ValueError, match="Missing OAuth state parameter"):
+        await handle_auth_callback(
+            scopes=["scope.a"],
+            authorization_response="http://localhost/callback?code=code123",
+            redirect_uri="http://localhost/callback",
+            session_id=None,
+        )
+
+    assert oauth_store.latest_calls == []
+
+
+@pytest.mark.asyncio
+async def test_callback_missing_state_uses_explicit_stdio_fallback(monkeypatch):
+    callback_credentials = _make_credentials(refresh_token="callback-refresh-token")
+    oauth_store = _DummyOAuthStore(
+        session_credentials=None,
+        latest_state_info={
+            "session_id": "stdio-origin-session",
+            "code_verifier": "stdio-verifier",
+        },
+    )
+    credential_store = _DummyCredentialStore(existing_credentials=None)
+
+    monkeypatch.setattr(
+        "auth.google_auth.create_oauth_flow",
+        lambda **kwargs: _DummyFlow(callback_credentials),  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_oauth21_session_store", lambda: oauth_store
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_credential_store", lambda: credential_store
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_user_info",
+        lambda credentials: {"email": "user@gmail.com"},  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.save_credentials_to_session", lambda *args: None
+    )
+    monkeypatch.setattr("auth.google_auth.is_stateless_mode", lambda: False)
+
+    _email, credentials = await handle_auth_callback(
+        scopes=["scope.a"],
+        authorization_response="http://localhost/callback?code=code123",
+        redirect_uri="http://localhost/callback",
+        session_id=None,
+        allow_missing_state_fallback=True,
+    )
+
+    assert credentials.refresh_token == "callback-refresh-token"
+    assert oauth_store.latest_calls == [(None, True)]
 
 
 @pytest.mark.asyncio

--- a/tests/auth/test_google_auth_callback_refresh_token.py
+++ b/tests/auth/test_google_auth_callback_refresh_token.py
@@ -71,6 +71,7 @@ def _make_credentials(refresh_token):
 async def test_callback_missing_state_does_not_use_latest_state_by_default(
     monkeypatch,
 ):
+    monkeypatch.delenv("MCP_SINGLE_USER_MODE", raising=False)
     oauth_store = _DummyOAuthStore(session_credentials=None)
 
     monkeypatch.setattr(
@@ -89,7 +90,33 @@ async def test_callback_missing_state_does_not_use_latest_state_by_default(
 
 
 @pytest.mark.asyncio
-async def test_callback_missing_state_uses_explicit_stdio_fallback(monkeypatch):
+async def test_callback_missing_state_rejects_explicit_fallback_outside_single_user(
+    monkeypatch,
+):
+    monkeypatch.delenv("MCP_SINGLE_USER_MODE", raising=False)
+    oauth_store = _DummyOAuthStore(session_credentials=None)
+
+    monkeypatch.setattr(
+        "auth.google_auth.get_oauth21_session_store", lambda: oauth_store
+    )
+
+    with pytest.raises(ValueError, match="Missing OAuth state parameter"):
+        await handle_auth_callback(
+            scopes=["scope.a"],
+            authorization_response="http://localhost/callback?code=code123",
+            redirect_uri="http://localhost/callback",
+            session_id=None,
+            allow_missing_state_fallback=True,
+        )
+
+    assert oauth_store.latest_calls == []
+
+
+@pytest.mark.asyncio
+async def test_callback_missing_state_uses_explicit_single_user_stdio_fallback(
+    monkeypatch,
+):
+    monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
     callback_credentials = _make_credentials(refresh_token="callback-refresh-token")
     oauth_store = _DummyOAuthStore(
         session_credentials=None,

--- a/tests/auth/test_oauth21_session_store.py
+++ b/tests/auth/test_oauth21_session_store.py
@@ -41,6 +41,24 @@ def test_consume_latest_oauth_state_reads_from_shared_file(tmp_path):
     assert store_a.consume_latest_oauth_state() is None
 
 
+def test_consume_latest_oauth_state_without_session_reads_bound_state(tmp_path):
+    state_file = tmp_path / "oauth_states.json"
+    store_a = OAuth21SessionStore(oauth_state_file=str(state_file))
+    store_b = OAuth21SessionStore(oauth_state_file=str(state_file))
+
+    store_a.store_oauth_state(
+        "bound-state",
+        session_id="session-123",
+        code_verifier="bound-verifier",
+    )
+
+    state_info = store_b.consume_latest_oauth_state()
+
+    assert state_info is not None
+    assert state_info["session_id"] == "session-123"
+    assert state_info["code_verifier"] == "bound-verifier"
+
+
 def test_consume_latest_oauth_state_filters_by_initiating_session_id(tmp_path):
     state_file = tmp_path / "oauth_states.json"
     store_a = OAuth21SessionStore(oauth_state_file=str(state_file))

--- a/tests/auth/test_oauth21_session_store.py
+++ b/tests/auth/test_oauth21_session_store.py
@@ -41,7 +41,9 @@ def test_consume_latest_oauth_state_reads_from_shared_file(tmp_path):
     assert store_a.consume_latest_oauth_state() is None
 
 
-def test_consume_latest_oauth_state_without_session_reads_bound_state(tmp_path):
+def test_consume_latest_oauth_state_without_session_does_not_read_bound_state_by_default(
+    tmp_path,
+):
     state_file = tmp_path / "oauth_states.json"
     store_a = OAuth21SessionStore(oauth_state_file=str(state_file))
     store_b = OAuth21SessionStore(oauth_state_file=str(state_file))
@@ -53,6 +55,31 @@ def test_consume_latest_oauth_state_without_session_reads_bound_state(tmp_path):
     )
 
     state_info = store_b.consume_latest_oauth_state()
+
+    assert state_info is None
+
+    remaining_state_info = store_a.consume_latest_oauth_state(
+        initiating_session_id="session-123"
+    )
+    assert remaining_state_info is not None
+    assert remaining_state_info["session_id"] == "session-123"
+    assert remaining_state_info["code_verifier"] == "bound-verifier"
+
+
+def test_consume_latest_oauth_state_without_session_reads_bound_state_when_allowed(
+    tmp_path,
+):
+    state_file = tmp_path / "oauth_states.json"
+    store_a = OAuth21SessionStore(oauth_state_file=str(state_file))
+    store_b = OAuth21SessionStore(oauth_state_file=str(state_file))
+
+    store_a.store_oauth_state(
+        "bound-state",
+        session_id="session-123",
+        code_verifier="bound-verifier",
+    )
+
+    state_info = store_b.consume_latest_oauth_state(allow_any_session=True)
 
     assert state_info is not None
     assert state_info["session_id"] == "session-123"

--- a/tests/auth/test_oauth_callback_server.py
+++ b/tests/auth/test_oauth_callback_server.py
@@ -1,5 +1,7 @@
 import errno
 
+from starlette.testclient import TestClient
+
 from auth import oauth_callback_server
 
 
@@ -138,3 +140,37 @@ def test_ensure_oauth_callback_skips_start_when_other_instance_owns_port(monkeyp
     assert error == ""
     assert len(_PortInUseServer.instances) == 1
     assert _PortInUseServer.instances[0].start_calls == 0
+
+
+def test_oauth_callback_missing_state_fallback_follows_single_user_mode(monkeypatch):
+    calls = []
+
+    async def fake_handle_auth_callback(**kwargs):
+        calls.append(kwargs)
+        return "user@example.com", object()
+
+    monkeypatch.setattr(oauth_callback_server, "check_client_secrets", lambda: None)
+    monkeypatch.setattr(oauth_callback_server, "get_current_scopes", lambda: ["scope"])
+    monkeypatch.setattr(
+        oauth_callback_server,
+        "get_oauth_redirect_uri",
+        lambda: "http://localhost:8000/oauth2callback",
+    )
+    monkeypatch.setattr(
+        oauth_callback_server,
+        "handle_auth_callback",
+        fake_handle_auth_callback,
+    )
+
+    monkeypatch.delenv("MCP_SINGLE_USER_MODE", raising=False)
+    server = oauth_callback_server.MinimalOAuthServer(8000, "http://localhost")
+    response = TestClient(server.app).get("/oauth2callback?code=code123")
+
+    assert response.status_code == 200
+    assert calls[-1]["allow_missing_state_fallback"] is False
+
+    monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
+    response = TestClient(server.app).get("/oauth2callback?code=code123")
+
+    assert response.status_code == 200
+    assert calls[-1]["allow_missing_state_fallback"] is True


### PR DESCRIPTION
Closes #755 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents accidental cross-session consumption of bound OAuth state by keeping strict matching by default; explicit allowance is required to relax this.

* **New Features**
  * Optional local/stdio-style fallback to recover a missing OAuth state, enabled explicitly or automatically in single-user mode.

* **Tests**
  * Added and extended tests covering cross-session state consumption and missing-state fallback behavior.

* **Documentation**
  * Clarified safety and limits of the local/stdio fallback for multi-user/hosted deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->