### PR TITLE
feat(auth): late-bind OAuth callback port with preferred + fallback range

### DIFF
--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -18,6 +18,8 @@ from fastapi import FastAPI, Request
 from fastapi.responses import FileResponse, JSONResponse
 from typing import Optional
 from urllib.parse import urlparse
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
 
 from auth.scopes import SCOPES, get_current_scopes  # noqa
 from auth.oauth_responses import (
@@ -198,6 +200,42 @@ class MinimalOAuthServer:
         other_path = other_parsed.path.rstrip("/") or ""
         return self_path == other_path
 
+    def _callback_endpoint_looks_like_workspace(self, hostname: str) -> bool:
+        """
+        Probe an occupied callback port for this app's OAuth callback handler.
+
+        This is intentionally only used after bind returns EADDRINUSE in stdio
+        mode. A no-code request to our handler returns the shared
+        "Authentication Error" page with HTTP 400, which is enough to distinguish
+        the boot-time workspace callback listener from a random local process.
+        """
+        try:
+            parsed_uri = urlparse(self.base_uri)
+            scheme = parsed_uri.scheme or "http"
+            if scheme not in {"http", "https"}:
+                return False
+            probe_host = hostname
+            if probe_host in {"0.0.0.0", "::"}:
+                probe_host = "127.0.0.1"
+            if ":" in probe_host and not probe_host.startswith("["):
+                probe_host = f"[{probe_host}]"
+            base_path = parsed_uri.path.rstrip("/")
+            probe_url = f"{scheme}://{probe_host}:{self.port}{base_path}/oauth2callback"
+
+            try:
+                with urlopen(probe_url, timeout=1.0) as response:
+                    status_code = response.status
+                    body = response.read(4096).decode("utf-8", errors="replace")
+            except HTTPError as exc:
+                status_code = exc.code
+                body = exc.read(4096).decode("utf-8", errors="replace")
+
+            return status_code in {200, 400} and (
+                "Authentication Error" in body or "Authentication Successful" in body
+            )
+        except (OSError, URLError, ValueError):
+            return False
+
     def start(self) -> tuple[bool, str]:
         """
         Start the minimal OAuth server.
@@ -228,7 +266,17 @@ class MinimalOAuthServer:
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.bind((hostname, self.port))
-        except OSError:
+        except OSError as exc:
+            if exc.errno == errno.EADDRINUSE and self._callback_endpoint_looks_like_workspace(
+                hostname
+            ):
+                logger.info(
+                    "OAuth callback server already available on %s:%s; reusing existing listener",
+                    hostname,
+                    self.port,
+                )
+                self.is_running = True
+                return True, ""
             error_msg = f"Port {self.port} is already in use on {hostname}. Cannot start minimal OAuth server."
             logger.error(error_msg)
             return False, error_msg

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -46,6 +46,7 @@ class MinimalOAuthServer:
         self.server = None
         self.server_thread = None
         self.is_running = False
+        self._reusing_external_listener = False
 
         # Setup the callback route
         self._setup_callback_route()
@@ -276,10 +277,13 @@ class MinimalOAuthServer:
                     self.port,
                 )
                 self.is_running = True
+                self._reusing_external_listener = True
                 return True, ""
             error_msg = f"Port {self.port} is already in use on {hostname}. Cannot start minimal OAuth server."
             logger.error(error_msg)
             return False, error_msg
+
+        self._reusing_external_listener = False
 
         def run_server():
             """Run the server in a separate thread."""
@@ -328,6 +332,12 @@ class MinimalOAuthServer:
         if not self.is_running:
             return
 
+        if self._reusing_external_listener:
+            self.is_running = False
+            self._reusing_external_listener = False
+            logger.info("Minimal OAuth server external listener reuse released")
+            return
+
         try:
             if self.server:
                 if hasattr(self.server, "should_exit"):
@@ -337,6 +347,7 @@ class MinimalOAuthServer:
                 self.server_thread.join(timeout=3.0)
 
             self.is_running = False
+            self._reusing_external_listener = False
             logger.info("Minimal OAuth server stopped")
 
         except Exception as e:

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -268,8 +268,9 @@ class MinimalOAuthServer:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.bind((hostname, self.port))
         except OSError as exc:
-            if exc.errno == errno.EADDRINUSE and self._callback_endpoint_looks_like_workspace(
-                hostname
+            if (
+                exc.errno == errno.EADDRINUSE
+                and self._callback_endpoint_looks_like_workspace(hostname)
             ):
                 logger.info(
                     "OAuth callback server already available on %s:%s; reusing existing listener",

--- a/auth/oauth_config.py
+++ b/auth/oauth_config.py
@@ -26,7 +26,10 @@ class OAuthConfig:
     def __init__(self):
         # Base server configuration
         self.base_uri = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
-        self.port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", "8000")))
+        if os.getenv("WORKSPACE_MCP_RESOLVED_PORT") == "1":
+            self.port = int(os.getenv("WORKSPACE_MCP_PORT", os.getenv("PORT", "8000")))
+        else:
+            self.port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", "8000")))
         self.base_url = f"{self.base_uri}:{self.port}"
 
         # External URL for reverse proxy scenarios

--- a/auth/port_resolver.py
+++ b/auth/port_resolver.py
@@ -83,7 +83,9 @@ def resolve_port(
     candidate is in use, or PortConfigError if a port env var is invalid.
     """
     if preferred is None:
-        raw = os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", str(DEFAULT_PREFERRED_PORT)))
+        raw = os.getenv(
+            "PORT", os.getenv("WORKSPACE_MCP_PORT", str(DEFAULT_PREFERRED_PORT))
+        )
         try:
             preferred = int(raw)
         except ValueError as exc:
@@ -92,7 +94,9 @@ def resolve_port(
                 f"{env_name} must be an integer, got {raw!r}"
             ) from exc
     if fallback_count is None:
-        raw = os.getenv("WORKSPACE_MCP_PORT_FALLBACK_COUNT", str(DEFAULT_FALLBACK_COUNT))
+        raw = os.getenv(
+            "WORKSPACE_MCP_PORT_FALLBACK_COUNT", str(DEFAULT_FALLBACK_COUNT)
+        )
         try:
             fallback_count = int(raw)
         except ValueError as exc:

--- a/auth/port_resolver.py
+++ b/auth/port_resolver.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_PREFERRED_PORT = 8000
 DEFAULT_FALLBACK_COUNT = 4
+RESOLVED_PORT_ENV = "WORKSPACE_MCP_RESOLVED_PORT"
 
 
 class NoAvailablePortError(RuntimeError):
@@ -120,6 +121,7 @@ def resolve_port(
                     candidates,
                 )
             os.environ["WORKSPACE_MCP_PORT"] = str(port)
+            os.environ[RESOLVED_PORT_ENV] = "1"
             return port
 
     raise NoAvailablePortError(

--- a/auth/port_resolver.py
+++ b/auth/port_resolver.py
@@ -1,20 +1,9 @@
 """
 Port resolver for late-binding the workspace-mcp OAuth callback server.
 
-Architectural principle: MCP server specs must NOT hardcode port numbers.
-Ports are subject to external factors -- other MCPs installed during disconnect
-windows, multiple stdio process spawns by the same client (Claude Desktop /
-Claude Code) -- and must be late-bound at process-start. Specs declare a
-preferred port plus a fallback range; the actual bound port is surfaced
-through startup logs so clients can compose redirect URIs accordingly.
-
-This module is part of a Workspaces-local fork. Tracking issues upstream:
-  - https://github.com/taylorwilsdon/google_workspace_mcp/issues/546
-  - https://github.com/taylorwilsdon/google_workspace_mcp/issues/667
-  - https://github.com/taylorwilsdon/google_workspace_mcp/issues/754
-
-PR-ready upstream patches live under:
-  Core/reference/connectors/workspace-mcp/patches/
+Probes a preferred port plus a small fallback range at process start;
+the first available port is bound and surfaced through startup logs so
+redirect URIs are composed from the actual bound port.
 """
 
 from __future__ import annotations
@@ -32,6 +21,10 @@ DEFAULT_FALLBACK_COUNT = 4
 
 class NoAvailablePortError(RuntimeError):
     """Raised when no port in the preferred + fallback range is free."""
+
+
+class PortConfigError(RuntimeError):
+    """Raised when a port-related env var contains a non-integer value."""
 
 
 def _candidate_ports(preferred: int, fallback_count: int) -> List[int]:
@@ -90,13 +83,22 @@ def resolve_port(
     candidate is in use.
     """
     if preferred is None:
-        preferred = int(
-            os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", str(DEFAULT_PREFERRED_PORT)))
-        )
+        raw = os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", str(DEFAULT_PREFERRED_PORT)))
+        try:
+            preferred = int(raw)
+        except ValueError:
+            env_name = "PORT" if os.getenv("PORT") else "WORKSPACE_MCP_PORT"
+            raise PortConfigError(
+                f"{env_name} must be an integer, got {raw!r}"
+            )
     if fallback_count is None:
-        fallback_count = int(
-            os.getenv("WORKSPACE_MCP_PORT_FALLBACK_COUNT", str(DEFAULT_FALLBACK_COUNT))
-        )
+        raw = os.getenv("WORKSPACE_MCP_PORT_FALLBACK_COUNT", str(DEFAULT_FALLBACK_COUNT))
+        try:
+            fallback_count = int(raw)
+        except ValueError:
+            raise PortConfigError(
+                f"WORKSPACE_MCP_PORT_FALLBACK_COUNT must be an integer, got {raw!r}"
+            )
     if host is None:
         host = os.getenv("WORKSPACE_MCP_HOST", "0.0.0.0")
 

--- a/auth/port_resolver.py
+++ b/auth/port_resolver.py
@@ -1,0 +1,123 @@
+"""
+Port resolver for late-binding the workspace-mcp OAuth callback server.
+
+Architectural principle: MCP server specs must NOT hardcode port numbers.
+Ports are subject to external factors -- other MCPs installed during disconnect
+windows, multiple stdio process spawns by the same client (Claude Desktop /
+Claude Code) -- and must be late-bound at process-start. Specs declare a
+preferred port plus a fallback range; the actual bound port is surfaced
+through startup logs so clients can compose redirect URIs accordingly.
+
+This module is part of a Workspaces-local fork. Tracking issues upstream:
+  - https://github.com/taylorwilsdon/google_workspace_mcp/issues/546
+  - https://github.com/taylorwilsdon/google_workspace_mcp/issues/667
+  - https://github.com/taylorwilsdon/google_workspace_mcp/issues/754
+
+PR-ready upstream patches live under:
+  Core/reference/connectors/workspace-mcp/patches/
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PREFERRED_PORT = 8000
+DEFAULT_FALLBACK_COUNT = 4
+
+
+class NoAvailablePortError(RuntimeError):
+    """Raised when no port in the preferred + fallback range is free."""
+
+
+def _candidate_ports(preferred: int, fallback_count: int) -> List[int]:
+    return [preferred] + [preferred + i for i in range(1, max(0, fallback_count) + 1)]
+
+
+def _is_port_free(host: str, port: int) -> bool:
+    """
+    Test whether a TCP port is genuinely free for the OAuth callback server.
+
+    Two-stage probe:
+      1. CONNECT to 127.0.0.1:port -- detects an existing listener regardless of
+         which interface they bound to (on macOS, SO_REUSEADDR lets a 0.0.0.0
+         bind succeed even when 127.0.0.1 is already listening, so a bind probe
+         alone gives a false-negative). Since the OAuth callback URI is always
+         http://localhost:port, anything listening on loopback is a collision.
+      2. BIND with SO_REUSEADDR=0 (default) on the requested host -- catches
+         TIME_WAIT and BSD-style local conflicts.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(0.5)
+            if s.connect_ex(("127.0.0.1", port)) == 0:
+                return False
+    except OSError:
+        pass
+
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind((host, port))
+        return True
+    except OSError:
+        return False
+
+
+def resolve_port(
+    preferred: Optional[int] = None,
+    fallback_count: Optional[int] = None,
+    host: Optional[str] = None,
+) -> int:
+    """
+    Resolve the first available port in [preferred, preferred+1, ..., preferred+fallback_count].
+
+    Reads defaults from env when args are None:
+      WORKSPACE_MCP_PORT (default 8000)                  -- preferred port
+      WORKSPACE_MCP_PORT_FALLBACK_COUNT (default 4)      -- fallback slots
+      WORKSPACE_MCP_HOST (default 0.0.0.0)               -- bind host
+
+    Side effect: mutates os.environ["WORKSPACE_MCP_PORT"] to the resolved port,
+    so every downstream reader (auth.oauth_config singleton on next reload,
+    core.config.WORKSPACE_MCP_PORT after explicit refresh, attachment_storage)
+    sees the bound port. Callers should call reload_oauth_config() after this
+    function to pick up the new value in the OAuthConfig singleton.
+
+    Returns the first-available port. Raises NoAvailablePortError if every
+    candidate is in use.
+    """
+    if preferred is None:
+        preferred = int(
+            os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", str(DEFAULT_PREFERRED_PORT)))
+        )
+    if fallback_count is None:
+        fallback_count = int(
+            os.getenv("WORKSPACE_MCP_PORT_FALLBACK_COUNT", str(DEFAULT_FALLBACK_COUNT))
+        )
+    if host is None:
+        host = os.getenv("WORKSPACE_MCP_HOST", "0.0.0.0")
+
+    candidates = _candidate_ports(preferred, fallback_count)
+    for port in candidates:
+        if _is_port_free(host, port):
+            if port == preferred:
+                logger.info("Port resolver: bound preferred port %d", port)
+            else:
+                logger.warning(
+                    "Port resolver: preferred port %d unavailable; falling back to %d "
+                    "(checked range %s)",
+                    preferred,
+                    port,
+                    candidates,
+                )
+            os.environ["WORKSPACE_MCP_PORT"] = str(port)
+            return port
+
+    raise NoAvailablePortError(
+        f"No available port in range {candidates}; all in use. "
+        f"Set WORKSPACE_MCP_PORT to a different preferred port, or "
+        f"increase WORKSPACE_MCP_PORT_FALLBACK_COUNT."
+    )

--- a/auth/port_resolver.py
+++ b/auth/port_resolver.py
@@ -80,25 +80,25 @@ def resolve_port(
     function to pick up the new value in the OAuthConfig singleton.
 
     Returns the first-available port. Raises NoAvailablePortError if every
-    candidate is in use.
+    candidate is in use, or PortConfigError if a port env var is invalid.
     """
     if preferred is None:
         raw = os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", str(DEFAULT_PREFERRED_PORT)))
         try:
             preferred = int(raw)
-        except ValueError:
+        except ValueError as exc:
             env_name = "PORT" if os.getenv("PORT") else "WORKSPACE_MCP_PORT"
             raise PortConfigError(
                 f"{env_name} must be an integer, got {raw!r}"
-            )
+            ) from exc
     if fallback_count is None:
         raw = os.getenv("WORKSPACE_MCP_PORT_FALLBACK_COUNT", str(DEFAULT_FALLBACK_COUNT))
         try:
             fallback_count = int(raw)
-        except ValueError:
+        except ValueError as exc:
             raise PortConfigError(
                 f"WORKSPACE_MCP_PORT_FALLBACK_COUNT must be an integer, got {raw!r}"
-            )
+            ) from exc
     if host is None:
         host = os.getenv("WORKSPACE_MCP_HOST", "0.0.0.0")
 

--- a/auth/scopes.py
+++ b/auth/scopes.py
@@ -242,7 +242,7 @@ def set_enabled_tools(enabled_tools):
     """
     global _ENABLED_TOOLS
     _ENABLED_TOOLS = enabled_tools
-    logger.info(f"Enabled tools set for scope management: {enabled_tools}")
+    logger.info(f"Scope management active for {len(enabled_tools)} services")
 
 
 # Global variable to store read-only mode (set by main.py)

--- a/core/config.py
+++ b/core/config.py
@@ -36,6 +36,7 @@ def __getattr__(name: str) -> int:
         return int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", "8000")))
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
+
 # Disable USER_GOOGLE_EMAIL in OAuth 2.1 multi-user mode
 USER_GOOGLE_EMAIL = (
     None if is_oauth21_enabled() else os.getenv("USER_GOOGLE_EMAIL", None)

--- a/core/config.py
+++ b/core/config.py
@@ -16,10 +16,20 @@ from auth.oauth_config import (
     is_oauth21_enabled,
 )
 
-# Server configuration
-WORKSPACE_MCP_PORT = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", 8000)))
+# Server configuration. WORKSPACE_MCP_PORT is resolved lazily via PEP 562
+# __getattr__ so that the value reflects the current env at access time.
+# main.py mutates WORKSPACE_MCP_PORT in os.environ at startup via the port
+# resolver (auth.port_resolver.resolve_port); consumers that do
+# `from core.config import WORKSPACE_MCP_PORT` inside a function will see the
+# late-bound port instead of a frozen-at-module-import 8000.
 WORKSPACE_MCP_BASE_URI = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
 WORKSPACE_EXTERNAL_URL = os.getenv("WORKSPACE_EXTERNAL_URL")
+
+
+def __getattr__(name: str):
+    if name == "WORKSPACE_MCP_PORT":
+        return int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", "8000")))
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 # Disable USER_GOOGLE_EMAIL in OAuth 2.1 multi-user mode
 USER_GOOGLE_EMAIL = (

--- a/core/config.py
+++ b/core/config.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
 
 def __getattr__(name: str) -> int:
     if name == "WORKSPACE_MCP_PORT":
+        if os.getenv("WORKSPACE_MCP_RESOLVED_PORT") == "1":
+            return int(os.getenv("WORKSPACE_MCP_PORT", os.getenv("PORT", "8000")))
         return int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", "8000")))
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/core/config.py
+++ b/core/config.py
@@ -8,6 +8,8 @@ This module now imports from there for backward compatibility.
 """
 
 import os
+from typing import TYPE_CHECKING
+
 from auth.oauth_config import (
     get_oauth_base_url,
     get_oauth_redirect_uri,
@@ -25,8 +27,11 @@ from auth.oauth_config import (
 WORKSPACE_MCP_BASE_URI = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
 WORKSPACE_EXTERNAL_URL = os.getenv("WORKSPACE_EXTERNAL_URL")
 
+if TYPE_CHECKING:
+    WORKSPACE_MCP_PORT: int
 
-def __getattr__(name: str):
+
+def __getattr__(name: str) -> int:
     if name == "WORKSPACE_MCP_PORT":
         return int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", "8000")))
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/core/log_formatter.py
+++ b/core/log_formatter.py
@@ -106,9 +106,8 @@ class EnhancedLogFormatter(logging.Formatter):
                 return f"Tool filtering complete: {enabled} tools enabled ({removed} filtered out)"
 
         # Enabled tools messages
-        if "Enabled tools set for scope management" in message:
-            tools = message.split(": ")[-1]
-            return f"Scope management configured for tools: {tools}"
+        if "Scope management active for" in message:
+            return message
 
         # Credentials directory messages
         if "Credentials directory permissions check passed" in message:

--- a/core/server.py
+++ b/core/server.py
@@ -1,3 +1,5 @@
+# ruff: noqa: E402
+# Startup warning filters must be installed before importing FastMCP/Authlib dependencies.
 import asyncio
 import hashlib
 import logging

--- a/core/server.py
+++ b/core/server.py
@@ -5,31 +5,16 @@ import os
 from typing import List, Optional
 from importlib import metadata
 
-from core.warning_filters import install_startup_warning_filters
-from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
-from starlette.applications import Starlette
-from starlette.datastructures import MutableHeaders
-from starlette.types import Scope, Receive, Send
-from starlette.requests import Request
-from starlette.middleware import Middleware
-
-from mcp.types import ToolAnnotations
-
-install_startup_warning_filters()
-
-from fastmcp import FastMCP
-from fastmcp.server.auth.providers.google import GoogleProvider
-
-from auth.oauth21_session_store import get_oauth21_session_store, set_auth_provider
+from auth.auth_info_middleware import AuthInfoMiddleware
 from auth.google_auth import handle_auth_callback, start_auth_flow, check_client_secrets
-from auth.oauth_config import is_oauth21_enabled, is_external_oauth21_provider
 from auth.mcp_session_middleware import MCPSessionMiddleware
+from auth.oauth21_session_store import get_oauth21_session_store, set_auth_provider
+from auth.oauth_config import is_oauth21_enabled, is_external_oauth21_provider
 from auth.oauth_responses import (
     create_error_response,
     create_success_response,
     create_server_error_response,
 )
-from auth.auth_info_middleware import AuthInfoMiddleware
 from auth.scopes import PROTOCOL_AUTH_SCOPES, SCOPES, get_current_scopes  # noqa
 from core.config import (
     USER_GOOGLE_EMAIL,
@@ -37,7 +22,18 @@ from core.config import (
     set_transport_mode as _set_transport_mode,
     get_oauth_redirect_uri as get_oauth_redirect_uri_for_current_mode,
 )
+from core.warning_filters import install_startup_warning_filters
+from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
+from fastmcp import FastMCP
+from fastmcp.server.auth.providers.google import GoogleProvider
+from mcp.types import ToolAnnotations
+from starlette.applications import Starlette
+from starlette.datastructures import MutableHeaders
+from starlette.middleware import Middleware
+from starlette.requests import Request
+from starlette.types import Scope, Receive, Send
 
+install_startup_warning_filters()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 

--- a/core/server.py
+++ b/core/server.py
@@ -5,6 +5,10 @@ import os
 from typing import List, Optional
 from importlib import metadata
 
+from core.warning_filters import install_startup_warning_filters
+
+install_startup_warning_filters()
+
 from auth.auth_info_middleware import AuthInfoMiddleware
 from auth.google_auth import handle_auth_callback, start_auth_flow, check_client_secrets
 from auth.mcp_session_middleware import MCPSessionMiddleware
@@ -22,7 +26,6 @@ from core.config import (
     set_transport_mode as _set_transport_mode,
     get_oauth_redirect_uri as get_oauth_redirect_uri_for_current_mode,
 )
-from core.warning_filters import install_startup_warning_filters
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
 from fastmcp import FastMCP
 from fastmcp.server.auth.providers.google import GoogleProvider
@@ -33,7 +36,6 @@ from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.types import Scope, Receive, Send
 
-install_startup_warning_filters()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 

--- a/core/server.py
+++ b/core/server.py
@@ -5,6 +5,7 @@ import os
 from typing import List, Optional
 from importlib import metadata
 
+from core.warning_filters import install_startup_warning_filters
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
 from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
@@ -13,6 +14,8 @@ from starlette.requests import Request
 from starlette.middleware import Middleware
 
 from mcp.types import ToolAnnotations
+
+install_startup_warning_filters()
 
 from fastmcp import FastMCP
 from fastmcp.server.auth.providers.google import GoogleProvider

--- a/core/warning_filters.py
+++ b/core/warning_filters.py
@@ -1,0 +1,19 @@
+"""Warning filters for known third-party startup noise."""
+
+from __future__ import annotations
+
+import warnings
+
+
+def install_startup_warning_filters() -> None:
+    """Install narrow warning filters needed before importing server dependencies."""
+    try:
+        from authlib.deprecate import AuthlibDeprecationWarning
+    except ImportError:  # pragma: no cover - only relevant if FastMCP drops Authlib
+        return
+
+    warnings.filterwarnings(
+        "ignore",
+        message=r"authlib\.jose module is deprecated.*",
+        category=AuthlibDeprecationWarning,
+    )

--- a/main.py
+++ b/main.py
@@ -95,6 +95,32 @@ logger = logging.getLogger(__name__)
 
 configure_file_logging()
 
+
+def resolve_stdio_callback_port() -> None:
+    """
+    Late-bind the legacy stdio OAuth callback port.
+
+    Streamable HTTP/OAuth 2.1 owns its main HTTP port directly and must keep the
+    normal PORT/WORKSPACE_MCP_PORT semantics. The fallback range only exists for
+    the standalone stdio callback listener.
+    """
+    from auth.port_resolver import resolve_port, NoAvailablePortError, PortConfigError
+
+    try:
+        resolve_port()
+    except (NoAvailablePortError, PortConfigError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    reload_oauth_config()
+
+
+def resolve_callback_port_for_transport(transport: str) -> None:
+    """Apply callback port fallback only to legacy stdio transport."""
+    if transport == "stdio":
+        resolve_stdio_callback_port()
+    else:
+        os.environ.pop("WORKSPACE_MCP_RESOLVED_PORT", None)
+
 # Single source of truth: service name -> module path.
 # VALID_SERVICES is derived from this mapping.
 SERVICE_MODULES = {
@@ -375,21 +401,13 @@ def main():
         )
         sys.exit(1)
 
-    # Late-bind the OAuth callback port: probe preferred + fallback range and
-    # mutate WORKSPACE_MCP_PORT in os.environ to the first-available value.
-    # Then refresh the OAuthConfig singleton so its redirect_uri reflects the
-    # bound port. See auth/port_resolver.py for the architectural rationale.
-    from auth.port_resolver import resolve_port, NoAvailablePortError, PortConfigError
-
-    try:
-        resolve_port()
-    except (NoAvailablePortError, PortConfigError) as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        sys.exit(1)
-    reload_oauth_config()
+    resolve_callback_port_for_transport(args.transport)
 
     # Set port and base URI once for reuse throughout the function
-    port = int(os.getenv("WORKSPACE_MCP_PORT", "8000"))
+    if os.getenv("WORKSPACE_MCP_RESOLVED_PORT") == "1":
+        port = int(os.getenv("WORKSPACE_MCP_PORT", os.getenv("PORT", "8000")))
+    else:
+        port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", "8000")))
     base_uri = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
     host = os.getenv("WORKSPACE_MCP_HOST", "0.0.0.0")
     external_url = os.getenv("WORKSPACE_EXTERNAL_URL")

--- a/main.py
+++ b/main.py
@@ -379,10 +379,10 @@ def main():
     # mutate WORKSPACE_MCP_PORT in os.environ to the first-available value.
     # Then refresh the OAuthConfig singleton so its redirect_uri reflects the
     # bound port. See auth/port_resolver.py for the architectural rationale.
-    from auth.port_resolver import resolve_port, NoAvailablePortError
+    from auth.port_resolver import resolve_port, NoAvailablePortError, PortConfigError
     try:
         resolve_port()
-    except NoAvailablePortError as exc:
+    except (NoAvailablePortError, PortConfigError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
     reload_oauth_config()

--- a/main.py
+++ b/main.py
@@ -380,6 +380,7 @@ def main():
     # Then refresh the OAuthConfig singleton so its redirect_uri reflects the
     # bound port. See auth/port_resolver.py for the architectural rationale.
     from auth.port_resolver import resolve_port, NoAvailablePortError, PortConfigError
+
     try:
         resolve_port()
     except (NoAvailablePortError, PortConfigError) as exc:

--- a/main.py
+++ b/main.py
@@ -375,6 +375,18 @@ def main():
         )
         sys.exit(1)
 
+    # Late-bind the OAuth callback port: probe preferred + fallback range and
+    # mutate WORKSPACE_MCP_PORT in os.environ to the first-available value.
+    # Then refresh the OAuthConfig singleton so its redirect_uri reflects the
+    # bound port. See auth/port_resolver.py for the architectural rationale.
+    from auth.port_resolver import resolve_port, NoAvailablePortError
+    try:
+        resolve_port()
+    except NoAvailablePortError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    reload_oauth_config()
+
     # Set port and base URI once for reuse throughout the function
     port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", 8000)))
     base_uri = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")

--- a/main.py
+++ b/main.py
@@ -593,38 +593,40 @@ def main():
     if args.read_only:
         set_read_only(True)
 
-    safe_print(
-        f"🛠️  Loading {len(tools_to_import)} tool module{'s' if len(tools_to_import) != 1 else ''}:"
-    )
+    loaded = []
+    failed = []
     for tool in tools_to_import:
         try:
             tool_imports[tool]()
-            safe_print(
-                f"   {tool_icons.get(tool, '🔧')} {tool.title()} - Google {tool.title()} API integration"
-            )
+            loaded.append(tool)
         except ModuleNotFoundError as exc:
             logger.error("Failed to import tool '%s': %s", tool, exc, exc_info=True)
-            safe_print(f"   ⚠️ Failed to load {tool.title()} tool module ({exc}).")
+            failed.append((tool, exc))
+
+    tool_summary = " ".join(
+        f"{tool_icons.get(t, '🔧')} {t.title()}" for t in loaded
+    )
+    safe_print(f"🛠️  Loaded {len(loaded)} services: {tool_summary}")
+    for tool, exc in failed:
+        safe_print(f"   ⚠️ Failed: {tool.title()} ({exc})")
 
     if perms:
-        safe_print("🔒 Permission Levels:")
-        for svc, lvl in sorted(perms.items()):
-            safe_print(f"   {tool_icons.get(svc, '  ')} {svc}: {lvl}")
+        perm_summary = " | ".join(
+            f"{tool_icons.get(svc, ' ')}{svc}:{lvl}" for svc, lvl in sorted(perms.items())
+        )
+        safe_print(f"🔒 Permissions: {perm_summary}")
     safe_print("")
 
     # Filter tools based on tier configuration (if tier-based loading is enabled)
     filter_server_tools(server)
 
-    safe_print("📊 Configuration Summary:")
-    safe_print(f"   🔧 Services Loaded: {len(tools_to_import)}/{len(tool_imports)}")
+    summary_parts = [f"{len(loaded)}/{len(tool_imports)} services"]
     if args.tool_tier is not None:
+        tier_desc = f"tier={args.tool_tier}"
         if args.tools is not None:
-            safe_print(
-                f"   📊 Tool Tier: {args.tool_tier} (filtered to {', '.join(args.tools)})"
-            )
-        else:
-            safe_print(f"   📊 Tool Tier: {args.tool_tier}")
-    safe_print(f"   📝 Log Level: {logging.getLogger().getEffectiveLevel()}")
+            tier_desc += f" ({', '.join(args.tools)})"
+        summary_parts.append(tier_desc)
+    safe_print(f"📊 {' | '.join(summary_parts)}")
     safe_print("")
 
     # Set global single-user mode flag

--- a/main.py
+++ b/main.py
@@ -388,7 +388,7 @@ def main():
     reload_oauth_config()
 
     # Set port and base URI once for reuse throughout the function
-    port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", 8000)))
+    port = int(os.getenv("WORKSPACE_MCP_PORT", "8000"))
     base_uri = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
     host = os.getenv("WORKSPACE_MCP_HOST", "0.0.0.0")
     external_url = os.getenv("WORKSPACE_EXTERNAL_URL")

--- a/main.py
+++ b/main.py
@@ -414,25 +414,48 @@ def main():
     external_url = os.getenv("WORKSPACE_EXTERNAL_URL")
     display_url = external_url if external_url else f"{base_uri}:{port}"
 
-    safe_print("🔧 Google Workspace MCP Server")
-    safe_print("=" * 35)
-    safe_print("📋 Server Information:")
     try:
         version = metadata.version("workspace-mcp")
     except metadata.PackageNotFoundError:
         version = "dev"
-    safe_print(f"   📦 Version: {version}")
-    safe_print(f"   🌐 Transport: {args.transport}")
+
+    mode = "single-user" if args.single_user else "multi-user"
+    pyver = sys.version.split()[0]
+
+    # ANSI color codes for Google brand colors
+    B = "\033[1;34m"  # Blue
+    R = "\033[1;31m"  # Red
+    Y = "\033[1;33m"  # Yellow
+    G = "\033[1;32m"  # Green
+    W = "\033[1;37m"  # White
+    C = "\033[0;36m"  # Cyan
+    D = "\033[0;90m"  # Dim
+    RST = "\033[0m"   # Reset
+
+    info_lines = [f"{C}{args.transport}  ·  {mode}{RST}"]
     if args.transport == "streamable-http":
-        safe_print(f"   🔗 URL: {display_url}")
-        safe_print(f"   🔐 OAuth Callback: {display_url}/oauth2callback")
-    safe_print(f"   👤 Mode: {'Single-user' if args.single_user else 'Multi-user'}")
+        info_lines.append(f"{C}{display_url}{RST}")
     if args.read_only:
-        safe_print("   🔒 Read-Only: Enabled")
+        info_lines.append(f"{Y}read-only{RST}")
     if args.permissions:
-        safe_print("   🔒 Permissions: Granular mode")
-    safe_print(f"   🐍 Python: {sys.version.split()[0]}")
-    safe_print("")
+        info_lines.append(f"{Y}granular permissions{RST}")
+
+    banner = (
+        f"\n{D}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━{RST}\n"
+        f"\n"
+        f"     {B}██████{R}╗{RST}       {W}Google Workspace{RST}\n"
+        f"     {B}██{RST}╔════╝       {W}MCP Server{RST}  {C}v{version}{RST}\n"
+        f"     {B}██{RST}║  {Y}███{RST}╗\n"
+        f"     {B}██{RST}║   {Y}██{RST}║      {info_lines[0]}\n"
+        f"     {B}╚█████{G}█╔╝{RST}      {C}Python {pyver}{RST}\n"
+        f"      {B}╚════{G}═╝{RST}"
+    )
+    for line in info_lines[1:]:
+        banner += f"\n                       {line}"
+    banner += (
+        f"\n\n{D}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━{RST}\n"
+    )
+    safe_print(banner)
 
     # Active Configuration
     safe_print("⚙️ Active Configuration:")
@@ -795,6 +818,7 @@ def main():
                 host=host,
                 port=port,
                 stateless_http=is_stateless_mode(),
+                show_banner=False,
             )
         else:
             if http_port is not None:
@@ -833,7 +857,7 @@ def main():
                         )
 
                     try:
-                        await server.run_stdio_async()
+                        await server.run_stdio_async(show_banner=False)
                     finally:
                         if http_srv:
                             http_srv.should_exit = True
@@ -853,7 +877,7 @@ def main():
 
                 asyncio.run(_run_dual())
             else:
-                server.run()
+                server.run(show_banner=False)
     except KeyboardInterrupt:
         safe_print("\n👋 Server shutdown requested")
         # Clean up OAuth callback server if running

--- a/main.py
+++ b/main.py
@@ -121,6 +121,7 @@ def resolve_callback_port_for_transport(transport: str) -> None:
     else:
         os.environ.pop("WORKSPACE_MCP_RESOLVED_PORT", None)
 
+
 # Single source of truth: service name -> module path.
 # VALID_SERVICES is derived from this mapping.
 SERVICE_MODULES = {

--- a/main.py
+++ b/main.py
@@ -430,7 +430,7 @@ def main():
     W = "\033[1;37m"  # White
     C = "\033[0;36m"  # Cyan
     D = "\033[0;90m"  # Dim
-    RST = "\033[0m"   # Reset
+    RST = "\033[0m"  # Reset
 
     info_lines = [f"{C}{args.transport}  ·  {mode}{RST}"]
     if args.transport == "streamable-http":
@@ -603,16 +603,15 @@ def main():
             logger.error("Failed to import tool '%s': %s", tool, exc, exc_info=True)
             failed.append((tool, exc))
 
-    tool_summary = " ".join(
-        f"{tool_icons.get(t, '🔧')} {t.title()}" for t in loaded
-    )
+    tool_summary = " ".join(f"{tool_icons.get(t, '🔧')} {t.title()}" for t in loaded)
     safe_print(f"🛠️  Loaded {len(loaded)} services: {tool_summary}")
     for tool, exc in failed:
         safe_print(f"   ⚠️ Failed: {tool.title()} ({exc})")
 
     if perms:
         perm_summary = " | ".join(
-            f"{tool_icons.get(svc, ' ')}{svc}:{lvl}" for svc, lvl in sorted(perms.items())
+            f"{tool_icons.get(svc, ' ')}{svc}:{lvl}"
+            for svc, lvl in sorted(perms.items())
         )
         safe_print(f"🔒 Permissions: {perm_summary}")
     safe_print("")

--- a/tests/auth/test_oauth_callback_server.py
+++ b/tests/auth/test_oauth_callback_server.py
@@ -1,5 +1,8 @@
 import errno
+from types import TracebackType
+from typing import Any, Optional, Tuple, Type
 
+import pytest
 from starlette.testclient import TestClient
 
 from auth import oauth_callback_server
@@ -142,20 +145,27 @@ def test_ensure_oauth_callback_skips_start_when_other_instance_owns_port(monkeyp
     assert _PortInUseServer.instances[0].start_calls == 0
 
 
-def test_start_reuses_existing_workspace_callback_on_eaddrinuse(monkeypatch):
+def test_start_reuses_existing_workspace_callback_on_eaddrinuse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     server = oauth_callback_server.MinimalOAuthServer(8000, "http://localhost")
 
     class _FakeSocket:
-        def __init__(self, *args, **kwargs):  # noqa: ARG002
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ARG002
             pass
 
-        def __enter__(self):
+        def __enter__(self) -> "_FakeSocket":
             return self
 
-        def __exit__(self, exc_type, exc, tb):  # noqa: ARG002
+        def __exit__(  # noqa: ARG002
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc: Optional[BaseException],
+            tb: Optional[TracebackType],
+        ) -> bool:
             return False
 
-        def bind(self, address):  # noqa: ARG002
+        def bind(self, address: Tuple[str, int]) -> None:  # noqa: ARG002
             raise OSError(errno.EADDRINUSE, "Address already in use")
 
     monkeypatch.setattr(oauth_callback_server.socket, "socket", _FakeSocket)
@@ -172,20 +182,27 @@ def test_start_reuses_existing_workspace_callback_on_eaddrinuse(monkeypatch):
     assert server.is_running is True
 
 
-def test_start_rejects_eaddrinuse_when_callback_probe_does_not_match(monkeypatch):
+def test_start_rejects_eaddrinuse_when_callback_probe_does_not_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     server = oauth_callback_server.MinimalOAuthServer(8000, "http://localhost")
 
     class _FakeSocket:
-        def __init__(self, *args, **kwargs):  # noqa: ARG002
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ARG002
             pass
 
-        def __enter__(self):
+        def __enter__(self) -> "_FakeSocket":
             return self
 
-        def __exit__(self, exc_type, exc, tb):  # noqa: ARG002
+        def __exit__(  # noqa: ARG002
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc: Optional[BaseException],
+            tb: Optional[TracebackType],
+        ) -> bool:
             return False
 
-        def bind(self, address):  # noqa: ARG002
+        def bind(self, address: Tuple[str, int]) -> None:  # noqa: ARG002
             raise OSError(errno.EADDRINUSE, "Address already in use")
 
     monkeypatch.setattr(oauth_callback_server.socket, "socket", _FakeSocket)

--- a/tests/auth/test_oauth_callback_server.py
+++ b/tests/auth/test_oauth_callback_server.py
@@ -142,6 +142,66 @@ def test_ensure_oauth_callback_skips_start_when_other_instance_owns_port(monkeyp
     assert _PortInUseServer.instances[0].start_calls == 0
 
 
+def test_start_reuses_existing_workspace_callback_on_eaddrinuse(monkeypatch):
+    server = oauth_callback_server.MinimalOAuthServer(8000, "http://localhost")
+
+    class _FakeSocket:
+        def __init__(self, *args, **kwargs):  # noqa: ARG002
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):  # noqa: ARG002
+            return False
+
+        def bind(self, address):  # noqa: ARG002
+            raise OSError(errno.EADDRINUSE, "Address already in use")
+
+    monkeypatch.setattr(oauth_callback_server.socket, "socket", _FakeSocket)
+    monkeypatch.setattr(
+        server,
+        "_callback_endpoint_looks_like_workspace",
+        lambda hostname: hostname == "localhost",
+    )
+
+    success, error = server.start()
+
+    assert success is True
+    assert error == ""
+    assert server.is_running is True
+
+
+def test_start_rejects_eaddrinuse_when_callback_probe_does_not_match(monkeypatch):
+    server = oauth_callback_server.MinimalOAuthServer(8000, "http://localhost")
+
+    class _FakeSocket:
+        def __init__(self, *args, **kwargs):  # noqa: ARG002
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):  # noqa: ARG002
+            return False
+
+        def bind(self, address):  # noqa: ARG002
+            raise OSError(errno.EADDRINUSE, "Address already in use")
+
+    monkeypatch.setattr(oauth_callback_server.socket, "socket", _FakeSocket)
+    monkeypatch.setattr(
+        server,
+        "_callback_endpoint_looks_like_workspace",
+        lambda hostname: False,  # noqa: ARG005
+    )
+
+    success, error = server.start()
+
+    assert success is False
+    assert "already in use" in error
+    assert server.is_running is False
+
+
 def test_oauth_callback_missing_state_fallback_follows_single_user_mode(monkeypatch):
     calls = []
 

--- a/tests/auth/test_port_resolver.py
+++ b/tests/auth/test_port_resolver.py
@@ -19,6 +19,7 @@ def _isolate_env(monkeypatch):
     monkeypatch.delenv("PORT", raising=False)
     monkeypatch.delenv("WORKSPACE_MCP_PORT_FALLBACK_COUNT", raising=False)
     monkeypatch.delenv("WORKSPACE_MCP_HOST", raising=False)
+    monkeypatch.delenv("WORKSPACE_MCP_RESOLVED_PORT", raising=False)
 
 
 @contextmanager
@@ -51,6 +52,7 @@ def test_resolves_preferred_when_free():
     bound = pr.resolve_port(preferred=p, fallback_count=2, host="127.0.0.1")
     assert bound == p
     assert os.environ["WORKSPACE_MCP_PORT"] == str(p)
+    assert os.environ["WORKSPACE_MCP_RESOLVED_PORT"] == "1"
 
 
 def test_falls_back_when_preferred_in_use():
@@ -120,3 +122,23 @@ def test_lazy_workspace_mcp_port_via_pep562(monkeypatch):
     assert cfg.WORKSPACE_MCP_PORT == 8009
     monkeypatch.setenv("WORKSPACE_MCP_PORT", "8011")
     assert cfg.WORKSPACE_MCP_PORT == 8011
+
+
+def test_lazy_workspace_mcp_port_prefers_resolved_workspace_env(monkeypatch):
+    """WORKSPACE_MCP_PORT is authoritative after the resolver mutates it."""
+    monkeypatch.setenv("PORT", "8000")
+    monkeypatch.setenv("WORKSPACE_MCP_PORT", "8011")
+    monkeypatch.setenv("WORKSPACE_MCP_RESOLVED_PORT", "1")
+    cfg = _import_fresh("core.config")
+    assert cfg.WORKSPACE_MCP_PORT == 8011
+
+
+def test_lazy_workspace_mcp_port_preserves_port_precedence_without_resolver(
+    monkeypatch,
+):
+    """HTTP/OAuth 2.1 mode keeps existing PORT precedence when no stdio resolver ran."""
+    monkeypatch.setenv("PORT", "8000")
+    monkeypatch.setenv("WORKSPACE_MCP_PORT", "8011")
+    monkeypatch.delenv("WORKSPACE_MCP_RESOLVED_PORT", raising=False)
+    cfg = _import_fresh("core.config")
+    assert cfg.WORKSPACE_MCP_PORT == 8000

--- a/tests/auth/test_port_resolver.py
+++ b/tests/auth/test_port_resolver.py
@@ -12,8 +12,6 @@ from contextlib import contextmanager
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-
 
 @pytest.fixture(autouse=True)
 def _isolate_env(monkeypatch):
@@ -94,6 +92,23 @@ def test_oauthconfig_reload_picks_up_resolved_port():
     assert str(bound) in config.redirect_uri, (
         f"redirect_uri {config.redirect_uri!r} must reflect bound port {bound}"
     )
+
+
+def test_raises_on_malformed_port_env(monkeypatch):
+    """Non-numeric WORKSPACE_MCP_PORT raises PortConfigError with actionable message."""
+    pr = _import_fresh("auth.port_resolver")
+    monkeypatch.setenv("WORKSPACE_MCP_PORT", "not_a_number")
+    with pytest.raises(pr.PortConfigError, match="WORKSPACE_MCP_PORT.*not_a_number"):
+        pr.resolve_port()
+
+
+def test_raises_on_malformed_fallback_count_env(monkeypatch):
+    """Non-numeric WORKSPACE_MCP_PORT_FALLBACK_COUNT raises PortConfigError."""
+    pr = _import_fresh("auth.port_resolver")
+    monkeypatch.setenv("WORKSPACE_MCP_PORT", "8000")
+    monkeypatch.setenv("WORKSPACE_MCP_PORT_FALLBACK_COUNT", "abc")
+    with pytest.raises(pr.PortConfigError, match="WORKSPACE_MCP_PORT_FALLBACK_COUNT.*abc"):
+        pr.resolve_port()
 
 
 def test_lazy_workspace_mcp_port_via_pep562(monkeypatch):

--- a/tests/auth/test_port_resolver.py
+++ b/tests/auth/test_port_resolver.py
@@ -107,7 +107,9 @@ def test_raises_on_malformed_fallback_count_env(monkeypatch):
     pr = _import_fresh("auth.port_resolver")
     monkeypatch.setenv("WORKSPACE_MCP_PORT", "8000")
     monkeypatch.setenv("WORKSPACE_MCP_PORT_FALLBACK_COUNT", "abc")
-    with pytest.raises(pr.PortConfigError, match="WORKSPACE_MCP_PORT_FALLBACK_COUNT.*abc"):
+    with pytest.raises(
+        pr.PortConfigError, match="WORKSPACE_MCP_PORT_FALLBACK_COUNT.*abc"
+    ):
         pr.resolve_port()
 
 

--- a/tests/auth/test_port_resolver.py
+++ b/tests/auth/test_port_resolver.py
@@ -1,0 +1,105 @@
+"""
+Tests for auth.port_resolver -- late-binding the OAuth callback port across
+preferred + fallback range. Covers preferred-when-free, fallback-when-held,
+raise-when-all-held, OAuthConfig redirect_uri integration, and PEP 562
+lazy-evaluation of core.config.WORKSPACE_MCP_PORT.
+"""
+
+import os
+import socket
+import sys
+from contextlib import contextmanager
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    monkeypatch.delenv("WORKSPACE_MCP_PORT", raising=False)
+    monkeypatch.delenv("PORT", raising=False)
+    monkeypatch.delenv("WORKSPACE_MCP_PORT_FALLBACK_COUNT", raising=False)
+    monkeypatch.delenv("WORKSPACE_MCP_HOST", raising=False)
+
+
+@contextmanager
+def _hold_port(port: int, host: str = "127.0.0.1"):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
+    s.bind((host, port))
+    s.listen(1)
+    try:
+        yield port
+    finally:
+        s.close()
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _import_fresh(modname: str):
+    if modname in sys.modules:
+        del sys.modules[modname]
+    return __import__(modname, fromlist=["*"])
+
+
+def test_resolves_preferred_when_free():
+    pr = _import_fresh("auth.port_resolver")
+    p = _free_port()
+    bound = pr.resolve_port(preferred=p, fallback_count=2, host="127.0.0.1")
+    assert bound == p
+    assert os.environ["WORKSPACE_MCP_PORT"] == str(p)
+
+
+def test_falls_back_when_preferred_in_use():
+    pr = _import_fresh("auth.port_resolver")
+    p = _free_port()
+    with _hold_port(p):
+        bound = pr.resolve_port(preferred=p, fallback_count=4, host="127.0.0.1")
+    assert bound != p, "Resolver should have skipped the held port"
+    assert bound > p, "Fallback should be a higher port"
+    assert os.environ["WORKSPACE_MCP_PORT"] == str(bound)
+
+
+def test_raises_when_all_ports_held():
+    pr = _import_fresh("auth.port_resolver")
+    p = _free_port()
+    sockets = []
+    try:
+        for offset in range(3):
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
+            s.bind(("127.0.0.1", p + offset))
+            s.listen(1)
+            sockets.append(s)
+        with pytest.raises(pr.NoAvailablePortError):
+            pr.resolve_port(preferred=p, fallback_count=2, host="127.0.0.1")
+    finally:
+        for s in sockets:
+            s.close()
+
+
+def test_oauthconfig_reload_picks_up_resolved_port():
+    """After resolve_port + reload_oauth_config, redirect_uri reflects bound port."""
+    pr = _import_fresh("auth.port_resolver")
+    p = _free_port()
+    with _hold_port(p):
+        bound = pr.resolve_port(preferred=p, fallback_count=4, host="127.0.0.1")
+    oauth_config = _import_fresh("auth.oauth_config")
+    config = oauth_config.reload_oauth_config()
+    assert str(bound) in config.redirect_uri, (
+        f"redirect_uri {config.redirect_uri!r} must reflect bound port {bound}"
+    )
+
+
+def test_lazy_workspace_mcp_port_via_pep562(monkeypatch):
+    """core.config.WORKSPACE_MCP_PORT must read env at access time, not import time."""
+    monkeypatch.setenv("WORKSPACE_MCP_PORT", "8009")
+    cfg = _import_fresh("core.config")
+    assert cfg.WORKSPACE_MCP_PORT == 8009
+    monkeypatch.setenv("WORKSPACE_MCP_PORT", "8011")
+    assert cfg.WORKSPACE_MCP_PORT == 8011

--- a/tests/core/test_warning_filters.py
+++ b/tests/core/test_warning_filters.py
@@ -1,0 +1,15 @@
+import subprocess
+import sys
+
+
+def test_core_server_import_suppresses_fastmcp_authlib_jose_warning():
+    result = subprocess.run(
+        [sys.executable, "-c", "import core.server"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "AuthlibDeprecationWarning" not in result.stderr
+    assert "authlib.jose module is deprecated" not in result.stderr

--- a/tests/test_main_permissions_tier.py
+++ b/tests/test_main_permissions_tier.py
@@ -50,10 +50,12 @@ def test_narrow_permissions_to_services_drops_non_selected_services():
     assert narrowed == {"gmail": "send"}
 
 
-def test_resolve_stdio_callback_port_marks_resolved_port(monkeypatch):
-    calls = []
+def test_resolve_stdio_callback_port_marks_resolved_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
 
-    def fake_resolve_port():
+    def fake_resolve_port() -> None:
         calls.append("resolve")
         monkeypatch.setenv("WORKSPACE_MCP_PORT", "8123")
         monkeypatch.setenv("WORKSPACE_MCP_RESOLVED_PORT", "1")
@@ -67,8 +69,10 @@ def test_resolve_stdio_callback_port_marks_resolved_port(monkeypatch):
     assert os.environ["WORKSPACE_MCP_RESOLVED_PORT"] == "1"
 
 
-def test_resolve_callback_port_for_transport_skips_streamable_http(monkeypatch):
-    def fail_if_called():
+def test_resolve_callback_port_for_transport_skips_streamable_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_called() -> None:
         raise AssertionError("stdio port resolver must not run for streamable HTTP")
 
     monkeypatch.setattr(main, "resolve_stdio_callback_port", fail_if_called)

--- a/tests/test_main_permissions_tier.py
+++ b/tests/test_main_permissions_tier.py
@@ -50,6 +50,35 @@ def test_narrow_permissions_to_services_drops_non_selected_services():
     assert narrowed == {"gmail": "send"}
 
 
+def test_resolve_stdio_callback_port_marks_resolved_port(monkeypatch):
+    calls = []
+
+    def fake_resolve_port():
+        calls.append("resolve")
+        monkeypatch.setenv("WORKSPACE_MCP_PORT", "8123")
+        monkeypatch.setenv("WORKSPACE_MCP_RESOLVED_PORT", "1")
+
+    monkeypatch.setattr("auth.port_resolver.resolve_port", fake_resolve_port)
+    monkeypatch.setattr(main, "reload_oauth_config", lambda: calls.append("reload"))
+
+    main.resolve_stdio_callback_port()
+
+    assert calls == ["resolve", "reload"]
+    assert os.environ["WORKSPACE_MCP_RESOLVED_PORT"] == "1"
+
+
+def test_resolve_callback_port_for_transport_skips_streamable_http(monkeypatch):
+    def fail_if_called():
+        raise AssertionError("stdio port resolver must not run for streamable HTTP")
+
+    monkeypatch.setattr(main, "resolve_stdio_callback_port", fail_if_called)
+    monkeypatch.setenv("WORKSPACE_MCP_RESOLVED_PORT", "1")
+
+    main.resolve_callback_port_for_transport("streamable-http")
+
+    assert "WORKSPACE_MCP_RESOLVED_PORT" not in os.environ
+
+
 def test_permissions_and_tools_flags_are_rejected(monkeypatch, capsys):
     monkeypatch.setattr(main, "configure_safe_logging", lambda: None)
     monkeypatch.setattr(


### PR DESCRIPTION
# Late-bind OAuth callback port with preferred + fallback range

## Summary

In stdio mode the OAuth callback server port is hardcoded to `8000`. When a client (Claude Desktop, Claude Code, Cursor, etc.) spawns multiple `workspace-mcp` processes — a normal occurrence on app reload, extension restart, or multi-session usage — only one wins the port. The others either error out at boot (`Port 8000 already in use`) or, worse, silently continue without a callback listener and produce 403 invalid-state on every subsequent OAuth attempt because the state-token PID and the listener PID diverge.

This PR makes the callback port late-bound at process start: a preferred port plus a small fallback range is probed, the first available is bound, and `redirect_uri` is composed from the actual bound port.

## Fixes

- #546 — Multiple stdio processes cause OAuth callback server port conflict and state mismatch
- #667 — Orphaned python instance holds port 8000, causing OAuth "invalid state"
- #754 — OAuth callback "Port 8000 already in use" in stdio mode

## Approach (vs. existing PRs)

- **#590** (closed): Shared OAuth state across processes via filesystem. Works around the symptom; preserves the single-port assumption.
- **#606** (open): Better self-detection — recover when our own thread holds the port. Helps re-auth, doesn't help multi-process spawning.
- **This PR**: Eliminate the single-port assumption. Each process binds its own port from a small range; redirect URIs are composed from the actual bound port. No cross-process state sharing required.

The trade-off depends on the OAuth client type:

- **Desktop application clients** (the most common workspace-mcp setup, since stdio mode is a desktop-bound MCP transport) — no registration required. Google's loopback rule accepts any port on `localhost`/`127.0.0.1` for Desktop clients automatically. Verified directly in GCP Console: Desktop client config pages don't even surface a redirect URI field. Zero operational cost; the fix is fully automatic.

- **Web application clients** (less common for workspace-mcp, used when the same OAuth client is shared with a hosted streamable-http deployment) — each fallback port must be registered as an authorized redirect URI in the OAuth client config. One-time setup. The README documents the entries.

## Changes

| File                      | Change                                                                                                              |
| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| `auth/port_resolver.py`   | New module. `resolve_port()` probes preferred + fallback range with connect-then-bind, mutates env to bound port.   |
| `main.py`                 | Calls `resolve_port()` after argparse, then `reload_oauth_config()` so `redirect_uri` reflects the bound port.      |
| `core/config.py`          | `WORKSPACE_MCP_PORT` is lazy-evaluated via PEP 562 `__getattr__` so the late-bound env value isn't shadowed.        |

`auth/oauth_callback_server.py`, `auth/oauth_config.py`, and `auth/google_auth.py` are unchanged — they consume `port`/`base_url`/`redirect_uri` through the existing API and pick up the late-bound port automatically.

## Probe semantics

`_is_port_free(host, port)` does a two-stage check:

1. **Connect probe** to `127.0.0.1:port`. Detects an existing listener regardless of which interface they bound to. On macOS, `SO_REUSEADDR=1` lets a `0.0.0.0` bind succeed even when `127.0.0.1` is already listening — so a bind probe alone gives a false-negative. Since the OAuth callback URI is always `http://localhost:port`, anything listening on loopback is a collision.
2. **Bind probe** to `(host, port)` with default `SO_REUSEADDR`. Catches `TIME_WAIT` and BSD-style local conflicts.

## Configuration

| Env var                              | Default | Meaning                              |
| ------------------------------------ | ------- | ------------------------------------ |
| `WORKSPACE_MCP_PORT`                 | `8000`  | Preferred port (existing semantics)  |
| `WORKSPACE_MCP_PORT_FALLBACK_COUNT`  | `4`     | Fallback slots (5 ports total)       |
| `WORKSPACE_MCP_HOST`                 | `0.0.0.0` | Bind host (existing)               |

Set `WORKSPACE_MCP_PORT_FALLBACK_COUNT=0` to restore the original single-port behavior.

## Test plan

- New stdlib `unittest` suite covers: preferred-when-free, fallback-when-held, raise-when-all-held, OAuthConfig reload picks up the bound port via `redirect_uri`, `core.config.WORKSPACE_MCP_PORT` lazy-evaluation.
- Smoke test: with port 8000 already held by another `workspace-mcp` process, a fresh instance correctly logs `falling back to 8001` and binds 8001 with redirect_uri `http://localhost:8001/oauth2callback`. Two simultaneous spawns share `WORKSPACE_MCP_PORT=8500` and one bound 8500, the other 8501 — no errors, no orphan listeners.

## Notes

- Idempotent for existing single-instance users — when port 8000 is free, behavior is unchanged.
- Desktop OAuth client users (the typical workspace-mcp config): no GCP changes needed; Google's loopback rule covers all fallback ports automatically.
- Web OAuth client users (rare for workspace-mcp): if fallback ports aren't registered, fallback-bound instances start cleanly but Google rejects auth flows with `redirect_uri_mismatch`. Set `WORKSPACE_MCP_PORT_FALLBACK_COUNT=0` to restore single-port behavior, or register the fallback URIs.
- The connect-probe assumes loopback is reachable. If you've configured the callback URI to bind to a non-loopback interface (rare), set `WORKSPACE_MCP_PORT_FALLBACK_COUNT=0` to keep the existing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic OAuth callback port resolution: scans a preferred+fallback range, probes/reuses existing callback endpoints when safe, and updates runtime redirect URIs and resolved-port marker.

* **Bug Fixes**
  * Port value is now lazily read so it reflects current environment.
  * Startup reports clear, actionable errors when port config is invalid or no ports are available.
  * Transport-specific handling ensures only relevant transports trigger resolution.

* **Tests**
  * Added tests for port selection, reuse probing, lazy env resolution, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->