### PR TITLE
fix(core): use unique probe filename in check_credentials_directory_permissions to avoid concurrent race

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 import os
+import tempfile
 import zipfile
 import ssl
 import asyncio
@@ -240,6 +241,40 @@ def validate_file_path(file_path: str) -> Path:
     )
 
 
+def _probe_credentials_directory_writable(credentials_dir: str) -> None:
+    """
+    Probe write access to ``credentials_dir`` using a uniquely-named
+    temporary file.
+
+    Uses ``tempfile.mkstemp`` so each call gets a random unique suffix —
+    concurrent callers (multiple processes sharing the same credentials
+    directory via ``WORKSPACE_MCP_CREDENTIALS_DIR``) never race on the
+    same probe filename. ``mkstemp`` is preferred over
+    ``NamedTemporaryFile`` here because the latter holds the file open
+    with ``O_TEMPORARY`` on Windows (Python ≤3.11), which can fail to
+    delete cleanly when antivirus or indexing services have a transient
+    handle on the file.
+
+    Lets ``PermissionError`` / ``OSError`` propagate from ``mkstemp`` /
+    ``os.write``. Best-effort cleanup of the probe file; unlink errors
+    are swallowed since the unique path means no peer can race the
+    unlink (and the function's contract is "can write", not "can
+    delete").
+    """
+    fd, path = tempfile.mkstemp(prefix=".permission_test_", dir=credentials_dir)
+    try:
+        os.write(fd, b"test")
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
 def check_credentials_directory_permissions(credentials_dir: str = None) -> None:
     """
     Check if the service has appropriate permissions to create and write to the .credentials directory.
@@ -260,11 +295,8 @@ def check_credentials_directory_permissions(credentials_dir: str = None) -> None
         # Check if directory exists
         if os.path.exists(credentials_dir):
             # Directory exists, check if we can write to it
-            test_file = os.path.join(credentials_dir, ".permission_test")
             try:
-                with open(test_file, "w") as f:
-                    f.write("test")
-                os.remove(test_file)
+                _probe_credentials_directory_writable(credentials_dir)
                 logger.info(
                     f"Credentials directory permissions check passed: {os.path.abspath(credentials_dir)}"
                 )
@@ -277,10 +309,7 @@ def check_credentials_directory_permissions(credentials_dir: str = None) -> None
             try:
                 os.makedirs(credentials_dir, exist_ok=True)
                 # Test writing to the new directory
-                test_file = os.path.join(credentials_dir, ".permission_test")
-                with open(test_file, "w") as f:
-                    f.write("test")
-                os.remove(test_file)
+                _probe_credentials_directory_writable(credentials_dir)
                 logger.info(
                     f"Created credentials directory with proper permissions: {os.path.abspath(credentials_dir)}"
                 )

--- a/tests/test_credentials_dir_permissions.py
+++ b/tests/test_credentials_dir_permissions.py
@@ -62,8 +62,8 @@ def test_concurrent_callers_do_not_race_on_probe_filename(tmp_path):
     Pre-fix, multiple processes sharing a credentials directory would
     collide on the fixed probe filename — one would ENOENT during the
     write/remove sequence and raise PermissionError. The fix uses
-    ``tempfile.NamedTemporaryFile`` with a random suffix so each call
-    gets a unique probe path.
+    ``tempfile.mkstemp`` with a random suffix so each call gets a unique
+    probe path.
     """
     creds_dir = tmp_path / "shared_creds"
     creds_dir.mkdir()

--- a/tests/test_credentials_dir_permissions.py
+++ b/tests/test_credentials_dir_permissions.py
@@ -1,0 +1,96 @@
+"""
+Tests for check_credentials_directory_permissions() — focuses on the
+concurrent-callers regression where two processes sharing a credentials
+directory raced on a fixed ``.permission_test`` filename and one would
+ENOENT during write/remove.
+"""
+
+import multiprocessing as mp
+import os
+
+import pytest
+
+from core.utils import check_credentials_directory_permissions
+
+
+def test_existing_writable_directory(tmp_path):
+    """Happy path: an existing writable directory passes the check."""
+    check_credentials_directory_permissions(str(tmp_path))
+
+
+def test_creates_missing_directory(tmp_path):
+    """Function creates the directory if it doesn't exist."""
+    target = tmp_path / "new_creds_dir"
+    assert not target.exists()
+    check_credentials_directory_permissions(str(target))
+    assert target.is_dir()
+
+
+def test_does_not_leave_probe_files(tmp_path):
+    """The probe file must be cleaned up regardless of how the check exits."""
+    check_credentials_directory_permissions(str(tmp_path))
+    leftovers = list(tmp_path.iterdir())
+    assert leftovers == [], f"probe file leak: {leftovers}"
+
+
+def test_read_only_directory_raises_permission_error(tmp_path):
+    """A read-only directory must raise PermissionError."""
+    ro_dir = tmp_path / "readonly"
+    ro_dir.mkdir()
+    ro_dir.chmod(0o555)
+    try:
+        with pytest.raises(PermissionError):
+            check_credentials_directory_permissions(str(ro_dir))
+    finally:
+        ro_dir.chmod(0o755)
+
+
+def _worker(creds_dir: str, iterations: int, result_queue: "mp.Queue") -> None:
+    """Call the permission check N times; report any exception."""
+    try:
+        for _ in range(iterations):
+            check_credentials_directory_permissions(creds_dir)
+        result_queue.put(("ok", os.getpid(), None))
+    except Exception as exc:  # noqa: BLE001 — test deliberately wide
+        result_queue.put(("error", os.getpid(), f"{type(exc).__name__}: {exc}"))
+
+
+def test_concurrent_callers_do_not_race_on_probe_filename(tmp_path):
+    """
+    Regression test for the ``.permission_test`` race.
+
+    Pre-fix, multiple processes sharing a credentials directory would
+    collide on the fixed probe filename — one would ENOENT during the
+    write/remove sequence and raise PermissionError. The fix uses
+    ``tempfile.NamedTemporaryFile`` with a random suffix so each call
+    gets a unique probe path.
+    """
+    creds_dir = tmp_path / "shared_creds"
+    creds_dir.mkdir()
+
+    procs = []
+    queue = mp.Queue()
+    n_workers = 8
+    iterations = 50
+
+    for _ in range(n_workers):
+        p = mp.Process(target=_worker, args=(str(creds_dir), iterations, queue))
+        p.start()
+        procs.append(p)
+
+    for p in procs:
+        p.join(timeout=30)
+        assert p.exitcode == 0, (
+            f"worker pid={p.pid} exited with code {p.exitcode}"
+        )
+
+    results = []
+    while not queue.empty():
+        results.append(queue.get_nowait())
+
+    errors = [r for r in results if r[0] == "error"]
+    assert errors == [], f"concurrent callers raced: {errors}"
+    assert len(results) == n_workers, f"missing worker reports: {results}"
+
+    leftovers = list(creds_dir.iterdir())
+    assert leftovers == [], f"probe file leak after concurrent run: {leftovers}"


### PR DESCRIPTION
## Description

`core/utils.check_credentials_directory_permissions()` writes a probe file at the fixed path `{credentials_dir}/.permission_test` to test write+remove permission. When two or more processes share a credentials directory (`WORKSPACE_MCP_CREDENTIALS_DIR`), they collide on that literal filename and one observes ENOENT during the write/remove sequence. The OSError is caught and re-raised as `PermissionError("Cannot write to existing credentials directory ...")`, the subprocess exits, and the MCP client sees `Connection closed`.

The interleaving:

```
P1 open(.permission_test, "w")    -> ok
P1 write / os.remove              -> ok
P2 open(.permission_test, "w")    -> ok
P2 os.remove                      -> ENOENT (P1 already removed it; or vice versa)
P2 catches (PermissionError, OSError) -> re-raises as PermissionError
P2 exits                          -> MCP client: "Connection closed"
```

Empirically, in a deployment where six launchd services spawn `workspace-mcp` subprocesses against the same `WORKSPACE_MCP_CREDENTIALS_DIR`, this produced ~109 `[ERROR]` log entries over an 8-day window, correlating ~1:1 with downstream tool-call failures.

## Fix

Replace the fixed-name probe with `tempfile.mkstemp(prefix=".permission_test_", dir=credentials_dir)`, which gives each call a unique random suffix — concurrent callers never collide. Extracted into a private helper `_probe_credentials_directory_writable()` to deduplicate the two probe sites (existing-dir branch and newly-created-dir branch).

`mkstemp` is preferred over `tempfile.NamedTemporaryFile` because the latter holds the file open with `O_TEMPORARY` on Windows for Python ≤3.11, which can fail to delete cleanly when antivirus or indexing services hold a transient handle on the file. Since `requires-python = ">=3.10"` is the declared floor, `NamedTemporaryFile(delete=True)` would be a regression risk on Windows.

Existing `PermissionError` / `OSError` exception wrapping and messages are preserved.

## Reproducer

A multiprocessing regression test is included (`tests/test_credentials_dir_permissions.py::test_concurrent_callers_do_not_race_on_probe_filename`): 8 worker processes × 50 iterations each, all calling `check_credentials_directory_permissions()` against the same directory. Fails on `main` at `0d1475c`, passes after this patch.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pytest tests/test_credentials_dir_permissions.py tests/test_main_permissions_tier.py` — 13 passed)
- [x] I have tested this change manually (8-worker concurrent test fails on pre-fix `main`, passes after patch; `ruff check` clean)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

- The new tests don't use `@pytest.mark.asyncio`, which is correct given they exercise blocking I/O — flagging here pre-emptively given the repo's `asyncio_mode = "strict"` config.
- Pre-existing tests in `tests/test_main_permissions_tier.py` that monkeypatch `check_credentials_directory_permissions` continue to pass — the function's public signature and exception types are unchanged.
- I grepped the rest of the tree for the same probe pattern; this is the only fixed-filename probe-write site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credentials-directory writability check using a safer temporary-file probe, avoiding leftover probe files and reducing race conditions.

* **Tests**
  * Added tests for directory permission checks, automatic creation, cleanup assurance, read-only error handling, and concurrent access stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->