### PR TITLE
search_drive_files: surface lastModifyingUser, createdTime, and anyon…

### DIFF
--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -207,7 +207,12 @@ def build_drive_list_params(
         Dictionary of parameters for Drive API list calls
     """
     if detailed:
-        fields = "nextPageToken, files(id, name, mimeType, webViewLink, iconLink, modifiedTime, size, driveId)"
+        fields = (
+            "nextPageToken, files(id, name, mimeType, webViewLink, iconLink,"
+            " modifiedTime, createdTime, size, driveId,"
+            " lastModifyingUser(displayName, emailAddress),"
+            " permissions(id, type, role))"
+        )
     else:
         fields = "nextPageToken, files(id, name, mimeType)"
     list_params = {

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -235,8 +235,44 @@ async def search_drive_files(
     for item in files:
         if detailed:
             size_str = f", Size: {item.get('size', 'N/A')}" if "size" in item else ""
+            created_str = (
+                f", Created: {item['createdTime']}"
+                if item.get("createdTime")
+                else ""
+            )
+            # Last modifying user (not available for all files)
+            lmu = item.get("lastModifyingUser")
+            if lmu:
+                lmu_name = lmu.get("displayName", "")
+                lmu_email = lmu.get("emailAddress", "")
+                if lmu_name and lmu_email:
+                    last_edited_by_str = f", Last Edited By: {lmu_name} <{lmu_email}>"
+                elif lmu_name:
+                    last_edited_by_str = f", Last Edited By: {lmu_name}"
+                elif lmu_email:
+                    last_edited_by_str = f", Last Edited By: {lmu_email}"
+                else:
+                    last_edited_by_str = ""
+            else:
+                last_edited_by_str = ""
+            # Anyone-with-link permission role (reader/commenter/writer)
+            anyone_role_str = ""
+            for perm in item.get("permissions", []):
+                if perm.get("type") == "anyone":
+                    anyone_role_str = (
+                        f", Anyone with link: {perm.get('role', 'unknown')}"
+                    )
+                    break
+            # TODO: "Created By" (original file creator) is not included here.
+            # For Shared Drive files the `owners` field is always empty — the drive
+            # owns the file.  True creator attribution requires fetching revision 1
+            # via files/{id}/revisions and reading its lastModifyingUser.  That adds
+            # one API call per file and should be a separate follow-up.
             formatted_files_text_parts.append(
-                f'- Name: "{item["name"]}" (ID: {item["id"]}, Type: {item["mimeType"]}{size_str}, Modified: {item.get("modifiedTime", "N/A")}) Link: {item.get("webViewLink", "#")}'
+                f'- Name: "{item["name"]}" (ID: {item["id"]}, Type: {item["mimeType"]}{size_str}'
+                f'{created_str}, Modified: {item.get("modifiedTime", "N/A")}'
+                f"{last_edited_by_str}{anyone_role_str})"
+                f' Link: {item.get("webViewLink", "#")}'
             )
         else:
             formatted_files_text_parts.append(

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -338,6 +338,9 @@ def _make_file(
     modified: str = "2024-01-01T00:00:00Z",
     size: str | None = None,
     drive_id: str | None = None,
+    created: str | None = None,
+    last_modifying_user: dict | None = None,
+    permissions: list | None = None,
 ) -> dict:
     item = {
         "id": file_id,
@@ -350,6 +353,12 @@ def _make_file(
         item["size"] = size
     if drive_id is not None:
         item["driveId"] = drive_id
+    if created is not None:
+        item["createdTime"] = created
+    if last_modifying_user is not None:
+        item["lastModifyingUser"] = last_modifying_user
+    if permissions is not None:
+        item["permissions"] = permissions
     return item
 
 
@@ -398,12 +407,15 @@ async def test_create_drive_folder():
 
 
 def test_build_params_detailed_true_includes_extra_fields():
-    """detailed=True requests modifiedTime, webViewLink, size, and driveId from the API."""
+    """detailed=True requests modifiedTime, webViewLink, size, driveId, and new metadata from the API."""
     params = build_drive_list_params(query="name='x'", page_size=10, detailed=True)
     assert "modifiedTime" in params["fields"]
     assert "webViewLink" in params["fields"]
     assert "size" in params["fields"]
     assert "driveId" in params["fields"]
+    assert "createdTime" in params["fields"]
+    assert "lastModifyingUser" in params["fields"]
+    assert "permissions" in params["fields"]
 
 
 def test_build_params_detailed_false_omits_extra_fields():
@@ -413,6 +425,9 @@ def test_build_params_detailed_false_omits_extra_fields():
     assert "webViewLink" not in params["fields"]
     assert "size" not in params["fields"]
     assert "driveId" not in params["fields"]
+    assert "createdTime" not in params["fields"]
+    assert "lastModifyingUser" not in params["fields"]
+    assert "permissions" not in params["fields"]
 
 
 def test_build_params_detailed_false_keeps_core_fields():
@@ -561,6 +576,150 @@ async def test_search_detailed_true_with_size():
 
 
 @pytest.mark.asyncio
+async def test_search_detailed_shows_created_time():
+    """detailed=True shows createdTime when present."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {
+        "files": [
+            _make_file(
+                "f1",
+                "Doc",
+                "application/vnd.google-apps.document",
+                created="2024-05-15T09:00:00Z",
+            )
+        ]
+    }
+
+    result = await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="doc",
+        detailed=True,
+    )
+
+    assert "Created: 2024-05-15T09:00:00Z" in result
+
+
+@pytest.mark.asyncio
+async def test_search_detailed_shows_last_modifying_user():
+    """detailed=True shows lastModifyingUser displayName and email."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {
+        "files": [
+            _make_file(
+                "f1",
+                "Doc",
+                "application/vnd.google-apps.document",
+                last_modifying_user={
+                    "displayName": "Alice Smith",
+                    "emailAddress": "alice@example.com",
+                },
+            )
+        ]
+    }
+
+    result = await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="doc",
+        detailed=True,
+    )
+
+    assert "Last Edited By: Alice Smith <alice@example.com>" in result
+
+
+@pytest.mark.asyncio
+async def test_search_detailed_shows_anyone_permission_role():
+    """detailed=True shows the role on an anyone-with-link permission."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {
+        "files": [
+            _make_file(
+                "f1",
+                "Public Doc",
+                "application/vnd.google-apps.document",
+                permissions=[
+                    {"id": "anyoneWithLink", "type": "anyone", "role": "writer"},
+                ],
+            )
+        ]
+    }
+
+    result = await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="public",
+        detailed=True,
+    )
+
+    assert "Anyone with link: writer" in result
+
+
+@pytest.mark.asyncio
+async def test_search_detailed_no_anyone_permission():
+    """When no anyone permission exists, the anyone-with-link field is absent."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {
+        "files": [
+            _make_file(
+                "f1",
+                "Private Doc",
+                "application/vnd.google-apps.document",
+                permissions=[
+                    {"id": "user123", "type": "user", "role": "writer"},
+                ],
+            )
+        ]
+    }
+
+    result = await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="private",
+        detailed=True,
+    )
+
+    assert "Anyone with link" not in result
+
+
+@pytest.mark.asyncio
+async def test_search_detailed_all_new_fields_together():
+    """All new metadata fields appear together in output."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {
+        "files": [
+            _make_file(
+                "f1",
+                "Full Doc",
+                "application/vnd.google-apps.document",
+                created="2024-03-01T10:00:00Z",
+                last_modifying_user={
+                    "displayName": "Bob",
+                    "emailAddress": "bob@example.com",
+                },
+                permissions=[
+                    {"id": "anyoneWithLink", "type": "anyone", "role": "reader"},
+                ],
+            )
+        ]
+    }
+
+    result = await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="full",
+        detailed=True,
+    )
+
+    assert "Created: 2024-03-01T10:00:00Z" in result
+    assert "Last Edited By: Bob <bob@example.com>" in result
+    assert "Anyone with link: reader" in result
+    # Existing fields still present
+    assert "Modified:" in result
+    assert "Link:" in result
+
+
+@pytest.mark.asyncio
 async def test_search_detailed_true_requests_extra_api_fields():
     """detailed=True passes full fields string to the Drive API."""
     mock_service = Mock()
@@ -577,6 +736,9 @@ async def test_search_detailed_true_requests_extra_api_fields():
     assert "modifiedTime" in call_kwargs["fields"]
     assert "webViewLink" in call_kwargs["fields"]
     assert "size" in call_kwargs["fields"]
+    assert "createdTime" in call_kwargs["fields"]
+    assert "lastModifyingUser" in call_kwargs["fields"]
+    assert "permissions" in call_kwargs["fields"]
 
 
 @pytest.mark.asyncio
@@ -596,6 +758,9 @@ async def test_search_detailed_false_requests_compact_api_fields():
     assert "modifiedTime" not in call_kwargs["fields"]
     assert "webViewLink" not in call_kwargs["fields"]
     assert "size" not in call_kwargs["fields"]
+    assert "createdTime" not in call_kwargs["fields"]
+    assert "lastModifyingUser" not in call_kwargs["fields"]
+    assert "permissions" not in call_kwargs["fields"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
…e-permission role (#1)

Expand the Drive API fields parameter and response formatter so that search_drive_files returns the metadata needed for public link audits: createdTime, lastModifyingUser (displayName + email), and the role on any "anyone" permission (reader/commenter/writer).

No OAuth scope changes required. Created By (via owners) is intentionally omitted for Shared Drive files — see TODO comment for the revisions API workaround.

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Add any other context about the pull request here.

---

**⚠️ IMPORTANT:** This repository requires that you enable "Allow edits from maintainers" when creating your pull request. This allows maintainers to make small fixes and improvements directly to your branch, speeding up the review process.

To enable this setting:
1. When creating the PR, check the "Allow edits from maintainers" checkbox
2. If you've already created the PR, you can enable this in the PR sidebar under "Allow edits from maintainers"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced detailed file information display to include creation date, last editor attribution (name and email), and "Anyone with link" sharing status.

* **Tests**
  * Expanded test coverage for new metadata fields in detailed file output and API field requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/791)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->