### PR TITLE
feat(calendar): support conference_data in manage_event update path

### DIFF
--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -1377,7 +1377,7 @@ async def manage_event(
         timezone (Optional[str]): Timezone (e.g., "America/New_York").
         attachments (Optional[List[str]]): List of Google Drive file URLs or IDs to attach.
         add_google_meet (Optional[bool]): Whether to add/remove Google Meet.
-        conference_data (Optional[Dict[str, Any]]): Raw `conferenceData` payload (e.g. third-party `entryPoints` such as a Microsoft Teams `joinWebUrl`). When provided, it is set verbatim on the event and `add_google_meet` is ignored. `conferenceDataVersion=1` is sent automatically. Create action only.
+        conference_data (Optional[Dict[str, Any]]): Raw `conferenceData` payload (e.g. third-party `entryPoints` whose `uri` points to a Microsoft Teams meeting). When provided, it is set verbatim on the event and `add_google_meet` is ignored. `conferenceDataVersion=1` is sent automatically. Applies to both create and update actions.
         reminders (Optional[Union[str, List[Dict[str, Any]]]]): Custom reminder objects.
         use_default_reminders (Optional[bool]): Whether to use default reminders.
         transparency (Optional[str]): "opaque" (busy) or "transparent" (free).

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -952,6 +952,7 @@ async def _modify_event_impl(
     attendees: Optional[Union[List[str], List[Dict[str, Any]]]] = None,
     timezone: Optional[str] = None,
     add_google_meet: Optional[bool] = None,
+    conference_data: Optional[Dict[str, Any]] = None,
     reminders: Optional[Union[str, List[Dict[str, Any]]]] = None,
     use_default_reminders: Optional[bool] = None,
     transparency: Optional[str] = None,
@@ -1082,7 +1083,9 @@ async def _modify_event_impl(
             "[modify_event] Timezone provided but start_time and end_time are missing. Timezone will not be applied unless start/end times are also provided."
         )
 
-    if not event_body:
+    _uses_conference = conference_data is not None or add_google_meet is not None
+
+    if not event_body and not _uses_conference:
         message = "No fields provided to modify the event."
         logger.warning(f"[modify_event] {message}")
         raise Exception(message)
@@ -1111,6 +1114,10 @@ async def _modify_event_impl(
                 "summary": summary,
                 "description": description,
                 "location": location,
+                # Preserve existing start/end (incl. timeZone) when the caller did not
+                # supply start_time/end_time — protects description-only updates.
+                "start": event_body.get("start"),
+                "end": event_body.get("end"),
                 # Use the already-normalized attendee objects (if provided); otherwise preserve existing
                 "attendees": event_body.get("attendees"),
                 "colorId": event_body.get("colorId"),
@@ -1118,26 +1125,29 @@ async def _modify_event_impl(
             },
         )
 
-        # Handle Google Meet conference data
-        if add_google_meet is not None:
-            if add_google_meet:
-                # Add Google Meet
-                request_id = str(uuid.uuid4())
-                event_body["conferenceData"] = {
-                    "createRequest": {
-                        "requestId": request_id,
-                        "conferenceSolutionKey": {"type": "hangoutsMeet"},
-                    }
+        # Handle conference data — caller-supplied payload takes precedence over Meet auto-create.
+        if conference_data is not None:
+            event_body["conferenceData"] = conference_data
+            logger.info(
+                "[modify_event] Using caller-supplied conferenceData (skipping Meet auto-create)"
+            )
+        elif add_google_meet is True:
+            request_id = str(uuid.uuid4())
+            event_body["conferenceData"] = {
+                "createRequest": {
+                    "requestId": request_id,
+                    "conferenceSolutionKey": {"type": "hangoutsMeet"},
                 }
-                logger.info(
-                    f"[modify_event] Adding Google Meet conference with request ID: {request_id}"
-                )
-            else:
-                # Remove Google Meet by setting conferenceData to empty
-                event_body["conferenceData"] = {}
-                logger.info("[modify_event] Removing Google Meet conference")
+            }
+            logger.info(
+                f"[modify_event] Adding Google Meet conference with request ID: {request_id}"
+            )
+        elif add_google_meet is False:
+            # Remove Google Meet by setting conferenceData to empty
+            event_body["conferenceData"] = {}
+            logger.info("[modify_event] Removing Google Meet conference")
         elif "conferenceData" in existing_event:
-            # Preserve existing conference data if not specified
+            # Preserve existing conference data if neither override was specified
             event_body["conferenceData"] = existing_event["conferenceData"]
             logger.info("[modify_event] Preserving existing conference data")
 
@@ -1161,7 +1171,7 @@ async def _modify_event_impl(
                 calendarId=calendar_id,
                 eventId=event_id,
                 body=event_body,
-                conferenceDataVersion=1,
+                conferenceDataVersion=1 if _uses_conference else 0,
                 sendUpdates=send_updates,
             )
             .execute()
@@ -1440,6 +1450,7 @@ async def manage_event(
             attendees=attendees,
             timezone=timezone,
             add_google_meet=add_google_meet,
+            conference_data=conference_data,
             reminders=reminders,
             use_default_reminders=use_default_reminders,
             transparency=transparency,

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -679,6 +679,7 @@ async def _create_event_impl(
     timezone: Optional[str] = None,
     attachments: Optional[List[str]] = None,
     add_google_meet: bool = False,
+    conference_data: Optional[Dict[str, Any]] = None,
     reminders: Optional[Union[str, List[Dict[str, Any]]]] = None,
     use_default_reminders: bool = True,
     transparency: Optional[str] = None,
@@ -774,7 +775,12 @@ async def _create_event_impl(
             f"[create_event] Set guestsCanSeeOtherGuests to {guests_can_see_other_guests}"
         )
 
-    if add_google_meet:
+    if conference_data is not None:
+        event_body["conferenceData"] = conference_data
+        logger.info(
+            "[create_event] Using caller-supplied conferenceData (skipping Meet auto-create)"
+        )
+    elif add_google_meet:
         request_id = str(uuid.uuid4())
         event_body["conferenceData"] = {
             "createRequest": {
@@ -785,6 +791,8 @@ async def _create_event_impl(
         logger.info(
             f"[create_event] Adding Google Meet conference with request ID: {request_id}"
         )
+
+    _uses_conference = conference_data is not None or add_google_meet
 
     if attachments:
         # Accept both file URLs and file IDs. If a URL, extract the fileId.
@@ -863,7 +871,7 @@ async def _create_event_impl(
                     calendarId=calendar_id,
                     body=event_body,
                     supportsAttachments=True,
-                    conferenceDataVersion=1 if add_google_meet else 0,
+                    conferenceDataVersion=1 if _uses_conference else 0,
                     sendUpdates=send_updates,
                 )
                 .execute()
@@ -876,7 +884,7 @@ async def _create_event_impl(
                 .insert(
                     calendarId=calendar_id,
                     body=event_body,
-                    conferenceDataVersion=1 if add_google_meet else 0,
+                    conferenceDataVersion=1 if _uses_conference else 0,
                     sendUpdates=send_updates,
                 )
                 .execute()
@@ -1328,6 +1336,7 @@ async def manage_event(
     timezone: Optional[str] = None,
     attachments: Optional[StringList] = None,
     add_google_meet: Optional[bool] = None,
+    conference_data: Optional[Dict[str, Any]] = None,
     reminders: Optional[Union[str, List[Dict[str, Any]]]] = None,
     use_default_reminders: Optional[bool] = None,
     transparency: Optional[str] = None,
@@ -1358,6 +1367,7 @@ async def manage_event(
         timezone (Optional[str]): Timezone (e.g., "America/New_York").
         attachments (Optional[List[str]]): List of Google Drive file URLs or IDs to attach.
         add_google_meet (Optional[bool]): Whether to add/remove Google Meet.
+        conference_data (Optional[Dict[str, Any]]): Raw `conferenceData` payload (e.g. third-party `entryPoints` such as a Microsoft Teams `joinWebUrl`). When provided, it is set verbatim on the event and `add_google_meet` is ignored. `conferenceDataVersion=1` is sent automatically. Create action only.
         reminders (Optional[Union[str, List[Dict[str, Any]]]]): Custom reminder objects.
         use_default_reminders (Optional[bool]): Whether to use default reminders.
         transparency (Optional[str]): "opaque" (busy) or "transparent" (free).
@@ -1401,6 +1411,7 @@ async def manage_event(
             timezone=timezone,
             attachments=attachments,
             add_google_meet=add_google_meet or False,
+            conference_data=conference_data,
             reminders=reminders,
             use_default_reminders=use_default_reminders
             if use_default_reminders is not None

--- a/tests/gcalendar/test_manage_event.py
+++ b/tests/gcalendar/test_manage_event.py
@@ -211,3 +211,133 @@ async def test_manage_event_rejects_invalid_send_updates(action):
             response="accepted",
             send_updates="invalid",
         )
+
+
+@pytest.mark.asyncio
+async def test_update_event_passes_conference_data_verbatim():
+    mock_service = _create_mock_service()
+    mock_service.events().get().execute = Mock(
+        return_value={
+            "id": "evt123",
+            "summary": "Sync",
+            "start": {"dateTime": "2026-04-06T09:00:00Z"},
+            "end": {"dateTime": "2026-04-06T09:30:00Z"},
+        }
+    )
+    mock_service.events().update().execute = Mock(
+        return_value={"id": "evt123", "htmlLink": "link", "summary": "Sync"}
+    )
+
+    teams_payload = {
+        "entryPoints": [
+            {
+                "entryPointType": "video",
+                "uri": "https://teams.microsoft.com/l/meetup-join/abc",
+                "label": "Microsoft Teams",
+            }
+        ]
+    }
+
+    await _modify_event_impl(
+        service=mock_service,
+        user_google_email="user@example.com",
+        event_id="evt123",
+        conference_data=teams_payload,
+    )
+
+    call = mock_service.events().update.call_args
+    assert call[1]["body"]["conferenceData"] == teams_payload
+    assert call[1]["conferenceDataVersion"] == 1
+
+
+@pytest.mark.asyncio
+async def test_update_event_default_omits_conference_data():
+    mock_service = _create_mock_service()
+    mock_service.events().get().execute = Mock(
+        return_value={
+            "id": "evt123",
+            "summary": "Sync",
+            "start": {"dateTime": "2026-04-06T09:00:00Z"},
+            "end": {"dateTime": "2026-04-06T09:30:00Z"},
+        }
+    )
+    mock_service.events().update().execute = Mock(
+        return_value={"id": "evt123", "htmlLink": "link", "summary": "Renamed"}
+    )
+
+    await _modify_event_impl(
+        service=mock_service,
+        user_google_email="user@example.com",
+        event_id="evt123",
+        summary="Renamed",
+    )
+
+    call = mock_service.events().update.call_args
+    assert "conferenceData" not in call[1]["body"]
+    assert call[1]["conferenceDataVersion"] == 0
+
+
+@pytest.mark.asyncio
+async def test_update_event_conference_data_takes_precedence_over_meet():
+    mock_service = _create_mock_service()
+    mock_service.events().get().execute = Mock(
+        return_value={
+            "id": "evt123",
+            "summary": "Sync",
+            "start": {"dateTime": "2026-04-06T09:00:00Z"},
+            "end": {"dateTime": "2026-04-06T09:30:00Z"},
+        }
+    )
+    mock_service.events().update().execute = Mock(
+        return_value={"id": "evt123", "htmlLink": "link", "summary": "Sync"}
+    )
+
+    teams_payload = {
+        "entryPoints": [
+            {"entryPointType": "video", "uri": "https://teams.microsoft.com/l/x"}
+        ]
+    }
+
+    await _modify_event_impl(
+        service=mock_service,
+        user_google_email="user@example.com",
+        event_id="evt123",
+        add_google_meet=True,
+        conference_data=teams_payload,
+    )
+
+    call = mock_service.events().update.call_args
+    assert call[1]["body"]["conferenceData"] == teams_payload
+    assert "createRequest" not in call[1]["body"]["conferenceData"]
+    assert call[1]["conferenceDataVersion"] == 1
+
+
+@pytest.mark.asyncio
+async def test_update_event_preserves_start_end_when_omitted():
+    """description-only update should not lose existing start/end."""
+    mock_service = _create_mock_service()
+    existing_start = {"dateTime": "2026-04-06T09:00:00+09:00", "timeZone": "Asia/Seoul"}
+    existing_end = {"dateTime": "2026-04-06T10:00:00+09:00", "timeZone": "Asia/Seoul"}
+    mock_service.events().get().execute = Mock(
+        return_value={
+            "id": "evt123",
+            "summary": "Sync",
+            "start": existing_start,
+            "end": existing_end,
+        }
+    )
+    mock_service.events().update().execute = Mock(
+        return_value={"id": "evt123", "htmlLink": "link", "summary": "Sync"}
+    )
+
+    await _modify_event_impl(
+        service=mock_service,
+        user_google_email="user@example.com",
+        event_id="evt123",
+        description="updated description only",
+    )
+
+    update_body = mock_service.events().update.call_args[1]["body"]
+    assert update_body["start"] == existing_start
+    assert update_body["end"] == existing_end
+    assert update_body["description"] == "updated description only"

--- a/tests/gcalendar/test_manage_event.py
+++ b/tests/gcalendar/test_manage_event.py
@@ -36,6 +36,86 @@ def _create_mock_service():
 
 
 @pytest.mark.asyncio
+async def test_create_event_passes_conference_data_verbatim():
+    mock_service = _create_mock_service()
+    mock_service.events().insert().execute = Mock(
+        return_value={"id": "evt123", "htmlLink": "link", "summary": "Sync"}
+    )
+
+    teams_payload = {
+        "entryPoints": [
+            {
+                "entryPointType": "video",
+                "uri": "https://teams.microsoft.com/l/meetup-join/abc",
+                "label": "Microsoft Teams",
+            }
+        ]
+    }
+
+    await _create_event_impl(
+        service=mock_service,
+        user_google_email="user@example.com",
+        summary="Sync",
+        start_time="2026-04-06T09:00:00Z",
+        end_time="2026-04-06T09:30:00Z",
+        conference_data=teams_payload,
+    )
+
+    call = mock_service.events().insert.call_args
+    assert call[1]["body"]["conferenceData"] == teams_payload
+    assert call[1]["conferenceDataVersion"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_event_default_omits_conference_data():
+    mock_service = _create_mock_service()
+    mock_service.events().insert().execute = Mock(
+        return_value={"id": "evt123", "htmlLink": "link", "summary": "Sync"}
+    )
+
+    await _create_event_impl(
+        service=mock_service,
+        user_google_email="user@example.com",
+        summary="Sync",
+        start_time="2026-04-06T09:00:00Z",
+        end_time="2026-04-06T09:30:00Z",
+    )
+
+    call = mock_service.events().insert.call_args
+    assert "conferenceData" not in call[1]["body"]
+    assert call[1]["conferenceDataVersion"] == 0
+
+
+@pytest.mark.asyncio
+async def test_create_event_conference_data_takes_precedence_over_meet():
+    mock_service = _create_mock_service()
+    mock_service.events().insert().execute = Mock(
+        return_value={"id": "evt123", "htmlLink": "link", "summary": "Sync"}
+    )
+
+    teams_payload = {
+        "entryPoints": [
+            {"entryPointType": "video", "uri": "https://teams.microsoft.com/l/x"}
+        ]
+    }
+
+    await _create_event_impl(
+        service=mock_service,
+        user_google_email="user@example.com",
+        summary="Sync",
+        start_time="2026-04-06T09:00:00Z",
+        end_time="2026-04-06T09:30:00Z",
+        add_google_meet=True,
+        conference_data=teams_payload,
+    )
+
+    call = mock_service.events().insert.call_args
+    assert call[1]["body"]["conferenceData"] == teams_payload
+    assert "createRequest" not in call[1]["body"]["conferenceData"]
+    assert call[1]["conferenceDataVersion"] == 1
+
+
+@pytest.mark.asyncio
 async def test_create_event_supports_recurrence():
     mock_service = _create_mock_service()
     mock_service.events().insert().execute = Mock(


### PR DESCRIPTION
## Summary

Adds `conference_data` support to the `manage_event` **update** path, mirroring what `_create_event_impl` already accepts on the **create** path. This lets callers replace the conference link of an already-registered event with a caller-supplied payload (e.g. Microsoft Teams `entryPoints`), and protects description-only updates from losing the existing `start`/`end`.

This PR contains two commits:

1. `cf74ca4` — adds `conference_data` to **create** path (`_create_event_impl` / `manage_event` create branch)
2. `27750f8` — mirrors the same support to the **update** path

## Background

`_create_event_impl` already accepted a `conference_data` payload that lets callers attach an arbitrary `entryPoints` array. The mirrored update path was missing, so:

- callers could attach Teams/Webex links at creation but had no way to change them on an existing event
- the early `if not event_body` guard rejected updates that only changed conference data
- `_preserve_existing_fields` did not preserve `start`/`end`, so a description-only update sent through `events().update()` (PUT, full replace) could occasionally clear them depending on the caller

## Changes (update path commit)

1. Add `conference_data: Optional[Dict[str, Any]] = None` to `_modify_event_impl`, mirroring the create-path signature
2. Propagate `conference_data` from `manage_event` action=`update` branch to `_modify_event_impl`
3. Make `conferenceDataVersion` conditional in the `events().update()` call (`1` if `conference_data` or `add_google_meet` is set, else `0`) — matches create-path semantics
4. Preserve existing `start`/`end` (which carry `timeZone`) in `_preserve_existing_fields` so description-only updates do not lose them
5. Loosen the early "No fields provided to modify the event" guard so updates that only change conference data are allowed
6. Add 4 pytest cases in `tests/gcalendar/test_manage_event.py` mirroring the create-path coverage

## Precedence (same as create)

- `conference_data` set → used verbatim, `add_google_meet` is ignored (with log line)
- `add_google_meet=True` and no `conference_data` → Meet `createRequest`
- `add_google_meet=False` → `conferenceData` cleared
- both `None` → existing event's `conferenceData` preserved

## Tests

\`\`\`
14 passed in 1.81s
\`\`\`

(10 existing + 4 new cases for the update path: `verbatim`, `default omission`, `precedence over add_google_meet`, `start/end preservation`.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar events accept caller-supplied conference data and allow conference-only updates.

* **Behavior Changes**
  * Supplied conference data takes precedence over automatic meeting creation; auto-create/confirmation is suppressed for supplied conference data.
  * Conference metadata versioning is now set dynamically to reflect whether conference data is present.

* **Tests**
  * Added tests for conference data handling in create and update flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->