### PR TITLE
wip: resetting event color to calendar default — investigation + known limitations

### DIFF
--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -994,10 +994,8 @@ async def _modify_event_impl(
     if normalized_attendees is not None:
         event_body["attendees"] = normalized_attendees
 
-    if color_id is not None:
-        # Pass "0" to explicitly clear the color and reset to calendar default.
-        # Without this, there is no way to remove a previously set colorId via PATCH.
-        event_body["colorId"] = None if color_id == "0" else color_id
+    if color_id is not None and color_id != "0":
+        event_body["colorId"] = color_id
     if recurrence is not None:
         event_body["recurrence"] = recurrence
 
@@ -1111,6 +1109,12 @@ async def _modify_event_impl(
                 "recurrence": recurrence,
             },
         )
+
+        # Apply color reset AFTER field preservation so it cannot be overwritten.
+        # _preserve_existing_fields treats None as "not provided" and would restore
+        # the existing colorId, silently undoing the reset sentinel.
+        if color_id == "0":
+            event_body["colorId"] = None
 
         # Handle Google Meet conference data
         if add_google_meet is not None:

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -995,7 +995,9 @@ async def _modify_event_impl(
         event_body["attendees"] = normalized_attendees
 
     if color_id is not None:
-        event_body["colorId"] = color_id
+        # Pass "0" to explicitly clear the color and reset to calendar default.
+        # Without this, there is no way to remove a previously set colorId via PATCH.
+        event_body["colorId"] = None if color_id == "0" else color_id
     if recurrence is not None:
         event_body["recurrence"] = recurrence
 
@@ -1362,7 +1364,7 @@ async def manage_event(
         use_default_reminders (Optional[bool]): Whether to use default reminders.
         transparency (Optional[str]): "opaque" (busy) or "transparent" (free).
         visibility (Optional[str]): "default", "public", "private", or "confidential".
-        color_id (Optional[str]): Event color ID (1-11, update only).
+        color_id (Optional[str]): Event color ID (1-11, update only). Pass "0" to reset to the calendar's default color.
         recurrence (Optional[List[str]]): RFC5545 recurrence rules for a recurring event, e.g. ["RRULE:FREQ=WEEKLY;COUNT=10"].
         guests_can_modify (Optional[bool]): Whether attendees can modify.
         guests_can_invite_others (Optional[bool]): Whether attendees can invite others.

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -1111,10 +1111,12 @@ async def _modify_event_impl(
         )
 
         # Apply color reset AFTER field preservation so it cannot be overwritten.
-        # _preserve_existing_fields treats None as "not provided" and would restore
-        # the existing colorId, silently undoing the reset sentinel.
+        # _preserve_existing_fields treats None as "not provided" and restores the
+        # existing colorId. We then remove the key entirely — the Google API client
+        # strips None values before sending, so null doesn't reach the API. In a
+        # full PUT (events.update), an absent colorId resets to the calendar default.
         if color_id == "0":
-            event_body["colorId"] = None
+            event_body.pop("colorId", None)
 
         # Handle Google Meet conference data
         if add_google_meet is not None:


### PR DESCRIPTION
## Problem

There is currently no way to remove a custom `colorId` from a Google Calendar event and restore it to the calendar's default color.

- Passing a valid `color_id` (1-11) sets a color ✓
- Passing `color_id=None` is a no-op — the field is omitted from the request body, leaving the existing color unchanged ✗
- There is no sentinel value to explicitly clear it ✗

The Google Calendar API supports clearing `colorId` by explicitly including the field as `null` in the PATCH/PUT request body. The current implementation has no path to produce this.

## Investigation

Three separate issues make this harder than expected:

### Issue 1: `_preserve_existing_fields` clobbers `None` assignments

After an `event_body["colorId"] = None` assignment, `_preserve_existing_fields()` runs and restores the existing `colorId` when `new_value is None`. This silently undoes any sentinel-based approach that uses `None`.

### Issue 2: Google API Python client strips `None` values before serialization

Even if `None` is successfully placed into `event_body`, `googleapiclient` filters out `None` values before constructing the HTTP request body. So `{"colorId": None}` in Python never reaches the API as `{"colorId": null}` in JSON.

### Issue 3: `events.update` (PUT) preserves `colorId` even when absent from body

The Google Calendar `events.update` endpoint uses PUT semantics but behaves like PATCH for `colorId` — if the field is absent from the request body entirely, the API preserves the existing color rather than clearing it. Popping the key from the body has no effect.

## Attempted Fixes

**Attempt 1**: `None if color_id == "0" else color_id`
→ Clobbered by `_preserve_existing_fields`

**Attempt 2**: Split the fix around `_preserve_existing_fields` — skip initial assignment for `"0"`, then set `None` after preservation
→ Google API Python client strips `None` before HTTP serialization

**Attempt 3**: `event_body.pop("colorId", None)` after `_preserve_existing_fields`
→ Google's `events.update` preserves `colorId` even when absent from PUT body

## Current Status

All three approaches fail. The fix is blocked by the combination of:
1. `_preserve_existing_fields` clobbering sentinel values
2. Python client stripping `None` from request bodies  
3. Google Calendar API not treating absent fields as "clear" in PUT requests

## Workaround

**Delete the event and recreate it without a `color_id`.** A newly created event uses the calendar's default color.

## What Would Actually Work

The only viable path is bypassing `googleapiclient` and making a raw HTTP call with an explicit `null` in the JSON body. This is more invasive than this PR originally intended and would need a separate, larger refactor.