### PR TITLE
fix(gcalendar): strip literal quotes and null sentinels in _correct_time_format_for_api

### DIFF
--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -305,11 +305,7 @@ def _correct_time_format_for_api(
         return None
 
     # Defensive normalization: some LLM-driven MCP clients double-encode JSON
-    # string arguments, passing values like '"2026-05-15T00:00:00Z"' (with
-    # literal quotes inside the string) or the literal string "null"/"None"
-    # instead of omitting the parameter. Strip outer quotes/whitespace and
-    # treat the null sentinels as absent so we don't ship the malformed value
-    # straight to the Calendar API (which would 400 Bad Request).
+    # string arguments, passing values like '"2026-05-15T00:00:00Z"'
     time_str = time_str.strip().strip('"').strip("'").strip()
     if not time_str or time_str.lower() in ("null", "none"):
         return None

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -304,6 +304,16 @@ def _correct_time_format_for_api(
     if not time_str:
         return None
 
+    # Defensive normalization: some LLM-driven MCP clients double-encode JSON
+    # string arguments, passing values like '"2026-05-15T00:00:00Z"' (with
+    # literal quotes inside the string) or the literal string "null"/"None"
+    # instead of omitting the parameter. Strip outer quotes/whitespace and
+    # treat the null sentinels as absent so we don't ship the malformed value
+    # straight to the Calendar API (which would 400 Bad Request).
+    time_str = time_str.strip().strip('"').strip("'").strip()
+    if not time_str or time_str.lower() in ("null", "none"):
+        return None
+
     logger.info(
         f"_correct_time_format_for_api: Processing {param_name} with value '{time_str}', timezone: '{timezone}'"
     )

--- a/tests/gcalendar/test_correct_time_format_for_api.py
+++ b/tests/gcalendar/test_correct_time_format_for_api.py
@@ -1,0 +1,61 @@
+"""
+Unit tests for _correct_time_format_for_api defensive input normalization.
+
+Covers the case where LLM-driven MCP clients double-encode JSON string args,
+passing values like '"2026-05-15T00:00:00Z"' with literal quotes inside the
+string, or the literal string "null"/"None" instead of omitting the param.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gcalendar.calendar_tools import _correct_time_format_for_api
+
+
+@pytest.mark.parametrize("empty", [None, "", "   "])
+def test_empty_returns_none(empty):
+    assert _correct_time_format_for_api(empty, "time_min") is None
+
+
+@pytest.mark.parametrize("sentinel", ['"null"', '"NULL"', "'null'", "null", "None", '"none"', "  null  "])
+def test_null_sentinel_returns_none(sentinel):
+    # Some clients pass the literal string "null"/"None" instead of omitting the param.
+    assert _correct_time_format_for_api(sentinel, "time_min") is None
+
+
+def test_plain_date_only_normalizes_to_rfc3339_utc():
+    assert _correct_time_format_for_api("2026-05-15", "time_min") == "2026-05-15T00:00:00Z"
+
+
+def test_double_quoted_date_only_is_stripped():
+    # The value the LLM emitted as `time_min: "2026-05-15"` ended up double-encoded
+    # into a string containing the literal quote characters.
+    assert _correct_time_format_for_api('"2026-05-15"', "time_min") == "2026-05-15T00:00:00Z"
+
+
+def test_single_quoted_date_only_is_stripped():
+    assert _correct_time_format_for_api("'2026-05-15'", "time_min") == "2026-05-15T00:00:00Z"
+
+
+def test_double_quoted_rfc3339_is_stripped():
+    # Real failure mode observed in the wild: timeMin arrived as the string
+    # `"2026-05-15T00:00:00Z"` with quotes inside the value, producing
+    # `timeMin=%222026-05-15T00:00:00Z%22` on the Calendar API request URL,
+    # which returns HTTP 400 Bad Request.
+    out = _correct_time_format_for_api('"2026-05-15T00:00:00Z"', "time_min")
+    assert out == "2026-05-15T00:00:00Z"
+
+
+def test_whitespace_and_quotes_combined_are_stripped():
+    out = _correct_time_format_for_api('  "2026-05-15T10:30:00Z"  ', "time_min")
+    assert out == "2026-05-15T10:30:00Z"
+
+
+def test_unquoted_rfc3339_passes_through():
+    # Regression: well-formed values must not be mangled.
+    out = _correct_time_format_for_api("2026-05-15T10:30:00Z", "time_min")
+    assert out == "2026-05-15T10:30:00Z"

--- a/tests/gcalendar/test_correct_time_format_for_api.py
+++ b/tests/gcalendar/test_correct_time_format_for_api.py
@@ -21,24 +21,34 @@ def test_empty_returns_none(empty):
     assert _correct_time_format_for_api(empty, "time_min") is None
 
 
-@pytest.mark.parametrize("sentinel", ['"null"', '"NULL"', "'null'", "null", "None", '"none"', "  null  "])
+@pytest.mark.parametrize(
+    "sentinel", ['"null"', '"NULL"', "'null'", "null", "None", '"none"', "  null  "]
+)
 def test_null_sentinel_returns_none(sentinel):
     # Some clients pass the literal string "null"/"None" instead of omitting the param.
     assert _correct_time_format_for_api(sentinel, "time_min") is None
 
 
 def test_plain_date_only_normalizes_to_rfc3339_utc():
-    assert _correct_time_format_for_api("2026-05-15", "time_min") == "2026-05-15T00:00:00Z"
+    assert (
+        _correct_time_format_for_api("2026-05-15", "time_min") == "2026-05-15T00:00:00Z"
+    )
 
 
 def test_double_quoted_date_only_is_stripped():
     # The value the LLM emitted as `time_min: "2026-05-15"` ended up double-encoded
     # into a string containing the literal quote characters.
-    assert _correct_time_format_for_api('"2026-05-15"', "time_min") == "2026-05-15T00:00:00Z"
+    assert (
+        _correct_time_format_for_api('"2026-05-15"', "time_min")
+        == "2026-05-15T00:00:00Z"
+    )
 
 
 def test_single_quoted_date_only_is_stripped():
-    assert _correct_time_format_for_api("'2026-05-15'", "time_min") == "2026-05-15T00:00:00Z"
+    assert (
+        _correct_time_format_for_api("'2026-05-15'", "time_min")
+        == "2026-05-15T00:00:00Z"
+    )
 
 
 def test_double_quoted_rfc3339_is_stripped():

--- a/tests/gcalendar/test_correct_time_format_for_api.py
+++ b/tests/gcalendar/test_correct_time_format_for_api.py
@@ -6,36 +6,31 @@ passing values like '"2026-05-15T00:00:00Z"' with literal quotes inside the
 string, or the literal string "null"/"None" instead of omitting the param.
 """
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from gcalendar.calendar_tools import _correct_time_format_for_api
 
 
 @pytest.mark.parametrize("empty", [None, "", "   "])
-def test_empty_returns_none(empty):
+def test_empty_returns_none(empty: str | None) -> None:
     assert _correct_time_format_for_api(empty, "time_min") is None
 
 
 @pytest.mark.parametrize(
     "sentinel", ['"null"', '"NULL"', "'null'", "null", "None", '"none"', "  null  "]
 )
-def test_null_sentinel_returns_none(sentinel):
+def test_null_sentinel_returns_none(sentinel: str) -> None:
     # Some clients pass the literal string "null"/"None" instead of omitting the param.
     assert _correct_time_format_for_api(sentinel, "time_min") is None
 
 
-def test_plain_date_only_normalizes_to_rfc3339_utc():
+def test_plain_date_only_normalizes_to_rfc3339_utc() -> None:
     assert (
         _correct_time_format_for_api("2026-05-15", "time_min") == "2026-05-15T00:00:00Z"
     )
 
 
-def test_double_quoted_date_only_is_stripped():
+def test_double_quoted_date_only_is_stripped() -> None:
     # The value the LLM emitted as `time_min: "2026-05-15"` ended up double-encoded
     # into a string containing the literal quote characters.
     assert (
@@ -44,14 +39,14 @@ def test_double_quoted_date_only_is_stripped():
     )
 
 
-def test_single_quoted_date_only_is_stripped():
+def test_single_quoted_date_only_is_stripped() -> None:
     assert (
         _correct_time_format_for_api("'2026-05-15'", "time_min")
         == "2026-05-15T00:00:00Z"
     )
 
 
-def test_double_quoted_rfc3339_is_stripped():
+def test_double_quoted_rfc3339_is_stripped() -> None:
     # Real failure mode observed in the wild: timeMin arrived as the string
     # `"2026-05-15T00:00:00Z"` with quotes inside the value, producing
     # `timeMin=%222026-05-15T00:00:00Z%22` on the Calendar API request URL,
@@ -60,12 +55,12 @@ def test_double_quoted_rfc3339_is_stripped():
     assert out == "2026-05-15T00:00:00Z"
 
 
-def test_whitespace_and_quotes_combined_are_stripped():
+def test_whitespace_and_quotes_combined_are_stripped() -> None:
     out = _correct_time_format_for_api('  "2026-05-15T10:30:00Z"  ', "time_min")
     assert out == "2026-05-15T10:30:00Z"
 
 
-def test_unquoted_rfc3339_passes_through():
+def test_unquoted_rfc3339_passes_through() -> None:
     # Regression: well-formed values must not be mangled.
     out = _correct_time_format_for_api("2026-05-15T10:30:00Z", "time_min")
     assert out == "2026-05-15T10:30:00Z"


### PR DESCRIPTION
## Summary

`_correct_time_format_for_api` currently forwards its input string verbatim to the Google Calendar API. Some LLM-driven MCP clients double-encode JSON string arguments and pass values like `"2026-05-15T00:00:00Z"` — with the literal quote characters _inside_ the string — or the literal string `"null"`/`"None"` instead of omitting the parameter.

The malformed value then reaches the API as e.g.

```
…/events?timeMin=%222026-05-15T00:00:00Z%22&timeMax=%22null%22
```

…and Google replies `400 Bad Request`, which surfaces to the user as a confusing "API error in get_events". Every `get_events` call from that client is broken until the value is normalized at the boundary.

## What this PR does

Defensive normalization in `_correct_time_format_for_api`:

- Strip outer whitespace and outer single/double quotes from the input string.
- Treat the literal strings `"null"` and `"none"` (case-insensitive) as absent (`None`), matching how `if not time_str` already short-circuits real empties.

Behavior on well-formed input is unchanged.

## Where the bad input actually came from

Observed in the wild driving **Qwen 3.5 9B** through the **OpenClaw** gateway as the MCP host:

- The LLM emits a syntactically-correct JSON tool call: `{"time_min": "2026-05-14T00:00:00Z"}`.
- Somewhere in the round-trip — likely the gateway's tool-args serialization — the value is JSON-encoded a second time, so `time_min` arrives at the MCP server as the Python string `'"2026-05-14T00:00:00Z"'` (length 22, leading + trailing `"`).
- `_correct_time_format_for_api` returns it untouched, the URL builder percent-encodes the embedded quotes, and the request 400s.

The same pattern — string-of-a-string args — also shows up for `"null"` when the model intended to omit the parameter.

Fixing it client-side in every offending MCP host is impractical; one defensive boundary in the tool is the smallest robust fix.

## Tests

Adds `tests/gcalendar/test_correct_time_format_for_api.py` with 16 parametrized + standalone cases:

- Empty / whitespace / `None` → `None`
- `"null"` / `'null'` / `"NULL"` / `"None"` / `"  null  "` → `None`
- `"2026-05-15"` (plain) → `"2026-05-15T00:00:00Z"`
- `'"2026-05-15"'` (double-quoted date) → `"2026-05-15T00:00:00Z"`
- `"'2026-05-15'"` (single-quoted date) → `"2026-05-15T00:00:00Z"`
- `'"2026-05-15T00:00:00Z"'` (double-quoted RFC3339, the exact wire bug) → `"2026-05-15T00:00:00Z"`
- `'  "2026-05-15T10:30:00Z"  '` (whitespace + quotes) → `"2026-05-15T10:30:00Z"`
- `"2026-05-15T10:30:00Z"` (well-formed) → unchanged (regression guard)

```
$ pytest tests/gcalendar/test_correct_time_format_for_api.py -v
============================== 16 passed in 1.28s ==============================

$ pytest tests/gcalendar/ -v
============================== 72 passed in 0.99s ==============================
```

`ruff check gcalendar/calendar_tools.py tests/gcalendar/test_correct_time_format_for_api.py` — clean.

## Scope

`gcalendar/calendar_tools.py` only. There are similar `time_str` boundaries in `query_freebusy` (already calls `_correct_time_format_for_api`) and other event endpoints — they all benefit from this fix transparently.

Happy to extend to a similar defensive layer in other tools (Gmail date filters, Drive `modifiedTime` queries) if you'd like, but I kept the scope narrow here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of malformed time/date inputs: trims whitespace, strips surrounding quotes, treats literal "null"/"none" (any casing/quoting/spacing) as absent, and normalizes date-only values to UTC midnight while preserving valid RFC3339 timestamps.

* **Tests**
  * Added tests validating sentinel values, whitespace/quote removal, date-only normalization, quoted timestamps, combined edge cases, and a regression case for valid timestamps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->