### PR TITLE
feat(oauth): separate port for stdio-mode OAuth callback server

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -1278,7 +1278,7 @@ async def get_authenticated_google_service(
             success, error_msg = await asyncio.to_thread(
                 ensure_oauth_callback_available,
                 transport_mode,
-                config.port,
+                config.oauth_callback_port,
                 config.base_uri,
             )
             if not success:

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -229,7 +229,16 @@ class MinimalOAuthServer:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.bind((hostname, self.port))
         except OSError:
-            error_msg = f"Port {self.port} is already in use on {hostname}. Cannot start minimal OAuth server."
+            error_msg = (
+                f"Port {self.port} is already in use on {hostname}. "
+                f"This typically means the previous Workspace MCP server is still "
+                f"holding the port, or you are running the MCP server and the OAuth "
+                f"callback server on the same port. Set "
+                f"WORKSPACE_MCP_OAUTH_CALLBACK_PORT to a different port and register "
+                f"the matching redirect URI (http://{hostname}:<callback_port>/oauth2callback) "
+                f"in your Google Cloud Console OAuth client. Cannot start minimal "
+                f"OAuth server."
+            )
             logger.error(error_msg)
             return False, error_msg
 

--- a/auth/oauth_config.py
+++ b/auth/oauth_config.py
@@ -29,6 +29,16 @@ class OAuthConfig:
         self.port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", "8000")))
         self.base_url = f"{self.base_uri}:{self.port}"
 
+        # Separate port for the stdio-mode OAuth callback server. Defaults to the
+        # main MCP port for backward compatibility. Set
+        # WORKSPACE_MCP_OAUTH_CALLBACK_PORT to a different port to avoid the
+        # callback server conflicting with the main server (e.g., when the main
+        # server is already listening on self.port when an OAuth refresh fires).
+        self.oauth_callback_port = int(
+            os.getenv("WORKSPACE_MCP_OAUTH_CALLBACK_PORT", str(self.port))
+        )
+        self.oauth_callback_base_url = f"{self.base_uri}:{self.oauth_callback_port}"
+
         # External URL for reverse proxy scenarios
         self.external_url = os.getenv("WORKSPACE_EXTERNAL_URL")
 
@@ -103,13 +113,17 @@ class OAuthConfig:
         """
         Get the OAuth redirect URI, supporting reverse proxy configurations.
 
+        When WORKSPACE_MCP_OAUTH_CALLBACK_PORT is set to a value different from
+        the main MCP port, the redirect URI is built from the callback port so
+        that the URI matches the host:port that the callback server will bind.
+
         Returns:
             The configured redirect URI
         """
         explicit_uri = os.getenv("GOOGLE_OAUTH_REDIRECT_URI")
         if explicit_uri:
             return explicit_uri
-        return f"{self.base_url}/oauth2callback"
+        return f"{self.oauth_callback_base_url}/oauth2callback"
 
     @staticmethod
     def _get_redirect_path(uri: str) -> str:

--- a/core/server.py
+++ b/core/server.py
@@ -723,7 +723,7 @@ async def start_google_auth(
             success, error_msg = await asyncio.to_thread(
                 ensure_oauth_callback_available,
                 transport_mode,
-                config.port,
+                config.oauth_callback_port,
                 config.base_uri,
             )
             if not success:

--- a/main.py
+++ b/main.py
@@ -723,7 +723,6 @@ def main():
             # Start minimal OAuth callback server for stdio mode (not needed for service accounts)
             if not is_service_account_enabled():
                 from auth.oauth_callback_server import ensure_oauth_callback_available
-                from auth.oauth_config import get_oauth_config
 
                 callback_port = get_oauth_config().oauth_callback_port
                 success, error_msg = ensure_oauth_callback_available(

--- a/main.py
+++ b/main.py
@@ -723,9 +723,11 @@ def main():
             # Start minimal OAuth callback server for stdio mode (not needed for service accounts)
             if not is_service_account_enabled():
                 from auth.oauth_callback_server import ensure_oauth_callback_available
+                from auth.oauth_config import get_oauth_config
 
+                callback_port = get_oauth_config().oauth_callback_port
                 success, error_msg = ensure_oauth_callback_available(
-                    "stdio", port, base_uri
+                    "stdio", callback_port, base_uri
                 )
                 if success:
                     safe_print(

--- a/tests/core/test_start_google_auth.py
+++ b/tests/core/test_start_google_auth.py
@@ -57,7 +57,7 @@ async def test_start_google_auth_preflights_in_stdio(monkeypatch):
     monkeypatch.setattr("core.server.start_auth_flow", fake_start_auth_flow)
     monkeypatch.setattr(
         "auth.oauth_config.get_oauth_config",
-        lambda: SimpleNamespace(port=8000, base_uri="http://localhost"),
+        lambda: SimpleNamespace(port=8000, oauth_callback_port=8000, base_uri="http://localhost"),
     )
     monkeypatch.setattr(
         "auth.oauth_callback_server.ensure_oauth_callback_available",


### PR DESCRIPTION
## Problem

In stdio mode, the `MinimalOAuthServer` binds the same port as the main MCP server. When an OAuth refresh fires while the main server is already listening (e.g., the wrapper pins `WORKSPACE_MCP_PORT=18765` to avoid `PORT` collisions and that port is held by a prior process), the callback server cannot bind and dies with:

```
Port 18765 is already in use on localhost. Cannot start minimal OAuth server.
```

This is recurring for users whose OAuth consent screen is in Testing mode (refresh tokens expire every 7 days, forcing weekly re-auth) and is non-obvious to debug because the error points at the symptom rather than the cause.

## Fix

Add `WORKSPACE_MCP_OAUTH_CALLBACK_PORT` env var so the callback server can bind a separate port from the main MCP server. Defaults to the main port for backward compatibility. Updates redirect URI derivation, the three call sites that preflight the callback server, and the port-in-use error message.

## Tests

All 133 tests in `tests/auth` and `tests/core` pass (excluding unrelated `test_gcs_credential_store` collection error from missing optional dep). Mock SimpleNamespace in `test_start_google_auth.py` updated with the new attribute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth callback server now supports a separate dedicated port for greater flexibility in network setups.

* **Bug Fixes**
  * Improved error messaging when the OAuth callback port is unavailable, with clearer causes and guidance including the expected redirect URI format.

* **Tests**
  * Updated tests to account for the separate callback port behavior during OAuth preflight checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/787)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->