### PR TITLE
feat(gmail): add list_gmail_drafts and delete_gmail_draft tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,8 @@ cp .env.oauth21 .env
 | <sub>`manage_gmail_label`</sub> | <sub>Extended</sub> | <sub>Create/update/delete labels</sub> |
 | <sub>`manage_gmail_filter`</sub> | <sub>Extended</sub> | <sub>Create or delete Gmail filters</sub> |
 | <sub>`draft_gmail_message`</sub> | <sub>Extended</sub> | <sub>Create drafts</sub> |
+| <sub>`list_gmail_drafts`</sub> | <sub>Extended</sub> | <sub>List drafts with subject/recipients</sub> |
+| <sub>`delete_gmail_draft`</sub> | <sub>Extended</sub> | <sub>Permanently delete a draft</sub> |
 | <sub>`get_gmail_threads_content_batch`</sub> | <sub>Complete</sub> | <sub>Batch retrieve thread content</sub> |
 | <sub>`batch_modify_gmail_message_labels`</sub> | <sub>Complete</sub> | <sub>Batch modify labels</sub> |
 | <sub>`start_google_auth`</sub> | <sub>Complete</sub> | <sub>Legacy OAuth 2.0 auth (disabled when OAuth 2.1 is enabled)</sub> |

--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -12,6 +12,8 @@ gmail:
     - list_gmail_labels
     - manage_gmail_label
     - draft_gmail_message
+    - list_gmail_drafts
+    - delete_gmail_draft
     - list_gmail_filters
     - manage_gmail_filter
 

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2479,6 +2479,180 @@ def _format_thread_content(
 
 
 @server.tool(
+    title="List Gmail Drafts",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("list_gmail_drafts", is_read_only=True, service_type="gmail")
+@require_google_service("gmail", GMAIL_COMPOSE_SCOPE)
+async def list_gmail_drafts(
+    service,
+    user_google_email: str,
+    query: Annotated[
+        Optional[str],
+        Field(
+            description="Optional Gmail search query to filter drafts (same syntax as Gmail search, e.g. 'subject:invoice', 'to:user@example.com').",
+        ),
+    ] = None,
+    page_size: Annotated[
+        int,
+        Field(
+            description="Maximum number of drafts to return. Defaults to 25.",
+        ),
+    ] = 25,
+    page_token: Annotated[
+        Optional[str],
+        Field(
+            description="Token for retrieving the next page of results. Use the next_page_token from a previous response.",
+        ),
+    ] = None,
+) -> str:
+    """
+    Lists drafts in the user's Gmail account, optionally filtered by a Gmail search query.
+
+    For each draft, returns the Draft ID along with the underlying message's Subject,
+    From, To, and a short snippet so you can identify which draft is which without
+    needing to fetch each one separately.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        query (Optional[str]): Optional Gmail search query to filter the drafts list.
+        page_size (int): Maximum number of drafts to return. Defaults to 25.
+        page_token (Optional[str]): Pagination token from a previous response.
+
+    Returns:
+        str: A formatted list of drafts with their Draft IDs and key headers, or a
+            message indicating no drafts were found.
+    """
+    logger.info(
+        f"[list_gmail_drafts] Invoked. Email: '{user_google_email}', Query: '{query}', PageSize: {page_size}"
+    )
+
+    list_kwargs = {"userId": "me", "maxResults": page_size}
+    if query:
+        list_kwargs["q"] = query
+    if page_token:
+        list_kwargs["pageToken"] = page_token
+
+    response = await asyncio.to_thread(
+        service.users().drafts().list(**list_kwargs).execute
+    )
+
+    drafts = response.get("drafts", [])
+    next_page_token = response.get("nextPageToken")
+
+    if not drafts:
+        suffix = f" matching '{query}'" if query else ""
+        return f"No drafts found{suffix}."
+
+    lines = [f"Found {len(drafts)} draft(s)" + (f" matching '{query}'" if query else "") + ":\n"]
+
+    metadata_headers = ["Subject", "From", "To", "Cc", "Date"]
+    for idx, draft_stub in enumerate(drafts, 1):
+        draft_id = draft_stub.get("id")
+        try:
+            draft_full = await asyncio.to_thread(
+                service.users()
+                .drafts()
+                .get(
+                    userId="me",
+                    id=draft_id,
+                    format="metadata",
+                    metadataHeaders=metadata_headers,
+                )
+                .execute
+            )
+            message = draft_full.get("message", {})
+            payload = message.get("payload", {})
+            headers = {
+                h["name"]: h["value"] for h in payload.get("headers", [])
+            }
+            subject = headers.get("Subject", "(no subject)")
+            from_addr = headers.get("From", "(no sender)")
+            to_addr = headers.get("To", "(no recipient)")
+            cc_addr = headers.get("Cc")
+            date = headers.get("Date", "")
+            snippet = message.get("snippet", "")[:120]
+            message_id = message.get("id", "")
+            thread_id = message.get("threadId", "")
+
+            lines.append(f"{idx}. Draft ID: {draft_id}")
+            lines.append(f"   Subject: {subject}")
+            lines.append(f"   From: {from_addr}")
+            lines.append(f"   To: {to_addr}")
+            if cc_addr:
+                lines.append(f"   Cc: {cc_addr}")
+            if date:
+                lines.append(f"   Date: {date}")
+            lines.append(f"   Message ID: {message_id}")
+            if thread_id and thread_id != message_id:
+                lines.append(f"   Thread ID: {thread_id}")
+            if snippet:
+                lines.append(f"   Snippet: {snippet}")
+            lines.append("")
+        except HttpError as e:
+            lines.append(f"{idx}. Draft ID: {draft_id} (failed to fetch metadata: {e})")
+            lines.append("")
+
+    if next_page_token:
+        lines.append(
+            f"\nNext page available. Call list_gmail_drafts again with page_token='{next_page_token}' to retrieve the next page."
+        )
+
+    return "\n".join(lines).rstrip()
+
+
+@server.tool(
+    title="Delete Gmail Draft",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("delete_gmail_draft", service_type="gmail")
+@require_google_service("gmail", GMAIL_COMPOSE_SCOPE)
+async def delete_gmail_draft(
+    service,
+    user_google_email: str,
+    draft_id: Annotated[
+        str,
+        Field(
+            description="The ID of the draft to permanently delete. Get this from list_gmail_drafts or from the return value of draft_gmail_message.",
+        ),
+    ],
+) -> str:
+    """
+    Permanently deletes a draft email from the user's Gmail account.
+
+    This wraps the Gmail API's drafts.delete endpoint, which removes both the draft
+    container and its underlying message. The operation cannot be undone — the draft
+    is not moved to Trash, it is deleted outright.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        draft_id (str): The ID of the draft to delete.
+
+    Returns:
+        str: Confirmation that the draft was deleted.
+    """
+    logger.info(
+        f"[delete_gmail_draft] Invoked. Email: '{user_google_email}', Draft ID: '{draft_id}'"
+    )
+
+    await asyncio.to_thread(
+        service.users().drafts().delete(userId="me", id=draft_id).execute
+    )
+
+    return f"Draft {draft_id} deleted successfully."
+
+
+@server.tool(
     title="Get Gmail Thread Content",
     annotations=ToolAnnotations(
         readOnlyHint=True,

--- a/tests/gmail/test_list_and_delete_drafts.py
+++ b/tests/gmail/test_list_and_delete_drafts.py
@@ -1,0 +1,142 @@
+"""Tests for list_gmail_drafts and delete_gmail_draft tools."""
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gmail.gmail_tools import (  # noqa: E402
+    delete_gmail_draft,
+    list_gmail_drafts,
+)
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _draft_metadata(draft_id, subject, to, from_addr="user@example.com", snippet=""):
+    return {
+        "id": draft_id,
+        "message": {
+            "id": f"msg_{draft_id}",
+            "threadId": f"thread_{draft_id}",
+            "snippet": snippet,
+            "payload": {
+                "headers": [
+                    {"name": "Subject", "value": subject},
+                    {"name": "From", "value": from_addr},
+                    {"name": "To", "value": to},
+                ]
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_gmail_drafts_returns_formatted_drafts():
+    mock_service = Mock()
+    mock_service.users().drafts().list().execute.return_value = {
+        "drafts": [
+            {"id": "r123", "message": {"id": "msg_r123", "threadId": "t1"}},
+            {"id": "r456", "message": {"id": "msg_r456", "threadId": "t2"}},
+        ]
+    }
+    mock_service.users().drafts().get().execute.side_effect = [
+        _draft_metadata("r123", "First draft", "alice@example.com", snippet="Hi Alice"),
+        _draft_metadata("r456", "Second draft", "bob@example.com", snippet="Hi Bob"),
+    ]
+
+    result = await _unwrap(list_gmail_drafts)(
+        service=mock_service,
+        user_google_email="user@example.com",
+    )
+
+    assert "Found 2 draft(s)" in result
+    assert "Draft ID: r123" in result
+    assert "First draft" in result
+    assert "alice@example.com" in result
+    assert "Draft ID: r456" in result
+    assert "Second draft" in result
+    assert "bob@example.com" in result
+
+
+@pytest.mark.asyncio
+async def test_list_gmail_drafts_empty_account():
+    mock_service = Mock()
+    mock_service.users().drafts().list().execute.return_value = {}
+
+    result = await _unwrap(list_gmail_drafts)(
+        service=mock_service,
+        user_google_email="user@example.com",
+    )
+
+    assert result == "No drafts found."
+
+
+@pytest.mark.asyncio
+async def test_list_gmail_drafts_passes_query_to_api():
+    mock_service = Mock()
+    mock_service.users().drafts().list().execute.return_value = {}
+
+    result = await _unwrap(list_gmail_drafts)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="subject:invoice",
+    )
+
+    assert "matching 'subject:invoice'" in result
+    list_kwargs = (
+        mock_service.users.return_value.drafts.return_value.list.call_args.kwargs
+    )
+    assert list_kwargs["q"] == "subject:invoice"
+    assert list_kwargs["userId"] == "me"
+
+
+@pytest.mark.asyncio
+async def test_list_gmail_drafts_propagates_page_token():
+    mock_service = Mock()
+    mock_service.users().drafts().list().execute.return_value = {
+        "drafts": [{"id": "r1", "message": {"id": "msg_r1", "threadId": "t1"}}],
+        "nextPageToken": "token-next",
+    }
+    mock_service.users().drafts().get().execute.return_value = _draft_metadata(
+        "r1", "Subject", "to@example.com"
+    )
+
+    result = await _unwrap(list_gmail_drafts)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        page_token="token-current",
+    )
+
+    list_kwargs = (
+        mock_service.users.return_value.drafts.return_value.list.call_args.kwargs
+    )
+    assert list_kwargs["pageToken"] == "token-current"
+    assert "page_token='token-next'" in result
+
+
+@pytest.mark.asyncio
+async def test_delete_gmail_draft_calls_api_and_confirms():
+    mock_service = Mock()
+    mock_service.users().drafts().delete().execute.return_value = None
+
+    result = await _unwrap(delete_gmail_draft)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        draft_id="r_abc123",
+    )
+
+    assert "Draft r_abc123 deleted successfully." == result
+    delete_kwargs = (
+        mock_service.users.return_value.drafts.return_value.delete.call_args.kwargs
+    )
+    assert delete_kwargs["id"] == "r_abc123"
+    assert delete_kwargs["userId"] == "me"


### PR DESCRIPTION
## Summary

Adds two tools that surface Gmail API endpoints not currently exposed by this server:

- **`list_gmail_drafts`** — wraps `users.drafts.list` with optional Gmail-search query filtering and pagination. For each draft, resolves the underlying message metadata (Subject, From, To, Cc, Date, snippet, message/thread IDs) so callers can identify drafts without an extra round-trip.
- **`delete_gmail_draft`** — wraps `users.drafts.delete`, permanently removing the draft container and its underlying message.

Both tools live at the `gmail.compose` permission level (same scope as the existing `draft_gmail_message`), so they require no new scopes when granted at the `drafts` service level or above. Both are registered in the `extended` tier in `core/tool_tiers.yaml` and added to the README tools table.

## Motivation

Today the only draft-related tool is `draft_gmail_message`. Once a draft is created there's no way through MCP to enumerate drafts or remove them, which means anything that creates a draft (e.g. an agent preparing emails for human review) accumulates clutter that the user has to clean up by hand in the Gmail web UI. Adding these two endpoints closes the gap and keeps the draft lifecycle self-contained within the server's existing scope grant.

## Test plan

- [x] Unit tests added in `tests/gmail/test_list_and_delete_drafts.py` covering:
  - formatted output for a non-empty draft list (Subject/From/To resolution)
  - empty-account case (`No drafts found.`)
  - propagation of `query` parameter to `users.drafts.list`
  - propagation of `page_token` and emission of `nextPageToken` instructions
  - `delete_gmail_draft` invokes `users.drafts.delete` with the correct `id` and `userId`
- [x] Full `tests/gmail/` suite passes (119 tests) locally
- [x] `ruff check` clean on touched files

## Notes

- `list_gmail_drafts` makes one `drafts.list` call plus one `drafts.get` per returned draft. For typical drafts folders this is small; users with very large drafts folders should rely on `query` filtering or `page_size` to keep the round-trip count bounded. A future improvement could batch the `drafts.get` calls through Gmail's HTTP batch endpoint.
- `delete_gmail_draft` is annotated `destructiveHint=True, idempotentHint=True`. Idempotent because deleting a non-existent draft returns a 404 that `handle_http_errors` surfaces predictably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * List Gmail drafts with optional search filtering and configurable pagination
  * Permanently delete specific Gmail drafts by ID
  * View draft metadata including subject, recipients, and date information

* **Documentation**
  * Updated tool reference documentation to include new draft management capabilities

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/781)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->