### PR TITLE
fix(auth): resolve OAuth 2.1 credentials via fastmcp 3.x stores

### DIFF
--- a/auth/auth_info_middleware.py
+++ b/auth/auth_info_middleware.py
@@ -156,7 +156,7 @@ class AuthInfoMiddleware(Middleware):
                                         mcp_session_id = getattr(
                                             context.fastmcp_context, "session_id", None
                                         )
-                                        ensure_session_from_access_token(
+                                        await ensure_session_from_access_token(
                                             access_token,
                                             user_email,
                                             mcp_session_id,

--- a/auth/oauth21_session_store.py
+++ b/auth/oauth21_session_store.py
@@ -1032,42 +1032,95 @@ def _resolve_client_credentials() -> Tuple[Optional[str], Optional[str]]:
     return client_id, client_secret
 
 
-def _build_credentials_from_provider(
+def _extract_jti_from_jwt(token: str) -> Optional[str]:
+    """Extract the ``jti`` claim from a FastMCP-issued JWT without verifying.
+
+    The JWT signature has already been verified by the FastMCP middleware
+    before this code path runs; here we only need the ``jti`` to look up the
+    upstream token mapping. Decoding manually avoids depending on a specific
+    JWT library and avoids a redundant verification step.
+    """
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        import base64
+        import json as _json
+
+        payload = _json.loads(base64.urlsafe_b64decode(payload_b64))
+        jti = payload.get("jti")
+        return jti if isinstance(jti, str) else None
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+async def _build_credentials_from_provider(
     access_token: AccessToken,
 ) -> Optional[Credentials]:
-    """Construct Google credentials from the provider cache."""
+    """Construct Google credentials by resolving the upstream token via the
+    FastMCP OAuth proxy stores (``_jti_mapping_store`` -> ``_upstream_token_store``).
+
+    Returns ``None`` when the active provider is not a FastMCP ``OAuthProxy``
+    (e.g. external OAuth 2.1 providers, or single-user mode), so callers can
+    fall back to the manual-construction path.
+    """
     if not _auth_provider:
         return None
 
-    access_entry = getattr(_auth_provider, "_access_tokens", {}).get(access_token.token)
-    if not access_entry:
-        access_entry = access_token
+    jti_store = getattr(_auth_provider, "_jti_mapping_store", None)
+    upstream_store = getattr(_auth_provider, "_upstream_token_store", None)
+    if jti_store is None or upstream_store is None:
+        # Provider isn't a FastMCP OAuthProxy (e.g. raw token verifier in
+        # external-OAuth or single-user modes). Caller will fall back.
+        return None
+
+    jti = _extract_jti_from_jwt(access_token.token)
+    if not jti:
+        return None
+
+    try:
+        jti_mapping = await jti_store.get(key=jti)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("JTI mapping lookup failed for jti=%s: %s", jti[:8], exc)
+        return None
+    if jti_mapping is None:
+        # Token JTI not in mapping store (revoked, expired, or never issued
+        # by this proxy). Treat as a cache miss and let the caller fall back.
+        return None
+
+    upstream_token_id = getattr(jti_mapping, "upstream_token_id", None)
+    if not upstream_token_id:
+        return None
+
+    try:
+        upstream_set = await upstream_store.get(key=upstream_token_id)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug(
+            "Upstream token lookup failed for id=%s: %s", upstream_token_id[:8], exc
+        )
+        return None
+    if upstream_set is None:
+        return None
 
     client_id, client_secret = _resolve_client_credentials()
 
-    refresh_token_value = getattr(_auth_provider, "_access_to_refresh", {}).get(
-        access_token.token
-    )
-    refresh_token_obj = None
-    if refresh_token_value:
-        refresh_token_obj = getattr(_auth_provider, "_refresh_tokens", {}).get(
-            refresh_token_value
-        )
-
     expiry = None
-    expires_at = getattr(access_entry, "expires_at", None)
-    if expires_at:
+    upstream_expires_at = getattr(upstream_set, "expires_at", None)
+    if upstream_expires_at:
         try:
-            expiry_candidate = datetime.fromtimestamp(expires_at, tz=timezone.utc)
-            expiry = _normalize_expiry_to_naive_utc(expiry_candidate)
+            expiry = _normalize_expiry_to_naive_utc(
+                datetime.fromtimestamp(upstream_expires_at, tz=timezone.utc)
+            )
         except Exception:  # pragma: no cover - defensive
             expiry = None
 
-    scopes = getattr(access_entry, "scopes", None)
+    scope_str = getattr(upstream_set, "scope", "") or ""
+    scopes = scope_str.split() if scope_str else None
 
     return Credentials(
-        token=access_token.token,
-        refresh_token=refresh_token_obj.token if refresh_token_obj else None,
+        token=upstream_set.access_token,
+        refresh_token=upstream_set.refresh_token,
         token_uri="https://oauth2.googleapis.com/token",
         client_id=client_id,
         client_secret=client_secret,
@@ -1076,7 +1129,7 @@ def _build_credentials_from_provider(
     )
 
 
-def ensure_session_from_access_token(
+async def ensure_session_from_access_token(
     access_token: AccessToken,
     user_email: Optional[str],
     mcp_session_id: Optional[str] = None,
@@ -1090,7 +1143,7 @@ def ensure_session_from_access_token(
     if not email and getattr(access_token, "claims", None):
         email = access_token.claims.get("email")
 
-    credentials = _build_credentials_from_provider(access_token)
+    credentials = await _build_credentials_from_provider(access_token)
     store_expiry: Optional[datetime] = None
 
     if credentials is None:
@@ -1140,7 +1193,7 @@ def ensure_session_from_access_token(
     return credentials
 
 
-def get_credentials_from_token(
+async def get_credentials_from_token(
     access_token: str, user_email: Optional[str] = None
 ) -> Optional[Credentials]:
     """
@@ -1163,14 +1216,26 @@ def get_credentials_from_token(
                 logger.debug(f"Found matching credentials from store for {user_email}")
                 return credentials
 
-        # If the FastMCP provider is managing tokens, sync from provider storage
-        if _auth_provider:
-            access_record = getattr(_auth_provider, "_access_tokens", {}).get(
-                access_token
+        # If the FastMCP provider is managing tokens, sync from provider storage.
+        # The legacy `_access_tokens` dict no longer exists in fastmcp 3.x; the
+        # token-to-upstream lookup is now performed by `_build_credentials_from_provider`
+        # via the JTI mapping and upstream token stores. Construct a minimal
+        # AccessToken-like wrapper so that path can be reused.
+        if _auth_provider and getattr(_auth_provider, "_jti_mapping_store", None):
+            from types import SimpleNamespace
+
+            access_record = SimpleNamespace(
+                token=access_token,
+                claims=({"email": user_email} if user_email else None),
+                scopes=None,
+                expires_at=None,
             )
-            if access_record:
-                logger.debug("Building credentials from FastMCP provider cache")
-                return ensure_session_from_access_token(access_record, user_email)
+            credentials = await ensure_session_from_access_token(
+                access_record, user_email
+            )
+            if credentials is not None:
+                logger.debug("Built credentials from FastMCP provider cache")
+                return credentials
 
         # Otherwise, create minimal credentials with just the access token
         # Assume token is valid for 1 hour (typical for Google tokens)

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -365,7 +365,7 @@ async def get_authenticated_google_service_oauth21(
                 f"Authenticated account {token_email} does not match requested user {user_google_email}."
             )
 
-        credentials = ensure_session_from_access_token(
+        credentials = await ensure_session_from_access_token(
             access_token, resolved_email, session_id
         )
         if not credentials:

--- a/tests/auth/test_auth_info_middleware.py
+++ b/tests/auth/test_auth_info_middleware.py
@@ -51,9 +51,13 @@ async def test_on_call_tool_includes_authorization_header_for_bearer_auth(
             )
 
     monkeypatch.setattr("core.server.get_auth_provider", lambda: _FakeProvider())
+
+    async def _noop_ensure_session(*args, **kwargs):
+        return None
+
     monkeypatch.setattr(
         "auth.auth_info_middleware.ensure_session_from_access_token",
-        lambda *args, **kwargs: None,
+        _noop_ensure_session,
     )
 
     async def call_next(ctx):
@@ -105,9 +109,13 @@ async def test_on_call_tool_requests_authorization_header_when_default_headers_a
             )
 
     monkeypatch.setattr("core.server.get_auth_provider", lambda: _FakeProvider())
+
+    async def _noop_ensure_session(*args, **kwargs):
+        return None
+
     monkeypatch.setattr(
         "auth.auth_info_middleware.ensure_session_from_access_token",
-        lambda *args, **kwargs: None,
+        _noop_ensure_session,
     )
 
     async def call_next(ctx):

--- a/tests/auth/test_auth_info_middleware.py
+++ b/tests/auth/test_auth_info_middleware.py
@@ -53,6 +53,7 @@ async def test_on_call_tool_includes_authorization_header_for_bearer_auth(
     monkeypatch.setattr("core.server.get_auth_provider", lambda: _FakeProvider())
 
     async def _noop_ensure_session(*args, **kwargs):
+        """Async stand-in for ensure_session_from_access_token in middleware tests."""
         return None
 
     monkeypatch.setattr(
@@ -111,6 +112,7 @@ async def test_on_call_tool_requests_authorization_header_when_default_headers_a
     monkeypatch.setattr("core.server.get_auth_provider", lambda: _FakeProvider())
 
     async def _noop_ensure_session(*args, **kwargs):
+        """Async stand-in for ensure_session_from_access_token in middleware tests."""
         return None
 
     monkeypatch.setattr(

--- a/tests/auth/test_oauth21_session_store.py
+++ b/tests/auth/test_oauth21_session_store.py
@@ -200,12 +200,14 @@ def _make_jwt(jti: str) -> str:
 
 
 class _AsyncStore:
-    """Minimal stand-in for fastmcp's PydanticAdapter[T]."""
+    """Minimal stand-in for fastmcp's PydanticAdapter[T] used in tests."""
 
     def __init__(self, data):
+        """Initialize the fake store with a dict of key -> value entries."""
         self._data = data
 
     async def get(self, *, key):
+        """Return the stored value for ``key`` or ``None`` if absent."""
         return self._data.get(key)
 
 
@@ -213,6 +215,7 @@ class _FakeProxyProvider:
     """Stand-in for FastMCP GoogleProvider exposing the two stores we use."""
 
     def __init__(self, jti_mappings, upstream_tokens):
+        """Wrap two dict-based fakes as the provider's JTI and upstream stores."""
         self._jti_mapping_store = _AsyncStore(jti_mappings)
         self._upstream_token_store = _AsyncStore(upstream_tokens)
         # Used by _resolve_client_credentials to find client_id/secret.
@@ -221,17 +224,20 @@ class _FakeProxyProvider:
 
 
 def test_extract_jti_from_jwt_returns_claim():
+    """A well-formed JWT with a string ``jti`` returns that claim verbatim."""
     token = _make_jwt("abc123")
     assert _extract_jti_from_jwt(token) == "abc123"
 
 
 def test_extract_jti_from_jwt_returns_none_for_malformed_token():
+    """Tokens that don't have exactly three dot-separated segments return None."""
     assert _extract_jti_from_jwt("not.a.jwt.has-extra-part") is None
     assert _extract_jti_from_jwt("only-one-segment") is None
     assert _extract_jti_from_jwt("") is None
 
 
 def test_extract_jti_from_jwt_returns_none_when_jti_claim_missing():
+    """A valid JWT shape without a ``jti`` claim returns None rather than raising."""
     payload = base64.urlsafe_b64encode(_json.dumps({"sub": "x"}).encode()).rstrip(b"=")
     header = base64.urlsafe_b64encode(b"{}").rstrip(b"=")
     token = b".".join([header, payload, b"sig"]).decode()
@@ -240,6 +246,7 @@ def test_extract_jti_from_jwt_returns_none_when_jti_claim_missing():
 
 @pytest.mark.asyncio
 async def test_build_credentials_returns_none_when_no_provider(monkeypatch):
+    """With no auth provider registered, the function short-circuits to None."""
     monkeypatch.setattr(oauth21_session_store, "_auth_provider", None)
     access_token = SimpleNamespace(token=_make_jwt("x"), claims={}, scopes=[])
     assert await _build_credentials_from_provider(access_token) is None
@@ -296,6 +303,7 @@ async def test_build_credentials_resolves_via_jti_to_upstream_chain(monkeypatch)
 
 @pytest.mark.asyncio
 async def test_build_credentials_returns_none_when_jti_mapping_missing(monkeypatch):
+    """A revoked or never-issued JTI returns None so the caller can fall back."""
     provider = _FakeProxyProvider(jti_mappings={}, upstream_tokens={})
     monkeypatch.setattr(oauth21_session_store, "_auth_provider", provider)
     access_token = SimpleNamespace(token=_make_jwt("missing"), claims={}, scopes=[])
@@ -306,6 +314,7 @@ async def test_build_credentials_returns_none_when_jti_mapping_missing(monkeypat
 async def test_build_credentials_returns_none_when_upstream_token_missing(
     monkeypatch,
 ):
+    """Dangling JTI mapping pointing at a missing upstream token returns None."""
     provider = _FakeProxyProvider(
         jti_mappings={"j": SimpleNamespace(upstream_token_id="missing", jti="j")},
         upstream_tokens={},

--- a/tests/auth/test_oauth21_session_store.py
+++ b/tests/auth/test_oauth21_session_store.py
@@ -1,6 +1,16 @@
+import base64
+import json as _json
+from types import SimpleNamespace
+
 import pytest
 
-from auth.oauth21_session_store import OAuth21SessionStore
+import auth.oauth21_session_store as oauth21_session_store
+from auth.oauth21_session_store import (
+    OAuth21SessionStore,
+    _build_credentials_from_provider,
+    _extract_jti_from_jwt,
+    ensure_session_from_access_token,
+)
 
 
 def test_oauth_state_persists_across_store_instances(tmp_path):
@@ -172,3 +182,153 @@ def test_store_session_skips_mcp_binding_in_single_user_mode(tmp_path, monkeypat
 
     assert store.get_user_by_mcp_session("session-123") is None
     assert store.get_credentials("account-b@example.com").token == "token-b"
+
+
+# ---------------------------------------------------------------------------
+# _build_credentials_from_provider — fastmcp 3.x JTI -> upstream-token lookup
+# ---------------------------------------------------------------------------
+
+
+def _make_jwt(jti: str) -> str:
+    """Build a minimal three-segment JWT-shaped string with the given jti claim."""
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256","typ":"JWT"}').rstrip(b"=")
+    payload = base64.urlsafe_b64encode(
+        _json.dumps({"jti": jti, "client_id": "test"}).encode()
+    ).rstrip(b"=")
+    sig = b"signature"
+    return b".".join([header, payload, sig]).decode()
+
+
+class _AsyncStore:
+    """Minimal stand-in for fastmcp's PydanticAdapter[T]."""
+
+    def __init__(self, data):
+        self._data = data
+
+    async def get(self, *, key):
+        return self._data.get(key)
+
+
+class _FakeProxyProvider:
+    """Stand-in for FastMCP GoogleProvider exposing the two stores we use."""
+
+    def __init__(self, jti_mappings, upstream_tokens):
+        self._jti_mapping_store = _AsyncStore(jti_mappings)
+        self._upstream_token_store = _AsyncStore(upstream_tokens)
+        # Used by _resolve_client_credentials to find client_id/secret.
+        self._upstream_client_id = "test-client-id"
+        self._upstream_client_secret = "test-client-secret"
+
+
+def test_extract_jti_from_jwt_returns_claim():
+    token = _make_jwt("abc123")
+    assert _extract_jti_from_jwt(token) == "abc123"
+
+
+def test_extract_jti_from_jwt_returns_none_for_malformed_token():
+    assert _extract_jti_from_jwt("not.a.jwt.has-extra-part") is None
+    assert _extract_jti_from_jwt("only-one-segment") is None
+    assert _extract_jti_from_jwt("") is None
+
+
+def test_extract_jti_from_jwt_returns_none_when_jti_claim_missing():
+    payload = base64.urlsafe_b64encode(_json.dumps({"sub": "x"}).encode()).rstrip(b"=")
+    header = base64.urlsafe_b64encode(b"{}").rstrip(b"=")
+    token = b".".join([header, payload, b"sig"]).decode()
+    assert _extract_jti_from_jwt(token) is None
+
+
+@pytest.mark.asyncio
+async def test_build_credentials_returns_none_when_no_provider(monkeypatch):
+    monkeypatch.setattr(oauth21_session_store, "_auth_provider", None)
+    access_token = SimpleNamespace(token=_make_jwt("x"), claims={}, scopes=[])
+    assert await _build_credentials_from_provider(access_token) is None
+
+
+@pytest.mark.asyncio
+async def test_build_credentials_returns_none_when_provider_lacks_proxy_stores(
+    monkeypatch,
+):
+    """Provider without _jti_mapping_store (e.g. external OAuth or single-user)
+    must return None so callers can fall back to the manual-construction path."""
+    monkeypatch.setattr(
+        oauth21_session_store,
+        "_auth_provider",
+        SimpleNamespace(),  # no proxy stores
+    )
+    access_token = SimpleNamespace(token=_make_jwt("x"), claims={}, scopes=[])
+    assert await _build_credentials_from_provider(access_token) is None
+
+
+@pytest.mark.asyncio
+async def test_build_credentials_resolves_via_jti_to_upstream_chain(monkeypatch):
+    """Regression test for the OAuth 2.1 refresh bug: refresh_token must be
+    populated from the upstream token set, not be silently None."""
+    jti = "jti-abc"
+    upstream_id = "upstream-xyz"
+    upstream_set = SimpleNamespace(
+        upstream_token_id=upstream_id,
+        access_token="ya29.upstream-access",
+        refresh_token="1//upstream-refresh",
+        expires_at=2_000_000_000,  # far future
+        scope="https://www.googleapis.com/auth/spreadsheets openid email",
+    )
+    provider = _FakeProxyProvider(
+        jti_mappings={jti: SimpleNamespace(upstream_token_id=upstream_id, jti=jti)},
+        upstream_tokens={upstream_id: upstream_set},
+    )
+    monkeypatch.setattr(oauth21_session_store, "_auth_provider", provider)
+
+    access_token = SimpleNamespace(
+        token=_make_jwt(jti), claims={"email": "u@example.com"}, scopes=[]
+    )
+    creds = await _build_credentials_from_provider(access_token)
+
+    assert creds is not None
+    assert creds.token == "ya29.upstream-access"
+    assert creds.refresh_token == "1//upstream-refresh"
+    assert creds.client_id == "test-client-id"
+    assert creds.client_secret == "test-client-secret"
+    assert creds.token_uri == "https://oauth2.googleapis.com/token"
+    assert creds.scopes == upstream_set.scope.split()
+    assert creds.expiry is not None
+
+
+@pytest.mark.asyncio
+async def test_build_credentials_returns_none_when_jti_mapping_missing(monkeypatch):
+    provider = _FakeProxyProvider(jti_mappings={}, upstream_tokens={})
+    monkeypatch.setattr(oauth21_session_store, "_auth_provider", provider)
+    access_token = SimpleNamespace(token=_make_jwt("missing"), claims={}, scopes=[])
+    assert await _build_credentials_from_provider(access_token) is None
+
+
+@pytest.mark.asyncio
+async def test_build_credentials_returns_none_when_upstream_token_missing(
+    monkeypatch,
+):
+    provider = _FakeProxyProvider(
+        jti_mappings={"j": SimpleNamespace(upstream_token_id="missing", jti="j")},
+        upstream_tokens={},
+    )
+    monkeypatch.setattr(oauth21_session_store, "_auth_provider", provider)
+    access_token = SimpleNamespace(token=_make_jwt("j"), claims={}, scopes=[])
+    assert await _build_credentials_from_provider(access_token) is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_falls_back_to_manual_construction_when_provider_missing(
+    monkeypatch,
+):
+    """When no proxy is configured, ensure_session_from_access_token still
+    returns a Credentials object (with refresh_token=None) by manual construction."""
+    monkeypatch.setattr(oauth21_session_store, "_auth_provider", None)
+    access_token = SimpleNamespace(
+        token="raw-token",
+        claims={"email": "u@example.com"},
+        scopes=["https://www.googleapis.com/auth/userinfo.email"],
+        expires_at=2_000_000_000,
+    )
+    creds = await ensure_session_from_access_token(access_token, "u@example.com")
+    assert creds is not None
+    assert creds.token == "raw-token"
+    assert creds.refresh_token is None


### PR DESCRIPTION
Closes #775.

## Summary

`auth/oauth21_session_store.py:_build_credentials_from_provider()` reads three attributes off the FastMCP auth provider (`_access_to_refresh`, `_refresh_tokens`, `_access_tokens`) that **do not exist on any version of fastmcp** (verified against 2.10.0, 3.0.0, 3.1.0, 3.2.0, 3.2.4). Because the code uses `getattr(..., default={})`, the function silently returns `Credentials(refresh_token=None, ...)`. When `google-auth` later attempts to auto-refresh an expired access token, it raises:

```
RefreshError: The credentials do not contain the necessary fields need to refresh
the access token. You must specify refresh_token, token_uri, client_id, and client_secret.
```

The bug was introduced in `923df7e` ("refactor oauth2.1 support to fastmcp native", 2025-10-05). It only fires for sessions that hit the auto-refresh path (calls past Google's ~1h access-token TTL), which is why it has appeared as sporadic re-auth prompts rather than a constant failure.

## Fix

Replace the broken `getattr` chain with a proper resolution via the OAuth proxy's stores:

```
inbound FastMCP JWT → jti claim
                    → _jti_mapping_store.get(jti) → JTIMapping
                    → _upstream_token_store.get(upstream_token_id) → UpstreamTokenSet
                    → Credentials(access_token, refresh_token, ...)
```

Both stores are exposed on `OAuthProxy` (and therefore on `GoogleProvider`, the actual `_auth_provider` set in `core/server.py:541`). They handle Fernet decryption transparently. Per `proxy.py:1071`, both access-token and refresh-token JTIs are stored in the same `_jti_mapping_store`, so resolving from the inbound access-token JWT works directly.

When the active provider isn't a FastMCP `OAuthProxy` (external OAuth 2.1, single-user, raw token verifier modes), `_build_credentials_from_provider` returns `None` and the caller falls back to the existing manual-construction path — preserving current behavior in those modes.

## Async cascade

`_build_credentials_from_provider`, `ensure_session_from_access_token`, and `get_credentials_from_token` are now `async` to match the async stores (`PydanticAdapter[T].get`). Both production call sites are already inside `async` functions:

- `auth/service_decorator.py:368` (in `async def get_authenticated_google_service_oauth21`)
- `auth/auth_info_middleware.py:159` (in `async def on_call_tool`)

…so the cascade is local to these files. Existing mocks in `tests/auth/test_auth_info_middleware.py` are updated from `lambda` to `async def` helpers.

## Tests

Added `tests/auth/test_oauth21_session_store.py` coverage:

- `test_extract_jti_from_jwt_*` — header-only JWT decode for the `jti` claim, with malformed-input handling.
- `test_build_credentials_returns_none_when_no_provider` / `_when_provider_lacks_proxy_stores` — graceful fallback for non-OAuthProxy providers.
- `test_build_credentials_resolves_via_jti_to_upstream_chain` — **the regression test for the bug**. Mocks the two stores, calls the function with a JWT containing a known `jti`, and asserts the returned `Credentials` has `refresh_token` populated from the `UpstreamTokenSet` (not silently `None`).
- `test_build_credentials_returns_none_when_jti_mapping_missing` / `_when_upstream_token_missing` — cache-miss / revoked-token paths.
- `test_ensure_session_falls_back_to_manual_construction_when_provider_missing` — non-proxy mode regression.

Full suite: `1004 passed, 2 skipped` (vs `1004 passed, 2 skipped` on `main`). `ruff check` and `ruff format` both clean.

## Production verification

I'm running this patch in production via a sed-based fork (separate repo) and have validated the JWT → JTI → upstream-token → Google `refresh_token` chain works end-to-end against fastmcp 3.2.4. Happy to share more deployment detail or rebase if you'd like a different shape — also fine if you'd rather port the same idea on top of an in-flight refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable Google OAuth token verification and session establishment for smoother sign-in flows
  * Better handling and reconstruction of provider-issued credentials to improve access token resolution
  * Improved fallbacks to ensure access remains consistent when upstream mappings are unavailable

* **Tests**
  * Added and updated tests covering token-to-session resolution and edge-case fallbacks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->