### PR TITLE
fix: use sole credential user in single-user mode

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -133,6 +133,68 @@ def _find_any_credentials(
     return None, None
 
 
+def _find_single_user_credentials_for_request(
+    user_google_email: str,
+) -> tuple[Optional[Credentials], Optional[str]]:
+    """
+    Find credentials in single-user mode when the caller supplied an email.
+
+    A single-user deployment may receive a stale or client-profile email from
+    the MCP client. If the credential store contains exactly one account, trust
+    the local credential file over the caller-provided value. When multiple
+    users exist, keep the strict behavior to avoid selecting the wrong account.
+    """
+    credential_store = get_credential_store()
+    credentials = credential_store.get_credential(user_google_email)
+    if credentials:
+        logger.info(
+            f"[get_credentials] Single-user mode: found credentials for requested user {user_google_email}"
+        )
+        return credentials, user_google_email
+
+    try:
+        users = credential_store.list_users()
+    except Exception as e:
+        logger.info(
+            "[get_credentials] Single-user mode: no credentials for requested "
+            f"user {user_google_email}; cannot inspect local credential users: {e}"
+        )
+        return None, None
+
+    requested_lower = user_google_email.lower()
+    case_matches = [user for user in users if user.lower() == requested_lower]
+
+    if len(case_matches) == 1:
+        selected_user = case_matches[0]
+        logger.info(
+            "[get_credentials] Single-user mode: using credential store email "
+            f"{selected_user} for requested user {user_google_email}"
+        )
+    elif len(users) == 1:
+        selected_user = users[0]
+        logger.info(
+            "[get_credentials] Single-user mode: overriding requested user "
+            f"{user_google_email} with sole credential user {selected_user}"
+        )
+    else:
+        logger.info(
+            "[get_credentials] Single-user mode: no credentials for requested "
+            f"user {user_google_email}; not falling back because {len(users)} "
+            "credential users are available"
+        )
+        return None, None
+
+    credentials = credential_store.get_credential(selected_user)
+    if not credentials:
+        logger.info(
+            "[get_credentials] Single-user mode: selected credential user "
+            f"{selected_user} could not be loaded"
+        )
+        return None, None
+
+    return credentials, selected_user
+
+
 def save_credentials_to_session(session_id: str, credentials: Credentials):
     """Saves user credentials using OAuth21SessionStore."""
     # Get user email from credentials if possible
@@ -824,9 +886,10 @@ def get_credentials(
     """
     Retrieves stored credentials, prioritizing OAuth 2.1 store, then session, then file. Refreshes if necessary.
     If credentials are loaded from file and a session_id is present, they are cached in the session.
-    In single-user mode, bypasses session mapping. If user_google_email is provided, only credentials
-    for that email are used and the function returns None instead of falling back to any available
-    credentials. If user_google_email is not provided, any available credentials may be used.
+    In single-user mode, bypasses session mapping. If user_google_email is provided,
+    credentials for that email are preferred. If the credential store contains exactly
+    one user, that stored user is trusted over a caller-provided mismatch. If multiple
+    users exist, no fallback is used.
 
     Args:
         user_google_email: Optional user's Google email.
@@ -937,22 +1000,10 @@ def get_credentials(
         logger.info(
             "[get_credentials] Single-user mode: bypassing session mapping, finding any credentials"
         )
-        # If a specific email was requested, try to load that user's credentials first
-        # to avoid session binding conflicts when multiple credential files exist
         if user_google_email:
-            credential_store = get_credential_store()
-            credentials = credential_store.get_credential(user_google_email)
-            if credentials:
-                logger.info(
-                    f"[get_credentials] Single-user mode: found credentials for requested user {user_google_email}"
-                )
-                found_user_email = user_google_email
-            else:
-                logger.info(
-                    "[get_credentials] Single-user mode: no credentials for requested "
-                    f"user {user_google_email}; not falling back to another user"
-                )
-                return None
+            credentials, found_user_email = _find_single_user_credentials_for_request(
+                user_google_email
+            )
         else:
             credentials, found_user_email = _find_any_credentials(credentials_base_dir)
         if not credentials:
@@ -961,9 +1012,9 @@ def get_credentials(
             )
             return None
 
-        # Use the email from the credential file if not provided
-        # This ensures we can save refreshed credentials even when the token is expired
-        if not user_google_email and found_user_email:
+        # Use the email from the credential file so refreshed credentials are
+        # persisted back to the canonical account for this single-user instance.
+        if found_user_email and user_google_email != found_user_email:
             user_google_email = found_user_email
             logger.debug(
                 f"[get_credentials] Single-user mode: using email {user_google_email} from credential file"

--- a/tests/auth/test_google_auth_refresh_persistence.py
+++ b/tests/auth/test_google_auth_refresh_persistence.py
@@ -1,4 +1,6 @@
-from auth.google_auth import get_credentials
+import asyncio
+
+from auth.google_auth import get_authenticated_google_service, get_credentials
 
 
 class _RefreshableCredentials:
@@ -10,6 +12,7 @@ class _RefreshableCredentials:
         self.client_secret = "client-secret"
         self.scopes = ["scope.a"]
         self.expiry = None
+        self.id_token = None
         self.valid = valid
         self.expired = not valid
 
@@ -159,6 +162,69 @@ def test_get_credentials_single_user_uses_sole_stored_user_when_requested_user_m
     assert credential_store.get_calls == ["missing@example.com", "actual@example.com"]
     assert credential_store.list_calls == 1
     assert credential_store.store_calls == []
+
+
+def test_get_credentials_reports_resolved_single_user_email(monkeypatch):
+    stored_credentials = _RefreshableCredentials(valid=True)
+    credential_store = _CredentialStore(
+        credentials_by_user={"actual@example.com": stored_credentials}
+    )
+    resolved_emails = []
+
+    monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
+    monkeypatch.setattr(
+        "auth.google_auth.get_credential_store", lambda: credential_store
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.has_required_scopes", lambda scopes, required: True
+    )
+
+    result = get_credentials(
+        user_google_email="missing@example.com",
+        required_scopes=["scope.a"],
+        resolved_user_email=resolved_emails.append,
+    )
+
+    assert result is stored_credentials
+    assert resolved_emails == ["actual@example.com"]
+
+
+def test_get_authenticated_google_service_returns_resolved_single_user_email(
+    monkeypatch,
+):
+    stored_credentials = _RefreshableCredentials(valid=True)
+    credential_store = _CredentialStore(
+        credentials_by_user={"actual@example.com": stored_credentials}
+    )
+    built_service = object()
+
+    monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
+    monkeypatch.setattr(
+        "auth.google_auth.get_credential_store", lambda: credential_store
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.has_required_scopes", lambda scopes, required: True
+    )
+    monkeypatch.setattr("auth.google_auth.get_fastmcp_session_id", lambda: None)
+    monkeypatch.setattr("auth.google_auth.get_fastmcp_context", None)
+    monkeypatch.setattr(
+        "auth.google_auth.build",
+        lambda service_name, version, credentials: built_service,
+    )
+
+    async def run():
+        return await get_authenticated_google_service(
+            service_name="gmail",
+            version="v1",
+            tool_name="test_tool",
+            user_google_email="missing@example.com",
+            required_scopes=["scope.a"],
+        )
+
+    service, user_email = asyncio.run(run())
+
+    assert service is built_service
+    assert user_email == "actual@example.com"
 
 
 def test_get_credentials_single_user_does_not_fallback_when_multiple_users_exist(

--- a/tests/auth/test_google_auth_refresh_persistence.py
+++ b/tests/auth/test_google_auth_refresh_persistence.py
@@ -2,7 +2,7 @@ from auth.google_auth import get_credentials
 
 
 class _RefreshableCredentials:
-    def __init__(self):
+    def __init__(self, valid=False):
         self.token = "stale-token"
         self.refresh_token = "refresh-token"
         self.token_uri = "https://oauth2.googleapis.com/token"
@@ -10,8 +10,8 @@ class _RefreshableCredentials:
         self.client_secret = "client-secret"
         self.scopes = ["scope.a"]
         self.expiry = None
-        self.valid = False
-        self.expired = True
+        self.valid = valid
+        self.expired = not valid
 
     def refresh(self, request):  # noqa: ARG002
         self.token = "fresh-token"
@@ -36,15 +36,30 @@ class _OAuthSessionStore:
 
 
 class _CredentialStore:
-    def __init__(self, existing_credentials=None, store_result=True):
+    def __init__(
+        self,
+        existing_credentials=None,
+        store_result=True,
+        credentials_by_user=None,
+        users=None,
+    ):
         self._existing_credentials = existing_credentials
         self.store_result = store_result
+        self.credentials_by_user = credentials_by_user or {}
+        self.users = list(users if users is not None else self.credentials_by_user)
         self.get_calls = []
+        self.list_calls = 0
         self.store_calls = []
 
     def get_credential(self, user_email):
         self.get_calls.append(user_email)
+        if self.credentials_by_user:
+            return self.credentials_by_user.get(user_email)
         return self._existing_credentials
+
+    def list_users(self):
+        self.list_calls += 1
+        return self.users
 
     def store_credential(self, user_email, credentials):  # noqa: ARG002
         self.store_calls.append((user_email, credentials.token))
@@ -119,22 +134,47 @@ def test_get_credentials_skips_session_update_when_refresh_persist_fails(monkeyp
     assert session_cache_writes[0][0] == "session-1"
 
 
-def test_get_credentials_single_user_returns_none_for_missing_requested_user(
+def test_get_credentials_single_user_uses_sole_stored_user_when_requested_user_missing(
     monkeypatch,
 ):
-    credential_store = _CredentialStore(existing_credentials=None)
-    fallback_creds = _RefreshableCredentials()
-    fallback_calls = []
-
-    def _unexpected_fallback(credentials_base_dir):  # noqa: ARG001
-        fallback_calls.append(True)
-        return fallback_creds, "other@example.com"
+    stored_credentials = _RefreshableCredentials(valid=True)
+    credential_store = _CredentialStore(
+        credentials_by_user={"actual@example.com": stored_credentials}
+    )
 
     monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
     monkeypatch.setattr(
         "auth.google_auth.get_credential_store", lambda: credential_store
     )
-    monkeypatch.setattr("auth.google_auth._find_any_credentials", _unexpected_fallback)
+    monkeypatch.setattr(
+        "auth.google_auth.has_required_scopes", lambda scopes, required: True
+    )
+
+    result = get_credentials(
+        user_google_email="missing@example.com",
+        required_scopes=["scope.a"],
+    )
+
+    assert result is stored_credentials
+    assert credential_store.get_calls == ["missing@example.com", "actual@example.com"]
+    assert credential_store.list_calls == 1
+    assert credential_store.store_calls == []
+
+
+def test_get_credentials_single_user_does_not_fallback_when_multiple_users_exist(
+    monkeypatch,
+):
+    credential_store = _CredentialStore(
+        credentials_by_user={
+            "first@example.com": _RefreshableCredentials(valid=True),
+            "second@example.com": _RefreshableCredentials(valid=True),
+        }
+    )
+
+    monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
+    monkeypatch.setattr(
+        "auth.google_auth.get_credential_store", lambda: credential_store
+    )
 
     result = get_credentials(
         user_google_email="missing@example.com",
@@ -143,5 +183,5 @@ def test_get_credentials_single_user_returns_none_for_missing_requested_user(
 
     assert result is None
     assert credential_store.get_calls == ["missing@example.com"]
+    assert credential_store.list_calls == 1
     assert credential_store.store_calls == []
-    assert fallback_calls == []

--- a/tests/auth/test_google_auth_refresh_persistence.py
+++ b/tests/auth/test_google_auth_refresh_persistence.py
@@ -1,75 +1,92 @@
 import asyncio
+from typing import Any, Optional
+
+from pytest import MonkeyPatch
 
 from auth.google_auth import get_authenticated_google_service, get_credentials
 
 
 class _RefreshableCredentials:
-    def __init__(self, valid=False):
-        self.token = "stale-token"
-        self.refresh_token = "refresh-token"
-        self.token_uri = "https://oauth2.googleapis.com/token"
-        self.client_id = "client-id"
-        self.client_secret = "client-secret"
-        self.scopes = ["scope.a"]
-        self.expiry = None
-        self.id_token = None
-        self.valid = valid
-        self.expired = not valid
+    def __init__(self, valid: bool = False) -> None:
+        self.token: str = "stale-token"
+        self.refresh_token: str = "refresh-token"
+        self.token_uri: str = "https://oauth2.googleapis.com/token"
+        self.client_id: str = "client-id"
+        self.client_secret: str = "client-secret"
+        self.scopes: list[str] = ["scope.a"]
+        self.expiry: Optional[Any] = None
+        self.id_token: Optional[str] = None
+        self.valid: bool = valid
+        self.expired: bool = not valid
 
-    def refresh(self, request):  # noqa: ARG002
+    def refresh(self, request: Any) -> None:  # noqa: ARG002
         self.token = "fresh-token"
         self.valid = True
         self.expired = False
 
 
 class _OAuthSessionStore:
-    def __init__(self, session_credentials=None, session_user="user@example.com"):
-        self._session_credentials = session_credentials
-        self._session_user = session_user
-        self.store_calls = []
+    def __init__(
+        self,
+        session_credentials: Optional[_RefreshableCredentials] = None,
+        session_user: str = "user@example.com",
+    ) -> None:
+        self._session_credentials: Optional[_RefreshableCredentials] = session_credentials
+        self._session_user: str = session_user
+        self.store_calls: list[dict[str, Any]] = []
 
-    def get_user_by_mcp_session(self, session_id):  # noqa: ARG002
+    def get_user_by_mcp_session(self, session_id: str) -> str:  # noqa: ARG002
         return self._session_user
 
-    def get_credentials_by_mcp_session(self, session_id):  # noqa: ARG002
+    def get_credentials_by_mcp_session(
+        self, session_id: str
+    ) -> Optional[_RefreshableCredentials]:  # noqa: ARG002
         return self._session_credentials
 
-    def store_session(self, **kwargs):
+    def store_session(self, **kwargs: Any) -> None:
         self.store_calls.append(kwargs)
 
 
 class _CredentialStore:
     def __init__(
         self,
-        existing_credentials=None,
-        store_result=True,
-        credentials_by_user=None,
-        users=None,
-    ):
-        self._existing_credentials = existing_credentials
-        self.store_result = store_result
-        self.credentials_by_user = credentials_by_user or {}
-        self.users = list(users if users is not None else self.credentials_by_user)
-        self.get_calls = []
-        self.list_calls = 0
-        self.store_calls = []
+        existing_credentials: Optional[_RefreshableCredentials] = None,
+        store_result: bool = True,
+        credentials_by_user: Optional[dict[str, _RefreshableCredentials]] = None,
+        users: Optional[list[str]] = None,
+    ) -> None:
+        self._existing_credentials: Optional[_RefreshableCredentials] = existing_credentials
+        self.store_result: bool = store_result
+        self.credentials_by_user: dict[str, _RefreshableCredentials] = (
+            credentials_by_user or {}
+        )
+        self.users: list[str] = list(
+            users if users is not None else self.credentials_by_user
+        )
+        self.get_calls: list[str] = []
+        self.list_calls: int = 0
+        self.store_calls: list[tuple[str, str]] = []
 
-    def get_credential(self, user_email):
+    def get_credential(self, user_email: str) -> Optional[_RefreshableCredentials]:
         self.get_calls.append(user_email)
         if self.credentials_by_user:
             return self.credentials_by_user.get(user_email)
         return self._existing_credentials
 
-    def list_users(self):
+    def list_users(self) -> list[str]:
         self.list_calls += 1
         return self.users
 
-    def store_credential(self, user_email, credentials):  # noqa: ARG002
+    def store_credential(
+        self, user_email: str, credentials: _RefreshableCredentials
+    ) -> bool:  # noqa: ARG002
         self.store_calls.append((user_email, credentials.token))
         return self.store_result
 
 
-def test_get_credentials_skips_session_update_when_oauth21_persist_fails(monkeypatch):
+def test_get_credentials_skips_session_update_when_oauth21_persist_fails(
+    monkeypatch: MonkeyPatch,
+) -> None:
     session_creds = _RefreshableCredentials()
     oauth_store = _OAuthSessionStore(session_credentials=session_creds)
     credential_store = _CredentialStore(store_result=False)
@@ -97,7 +114,9 @@ def test_get_credentials_skips_session_update_when_oauth21_persist_fails(monkeyp
     assert oauth_store.store_calls == []
 
 
-def test_get_credentials_skips_session_update_when_refresh_persist_fails(monkeypatch):
+def test_get_credentials_skips_session_update_when_refresh_persist_fails(
+    monkeypatch: MonkeyPatch,
+) -> None:
     file_creds = _RefreshableCredentials()
     oauth_store = _OAuthSessionStore(session_credentials=None)
     credential_store = _CredentialStore(
@@ -138,8 +157,8 @@ def test_get_credentials_skips_session_update_when_refresh_persist_fails(monkeyp
 
 
 def test_get_credentials_single_user_uses_sole_stored_user_when_requested_user_missing(
-    monkeypatch,
-):
+    monkeypatch: MonkeyPatch,
+) -> None:
     stored_credentials = _RefreshableCredentials(valid=True)
     credential_store = _CredentialStore(
         credentials_by_user={"actual@example.com": stored_credentials}
@@ -164,7 +183,9 @@ def test_get_credentials_single_user_uses_sole_stored_user_when_requested_user_m
     assert credential_store.store_calls == []
 
 
-def test_get_credentials_reports_resolved_single_user_email(monkeypatch):
+def test_get_credentials_reports_resolved_single_user_email(
+    monkeypatch: MonkeyPatch,
+) -> None:
     stored_credentials = _RefreshableCredentials(valid=True)
     credential_store = _CredentialStore(
         credentials_by_user={"actual@example.com": stored_credentials}
@@ -190,8 +211,8 @@ def test_get_credentials_reports_resolved_single_user_email(monkeypatch):
 
 
 def test_get_authenticated_google_service_returns_resolved_single_user_email(
-    monkeypatch,
-):
+    monkeypatch: MonkeyPatch,
+) -> None:
     stored_credentials = _RefreshableCredentials(valid=True)
     credential_store = _CredentialStore(
         credentials_by_user={"actual@example.com": stored_credentials}
@@ -228,8 +249,8 @@ def test_get_authenticated_google_service_returns_resolved_single_user_email(
 
 
 def test_get_credentials_single_user_does_not_fallback_when_multiple_users_exist(
-    monkeypatch,
-):
+    monkeypatch: MonkeyPatch,
+) -> None:
     credential_store = _CredentialStore(
         credentials_by_user={
             "first@example.com": _RefreshableCredentials(valid=True),


### PR DESCRIPTION
## Description
Fixes single-user auth when the MCP client sends a stale or profile-derived `user_google_email` that does not match the local credential file. In single-user mode, the credential store is now allowed to use its sole stored account as the canonical user. If multiple credential users exist, the previous strict behavior is preserved to avoid selecting the wrong account.

Fixes #642

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

Commands run:
- `uv run pytest tests\\auth\\test_google_auth_refresh_persistence.py`
- `uv run ruff check auth\\google_auth.py tests\\auth\\test_google_auth_refresh_persistence.py`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
The fallback is intentionally limited to exactly one stored credential user, with a case-insensitive email match handled before the single-user fallback path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable Google sign-in in single-user mode with case-insensitive email matching, improved fallback when the requested account is missing, and consistent canonical email propagation for sessions and persistence.

* **Tests**
  * Expanded coverage for single-user authentication flows, credential resolution and storage behaviors.

* **Documentation**
  * Updated authentication docs to reflect refined single-user decision rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/765)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->