### PR TITLE
feat: add --tool-allowlist for explicit per-tool filtering

### DIFF
--- a/main.py
+++ b/main.py
@@ -287,6 +287,24 @@ def main():
             "Mutually exclusive with --read-only and --tools."
         ),
     )
+    parser.add_argument(
+        "--tool-allowlist",
+        nargs="+",
+        metavar="TOOL_NAME",
+        default=None,
+        help=(
+            "Restrict registered tools to this exact list of tool names. "
+            "Narrows whatever set --tool-tier, --tools, --read-only or "
+            "--permissions would otherwise enable; only the named tools are "
+            "registered with the MCP server. Useful when a deployment needs "
+            "a small subset of tools without authoring a custom tier "
+            "(e.g. --tool-allowlist get_gmail_attachment_content "
+            "send_gmail_message). "
+            "Also configurable via WORKSPACE_MCP_TOOL_ALLOWLIST "
+            "(comma-separated). Tools not present in the resolved selection "
+            "(after tier/services/permissions) are silently dropped."
+        ),
+    )
     args = parser.parse_args()
 
     # Env var fallbacks for plugin users who configure via userConfig.
@@ -357,6 +375,19 @@ def main():
             "WORKSPACE_MCP_PERMISSIONS ignored because %s was provided on the CLI",
             " and ".join(_conflicts),
         )
+    if args.tool_allowlist is None:
+        _env_allowlist = os.getenv("WORKSPACE_MCP_TOOL_ALLOWLIST", "").strip()
+        if _env_allowlist:
+            _parsed_allowlist = [
+                t.strip() for t in _env_allowlist.split(",") if t.strip()
+            ]
+            if not _parsed_allowlist:
+                _exit_with_env_error(
+                    "WORKSPACE_MCP_TOOL_ALLOWLIST",
+                    _env_allowlist,
+                    "comma-separated tool names",
+                )
+            args.tool_allowlist = _parsed_allowlist
     if args.transport is None:
         _env_transport = os.getenv("WORKSPACE_MCP_TRANSPORT", "").strip().lower()
         if _env_transport:
@@ -584,6 +615,38 @@ def main():
         tools_to_import = tool_imports.keys()
         # Don't filter individual tools when importing all
         set_enabled_tool_names(None)
+
+    # Optional final filter: narrow registered tools to an explicit allowlist.
+    # Applies on top of tier / services / read-only / permissions selection.
+    if args.tool_allowlist:
+        from core.tool_registry import get_enabled_tools
+
+        allowlist = {t.strip() for t in args.tool_allowlist if t.strip()}
+        if not allowlist:
+            safe_print(
+                "❌ --tool-allowlist / WORKSPACE_MCP_TOOL_ALLOWLIST produced an "
+                "empty set of tool names"
+            )
+            sys.exit(1)
+        current_enabled = get_enabled_tools()
+        if current_enabled is None:
+            # No prior tool filter (e.g. default mode or --tools only).
+            # The allowlist itself becomes the enabled set.
+            set_enabled_tool_names(allowlist)
+        else:
+            narrowed = current_enabled & allowlist
+            if not narrowed:
+                safe_print(
+                    "❌ --tool-allowlist filtered out every tool. "
+                    "Allowlist: %s. Available before allowlist: %s"
+                    % (sorted(allowlist), sorted(current_enabled))
+                )
+                sys.exit(1)
+            set_enabled_tool_names(narrowed)
+        logger.info(
+            "Tool allowlist applied: %d tool(s) will be registered",
+            len(allowlist),
+        )
 
     wrap_server_tool_method(server)
 

--- a/main.py
+++ b/main.py
@@ -630,22 +630,23 @@ def main():
             sys.exit(1)
         current_enabled = get_enabled_tools()
         if current_enabled is None:
-            # No prior tool filter (e.g. default mode or --tools only).
-            # The allowlist itself becomes the enabled set.
-            set_enabled_tool_names(allowlist)
+            # No prior tier filter (default mode or --tools-only). The
+            # allowlist becomes the enabled set; whether every name maps to
+            # an actually-imported tool is validated post-registration below.
+            applied = allowlist
         else:
-            narrowed = current_enabled & allowlist
-            if not narrowed:
+            applied = current_enabled & allowlist
+            if not applied:
                 safe_print(
                     "❌ --tool-allowlist filtered out every tool. "
                     "Allowlist: %s. Available before allowlist: %s"
                     % (sorted(allowlist), sorted(current_enabled))
                 )
                 sys.exit(1)
-            set_enabled_tool_names(narrowed)
+        set_enabled_tool_names(applied)
         logger.info(
-            "Tool allowlist applied: %d tool(s) will be registered",
-            len(allowlist),
+            "Tool allowlist applied: %d tool name(s) requested",
+            len(applied),
         )
 
     wrap_server_tool_method(server)
@@ -681,6 +682,34 @@ def main():
 
     # Filter tools based on tier configuration (if tier-based loading is enabled)
     filter_server_tools(server)
+
+    # Allowlist correctness: a name in the allowlist that doesn't belong to any
+    # imported service silently produces no registered tool. Validate post-filter
+    # so callers like `--tools gmail --tool-allowlist create_calendar_event`
+    # fail fast instead of starting empty.
+    if args.tool_allowlist:
+        from core.tool_registry import get_tool_components
+
+        registered = set(get_tool_components(server).keys())
+        if not registered:
+            safe_print(
+                "❌ --tool-allowlist / WORKSPACE_MCP_TOOL_ALLOWLIST resulted in "
+                "zero registered tools. Check that allowlist names match tools "
+                "provided by the services imported via --tools / --tool-tier. "
+                "Requested: %s" % sorted(allowlist)
+            )
+            sys.exit(1)
+        missing = allowlist - registered
+        if missing:
+            logger.warning(
+                "Allowlist names not registered (no matching imported tool): %s",
+                sorted(missing),
+            )
+        logger.info(
+            "Tool allowlist: %d tool(s) registered: %s",
+            len(registered),
+            sorted(registered),
+        )
 
     summary_parts = [f"{len(loaded)}/{len(tool_imports)} services"]
     if args.tool_tier is not None:

--- a/main.py
+++ b/main.py
@@ -638,9 +638,9 @@ def main():
             applied = current_enabled & allowlist
             if not applied:
                 safe_print(
-                    "❌ --tool-allowlist filtered out every tool. "
-                    "Allowlist: %s. Available before allowlist: %s"
-                    % (sorted(allowlist), sorted(current_enabled))
+                    f"❌ --tool-allowlist filtered out every tool. "
+                    f"Allowlist: {sorted(allowlist)}. "
+                    f"Available before allowlist: {sorted(current_enabled)}"
                 )
                 sys.exit(1)
         set_enabled_tool_names(applied)
@@ -693,17 +693,28 @@ def main():
         registered = set(get_tool_components(server).keys())
         if not registered:
             safe_print(
-                "❌ --tool-allowlist / WORKSPACE_MCP_TOOL_ALLOWLIST resulted in "
-                "zero registered tools. Check that allowlist names match tools "
-                "provided by the services imported via --tools / --tool-tier. "
-                "Requested: %s" % sorted(allowlist)
+                f"❌ --tool-allowlist / WORKSPACE_MCP_TOOL_ALLOWLIST resulted in "
+                f"zero registered tools. Check that allowlist names match tools "
+                f"provided by the services imported via --tools / --tool-tier. "
+                f"Requested: {sorted(allowlist)}"
             )
             sys.exit(1)
-        missing = allowlist - registered
+        # Two distinct cases for an allowlisted name that didn't register:
+        #   1. Tier/service selection dropped it before registration (`applied`).
+        #      Expected — the user asked for a narrowed set.
+        #   2. It survived intersection but matches no imported tool (`registered`).
+        #      Likely a typo or wrong tier.
+        missing = applied - registered
         if missing:
             logger.warning(
                 "Allowlist names not registered (no matching imported tool): %s",
                 sorted(missing),
+            )
+        filtered = allowlist - applied
+        if filtered:
+            logger.info(
+                "Allowlist names dropped by tier/service selection: %s",
+                sorted(filtered),
             )
         logger.info(
             "Tool allowlist: %d tool(s) registered: %s",

--- a/tests/test_tool_allowlist.py
+++ b/tests/test_tool_allowlist.py
@@ -97,3 +97,55 @@ def test_env_parsing_rejects_empty():
     raw = "   ,  ,   "
     parsed = [t.strip() for t in raw.split(",") if t.strip()]
     assert parsed == []
+
+
+def test_post_import_validation_detects_zero_registered():
+    """Allowlist name absent from imported services must fail post-registration.
+
+    Reproduces `--tools gmail --tool-allowlist create_calendar_event` where the
+    allowlist promotes to the enabled set but no calendar tools are imported.
+    """
+    from core.tool_registry import get_tool_components
+
+    class _FakeProvider:
+        def __init__(self, names):
+            self._components = {f"tool:{n}@1": object() for n in names}
+
+    class _FakeServer:
+        def __init__(self, names):
+            self.local_provider = _FakeProvider(names)
+
+    # Imported gmail-only universe; allowlist asks for a calendar tool.
+    server = _FakeServer(["send_gmail_message", "get_gmail_attachment_content"])
+    allowlist = {"create_calendar_event"}
+    set_enabled_tools(allowlist)
+
+    # Simulate post-filter step: a real filter would drop everything not in
+    # the allowlist, leaving zero registered.
+    registered_after_filter = {
+        n for n in get_tool_components(server).keys() if n in allowlist
+    }
+    assert registered_after_filter == set()
+    _reset_registry()
+
+
+def test_post_import_validation_reports_missing_names():
+    """Allowlist names that don't map to imported tools should be reportable."""
+    from core.tool_registry import get_tool_components
+
+    class _FakeProvider:
+        def __init__(self, names):
+            self._components = {f"tool:{n}@1": object() for n in names}
+
+    class _FakeServer:
+        def __init__(self, names):
+            self.local_provider = _FakeProvider(names)
+
+    server = _FakeServer(["send_gmail_message", "get_gmail_attachment_content"])
+    allowlist = {"send_gmail_message", "create_calendar_event"}
+    registered = set(get_tool_components(server).keys()) & allowlist
+    missing = allowlist - registered
+
+    assert registered == {"send_gmail_message"}
+    assert missing == {"create_calendar_event"}
+    _reset_registry()

--- a/tests/test_tool_allowlist.py
+++ b/tests/test_tool_allowlist.py
@@ -12,16 +12,35 @@ os.environ.setdefault("MCP_ENABLE_OAUTH21", "false")
 os.environ.setdefault("WORKSPACE_MCP_STATELESS_MODE", "false")
 
 from core.tool_registry import (  # noqa: E402
+    filter_server_tools,
     get_enabled_tools,
+    get_tool_components,
     set_enabled_tools,
 )
 
 
-def _reset_registry():
+def _reset_registry() -> None:
     set_enabled_tools(None)
 
 
-def test_allowlist_narrows_existing_enabled_set():
+class _FakeProvider:
+    def __init__(self, names: list[str]) -> None:
+        self._components: dict[str, object] = {
+            f"tool:{n}@1": object() for n in names
+        }
+
+    def remove_tool(self, tool_name: str) -> None:
+        for key in list(self._components):
+            if key.startswith("tool:") and key.split(":", 1)[1].rsplit("@", 1)[0] == tool_name:
+                del self._components[key]
+
+
+class _FakeServer:
+    def __init__(self, names: list[str]) -> None:
+        self.local_provider = _FakeProvider(names)
+
+
+def test_allowlist_narrows_existing_enabled_set() -> None:
     """Allowlist intersects with the set produced by tier/services."""
     _reset_registry()
     set_enabled_tools(
@@ -46,7 +65,7 @@ def test_allowlist_narrows_existing_enabled_set():
     _reset_registry()
 
 
-def test_allowlist_becomes_enabled_set_when_no_prior_filter():
+def test_allowlist_becomes_enabled_set_when_no_prior_filter() -> None:
     """When no tier/services filter is set, allowlist alone defines enabled set."""
     _reset_registry()
     assert get_enabled_tools() is None
@@ -58,7 +77,7 @@ def test_allowlist_becomes_enabled_set_when_no_prior_filter():
     _reset_registry()
 
 
-def test_allowlist_intersection_drops_tools_not_in_tier():
+def test_allowlist_intersection_drops_tools_not_in_tier() -> None:
     """Tools requested in allowlist but absent from tier selection are dropped."""
     _reset_registry()
     set_enabled_tools({"search_gmail_messages", "send_gmail_message"})
@@ -73,7 +92,7 @@ def test_allowlist_intersection_drops_tools_not_in_tier():
     _reset_registry()
 
 
-def test_empty_intersection_is_detectable_by_caller():
+def test_empty_intersection_is_detectable_by_caller() -> None:
     """If allowlist intersected with current produces nothing, caller can detect."""
     _reset_registry()
     set_enabled_tools({"search_gmail_messages"})
@@ -86,66 +105,55 @@ def test_empty_intersection_is_detectable_by_caller():
     _reset_registry()
 
 
-def test_env_parsing_splits_on_comma_and_trims():
+def test_env_parsing_splits_on_comma_and_trims() -> None:
     """Mimics the env-parsing branch added in main.py."""
     raw = "  send_gmail_message , get_gmail_attachment_content ,  "
     parsed = [t.strip() for t in raw.split(",") if t.strip()]
     assert parsed == ["send_gmail_message", "get_gmail_attachment_content"]
 
 
-def test_env_parsing_rejects_empty():
+def test_env_parsing_rejects_empty() -> None:
     raw = "   ,  ,   "
     parsed = [t.strip() for t in raw.split(",") if t.strip()]
     assert parsed == []
 
 
-def test_post_import_validation_detects_zero_registered():
+def test_post_import_validation_detects_zero_registered() -> None:
     """Allowlist name absent from imported services must fail post-registration.
 
     Reproduces `--tools gmail --tool-allowlist create_calendar_event` where the
     allowlist promotes to the enabled set but no calendar tools are imported.
+    Drives the real `filter_server_tools` so the production filter is exercised.
     """
-    from core.tool_registry import get_tool_components
-
-    class _FakeProvider:
-        def __init__(self, names):
-            self._components = {f"tool:{n}@1": object() for n in names}
-
-    class _FakeServer:
-        def __init__(self, names):
-            self.local_provider = _FakeProvider(names)
-
-    # Imported gmail-only universe; allowlist asks for a calendar tool.
     server = _FakeServer(["send_gmail_message", "get_gmail_attachment_content"])
     allowlist = {"create_calendar_event"}
     set_enabled_tools(allowlist)
 
-    # Simulate post-filter step: a real filter would drop everything not in
-    # the allowlist, leaving zero registered.
-    registered_after_filter = {
-        n for n in get_tool_components(server).keys() if n in allowlist
-    }
+    filter_server_tools(server)
+
+    registered_after_filter = set(get_tool_components(server).keys())
     assert registered_after_filter == set()
     _reset_registry()
 
 
-def test_post_import_validation_reports_missing_names():
+def test_post_import_validation_reports_missing_names() -> None:
     """Allowlist names that don't map to imported tools should be reportable."""
-    from core.tool_registry import get_tool_components
-
-    class _FakeProvider:
-        def __init__(self, names):
-            self._components = {f"tool:{n}@1": object() for n in names}
-
-    class _FakeServer:
-        def __init__(self, names):
-            self.local_provider = _FakeProvider(names)
-
     server = _FakeServer(["send_gmail_message", "get_gmail_attachment_content"])
     allowlist = {"send_gmail_message", "create_calendar_event"}
-    registered = set(get_tool_components(server).keys()) & allowlist
+    set_enabled_tools(allowlist)
+
+    filter_server_tools(server)
+
+    registered = set(get_tool_components(server).keys())
     missing = allowlist - registered
 
     assert registered == {"send_gmail_message"}
     assert missing == {"create_calendar_event"}
     _reset_registry()
+
+
+def test_env_parsing_rejects_mixed_empty_entries() -> None:
+    """Mixed empty entries like 'a,,b' should be detectable so the env var can fail fast."""
+    raw = "send_gmail_message,,get_gmail_attachment_content"
+    tokens = [t.strip() for t in raw.split(",")]
+    assert any(not t for t in tokens)

--- a/tests/test_tool_allowlist.py
+++ b/tests/test_tool_allowlist.py
@@ -1,0 +1,99 @@
+"""Tests for the --tool-allowlist CLI flag and WORKSPACE_MCP_TOOL_ALLOWLIST env var.
+
+These tests focus on the parsing and narrowing logic; full end-to-end startup
+is covered by the existing tier / permissions tests.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("MCP_ENABLE_OAUTH21", "false")
+os.environ.setdefault("WORKSPACE_MCP_STATELESS_MODE", "false")
+
+from core.tool_registry import (  # noqa: E402
+    get_enabled_tools,
+    set_enabled_tools,
+)
+
+
+def _reset_registry():
+    set_enabled_tools(None)
+
+
+def test_allowlist_narrows_existing_enabled_set():
+    """Allowlist intersects with the set produced by tier/services."""
+    _reset_registry()
+    set_enabled_tools(
+        {
+            "search_gmail_messages",
+            "get_gmail_message_content",
+            "send_gmail_message",
+            "get_gmail_attachment_content",
+            "draft_gmail_message",
+        }
+    )
+
+    allowlist = {"send_gmail_message", "get_gmail_attachment_content"}
+    current = get_enabled_tools()
+    narrowed = current & allowlist
+    set_enabled_tools(narrowed)
+
+    assert get_enabled_tools() == {
+        "send_gmail_message",
+        "get_gmail_attachment_content",
+    }
+    _reset_registry()
+
+
+def test_allowlist_becomes_enabled_set_when_no_prior_filter():
+    """When no tier/services filter is set, allowlist alone defines enabled set."""
+    _reset_registry()
+    assert get_enabled_tools() is None
+
+    allowlist = {"send_gmail_message", "get_gmail_attachment_content"}
+    set_enabled_tools(allowlist)
+
+    assert get_enabled_tools() == allowlist
+    _reset_registry()
+
+
+def test_allowlist_intersection_drops_tools_not_in_tier():
+    """Tools requested in allowlist but absent from tier selection are dropped."""
+    _reset_registry()
+    set_enabled_tools({"search_gmail_messages", "send_gmail_message"})
+
+    # User asks for send + attachment, but attachment isn't in the tier.
+    allowlist = {"send_gmail_message", "get_gmail_attachment_content"}
+    current = get_enabled_tools()
+    narrowed = current & allowlist
+    set_enabled_tools(narrowed)
+
+    assert get_enabled_tools() == {"send_gmail_message"}
+    _reset_registry()
+
+
+def test_empty_intersection_is_detectable_by_caller():
+    """If allowlist intersected with current produces nothing, caller can detect."""
+    _reset_registry()
+    set_enabled_tools({"search_gmail_messages"})
+
+    allowlist = {"send_gmail_message"}  # not in tier
+    current = get_enabled_tools()
+    narrowed = current & allowlist
+
+    assert narrowed == set()
+    _reset_registry()
+
+
+def test_env_parsing_splits_on_comma_and_trims():
+    """Mimics the env-parsing branch added in main.py."""
+    raw = "  send_gmail_message , get_gmail_attachment_content ,  "
+    parsed = [t.strip() for t in raw.split(",") if t.strip()]
+    assert parsed == ["send_gmail_message", "get_gmail_attachment_content"]
+
+
+def test_env_parsing_rejects_empty():
+    raw = "   ,  ,   "
+    parsed = [t.strip() for t in raw.split(",") if t.strip()]
+    assert parsed == []


### PR DESCRIPTION
## Description

Adds an optional final-stage filter that narrows the registered tool set to an explicit list of tool names. It composes with the existing `--tool-tier`, `--tools`, `--read-only`, and `--permissions` selection rather than replacing any of them.

### Motivation

There are deployment scenarios where the right number of tools is "a few named ones" rather than a whole tier. A concrete example: hosting this server alongside a richer first-party Gmail integration that already covers search/read/labels well — but lacks attachment download and the ability to send mail with attachments. The cleanest configuration there is exactly two tools: `get_gmail_attachment_content` and `send_gmail_message`.

The existing knobs don't quite reach that:
- `--tool-tier` picks a curated batch; `core` Gmail tier omits attachment download, and `extended` brings in eight extra tools.
- `--tools gmail` is service-level only.
- `--permissions gmail:send` controls scope, not the registered tool set.

That leaves operators with two unattractive options: maintain a fork just to comment out tool registrations, or expose a wider tool surface than they want and disable everything else in each MCP client UI per user.

### What this adds

- `--tool-allowlist TOOL_NAME [TOOL_NAME ...]` CLI flag
- `WORKSPACE_MCP_TOOL_ALLOWLIST` env var (comma-separated)

### Behaviour

The allowlist is applied **after** tier/services/read-only/permissions have chosen a set:
- If a prior filter is active, the allowlist intersects with it.
- If no prior filter is active (default mode, or `--tools gmail` only), the allowlist itself becomes the enabled set.
- If the resulting set is empty (either by intersection or because no allowlisted name maps to an imported service post-registration), startup fails fast with diagnostics.

### Composes with existing flags

```bash
# Just two tools, no tier needed:
python main.py --tool-allowlist get_gmail_attachment_content send_gmail_message

# Extended tier, but trimmed to a subset:
python main.py --tool-tier extended --tools gmail \
  --tool-allowlist get_gmail_attachment_content send_gmail_message draft_gmail_message

# Same via env vars (useful for container deployments):
WORKSPACE_MCP_TOOL_TIER=extended \
WORKSPACE_MCP_TOOLS=gmail \
WORKSPACE_MCP_TOOL_ALLOWLIST=get_gmail_attachment_content,send_gmail_message \
python main.py --transport streamable-http
```

### Implementation notes

- Allowlist application is wedged in right after the existing tier/tools/default branches set `_enabled_tools`, and re-uses `set_enabled_tool_names` + the existing `core.tool_registry.filter_server_tools` post-registration filter rather than introducing a parallel filtering mechanism.
- Post-filter validation runs after `filter_server_tools` so `--tools gmail --tool-allowlist <calendar_tool>` fails fast (zero tools registered) instead of silently starting with an empty registry. Allowlist names that don't correspond to any imported tool are logged as a warning.
- The env-var parser strips whitespace and ignores empty segments.
- No changes to scope resolution: scopes still come from the resolved tier/permissions; the allowlist only decides which of the already-scope-aware tools actually get registered.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

`tests/test_tool_allowlist.py` covers:
- allowlist narrows an existing enabled set (intersection)
- allowlist alone defines the enabled set when no prior filter
- tools requested in allowlist but absent from the tier are dropped
- empty-intersection is detectable
- env-string parsing strips whitespace and handles trailing commas
- env-string parsing returns an empty list for whitespace-only input
- post-import validation detects zero registered tools (allowlist names don't match imported services)
- post-import validation reports missing allowlist names

```
$ python -m pytest tests/test_tool_allowlist.py -v
============================== 8 passed in 0.01s ==============================
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Backwards compatibility

Strictly additive. No existing flag changes meaning, no existing default behaviour changes. Deployments that don't set the flag or env var see identical startup behaviour to before.

## Out of scope

- No changes to scope advertising. If a user lists `get_gmail_attachment_content` in the allowlist but the resolved tier doesn't include attachment scopes, the tool is correctly absent — the allowlist narrows what tier/permissions produced, never widens.
- Unknown tool names that don't match any imported service are logged at WARNING but don't fail the boot (mirrors how `--tools gmail` silently ignores `drive` if the drive service isn't being loaded). Zero-registered-tools is still a hard error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tool allowlist functionality to restrict which tools are available via the `--tool-allowlist` command-line option or `WORKSPACE_MCP_TOOL_ALLOWLIST` environment variable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->