### PR TITLE
fix: try alternative ports when OAuth callback port is in use

### DIFF
--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -307,7 +307,9 @@ def ensure_oauth_callback_available(
     Ensure OAuth callback endpoint is available for the given transport mode.
 
     For streamable-http: Assumes the main server is already running
-    For stdio: Starts a minimal server if needed
+    For stdio: Starts a minimal server if needed, trying alternative ports
+               if the preferred port is already in use (common when multiple
+               Claude Code sessions each spawn their own MCP server instance).
 
     Args:
         transport_mode: "stdio" or "streamable-http"
@@ -357,9 +359,49 @@ def ensure_oauth_callback_available(
                     )
                     return True, ""
                 else:
-                    logger.error(
-                        f"Failed to start minimal OAuth server on {base_uri}:{port}: {error_msg}"
+                    # Port conflict — try alternative ports.  Google allows any
+                    # localhost port for loopback redirect URIs on installed /
+                    # desktop OAuth clients, so we can safely pick another port
+                    # without pre-registering it.  This is the common case when
+                    # multiple Claude Code sessions each spawn their own
+                    # workspace-mcp instance on the same machine.
+                    max_port_attempts = int(
+                        os.getenv("WORKSPACE_MCP_PORT_RANGE", "10")
                     )
+                    for alt_port in range(port + 1, port + max_port_attempts):
+                        logger.info(
+                            f"Port {_minimal_oauth_server.port} unavailable, "
+                            f"trying alternative port {alt_port}"
+                        )
+                        _minimal_oauth_server = MinimalOAuthServer(
+                            alt_port, base_uri
+                        )
+                        success, error_msg = _minimal_oauth_server.start()
+                        if success:
+                            # Update the OAuth config so the redirect URI
+                            # matches the port we actually bound.
+                            from auth.oauth_config import get_oauth_config
+
+                            config = get_oauth_config()
+                            config.port = alt_port
+                            config.base_url = f"{config.base_uri}:{alt_port}"
+                            config.redirect_uri = (
+                                f"{config.base_url}/oauth2callback"
+                            )
+                            logger.info(
+                                f"Minimal OAuth server started on alternative "
+                                f"port {alt_port}; redirect URI updated to "
+                                f"{config.redirect_uri}"
+                            )
+                            return True, ""
+
+                    # All ports failed
+                    error_msg = (
+                        f"Failed to start minimal OAuth server: ports "
+                        f"{port}-{port + max_port_attempts - 1} are all in use "
+                        f"on {base_uri}"
+                    )
+                    logger.error(error_msg)
                     return False, error_msg
             else:
                 logger.info("Minimal OAuth server is already running")

--- a/tests/auth/test_oauth_callback_server.py
+++ b/tests/auth/test_oauth_callback_server.py
@@ -142,6 +142,80 @@ def test_ensure_oauth_callback_skips_start_when_other_instance_owns_port(monkeyp
     assert _PortInUseServer.instances[0].start_calls == 0
 
 
+def test_ensure_oauth_callback_falls_back_to_alternative_port(monkeypatch):
+    """When the preferred port is in use, the server should try alternative ports."""
+
+    class _PortConflictServer(_DummyMinimalOAuthServer):
+        def start(self):
+            self.start_calls += 1
+            if self.port == 8000:
+                return False, "Port 8000 is already in use"
+            self.running = True
+            return True, ""
+
+    _PortConflictServer.instances = []
+    monkeypatch.setattr(oauth_callback_server, "_minimal_oauth_server", None)
+    monkeypatch.setattr(
+        oauth_callback_server,
+        "MinimalOAuthServer",
+        _PortConflictServer,
+    )
+
+    # Mock the oauth config so the redirect URI update doesn't fail
+    class _FakeOAuthConfig:
+        def __init__(self):
+            self.port = 8000
+            self.base_uri = "http://localhost"
+            self.base_url = "http://localhost:8000"
+            self.redirect_uri = "http://localhost:8000/oauth2callback"
+
+    fake_config = _FakeOAuthConfig()
+    monkeypatch.setattr(
+        "auth.oauth_config.get_oauth_config",
+        lambda: fake_config,
+    )
+
+    success, error = oauth_callback_server.ensure_oauth_callback_available(
+        "stdio", 8000, "http://localhost"
+    )
+
+    assert success is True
+    assert error == ""
+    # First instance tried port 8000 and failed, second got 8001
+    assert len(_PortConflictServer.instances) == 2
+    assert _PortConflictServer.instances[0].port == 8000
+    assert _PortConflictServer.instances[1].port == 8001
+    assert fake_config.port == 8001
+    assert fake_config.redirect_uri == "http://localhost:8001/oauth2callback"
+
+
+def test_ensure_oauth_callback_fails_when_all_ports_exhausted(monkeypatch):
+    """When all ports in the range are in use, the server should fail gracefully."""
+
+    class _AllPortsBusyServer(_DummyMinimalOAuthServer):
+        def start(self):
+            self.start_calls += 1
+            return False, f"Port {self.port} is already in use"
+
+    _AllPortsBusyServer.instances = []
+    monkeypatch.setattr(oauth_callback_server, "_minimal_oauth_server", None)
+    monkeypatch.setattr(
+        oauth_callback_server,
+        "MinimalOAuthServer",
+        _AllPortsBusyServer,
+    )
+    monkeypatch.setenv("WORKSPACE_MCP_PORT_RANGE", "3")
+
+    success, error = oauth_callback_server.ensure_oauth_callback_available(
+        "stdio", 8000, "http://localhost"
+    )
+
+    assert success is False
+    assert "8000-8002" in error
+    # Tried 8000 (original) + 8001, 8002 (alternatives) = created 3 instances
+    assert len(_AllPortsBusyServer.instances) == 3
+
+
 def test_oauth_callback_missing_state_fallback_follows_single_user_mode(monkeypatch):
     calls = []
 


### PR DESCRIPTION
## Summary

When multiple Claude Code sessions run on the same machine, each spawns its own `workspace-mcp` instance in stdio mode. The first instance binds port 8000 for the OAuth callback server; subsequent instances fail with "Port 8000 is already in use" and cannot complete any OAuth flow — even though cached credentials exist and the callback server is only needed for fresh auth.

This PR makes the OAuth callback server try alternative ports (8001, 8002, ...) when the preferred port is already in use, up to a configurable range (`WORKSPACE_MCP_PORT_RANGE` env var, default 10). Google allows any localhost port for loopback redirect URIs on installed/desktop OAuth clients ([RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3)), so no pre-registration is needed. The `OAuthConfig.redirect_uri` is updated dynamically to match the port that was actually bound.

## Changes

- **`auth/oauth_callback_server.py`**: In `ensure_oauth_callback_available()`, when `MinimalOAuthServer.start()` fails due to port conflict, iterate through alternative ports and update the OAuth config's redirect URI to match.
- **`tests/auth/test_oauth_callback_server.py`**: Two new tests — one for successful fallback to an alternative port, one for graceful failure when all ports are exhausted.

## Test plan

- [x] All 7 existing + new tests pass (`pytest tests/auth/test_oauth_callback_server.py`)
- [ ] Manual test: run two Claude Code sessions simultaneously, verify both can complete OAuth flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth callback server now automatically attempts alternative ports when the preferred port is unavailable, updating configuration to match the successfully bound port. If all ports fail, an error is logged.

* **Tests**
  * Added comprehensive test coverage for OAuth callback server port fallback behavior, including successful alternative port binding and port exhaustion scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/793)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->