### PR TITLE
feat(gmail): support inline image attachments via content_id key

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -1097,6 +1097,7 @@ def _prepare_gmail_message(
         content_base64 = attachment.get("content")
         resolved_bytes = attachment.get("_resolved_bytes")
         mime_type = attachment.get("mime_type")
+        content_id = attachment.get("content_id")
 
         try:
             if resolved_bytes is not None:
@@ -1146,14 +1147,49 @@ def _prepare_gmail_message(
                 if mime_type and "/" in mime_type
                 else ("application", "octet-stream")
             )
-            message.add_attachment(
-                file_data,
-                maintype=main_type,
-                subtype=sub_type,
-                filename=safe_filename,
-            )
+            if content_id:
+                cid_value = str(content_id).strip("<>").strip()
+                # Find the right MIME part to attach the inline image to.
+                # First inline image: target text/html (creates multipart/related).
+                # Subsequent inline images: target the existing multipart/related
+                # (appends as sibling). Use walk() for recursive search since
+                # iter_parts() only iterates direct children and html may be nested
+                # inside multipart/related after the first inline image is added.
+                target = None
+                for part in message.walk():
+                    if part.get_content_type() == "multipart/related":
+                        target = part
+                        break
+                if target is None:
+                    for part in message.walk():
+                        if part.get_content_type() == "text/html":
+                            target = part
+                            break
+                if target is None:
+                    target = message  # Plain-text body fallback
+                target.add_related(
+                    file_data,
+                    maintype=main_type,
+                    subtype=sub_type,
+                    cid=f"<{cid_value}>",
+                    filename=safe_filename,
+                    disposition="inline",
+                )
+                logger.info(
+                    f"Attached inline (cid={cid_value}): "
+                    f"{safe_filename} ({len(file_data)} bytes)"
+                )
+            else:
+                message.add_attachment(
+                    file_data,
+                    maintype=main_type,
+                    subtype=sub_type,
+                    filename=safe_filename,
+                )
+                logger.info(
+                    f"Attached file: {safe_filename} ({len(file_data)} bytes)"
+                )
             attached_count += 1
-            logger.info(f"Attached file: {safe_filename} ({len(file_data)} bytes)")
         except (binascii.Error, ValueError) as e:
             logger.error(f"Failed to decode attachment {filename or file_path}: {e}")
             attachment_errors.append(_format_attachment_error(file_path, filename, e))
@@ -1907,7 +1943,7 @@ async def send_gmail_message(
     attachments: Annotated[
         Optional[DictList],
         Field(
-            description='Optional list of attachments. Each can have: "url" (fetch from URL — works with MCP attachment URLs from get_drive_file_download_url / get_gmail_attachment_content), OR "path" (file path, auto-encodes), OR "content" (standard base64, not urlsafe) + "filename". Optional "mime_type". Example: [{"url": "https://host/attachments/abc-123", "filename": "report.pdf"}]',
+            description='Optional list of attachments. Each can have: "url" (fetch from URL — works with MCP attachment URLs from get_drive_file_download_url / get_gmail_attachment_content), OR "path" (file path, auto-encodes), OR "content" (standard base64, not urlsafe) + "filename". Optional "mime_type". Optional "content_id" (string) makes the attachment inline-rendered: it lands in a multipart/related part with `Content-ID: <content_id>` and `Content-Disposition: inline`, and the HTML body can reference it via `<img src="cid:<content_id>">` (RFC 2392). Without `content_id` the attachment is a regular multipart/mixed attachment. Example: [{"url": "https://host/attachments/abc-123", "filename": "report.pdf"}]',
         ),
     ] = None,
     include_signature: Annotated[
@@ -2153,7 +2189,7 @@ async def draft_gmail_message(
     attachments: Annotated[
         Optional[DictList],
         Field(
-            description="Optional list of attachments. Each can have: 'url' (fetch from URL — works with MCP attachment URLs from get_drive_file_download_url / get_gmail_attachment_content), OR 'path' (file path, auto-encodes), OR 'content' (standard base64, not urlsafe) + 'filename'. Optional 'mime_type' (auto-detected if not provided).",
+            description="Optional list of attachments. Each can have: 'url' (fetch from URL — works with MCP attachment URLs from get_drive_file_download_url / get_gmail_attachment_content), OR 'path' (file path, auto-encodes), OR 'content' (standard base64, not urlsafe) + 'filename'. Optional 'mime_type'. Optional 'content_id' (string) makes the attachment inline-rendered: it lands in a multipart/related part with `Content-ID: <content_id>` and `Content-Disposition: inline`, and the HTML body can reference it via `<img src=\"cid:<content_id>\">` (RFC 2392). Without `content_id` the attachment is a regular multipart/mixed attachment.",
         ),
     ] = None,
     include_signature: Annotated[

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -76,7 +76,7 @@ LOW_VALUE_TEXT_FOOTER_MARKERS = (
     "manage preferences",
 )
 LOW_VALUE_TEXT_HTML_DIFF_MIN = 80
-CONTENT_ID_SAFE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._%+\-@]*$")
+CONTENT_ID_SAFE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+\-@]*$")
 
 
 class _HTMLTextExtractor(HTMLParser):
@@ -581,7 +581,7 @@ def _normalize_attachment_content_id(content_id: Any) -> str:
     if not CONTENT_ID_SAFE_RE.fullmatch(cid_value):
         raise ValueError(
             "content_id contains invalid characters; use letters, digits, "
-            "'.', '_', '%', '+', '-', or '@'"
+            "'.', '_', '+', '-', or '@'"
         )
     return cid_value
 
@@ -975,14 +975,14 @@ async def _resolve_url_attachments(
             continue
         if local is not None:
             data, local_filename, local_mime = local
-            resolved.append(
-                {
-                    "_resolved_bytes": data,
-                    "filename": filename or local_filename,
-                    "mime_type": mime_type or local_mime,
-                    "content_id": att.get("content_id"),
-                }
-            )
+            entry = {
+                "_resolved_bytes": data,
+                "filename": filename or local_filename,
+                "mime_type": mime_type or local_mime,
+            }
+            if "content_id" in att:
+                entry["content_id"] = att["content_id"]
+            resolved.append(entry)
             continue
 
         # External URL — SSRF-safe fetch.
@@ -1009,14 +1009,14 @@ async def _resolve_url_attachments(
             elif filename:
                 mime_type, _ = mimetypes.guess_type(filename)
 
-        resolved.append(
-            {
-                "_resolved_bytes": data,
-                "filename": filename,
-                "mime_type": mime_type,
-                "content_id": att.get("content_id"),
-            }
-        )
+        entry = {
+            "_resolved_bytes": data,
+            "filename": filename,
+            "mime_type": mime_type,
+        }
+        if "content_id" in att:
+            entry["content_id"] = att["content_id"]
+        resolved.append(entry)
 
     return resolved
 
@@ -1107,6 +1107,8 @@ def _prepare_gmail_message(
     else:
         message.set_content(body)
 
+    seen_content_ids: set[str] = set()
+
     for attachment in attachments or []:
         if attachment.get("error"):
             attachment_errors.append(_format_resolved_attachment_error(attachment))
@@ -1169,6 +1171,14 @@ def _prepare_gmail_message(
             )
             if content_id:
                 cid_value = _normalize_attachment_content_id(content_id)
+                if cid_value in seen_content_ids:
+                    logger.warning(
+                        "Duplicate content_id %r on attachment %s; "
+                        "email clients may only render one instance",
+                        cid_value,
+                        filename or file_path,
+                    )
+                seen_content_ids.add(cid_value)
                 # Find the right MIME part to attach the inline image to.
                 # First inline image: target text/html (creates multipart/related).
                 # Subsequent inline images: target the existing multipart/related

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -76,6 +76,7 @@ LOW_VALUE_TEXT_FOOTER_MARKERS = (
     "manage preferences",
 )
 LOW_VALUE_TEXT_HTML_DIFF_MIN = 80
+CONTENT_ID_SAFE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._%+\-@]*$")
 
 
 class _HTMLTextExtractor(HTMLParser):
@@ -568,6 +569,23 @@ def _format_attachment_error(
     return f"{label}: {detail}"
 
 
+def _normalize_attachment_content_id(content_id: Any) -> str:
+    """Return a header-safe Content-ID value without surrounding brackets."""
+    raw = str(content_id)
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in raw):
+        raise ValueError("content_id contains invalid control characters")
+
+    cid_value = raw.strip().strip("<>").strip()
+    if not cid_value:
+        raise ValueError("content_id must not be empty")
+    if not CONTENT_ID_SAFE_RE.fullmatch(cid_value):
+        raise ValueError(
+            "content_id contains invalid characters; use letters, digits, "
+            "'.', '_', '%', '+', '-', or '@'"
+        )
+    return cid_value
+
+
 def _format_base64_content_block(urlsafe_b64_data: str) -> List[str]:
     """
     Convert Gmail's URL-safe base64 attachment data to standard base64 and
@@ -962,6 +980,7 @@ async def _resolve_url_attachments(
                     "_resolved_bytes": data,
                     "filename": filename or local_filename,
                     "mime_type": mime_type or local_mime,
+                    "content_id": att.get("content_id"),
                 }
             )
             continue
@@ -995,6 +1014,7 @@ async def _resolve_url_attachments(
                 "_resolved_bytes": data,
                 "filename": filename,
                 "mime_type": mime_type,
+                "content_id": att.get("content_id"),
             }
         )
 
@@ -1148,7 +1168,7 @@ def _prepare_gmail_message(
                 else ("application", "octet-stream")
             )
             if content_id:
-                cid_value = str(content_id).strip("<>").strip()
+                cid_value = _normalize_attachment_content_id(content_id)
                 # Find the right MIME part to attach the inline image to.
                 # First inline image: target text/html (creates multipart/related).
                 # Subsequent inline images: target the existing multipart/related
@@ -1186,9 +1206,7 @@ def _prepare_gmail_message(
                     subtype=sub_type,
                     filename=safe_filename,
                 )
-                logger.info(
-                    f"Attached file: {safe_filename} ({len(file_data)} bytes)"
-                )
+                logger.info(f"Attached file: {safe_filename} ({len(file_data)} bytes)")
             attached_count += 1
         except (binascii.Error, ValueError) as e:
             logger.error(f"Failed to decode attachment {filename or file_path}: {e}")

--- a/tests/gmail/test_inline_image_attachments.py
+++ b/tests/gmail/test_inline_image_attachments.py
@@ -1,0 +1,233 @@
+"""Tests for inline image attachments via content_id key.
+
+When an attachment dict carries a `content_id` key, the resulting email
+must use multipart/related so the HTML body can reference the image via
+`cid:` URLs (RFC 2392).
+"""
+import base64
+from email import message_from_bytes
+from email.policy import SMTP
+
+import pytest
+
+from gmail.gmail_tools import _prepare_gmail_message
+
+
+# Minimal 1x1 PNG (89 bytes). Used as fake image payload.
+_TINY_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNg"
+    "YGD4DwABBAEAfbLI3wAAAABJRU5ErkJggg=="
+)
+
+
+def _decode_raw(raw_b64url: str):
+    """Decode the urlsafe-base64 raw message back into an EmailMessage tree."""
+    raw_bytes = base64.urlsafe_b64decode(raw_b64url)
+    return message_from_bytes(raw_bytes, policy=SMTP)
+
+
+def _walk_parts(msg):
+    """Yield every MIME part (including multiparts and leaves)."""
+    yield msg
+    if msg.is_multipart():
+        for part in msg.iter_parts():
+            yield from _walk_parts(part)
+
+
+def test_content_id_attachment_uses_multipart_related():
+    """An attachment with content_id must produce multipart/related with
+    the image carrying Content-ID header and inline disposition."""
+    raw_b64, _, attached, errors = _prepare_gmail_message(
+        subject="inline-img-test",
+        body=(
+            "<html><body>"
+            "<p>see image:</p>"
+            '<img src="cid:fig-001">'
+            "</body></html>"
+        ),
+        body_format="html",
+        to="someone@example.com",
+        attachments=[
+            {
+                "content": _TINY_PNG_B64,
+                "filename": "fig-001.png",
+                "mime_type": "image/png",
+                "content_id": "fig-001",
+            }
+        ],
+    )
+
+    assert errors == []
+    assert attached == 1
+
+    msg = _decode_raw(raw_b64)
+    parts = list(_walk_parts(msg))
+    content_types = [p.get_content_type() for p in parts]
+
+    # Must contain a multipart/related anywhere in the tree.
+    assert "multipart/related" in content_types, (
+        f"expected multipart/related in tree, got {content_types}"
+    )
+
+    # Find the image part by content type.
+    image_parts = [p for p in parts if p.get_content_type() == "image/png"]
+    assert len(image_parts) == 1, f"expected 1 image part, got {len(image_parts)}"
+    img = image_parts[0]
+
+    # Content-ID header must match the requested cid (after stripping
+    # angle brackets, since stdlib may add them).
+    cid_header = img.get("Content-ID", "")
+    assert cid_header.strip("<>") == "fig-001", (
+        f"Content-ID mismatch: got {cid_header!r}"
+    )
+
+    # Inline disposition (not attachment).
+    disposition = img.get("Content-Disposition", "")
+    assert disposition.startswith("inline"), (
+        f"expected inline disposition, got {disposition!r}"
+    )
+
+
+def test_multiple_inline_images_share_one_multipart_related():
+    """Two or more inline images must coexist under a single multipart/related,
+    not crash with 'Cannot convert alternative to related'."""
+    raw_b64, _, attached, errors = _prepare_gmail_message(
+        subject="multi-inline-test",
+        body=(
+            "<html><body>"
+            '<p>fig 1: <img src="cid:img1"></p>'
+            '<p>fig 2: <img src="cid:img2"></p>'
+            "</body></html>"
+        ),
+        body_format="html",
+        to="someone@example.com",
+        attachments=[
+            {
+                "content": _TINY_PNG_B64,
+                "filename": "a.png",
+                "mime_type": "image/png",
+                "content_id": "img1",
+            },
+            {
+                "content": _TINY_PNG_B64,
+                "filename": "b.png",
+                "mime_type": "image/png",
+                "content_id": "img2",
+            },
+        ],
+    )
+
+    assert errors == [], f"unexpected errors: {errors}"
+    assert attached == 2, f"expected 2 attachments, got {attached}"
+
+    msg = _decode_raw(raw_b64)
+    parts = list(_walk_parts(msg))
+    content_types = [p.get_content_type() for p in parts]
+
+    # Exactly ONE multipart/related — both images live inside it.
+    assert content_types.count("multipart/related") == 1, (
+        f"expected exactly 1 multipart/related, got {content_types}"
+    )
+
+    # Both images present with correct Content-IDs.
+    image_parts = [p for p in parts if p.get_content_type() == "image/png"]
+    assert len(image_parts) == 2, f"expected 2 image parts, got {len(image_parts)}"
+    cids = {(p.get("Content-ID") or "").strip("<>") for p in image_parts}
+    assert cids == {"img1", "img2"}, f"cid mismatch: {cids}"
+
+    # Both have inline disposition.
+    for img in image_parts:
+        disposition = img.get("Content-Disposition", "")
+        assert disposition.startswith("inline"), (
+            f"expected inline disposition, got {disposition!r}"
+        )
+
+
+def test_attachment_without_content_id_still_uses_mixed():
+    """Backward compat: an attachment dict without content_id must still
+    produce multipart/mixed with attachment disposition (legacy path)."""
+    raw_b64, _, attached, errors = _prepare_gmail_message(
+        subject="legacy-attachment-test",
+        body="<html><body><p>file attached</p></body></html>",
+        body_format="html",
+        to="someone@example.com",
+        attachments=[
+            {
+                "content": _TINY_PNG_B64,
+                "filename": "report.png",
+                "mime_type": "image/png",
+                # NO content_id key
+            }
+        ],
+    )
+
+    assert errors == []
+    assert attached == 1
+
+    msg = _decode_raw(raw_b64)
+    parts = list(_walk_parts(msg))
+    content_types = [p.get_content_type() for p in parts]
+
+    # Legacy path: multipart/mixed, no multipart/related.
+    assert "multipart/mixed" in content_types
+    assert "multipart/related" not in content_types
+
+    # Image part exists, no Content-ID, attachment disposition.
+    image_parts = [p for p in parts if p.get_content_type() == "image/png"]
+    assert len(image_parts) == 1
+    img = image_parts[0]
+    assert img.get("Content-ID") is None, (
+        f"unexpected Content-ID on legacy attachment: {img.get('Content-ID')!r}"
+    )
+    disposition = img.get("Content-Disposition", "")
+    assert disposition.startswith("attachment"), (
+        f"expected attachment disposition, got {disposition!r}"
+    )
+
+
+def test_mixed_inline_and_legacy_attachments():
+    """Both an inline image (content_id) and a regular attachment in the
+    same email must coexist correctly: inline image lands in
+    multipart/related, regular attachment in multipart/mixed."""
+    raw_b64, _, attached, errors = _prepare_gmail_message(
+        subject="mixed-test",
+        body=(
+            "<html><body>"
+            '<img src="cid:hero">'
+            "<p>and a doc:</p>"
+            "</body></html>"
+        ),
+        body_format="html",
+        to="someone@example.com",
+        attachments=[
+            {
+                "content": _TINY_PNG_B64,
+                "filename": "hero.png",
+                "mime_type": "image/png",
+                "content_id": "hero",
+            },
+            {
+                "content": _TINY_PNG_B64,
+                "filename": "appendix.png",
+                "mime_type": "image/png",
+                # NO content_id
+            },
+        ],
+    )
+
+    assert errors == []
+    assert attached == 2
+
+    msg = _decode_raw(raw_b64)
+    parts = list(_walk_parts(msg))
+    content_types = [p.get_content_type() for p in parts]
+
+    # Both wrappers present.
+    assert "multipart/mixed" in content_types
+    assert "multipart/related" in content_types
+
+    # One image with Content-ID = hero, one without.
+    image_parts = [p for p in parts if p.get_content_type() == "image/png"]
+    assert len(image_parts) == 2
+    cids = {(p.get("Content-ID") or "").strip("<>") for p in image_parts}
+    assert cids == {"hero", ""}, f"expected one cid 'hero' and one empty, got {cids}"

--- a/tests/gmail/test_inline_image_attachments.py
+++ b/tests/gmail/test_inline_image_attachments.py
@@ -309,9 +309,7 @@ def test_plaintext_body_with_content_id_fallback():
     assert len(image_parts) == 1, f"expected 1 image part, got {len(image_parts)}"
     img = image_parts[0]
     cid_header = img.get("Content-ID", "")
-    assert cid_header.strip("<>") == "chart", (
-        f"Content-ID mismatch: got {cid_header!r}"
-    )
+    assert cid_header.strip("<>") == "chart", f"Content-ID mismatch: got {cid_header!r}"
     disposition = img.get("Content-Disposition", "")
     assert disposition.startswith("inline"), (
         f"expected inline disposition, got {disposition!r}"
@@ -324,12 +322,7 @@ def test_duplicate_content_id_logs_warning(caplog):
     with caplog.at_level(logging.WARNING, logger="gmail.gmail_tools"):
         raw_b64, _, attached, errors = _prepare_gmail_message(
             subject="dup-cid-test",
-            body=(
-                "<html><body>"
-                '<img src="cid:same">'
-                '<img src="cid:same">'
-                "</body></html>"
-            ),
+            body=('<html><body><img src="cid:same"><img src="cid:same"></body></html>'),
             body_format="html",
             to="someone@example.com",
             attachments=[
@@ -352,7 +345,9 @@ def test_duplicate_content_id_logs_warning(caplog):
     assert attached == 2
 
     # Verify the duplicate warning was logged.
-    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    warning_messages = [
+        r.message for r in caplog.records if r.levelno == logging.WARNING
+    ]
     assert any("Duplicate content_id" in m for m in warning_messages), (
         f"expected duplicate content_id warning, got: {warning_messages}"
     )

--- a/tests/gmail/test_inline_image_attachments.py
+++ b/tests/gmail/test_inline_image_attachments.py
@@ -6,11 +6,14 @@ must use multipart/related so the HTML body can reference the image via
 """
 
 import base64
+import asyncio
 import logging
 from email import message_from_bytes
 from email.policy import SMTP
+from types import SimpleNamespace
 
-from gmail.gmail_tools import _prepare_gmail_message
+import gmail.gmail_tools as gmail_tools
+from gmail.gmail_tools import _prepare_gmail_message, _resolve_url_attachments
 
 
 # Minimal 1x1 PNG (89 bytes). Used as fake image payload.
@@ -83,21 +86,37 @@ def test_content_id_attachment_uses_multipart_related():
     )
 
 
-def test_url_based_inline_attachment_preserves_content_id():
+def test_url_based_inline_attachment_preserves_content_id(monkeypatch):
     """A URL-resolved attachment must keep content_id so it remains inline."""
+    async def fake_download_attachment_bytes(url):
+        assert url == "https://example.com/hero.png"
+        return (
+            base64.b64decode(_TINY_PNG_B64),
+            SimpleNamespace(headers={"content-type": "image/png"}),
+        )
+
+    monkeypatch.setattr(
+        gmail_tools, "_download_attachment_bytes", fake_download_attachment_bytes
+    )
+    attachments = asyncio.run(
+        _resolve_url_attachments(
+            [
+                {
+                    "url": "https://example.com/hero.png",
+                    "filename": "hero.png",
+                    "mime_type": "image/png",
+                    "content_id": "hero",
+                }
+            ]
+        )
+    )
+
     raw_b64, _, attached, errors = _prepare_gmail_message(
         subject="url-inline-img-test",
         body=('<html><body><img src="cid:hero"></body></html>'),
         body_format="html",
         to="someone@example.com",
-        attachments=[
-            {
-                "_resolved_bytes": base64.b64decode(_TINY_PNG_B64),
-                "filename": "hero.png",
-                "mime_type": "image/png",
-                "content_id": "hero",
-            }
-        ],
+        attachments=attachments,
     )
 
     assert errors == []
@@ -281,12 +300,12 @@ def test_mixed_inline_and_legacy_attachments():
 
 
 def test_plaintext_body_with_content_id_fallback():
-    """When body_format is 'text' (no text/html part), the inline image
+    """When body_format is 'plain' (no text/html part), the inline image
     must still attach via the plain-text message fallback target."""
     raw_b64, _, attached, errors = _prepare_gmail_message(
         subject="plaintext-inline-test",
         body="See the attached image.",
-        body_format="text",
+        body_format="plain",
         to="someone@example.com",
         attachments=[
             {

--- a/tests/gmail/test_inline_image_attachments.py
+++ b/tests/gmail/test_inline_image_attachments.py
@@ -4,11 +4,11 @@ When an attachment dict carries a `content_id` key, the resulting email
 must use multipart/related so the HTML body can reference the image via
 `cid:` URLs (RFC 2392).
 """
+
 import base64
 from email import message_from_bytes
 from email.policy import SMTP
 
-import pytest
 
 from gmail.gmail_tools import _prepare_gmail_message
 
@@ -39,12 +39,7 @@ def test_content_id_attachment_uses_multipart_related():
     the image carrying Content-ID header and inline disposition."""
     raw_b64, _, attached, errors = _prepare_gmail_message(
         subject="inline-img-test",
-        body=(
-            "<html><body>"
-            "<p>see image:</p>"
-            '<img src="cid:fig-001">'
-            "</body></html>"
-        ),
+        body=('<html><body><p>see image:</p><img src="cid:fig-001"></body></html>'),
         body_format="html",
         to="someone@example.com",
         attachments=[
@@ -86,6 +81,63 @@ def test_content_id_attachment_uses_multipart_related():
     assert disposition.startswith("inline"), (
         f"expected inline disposition, got {disposition!r}"
     )
+
+
+def test_url_based_inline_attachment_preserves_content_id():
+    """A URL-resolved attachment must keep content_id so it remains inline."""
+    raw_b64, _, attached, errors = _prepare_gmail_message(
+        subject="url-inline-img-test",
+        body=('<html><body><img src="cid:hero"></body></html>'),
+        body_format="html",
+        to="someone@example.com",
+        attachments=[
+            {
+                "_resolved_bytes": base64.b64decode(_TINY_PNG_B64),
+                "filename": "hero.png",
+                "mime_type": "image/png",
+                "content_id": "hero",
+            }
+        ],
+    )
+
+    assert errors == []
+    assert attached == 1
+
+    msg = _decode_raw(raw_b64)
+    parts = list(_walk_parts(msg))
+    content_types = [p.get_content_type() for p in parts]
+    assert "multipart/related" in content_types
+
+    image_parts = [p for p in parts if p.get_content_type() == "image/png"]
+    assert len(image_parts) == 1
+    cid_header = image_parts[0].get("Content-ID", "")
+    assert cid_header.strip("<>") == "hero"
+
+
+def test_content_id_rejects_control_characters():
+    """Unsafe content_id values must not reach MIME headers."""
+    raw_b64, _, attached, errors = _prepare_gmail_message(
+        subject="unsafe-cid-test",
+        body='<html><body><img src="cid:hero"></body></html>',
+        body_format="html",
+        to="someone@example.com",
+        attachments=[
+            {
+                "content": _TINY_PNG_B64,
+                "filename": "hero.png",
+                "mime_type": "image/png",
+                "content_id": "hero\r\nX-Injected: bad",
+            }
+        ],
+    )
+
+    assert attached == 0
+    assert len(errors) == 1
+    assert "content_id contains invalid control characters" in errors[0]
+
+    msg = _decode_raw(raw_b64)
+    parts = list(_walk_parts(msg))
+    assert [p for p in parts if p.get_content_type() == "image/png"] == []
 
 
 def test_multiple_inline_images_share_one_multipart_related():
@@ -191,12 +243,7 @@ def test_mixed_inline_and_legacy_attachments():
     multipart/related, regular attachment in multipart/mixed."""
     raw_b64, _, attached, errors = _prepare_gmail_message(
         subject="mixed-test",
-        body=(
-            "<html><body>"
-            '<img src="cid:hero">'
-            "<p>and a doc:</p>"
-            "</body></html>"
-        ),
+        body=('<html><body><img src="cid:hero"><p>and a doc:</p></body></html>'),
         body_format="html",
         to="someone@example.com",
         attachments=[

--- a/tests/gmail/test_inline_image_attachments.py
+++ b/tests/gmail/test_inline_image_attachments.py
@@ -88,6 +88,7 @@ def test_content_id_attachment_uses_multipart_related():
 
 def test_url_based_inline_attachment_preserves_content_id(monkeypatch):
     """A URL-resolved attachment must keep content_id so it remains inline."""
+
     async def fake_download_attachment_bytes(url):
         assert url == "https://example.com/hero.png"
         return (

--- a/tests/gmail/test_inline_image_attachments.py
+++ b/tests/gmail/test_inline_image_attachments.py
@@ -6,9 +6,9 @@ must use multipart/related so the HTML body can reference the image via
 """
 
 import base64
+import logging
 from email import message_from_bytes
 from email.policy import SMTP
-
 
 from gmail.gmail_tools import _prepare_gmail_message
 
@@ -278,3 +278,81 @@ def test_mixed_inline_and_legacy_attachments():
     assert len(image_parts) == 2
     cids = {(p.get("Content-ID") or "").strip("<>") for p in image_parts}
     assert cids == {"hero", ""}, f"expected one cid 'hero' and one empty, got {cids}"
+
+
+def test_plaintext_body_with_content_id_fallback():
+    """When body_format is 'text' (no text/html part), the inline image
+    must still attach via the plain-text message fallback target."""
+    raw_b64, _, attached, errors = _prepare_gmail_message(
+        subject="plaintext-inline-test",
+        body="See the attached image.",
+        body_format="text",
+        to="someone@example.com",
+        attachments=[
+            {
+                "content": _TINY_PNG_B64,
+                "filename": "chart.png",
+                "mime_type": "image/png",
+                "content_id": "chart",
+            }
+        ],
+    )
+
+    assert errors == []
+    assert attached == 1
+
+    msg = _decode_raw(raw_b64)
+    parts = list(_walk_parts(msg))
+
+    # Image part exists with correct Content-ID and inline disposition.
+    image_parts = [p for p in parts if p.get_content_type() == "image/png"]
+    assert len(image_parts) == 1, f"expected 1 image part, got {len(image_parts)}"
+    img = image_parts[0]
+    cid_header = img.get("Content-ID", "")
+    assert cid_header.strip("<>") == "chart", (
+        f"Content-ID mismatch: got {cid_header!r}"
+    )
+    disposition = img.get("Content-Disposition", "")
+    assert disposition.startswith("inline"), (
+        f"expected inline disposition, got {disposition!r}"
+    )
+
+
+def test_duplicate_content_id_logs_warning(caplog):
+    """Two attachments with the same content_id should both attach but
+    produce a warning about the duplicate."""
+    with caplog.at_level(logging.WARNING, logger="gmail.gmail_tools"):
+        raw_b64, _, attached, errors = _prepare_gmail_message(
+            subject="dup-cid-test",
+            body=(
+                "<html><body>"
+                '<img src="cid:same">'
+                '<img src="cid:same">'
+                "</body></html>"
+            ),
+            body_format="html",
+            to="someone@example.com",
+            attachments=[
+                {
+                    "content": _TINY_PNG_B64,
+                    "filename": "a.png",
+                    "mime_type": "image/png",
+                    "content_id": "same",
+                },
+                {
+                    "content": _TINY_PNG_B64,
+                    "filename": "b.png",
+                    "mime_type": "image/png",
+                    "content_id": "same",
+                },
+            ],
+        )
+
+    assert errors == []
+    assert attached == 2
+
+    # Verify the duplicate warning was logged.
+    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("Duplicate content_id" in m for m in warning_messages), (
+        f"expected duplicate content_id warning, got: {warning_messages}"
+    )


### PR DESCRIPTION
## Description

Adds support for inline image attachments via an optional `content_id` key in attachment dicts passed to `send_gmail_message()` and `draft_gmail_message()`. When `content_id` is present, the attachment is added via `EmailMessage.add_related()` instead of `add_attachment()`, producing a `multipart/related` MIME structure with `Content-ID: <cid>` and `Content-Disposition: inline`. HTML email bodies can then embed images inline via `<img src="cid:<content_id>">` per RFC 2392.

This is fully backward-compatible: attachments without `content_id` continue to use the existing `multipart/mixed` path.

**Use case:** LLM-driven email composition where the model embeds figures inline rather than dumping them as bottom-aligned attachments. The current behavior forces inline-intended images to render as broken HTML tags or to be flattened into PDF delivery.

**Implementation highlight:** Handles a Python `email.message.EmailMessage` quirk where calling `add_related()` on a `multipart/alternative` raises an error. The code recursively walks the message tree to find (or create) the appropriate `multipart/related` target, enabling 2+ inline images to coexist correctly.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

**Test coverage:** `tests/gmail/test_inline_image_attachments.py` includes:
- Single inline image → multipart/related + Content-ID + inline disposition
- Multiple inline images → coexist under one multipart/related
- Regression test: no content_id → multipart/mixed + attachment disposition (unchanged)
- Mixed scenario: inline image + regular attachment in same email

All 114 baseline gmail tests + 4 new tests pass without modification.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

- No new dependencies (pure stdlib `email.message.EmailMessage`).
- Docstrings on both `send_gmail_message()` and `draft_gmail_message()` updated to document the new `content_id` key.
- Commit: `501c406` — implements the feature, adds comprehensive tests, and updates docstrings in a single atomic change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline attachments for Gmail messages — images can be embedded and referenced in HTML via cid: links and rendered inline.

* **Documentation**
  * Updated send/draft message docs to explain attachments' content_id usage and cid referencing.

* **Bug Fixes**
  * Rejects malformed content IDs; duplicate content IDs attach but emit a logged warning.

* **Tests**
  * Added coverage for inline images, mixed inline/regular attachments, URL-resolved attachments, validation, duplicates, and body-format fallbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->