### PR TITLE
fixhance: protections for host binding on legacy oauth mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1334,6 +1334,8 @@ export DWD_ALLOWED_DOMAINS="corp.com,subsidiary.io"
 ```
 
 *Note: Make sure to start the server with `--transport streamable-http` when using VS Code MCP. For remote or shared HTTP endpoints, see the [OAuth 2.1 note in the HTTP Mode section](#http-mode-for-debugging-or-web-interfaces).*
+
+> **Origin validation**: VS Code webview clients send a `vscode-webview://<extension-id>` origin, which is rejected by default. Add the specific origin to `OAUTH_ALLOWED_ORIGINS` (e.g. `OAUTH_ALLOWED_ORIGINS=vscode-webview://your.extension-id`) to permit it. Connections to a `localhost`/`127.0.0.1` URL are allowed without extra configuration.
 </details>
 
 ### Claude Code MCP Client Support

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ uv run main.py --transport streamable-http --tools gmail drive calendar
 | **🖥️ Server** | | |
 | `WORKSPACE_MCP_BASE_URI` | | Base server URI (no port) — default `http://localhost` |
 | `WORKSPACE_MCP_PORT` | | Listening port — default `8000`. Also controls the stdio-mode OAuth callback port. The `PORT` env var takes precedence if set. |
-| `WORKSPACE_MCP_HOST` | | Bind host — default `0.0.0.0` for OAuth 2.1 HTTP. Legacy streamable HTTP defaults to `127.0.0.1` unless this is explicitly set. |
+| `WORKSPACE_MCP_HOST` | | Bind host (set via this environment variable or the `--host` CLI flag) — default `0.0.0.0` for OAuth 2.1 HTTP, `127.0.0.1` for legacy streamable HTTP. |
 | `WORKSPACE_MCP_TRANSPORT` | | `stdio` or `streamable-http`; used when `--transport` is not passed |
 | `WORKSPACE_MCP_HTTP_PORT` | | Advanced legacy-stdio sidecar `/mcp` port for local `workspace-cli` access. Disabled when empty. Binds to `127.0.0.1` only and is accessible to local processes. |
 | `WORKSPACE_EXTERNAL_URL` | | External URL for reverse proxy setups |
@@ -259,7 +259,7 @@ uv run main.py --transport streamable-http --tools gmail drive calendar
 | `WORKSPACE_MCP_READ_ONLY` | | `true`, `1`, or `yes` to request read-only scopes and filter write tools |
 | `WORKSPACE_MCP_PERMISSIONS` | | Space-separated `service:level` entries, e.g. `gmail:send drive:readonly`; mutually exclusive with tools and read-only |
 | **🔑 OAuth 2.1 & Multi-User** | | |
-| `MCP_ENABLE_OAUTH21` | | `true` to enable OAuth 2.1 multi-user support. Recommended for `--transport streamable-http`; legacy HTTP is local-only by default. |
+| `MCP_ENABLE_OAUTH21` | | `true` to enable OAuth 2.1 multi-user support. Required for remote or shared HTTP endpoints (`--transport streamable-http`); optional for local-only legacy HTTP, which binds to `127.0.0.1` by default. |
 | `EXTERNAL_OAUTH21_PROVIDER` | | `true` for external OAuth flow with bearer tokens |
 | `WORKSPACE_MCP_STATELESS_MODE` | | `true` for stateless container-friendly operation |
 | `GOOGLE_OAUTH_REDIRECT_URI` | | Override OAuth callback URL — default auto-constructed |
@@ -1104,6 +1104,8 @@ If `MCP_ENABLE_OAUTH21` is not set to `true`, the server uses legacy authenticat
 
 Streamable HTTP requests with an `Origin` header are checked against loopback origins, `WORKSPACE_EXTERNAL_URL`, and `OAUTH_ALLOWED_ORIGINS` to reduce DNS-rebinding risk. Non-browser MCP clients that omit `Origin` are unaffected.
 
+> **vscode-webview origins**: Origins with the `vscode-webview://` scheme are scoped per-extension using the authority component (e.g. `vscode-webview://publisher.extension`). Adding a vscode-webview URI to `OAUTH_ALLOWED_ORIGINS` permits only the specific extension identified by that authority; other extensions are rejected.
+
 <details open>
 <summary>🔐 <b>How the FastMCP GoogleProvider handles OAuth</b> <sub><sup>← Advanced OAuth 2.1 details</sup></sub></summary>
 
@@ -1331,7 +1333,7 @@ export DWD_ALLOWED_DOMAINS="corp.com,subsidiary.io"
 }
 ```
 
-*Note: Make sure to start the server with `--transport streamable-http` when using VS Code MCP. For remote or shared HTTP endpoints, also enable OAuth 2.1 with `MCP_ENABLE_OAUTH21=true` and `GOOGLE_OAUTH_CLIENT_ID`.*
+*Note: Make sure to start the server with `--transport streamable-http` when using VS Code MCP. For remote or shared HTTP endpoints, see the [OAuth 2.1 note in the HTTP Mode section](#http-mode-for-debugging-or-web-interfaces).*
 </details>
 
 ### Claude Code MCP Client Support

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ uv run main.py --transport streamable-http --tools gmail drive calendar
 | **🖥️ Server** | | |
 | `WORKSPACE_MCP_BASE_URI` | | Base server URI (no port) — default `http://localhost` |
 | `WORKSPACE_MCP_PORT` | | Listening port — default `8000`. Also controls the stdio-mode OAuth callback port. The `PORT` env var takes precedence if set. |
-| `WORKSPACE_MCP_HOST` | | Bind host — default `0.0.0.0` |
+| `WORKSPACE_MCP_HOST` | | Bind host — default `0.0.0.0` for OAuth 2.1 HTTP. Legacy streamable HTTP defaults to `127.0.0.1` unless this is explicitly set. |
 | `WORKSPACE_MCP_TRANSPORT` | | `stdio` or `streamable-http`; used when `--transport` is not passed |
 | `WORKSPACE_MCP_HTTP_PORT` | | Advanced legacy-stdio sidecar `/mcp` port for local `workspace-cli` access. Disabled when empty. Binds to `127.0.0.1` only and is accessible to local processes. |
 | `WORKSPACE_EXTERNAL_URL` | | External URL for reverse proxy setups |
@@ -259,7 +259,7 @@ uv run main.py --transport streamable-http --tools gmail drive calendar
 | `WORKSPACE_MCP_READ_ONLY` | | `true`, `1`, or `yes` to request read-only scopes and filter write tools |
 | `WORKSPACE_MCP_PERMISSIONS` | | Space-separated `service:level` entries, e.g. `gmail:send drive:readonly`; mutually exclusive with tools and read-only |
 | **🔑 OAuth 2.1 & Multi-User** | | |
-| `MCP_ENABLE_OAUTH21` | | `true` to enable OAuth 2.1 multi-user support |
+| `MCP_ENABLE_OAUTH21` | | `true` to enable OAuth 2.1 multi-user support. Recommended for `--transport streamable-http`; legacy HTTP is local-only by default. |
 | `EXTERNAL_OAUTH21_PROVIDER` | | `true` for external OAuth flow with bearer tokens |
 | `WORKSPACE_MCP_STATELESS_MODE` | | `true` for stateless container-friendly operation |
 | `GOOGLE_OAUTH_REDIRECT_URI` | | Override OAuth callback URL — default auto-constructed |
@@ -444,6 +444,8 @@ uv run main.py
 
 **◆ HTTP Mode (Recommended)**
 ```bash
+export MCP_ENABLE_OAUTH21=true
+export GOOGLE_OAUTH_CLIENT_ID="..."
 uv run main.py \
   --transport streamable-http
 ```
@@ -531,6 +533,8 @@ uv run main.py --tool-tier complete  # ○ All available tools
 ```bash
 docker build -t workspace-mcp .
 docker run -p 8000:8000 -v $(pwd):/app \
+  -e MCP_ENABLE_OAUTH21=true \
+  -e GOOGLE_OAUTH_CLIENT_ID="..." \
   workspace-mcp --transport streamable-http
 
 # With tool selection via environment variables
@@ -1062,7 +1066,7 @@ uv run pytest
 ```
 
 - `uv sync --group test` installs only the testing stack if you need a slimmer environment.
-- `uv run main.py --transport streamable-http` launches the server with your checked-out code for manual verification.
+- `MCP_ENABLE_OAUTH21=true GOOGLE_OAUTH_CLIENT_ID=... uv run main.py --transport streamable-http` launches the HTTP server with your checked-out code for manual verification.
 - Ruff is part of the `dev` group because pre-push hooks call `ruff check` automatically—run it locally before committing to avoid hook failures.
 
 </details>
@@ -1096,7 +1100,9 @@ export MCP_ENABLE_OAUTH21=true
 uv run main.py --transport streamable-http
 ```
 
-If `MCP_ENABLE_OAUTH21` is not set to `true`, the server will use legacy authentication, which is suitable for clients that do not support OAuth 2.1.
+If `MCP_ENABLE_OAUTH21` is not set to `true`, the server uses legacy authentication. In `streamable-http` mode, legacy authentication binds to `127.0.0.1` by default to keep cached Google credentials local. Set `WORKSPACE_MCP_HOST` explicitly only for trusted networks; use OAuth 2.1 for remote or shared HTTP deployments.
+
+Streamable HTTP requests with an `Origin` header are checked against loopback origins, `WORKSPACE_EXTERNAL_URL`, and `OAUTH_ALLOWED_ORIGINS` to reduce DNS-rebinding risk. Non-browser MCP clients that omit `Origin` are unaffected.
 
 <details open>
 <summary>🔐 <b>How the FastMCP GoogleProvider handles OAuth</b> <sub><sup>← Advanced OAuth 2.1 details</sup></sub></summary>
@@ -1133,6 +1139,7 @@ The server supports a stateless mode designed for containerized environments whe
 ```bash
 # Stateless mode requires OAuth 2.1 to be enabled
 export MCP_ENABLE_OAUTH21=true
+export GOOGLE_OAUTH_CLIENT_ID="..."
 export WORKSPACE_MCP_STATELESS_MODE=true
 uv run main.py --transport streamable-http
 ```
@@ -1218,6 +1225,7 @@ The server supports an external OAuth 2.1 provider mode for scenarios where auth
 ```bash
 # External OAuth provider mode requires OAuth 2.1 to be enabled
 export MCP_ENABLE_OAUTH21=true
+export GOOGLE_OAUTH_CLIENT_ID="..."
 export EXTERNAL_OAUTH21_PROVIDER=true
 uv run main.py --transport streamable-http
 ```
@@ -1323,7 +1331,7 @@ export DWD_ALLOWED_DOMAINS="corp.com,subsidiary.io"
 }
 ```
 
-*Note: Make sure to start the server with `--transport streamable-http` when using VS Code MCP.*
+*Note: Make sure to start the server with `--transport streamable-http` when using VS Code MCP. For remote or shared HTTP endpoints, also enable OAuth 2.1 with `MCP_ENABLE_OAUTH21=true` and `GOOGLE_OAUTH_CLIENT_ID`.*
 </details>
 
 ### Claude Code MCP Client Support
@@ -1335,6 +1343,8 @@ export DWD_ALLOWED_DOMAINS="corp.com,subsidiary.io"
 
 ```bash
 # Start the server in HTTP mode first
+export MCP_ENABLE_OAUTH21=true
+export GOOGLE_OAUTH_CLIENT_ID="..."
 uv run main.py --transport streamable-http
 
 # Then add to Claude Code
@@ -1391,6 +1401,8 @@ uvx workspace-mcp --tool-tier extended  # Core + additional features
 uvx workspace-mcp --tool-tier complete  # All tools
 
 # Start in HTTP mode for debugging
+export MCP_ENABLE_OAUTH21=true
+export GOOGLE_OAUTH_CLIENT_ID="..."
 uvx workspace-mcp --transport streamable-http
 ```
 </details>
@@ -1448,7 +1460,7 @@ If you need to use HTTP mode with Claude Desktop:
 }
 ```
 
-*Note: Make sure to start the server with `--transport streamable-http` when using HTTP mode.*
+*Note: Make sure to start the server with `--transport streamable-http` when using HTTP mode. For remote or shared HTTP endpoints, also enable OAuth 2.1 with `MCP_ENABLE_OAUTH21=true` and `GOOGLE_OAUTH_CLIENT_ID`.*
 
 ### First-Time Authentication
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ uv run main.py --transport streamable-http --tools gmail drive calendar
 | **🖥️ Server** | | |
 | `WORKSPACE_MCP_BASE_URI` | | Base server URI (no port) — default `http://localhost` |
 | `WORKSPACE_MCP_PORT` | | Listening port — default `8000`. Also controls the stdio-mode OAuth callback port. The `PORT` env var takes precedence if set. |
-| `WORKSPACE_MCP_HOST` | | Bind host (set via this environment variable or the `--host` CLI flag) — default `0.0.0.0` for OAuth 2.1 HTTP, `127.0.0.1` for legacy streamable HTTP. |
+| `WORKSPACE_MCP_HOST` | | Bind host — default `0.0.0.0` for OAuth 2.1 HTTP, `127.0.0.1` for legacy streamable HTTP. |
 | `WORKSPACE_MCP_TRANSPORT` | | `stdio` or `streamable-http`; used when `--transport` is not passed |
 | `WORKSPACE_MCP_HTTP_PORT` | | Advanced legacy-stdio sidecar `/mcp` port for local `workspace-cli` access. Disabled when empty. Binds to `127.0.0.1` only and is accessible to local processes. |
 | `WORKSPACE_EXTERNAL_URL` | | External URL for reverse proxy setups |

--- a/core/server.py
+++ b/core/server.py
@@ -94,9 +94,8 @@ class OriginValidationMiddleware:
                 origin = raw_origin.decode("latin-1")
                 normalized = _normalize_origin(origin)
                 allowed = _get_allowed_http_origins()
-                if (
-                    not normalized
-                    or (normalized not in allowed and not _is_loopback_origin(origin))
+                if not normalized or (
+                    normalized not in allowed and not _is_loopback_origin(origin)
                 ):
                     logger.warning("Rejected HTTP request from Origin: %s", origin)
                     response = JSONResponse(

--- a/core/server.py
+++ b/core/server.py
@@ -54,9 +54,15 @@ def _normalize_origin(origin: str) -> Optional[str]:
         return None
     if parsed.scheme == "vscode-webview":
         return f"vscode-webview://{parsed.netloc}" if parsed.netloc else None
-    if not parsed.netloc:
+    if not parsed.hostname:
         return None
-    return f"{parsed.scheme}://{parsed.netloc}"
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    netloc = f"{host}:{port}" if port is not None else host
+    return f"{parsed.scheme}://{netloc}"
 
 
 def _is_loopback_origin(origin: str) -> bool:
@@ -80,6 +86,15 @@ def _get_allowed_http_origins() -> set[str]:
     return origins
 
 
+def _is_origin_allowed(origin: str) -> bool:
+    if _is_loopback_origin(origin):
+        return True
+    normalized = _normalize_origin(origin)
+    if not normalized:
+        return False
+    return normalized in _get_allowed_http_origins()
+
+
 class OriginValidationMiddleware:
     """Reject browser-originated HTTP requests from untrusted origins."""
 
@@ -92,11 +107,7 @@ class OriginValidationMiddleware:
             raw_origin = headers.get(b"origin")
             if raw_origin:
                 origin = raw_origin.decode("latin-1")
-                normalized = _normalize_origin(origin)
-                allowed = _get_allowed_http_origins()
-                if not normalized or (
-                    normalized not in allowed and not _is_loopback_origin(origin)
-                ):
+                if not _is_origin_allowed(origin):
                     logger.warning("Rejected HTTP request from Origin: %s", origin)
                     response = JSONResponse(
                         {"error": "Origin not allowed"}, status_code=403

--- a/core/server.py
+++ b/core/server.py
@@ -37,7 +37,7 @@ from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
 from starlette.middleware import Middleware
 from starlette.requests import Request
-from starlette.types import Scope, Receive, Send
+from starlette.types import ASGIApp, Scope, Receive, Send
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -83,10 +83,10 @@ def _get_allowed_http_origins() -> set[str]:
 class OriginValidationMiddleware:
     """Reject browser-originated HTTP requests from untrusted origins."""
 
-    def __init__(self, app):
+    def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
-    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] == "http":
             headers = dict(scope.get("headers") or [])
             raw_origin = headers.get(b"origin")

--- a/core/server.py
+++ b/core/server.py
@@ -53,7 +53,7 @@ def _normalize_origin(origin: str) -> Optional[str]:
     if not parsed.scheme:
         return None
     if parsed.scheme == "vscode-webview":
-        return "vscode-webview://"
+        return f"vscode-webview://{parsed.netloc}" if parsed.netloc else None
     if not parsed.netloc:
         return None
     return f"{parsed.scheme}://{parsed.netloc}"

--- a/core/server.py
+++ b/core/server.py
@@ -6,6 +6,7 @@ import logging
 import os
 from typing import List, Optional
 from importlib import metadata
+from urllib.parse import urlparse
 
 from core.warning_filters import install_startup_warning_filters
 
@@ -45,6 +46,69 @@ _auth_provider: Optional[GoogleProvider] = None
 _legacy_callback_registered = False
 
 session_middleware = Middleware(MCPSessionMiddleware)
+
+
+def _normalize_origin(origin: str) -> Optional[str]:
+    parsed = urlparse(origin)
+    if not parsed.scheme:
+        return None
+    if parsed.scheme == "vscode-webview":
+        return "vscode-webview://"
+    if not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _is_loopback_origin(origin: str) -> bool:
+    parsed = urlparse(origin)
+    return parsed.hostname in {"localhost", "127.0.0.1", "::1"}
+
+
+def _get_allowed_http_origins() -> set[str]:
+    from auth.oauth_config import get_oauth_config
+
+    config = get_oauth_config()
+    origins = set()
+    for origin in config.get_allowed_origins():
+        normalized = _normalize_origin(origin)
+        if normalized:
+            origins.add(normalized)
+    if config.external_url:
+        normalized = _normalize_origin(config.external_url)
+        if normalized:
+            origins.add(normalized)
+    return origins
+
+
+class OriginValidationMiddleware:
+    """Reject browser-originated HTTP requests from untrusted origins."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+        if scope["type"] == "http":
+            headers = dict(scope.get("headers") or [])
+            raw_origin = headers.get(b"origin")
+            if raw_origin:
+                origin = raw_origin.decode("latin-1")
+                normalized = _normalize_origin(origin)
+                allowed = _get_allowed_http_origins()
+                if (
+                    not normalized
+                    or (normalized not in allowed and not _is_loopback_origin(origin))
+                ):
+                    logger.warning("Rejected HTTP request from Origin: %s", origin)
+                    response = JSONResponse(
+                        {"error": "Origin not allowed"}, status_code=403
+                    )
+                    await response(scope, receive, send)
+                    return
+
+        await self.app(scope, receive, send)
+
+
+origin_validation_middleware = Middleware(OriginValidationMiddleware)
 
 
 class WellKnownCacheControlMiddleware:
@@ -96,13 +160,17 @@ class SecureFastMCP(FastMCP):
 
         # Add middleware in order (first added = outermost layer)
         app.user_middleware.insert(0, well_known_cache_control_middleware)
+        app.user_middleware.insert(1, origin_validation_middleware)
 
         # Session Management - extracts session info for MCP context
-        app.user_middleware.insert(1, session_middleware)
+        app.user_middleware.insert(2, session_middleware)
 
         # Rebuild middleware stack
         app.middleware_stack = app.build_middleware_stack()
-        logger.info("Added middleware stack: WellKnownCacheControl, Session Management")
+        logger.info(
+            "Added middleware stack: WellKnownCacheControl, OriginValidation, "
+            "Session Management"
+        )
         return app
 
     async def list_tools(self, *, run_middleware: bool = True):
@@ -229,8 +297,10 @@ def configure_server_for_http():
 
     if oauth21_enabled:
         if not config.is_configured():
-            logger.warning("OAuth 2.1 enabled but OAuth credentials not configured")
-            return
+            raise RuntimeError(
+                "streamable-http transport requires GOOGLE_OAUTH_CLIENT_ID so OAuth 2.1 "
+                "protocol authentication can be configured."
+            )
 
         def validate_and_derive_jwt_key(
             jwt_signing_key_override: str | None, client_secret: str | None
@@ -550,7 +620,10 @@ def configure_server_for_http():
             )
             raise
     else:
-        logger.info("OAuth 2.0 mode - Server will use legacy authentication.")
+        logger.info(
+            "OAuth 2.0 legacy mode - streamable HTTP defaults to loopback unless "
+            "WORKSPACE_MCP_HOST is explicitly set."
+        )
         server.auth = None
         _auth_provider = None
         set_auth_provider(None)

--- a/helm-chart/workspace-mcp/README.md
+++ b/helm-chart/workspace-mcp/README.md
@@ -37,7 +37,7 @@ The following table lists the configurable parameters and their default values:
 | `secrets.googleOAuth.userEmail` | Default user email for single-user mode | `""` |
 | `singleUserMode` | Enable single-user mode | `false` |
 | `tools.enabled` | List of tools to enable | `[]` (all tools enabled) |
-| `env.MCP_ENABLE_OAUTH21` | Enable OAuth 2.1 support | `"false"` |
+| `env.MCP_ENABLE_OAUTH21` | Enable OAuth 2.1 support for streamable HTTP | `"true"` |
 | `service.type` | Kubernetes service type | `ClusterIP` |
 | `service.port` | Service port | `8000` |
 | `ingress.enabled` | Enable ingress | `false` |
@@ -79,21 +79,25 @@ helm install workspace-mcp ./helm-chart/workspace-mcp \
 
 ### Single-user mode deployment:
 
+Single-user mode is a legacy local-auth mode and is incompatible with OAuth 2.1.
+For Kubernetes, prefer the default OAuth 2.1 mode unless this deployment is
+strictly limited to trusted network paths.
+
 ```bash
 helm install workspace-mcp ./helm-chart/workspace-mcp \
   --set secrets.googleOAuth.clientId="your-client-id" \
   --set secrets.googleOAuth.clientSecret="your-secret" \
+  --set env.MCP_ENABLE_OAUTH21="false" \
   --set singleUserMode=true \
   --set secrets.googleOAuth.userEmail="user@yourdomain.com"
 ```
 
-### Enable OAuth 2.1 for multi-user environments:
+### OAuth 2.1 multi-user deployment:
 
 ```bash
 helm install workspace-mcp ./helm-chart/workspace-mcp \
   --set secrets.googleOAuth.clientId="your-client-id" \
-  --set secrets.googleOAuth.clientSecret="your-secret" \
-  --set env.MCP_ENABLE_OAUTH21="true"
+  --set secrets.googleOAuth.clientSecret="your-secret"
 ```
 
 ## Uninstalling the Chart

--- a/helm-chart/workspace-mcp/values.yaml
+++ b/helm-chart/workspace-mcp/values.yaml
@@ -84,8 +84,9 @@ env:
   # If set, this overrides the base_uri:port combination for OAuth endpoints
   WORKSPACE_EXTERNAL_URL: ""
   
-  # OAuth 2.1 support
-  MCP_ENABLE_OAUTH21: "false"
+  # OAuth 2.1 support. The chart runs streamable HTTP behind a Kubernetes
+  # Service, so OAuth 2.1 is the safe default for network-reachable deployments.
+  MCP_ENABLE_OAUTH21: "true"
   
   # Development only - set to "1" for local development
   OAUTHLIB_INSECURE_TRANSPORT: "0"

--- a/main.py
+++ b/main.py
@@ -122,6 +122,51 @@ def resolve_callback_port_for_transport(transport: str) -> None:
         os.environ.pop("WORKSPACE_MCP_RESOLVED_PORT", None)
 
 
+def resolve_bind_host_for_transport(transport: str) -> str:
+    """Choose a safe default bind host for the selected transport/auth mode."""
+    configured_host = os.getenv("WORKSPACE_MCP_HOST")
+    host = configured_host or "0.0.0.0"
+    if transport != "streamable-http":
+        return host
+
+    config = get_oauth_config()
+    if config.is_oauth21_enabled():
+        return host
+
+    if configured_host:
+        if configured_host not in {"localhost", "127.0.0.1", "::1"}:
+            logger.warning(
+                "Legacy streamable-http mode has no MCP-level auth provider and is "
+                "bound to %s because WORKSPACE_MCP_HOST was explicitly set. "
+                "Use MCP_ENABLE_OAUTH21=true for remotely reachable HTTP deployments.",
+                configured_host,
+            )
+        return configured_host
+
+    logger.warning(
+        "Legacy streamable-http mode has no MCP-level auth provider; binding to "
+        "127.0.0.1 by default. Set WORKSPACE_MCP_HOST explicitly only for trusted "
+        "networks, or use MCP_ENABLE_OAUTH21=true for remote HTTP deployments."
+    )
+    return "127.0.0.1"
+
+
+def validate_streamable_http_auth(transport: str) -> None:
+    """Reject misconfigured OAuth 2.1 HTTP before starting."""
+    if transport != "streamable-http":
+        return
+
+    config = get_oauth_config()
+    if config.is_oauth21_enabled() and not config.is_configured():
+        print(
+            "Error: streamable-http transport with MCP_ENABLE_OAUTH21=true requires "
+            "GOOGLE_OAUTH_CLIENT_ID so OAuth 2.1 protocol authentication can be "
+            "configured.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 # Single source of truth: service name -> module path.
 # VALID_SERVICES is derived from this mapping.
 SERVICE_MODULES = {
@@ -402,6 +447,7 @@ def main():
         )
         sys.exit(1)
 
+    validate_streamable_http_auth(args.transport)
     resolve_callback_port_for_transport(args.transport)
 
     # Set port and base URI once for reuse throughout the function
@@ -410,7 +456,7 @@ def main():
     else:
         port = int(os.getenv("PORT", os.getenv("WORKSPACE_MCP_PORT", "8000")))
     base_uri = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
-    host = os.getenv("WORKSPACE_MCP_HOST", "0.0.0.0")
+    host = resolve_bind_host_for_transport(args.transport)
     external_url = os.getenv("WORKSPACE_EXTERNAL_URL")
     display_url = external_url if external_url else f"{base_uri}:{port}"
 

--- a/tests/core/test_http_oauth_scope_config.py
+++ b/tests/core/test_http_oauth_scope_config.py
@@ -5,6 +5,49 @@ import pytest
 import core.server as server_module
 
 
+def test_configure_server_for_http_allows_legacy_oauth_callback(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(server_module, "get_transport_mode", lambda: "streamable-http")
+    monkeypatch.setattr(
+        server_module, "set_auth_provider", lambda provider: calls.append(provider)
+    )
+    monkeypatch.setattr(
+        server_module,
+        "_ensure_legacy_callback_route",
+        lambda: calls.append("callback"),
+    )
+    monkeypatch.setattr(server_module, "_auth_provider", object())
+    monkeypatch.setattr(server_module.server, "auth", object())
+    monkeypatch.setattr(
+        "auth.oauth_config.get_oauth_config",
+        lambda: SimpleNamespace(
+            is_oauth21_enabled=lambda: False,
+            is_configured=lambda: True,
+        ),
+    )
+
+    server_module.configure_server_for_http()
+
+    assert server_module.server.auth is None
+    assert server_module._auth_provider is None
+    assert calls == [None, "callback"]
+
+
+def test_configure_server_for_http_rejects_unconfigured_oauth21(monkeypatch):
+    monkeypatch.setattr(server_module, "get_transport_mode", lambda: "streamable-http")
+    monkeypatch.setattr(
+        "auth.oauth_config.get_oauth_config",
+        lambda: SimpleNamespace(
+            is_oauth21_enabled=lambda: True,
+            is_configured=lambda: False,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="requires GOOGLE_OAUTH_CLIENT_ID"):
+        server_module.configure_server_for_http()
+
+
 def test_configure_server_for_http_uses_protocol_auth_required_scopes(monkeypatch):
     captured = {}
 

--- a/tests/core/test_well_known_cache_control_middleware.py
+++ b/tests/core/test_well_known_cache_control_middleware.py
@@ -1,4 +1,5 @@
 import importlib
+from types import SimpleNamespace
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -49,6 +50,63 @@ def test_well_known_cache_control_middleware_rewrites_headers():
     assert extra.status_code == 200
     assert extra.headers["cache-control"] == "public, max-age=3600"
     assert "etag" not in extra.headers
+
+
+def test_origin_validation_rejects_untrusted_browser_origin(monkeypatch):
+    from core.server import OriginValidationMiddleware
+
+    monkeypatch.setattr(
+        "auth.oauth_config.get_oauth_config",
+        lambda: SimpleNamespace(
+            get_allowed_origins=lambda: ["http://localhost:8000"],
+            external_url=None,
+        ),
+    )
+
+    async def endpoint(request):
+        return Response("ok")
+
+    app = Starlette(
+        routes=[Route("/health", endpoint)],
+        middleware=[Middleware(OriginValidationMiddleware)],
+    )
+    client = TestClient(app)
+
+    assert (
+        client.get("/health", headers={"Origin": "http://evil.test"}).status_code
+        == 403
+    )
+    assert (
+        client.get("/health", headers={"Origin": "http://localhost:5173"}).status_code
+        == 200
+    )
+    assert client.get("/health").status_code == 200
+
+
+def test_origin_validation_allows_configured_external_origin(monkeypatch):
+    from core.server import OriginValidationMiddleware
+
+    monkeypatch.setattr(
+        "auth.oauth_config.get_oauth_config",
+        lambda: SimpleNamespace(
+            get_allowed_origins=lambda: ["http://localhost:8000"],
+            external_url="https://workspace.example.com/mcp",
+        ),
+    )
+
+    async def endpoint(request):
+        return Response("ok")
+
+    app = Starlette(
+        routes=[Route("/health", endpoint)],
+        middleware=[Middleware(OriginValidationMiddleware)],
+    )
+    client = TestClient(app)
+
+    response = client.get(
+        "/health", headers={"Origin": "https://workspace.example.com"}
+    )
+    assert response.status_code == 200
 
 
 def test_configured_server_applies_no_cache_to_served_oauth_discovery_routes(

--- a/tests/core/test_well_known_cache_control_middleware.py
+++ b/tests/core/test_well_known_cache_control_middleware.py
@@ -108,6 +108,44 @@ def test_origin_validation_allows_configured_external_origin(monkeypatch):
     assert response.status_code == 200
 
 
+def test_origin_validation_vscode_webview_scoping(monkeypatch):
+    from core.server import OriginValidationMiddleware
+
+    monkeypatch.setattr(
+        "auth.oauth_config.get_oauth_config",
+        lambda: SimpleNamespace(
+            get_allowed_origins=lambda: [
+                "vscode-webview://publisher.extension/somepath"
+            ],
+            external_url=None,
+        ),
+    )
+
+    async def endpoint(request):
+        return Response("ok")
+
+    app = Starlette(
+        routes=[Route("/health", endpoint)],
+        middleware=[Middleware(OriginValidationMiddleware)],
+    )
+    client = TestClient(app)
+
+    # Matching extension origin is accepted
+    assert (
+        client.get(
+            "/health", headers={"Origin": "vscode-webview://publisher.extension"}
+        ).status_code
+        == 200
+    )
+    # Different extension origin is rejected
+    assert (
+        client.get(
+            "/health", headers={"Origin": "vscode-webview://other.publisher"}
+        ).status_code
+        == 403
+    )
+
+
 def test_configured_server_applies_no_cache_to_served_oauth_discovery_routes(
     monkeypatch,
 ):

--- a/tests/core/test_well_known_cache_control_middleware.py
+++ b/tests/core/test_well_known_cache_control_middleware.py
@@ -73,8 +73,7 @@ def test_origin_validation_rejects_untrusted_browser_origin(monkeypatch):
     client = TestClient(app)
 
     assert (
-        client.get("/health", headers={"Origin": "http://evil.test"}).status_code
-        == 403
+        client.get("/health", headers={"Origin": "http://evil.test"}).status_code == 403
     )
     assert (
         client.get("/health", headers={"Origin": "http://localhost:5173"}).status_code

--- a/tests/test_main_permissions_tier.py
+++ b/tests/test_main_permissions_tier.py
@@ -83,6 +83,78 @@ def test_resolve_callback_port_for_transport_skips_streamable_http(
     assert "WORKSPACE_MCP_RESOLVED_PORT" not in os.environ
 
 
+def test_resolve_bind_host_defaults_legacy_streamable_http_to_loopback(monkeypatch):
+    monkeypatch.setattr(
+        main,
+        "get_oauth_config",
+        lambda: SimpleNamespace(
+            is_oauth21_enabled=lambda: False,
+            is_configured=lambda: True,
+        ),
+    )
+    monkeypatch.delenv("WORKSPACE_MCP_HOST", raising=False)
+
+    assert main.resolve_bind_host_for_transport("streamable-http") == "127.0.0.1"
+
+
+def test_resolve_bind_host_preserves_explicit_legacy_streamable_http_host(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        main,
+        "get_oauth_config",
+        lambda: SimpleNamespace(
+            is_oauth21_enabled=lambda: False,
+            is_configured=lambda: True,
+        ),
+    )
+    monkeypatch.setenv("WORKSPACE_MCP_HOST", "0.0.0.0")
+
+    assert main.resolve_bind_host_for_transport("streamable-http") == "0.0.0.0"
+
+
+def test_resolve_bind_host_preserves_oauth21_streamable_http_default(monkeypatch):
+    monkeypatch.setattr(
+        main,
+        "get_oauth_config",
+        lambda: SimpleNamespace(
+            is_oauth21_enabled=lambda: True,
+            is_configured=lambda: True,
+        ),
+    )
+    monkeypatch.delenv("WORKSPACE_MCP_HOST", raising=False)
+
+    assert main.resolve_bind_host_for_transport("streamable-http") == "0.0.0.0"
+
+
+def test_validate_streamable_http_auth_rejects_unconfigured_oauth21(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        main,
+        "get_oauth_config",
+        lambda: SimpleNamespace(
+            is_oauth21_enabled=lambda: True,
+            is_configured=lambda: False,
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main.validate_streamable_http_auth("streamable-http")
+
+    assert exc.value.code == 1
+    assert "requires GOOGLE_OAUTH_CLIENT_ID" in capsys.readouterr().err
+
+
+def test_validate_streamable_http_auth_allows_stdio(monkeypatch):
+    def fail_if_called():
+        raise AssertionError("stdio should not check OAuth 2.1 config")
+
+    monkeypatch.setattr(main, "get_oauth_config", fail_if_called)
+
+    main.validate_streamable_http_auth("stdio")
+
+
 def test_permissions_and_tools_flags_are_rejected(monkeypatch, capsys):
     monkeypatch.setattr(main, "configure_safe_logging", lambda: None)
     monkeypatch.setattr(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP origin validation: untrusted browser origins are rejected (403); VS Code webview origins normalized/allowlisted.

* **Security**
  * Startup now fails fast when OAuth 2.1 is enabled but OAuth is unconfigured.
  * Legacy HTTP defaults to loopback; allowlist checks include configured external origins to reduce exposure.

* **Documentation**
  * Updated setup, Docker/Helm examples and READMEs to require OAuth 2.1 and GOOGLE_OAUTH_CLIENT_ID for remote/shared HTTP.

* **Tests**
  * Added tests for origin checks, bind-host selection, and OAuth validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->