### PR TITLE
feat: configurable MCP server icon and website_url via env

### DIFF
--- a/core/server.py
+++ b/core/server.py
@@ -664,6 +664,54 @@ async def serve_attachment(request: Request):
     )
 
 
+def _resolve_favicon_dir() -> str:
+    """Return the directory to search for favicon assets.
+
+    Resolution order:
+    1. WORKSPACE_MCP_FAVICON_DIR (explicit override).
+    2. The configured credentials directory — the existing persistent-storage
+       mount in the default Docker setup. This lets operators drop a favicon
+       into the already-mounted volume (e.g. ``docker cp favicon.ico
+       gws_mcp:/app/store_creds/``) without editing docker-compose / Dockerfile.
+    3. The default credentials path under the user's home dir.
+    """
+    explicit = os.getenv("WORKSPACE_MCP_FAVICON_DIR", "").strip()
+    if explicit:
+        return os.path.expanduser(explicit)
+    for env_name in ("WORKSPACE_MCP_CREDENTIALS_DIR", "GOOGLE_MCP_CREDENTIALS_DIR"):
+        creds_dir = os.getenv(env_name, "").strip()
+        if creds_dir:
+            return os.path.expanduser(creds_dir)
+    return os.path.join(os.path.expanduser("~"), ".google_workspace_mcp", "credentials")
+
+
+async def _serve_favicon_file(filename: str, media_type: str):
+    """Serve a favicon asset from the resolved favicon directory, or 404."""
+    candidate = os.path.join(_resolve_favicon_dir(), filename)
+    if not os.path.isfile(candidate):
+        return JSONResponse({"error": "Not found"}, status_code=404)
+    return FileResponse(
+        path=candidate,
+        media_type=media_type,
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
+@server.custom_route("/favicon.ico", methods=["GET"])
+async def favicon_ico(request: Request):
+    return await _serve_favicon_file("favicon.ico", "image/vnd.microsoft.icon")
+
+
+@server.custom_route("/favicon.png", methods=["GET"])
+async def favicon_png(request: Request):
+    return await _serve_favicon_file("favicon.png", "image/png")
+
+
+@server.custom_route("/apple-touch-icon.png", methods=["GET"])
+async def apple_touch_icon(request: Request):
+    return await _serve_favicon_file("apple-touch-icon.png", "image/png")
+
+
 async def legacy_oauth2_callback(request: Request) -> HTMLResponse:
     state = request.query_params.get("state")
     code = request.query_params.get("code")

--- a/core/server.py
+++ b/core/server.py
@@ -4,8 +4,11 @@ import asyncio
 import hashlib
 import logging
 import os
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 from importlib import metadata
+
+if TYPE_CHECKING:
+    from mcp.types import Icon
 
 from core.warning_filters import install_startup_warning_filters
 
@@ -159,7 +162,7 @@ When using Google Workspace tools, always use `{USER_GOOGLE_EMAIL}` as the `user
     logger.info(f"Server instructions configured for user: {USER_GOOGLE_EMAIL}")
 
 
-def _build_server_icons() -> Optional[list]:
+def _build_server_icons() -> Optional[List["Icon"]]:
     """Build the optional MCP server icon list from environment variables.
 
     Returns None when no icon is configured, so we fall back to FastMCP's
@@ -168,9 +171,18 @@ def _build_server_icons() -> Optional[list]:
         WORKSPACE_MCP_SERVER_ICON_URL   - https:// or data: URI of the icon
         WORKSPACE_MCP_SERVER_ICON_MIME  - optional, e.g. "image/png"
         WORKSPACE_MCP_SERVER_ICON_SIZES - optional, e.g. "48x48,96x96,256x256"
+
+    Only ``https://`` and ``data:`` schemes are accepted; any other value is
+    rejected so we don't advertise arbitrary or unsafe URIs to MCP clients.
     """
     src = os.getenv("WORKSPACE_MCP_SERVER_ICON_URL", "").strip()
     if not src:
+        return None
+    if not (src.startswith("https://") or src.startswith("data:")):
+        logger.warning(
+            "Ignoring WORKSPACE_MCP_SERVER_ICON_URL: only https:// and data: "
+            "URIs are accepted."
+        )
         return None
     try:
         # Imported lazily so the dependency surface is unchanged when no
@@ -187,14 +199,22 @@ def _build_server_icons() -> Optional[list]:
     sizes = [s.strip() for s in sizes_raw.split(",") if s.strip()] if sizes_raw else None
 
     icon = Icon(src=src, mimeType=mime, sizes=sizes)
-    logger.info("Server icon configured: %s", src)
+    # Don't log the full src: data: URIs can embed the icon payload and bloat
+    # logs (and accidentally leak in shared dashboards).
+    scheme = "data" if src.startswith("data:") else "https"
+    logger.info("Server icon configured (scheme=%s)", scheme)
     return [icon]
 
 
 _server_icons = _build_server_icons()
 _server_website_url = os.getenv("WORKSPACE_MCP_SERVER_WEBSITE_URL", "").strip() or None
+if _server_website_url and not _server_website_url.startswith("https://"):
+    logger.warning(
+        "Ignoring WORKSPACE_MCP_SERVER_WEBSITE_URL: only https:// URLs are accepted."
+    )
+    _server_website_url = None
 if _server_website_url:
-    logger.info("Server website_url configured: %s", _server_website_url)
+    logger.info("Server website_url configured (https)")
 
 server = SecureFastMCP(
     name="google_workspace",

--- a/core/server.py
+++ b/core/server.py
@@ -31,7 +31,7 @@ from core.config import (
     set_transport_mode as _set_transport_mode,
     get_oauth_redirect_uri as get_oauth_redirect_uri_for_current_mode,
 )
-from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
+from fastapi.responses import HTMLResponse, JSONResponse, FileResponse, Response
 from fastmcp import FastMCP
 from fastmcp.server.auth.providers.google import GoogleProvider
 from mcp.types import ToolAnnotations
@@ -685,7 +685,7 @@ def _resolve_favicon_dir() -> str:
     return os.path.join(os.path.expanduser("~"), ".google_workspace_mcp", "credentials")
 
 
-async def _serve_favicon_file(filename: str, media_type: str):
+async def _serve_favicon_file(filename: str, media_type: str) -> Response:
     """Serve a favicon asset from the resolved favicon directory, or 404."""
     candidate = os.path.join(_resolve_favicon_dir(), filename)
     if not os.path.isfile(candidate):
@@ -698,17 +698,17 @@ async def _serve_favicon_file(filename: str, media_type: str):
 
 
 @server.custom_route("/favicon.ico", methods=["GET"])
-async def favicon_ico(request: Request):
+async def favicon_ico(request: Request) -> Response:
     return await _serve_favicon_file("favicon.ico", "image/vnd.microsoft.icon")
 
 
 @server.custom_route("/favicon.png", methods=["GET"])
-async def favicon_png(request: Request):
+async def favicon_png(request: Request) -> Response:
     return await _serve_favicon_file("favicon.png", "image/png")
 
 
 @server.custom_route("/apple-touch-icon.png", methods=["GET"])
-async def apple_touch_icon(request: Request):
+async def apple_touch_icon(request: Request) -> Response:
     return await _serve_favicon_file("apple-touch-icon.png", "image/png")
 
 

--- a/core/server.py
+++ b/core/server.py
@@ -158,10 +158,50 @@ if USER_GOOGLE_EMAIL:
 When using Google Workspace tools, always use `{USER_GOOGLE_EMAIL}` as the `user_google_email` parameter. Do not ask the user for their email address."""
     logger.info(f"Server instructions configured for user: {USER_GOOGLE_EMAIL}")
 
+
+def _build_server_icons() -> Optional[list]:
+    """Build the optional MCP server icon list from environment variables.
+
+    Returns None when no icon is configured, so we fall back to FastMCP's
+    default (no icon advertised). Reads:
+
+        WORKSPACE_MCP_SERVER_ICON_URL   - https:// or data: URI of the icon
+        WORKSPACE_MCP_SERVER_ICON_MIME  - optional, e.g. "image/png"
+        WORKSPACE_MCP_SERVER_ICON_SIZES - optional, e.g. "48x48,96x96,256x256"
+    """
+    src = os.getenv("WORKSPACE_MCP_SERVER_ICON_URL", "").strip()
+    if not src:
+        return None
+    try:
+        # Imported lazily so the dependency surface is unchanged when no
+        # icon is configured.
+        from mcp.types import Icon
+    except ImportError:  # pragma: no cover - mcp is a hard dep, but be safe
+        logger.warning(
+            "Could not import mcp.types.Icon; ignoring WORKSPACE_MCP_SERVER_ICON_URL"
+        )
+        return None
+
+    mime = os.getenv("WORKSPACE_MCP_SERVER_ICON_MIME", "").strip() or None
+    sizes_raw = os.getenv("WORKSPACE_MCP_SERVER_ICON_SIZES", "").strip()
+    sizes = [s.strip() for s in sizes_raw.split(",") if s.strip()] if sizes_raw else None
+
+    icon = Icon(src=src, mimeType=mime, sizes=sizes)
+    logger.info("Server icon configured: %s", src)
+    return [icon]
+
+
+_server_icons = _build_server_icons()
+_server_website_url = os.getenv("WORKSPACE_MCP_SERVER_WEBSITE_URL", "").strip() or None
+if _server_website_url:
+    logger.info("Server website_url configured: %s", _server_website_url)
+
 server = SecureFastMCP(
     name="google_workspace",
     auth=None,
     instructions=_server_instructions,
+    icons=_server_icons,
+    website_url=_server_website_url,
 )
 
 # Add the AuthInfo middleware to inject authentication into FastMCP context

--- a/main.py
+++ b/main.py
@@ -378,16 +378,16 @@ def main():
     if args.tool_allowlist is None:
         _env_allowlist = os.getenv("WORKSPACE_MCP_TOOL_ALLOWLIST", "").strip()
         if _env_allowlist:
-            _parsed_allowlist = [
-                t.strip() for t in _env_allowlist.split(",") if t.strip()
-            ]
-            if not _parsed_allowlist:
+            _raw_tokens = _env_allowlist.split(",")
+            # Reject mixed empty entries (`a,,b`) — likely a typo, not a deliberate
+            # value. The all-empty case (`   ,  ,   `) is also caught here.
+            if any(not t.strip() for t in _raw_tokens):
                 _exit_with_env_error(
                     "WORKSPACE_MCP_TOOL_ALLOWLIST",
                     _env_allowlist,
                     "comma-separated tool names",
                 )
-            args.tool_allowlist = _parsed_allowlist
+            args.tool_allowlist = [t.strip() for t in _raw_tokens]
     if args.transport is None:
         _env_transport = os.getenv("WORKSPACE_MCP_TRANSPORT", "").strip().lower()
         if _env_transport:

--- a/main.py
+++ b/main.py
@@ -287,6 +287,24 @@ def main():
             "Mutually exclusive with --read-only and --tools."
         ),
     )
+    parser.add_argument(
+        "--tool-allowlist",
+        nargs="+",
+        metavar="TOOL_NAME",
+        default=None,
+        help=(
+            "Restrict registered tools to this exact list of tool names. "
+            "Narrows whatever set --tool-tier, --tools, --read-only or "
+            "--permissions would otherwise enable; only the named tools are "
+            "registered with the MCP server. Useful when a deployment needs "
+            "a small subset of tools without authoring a custom tier "
+            "(e.g. --tool-allowlist get_gmail_attachment_content "
+            "send_gmail_message). "
+            "Also configurable via WORKSPACE_MCP_TOOL_ALLOWLIST "
+            "(comma-separated). Tools not present in the resolved selection "
+            "(after tier/services/permissions) are silently dropped."
+        ),
+    )
     args = parser.parse_args()
 
     # Env var fallbacks for plugin users who configure via userConfig.
@@ -357,6 +375,19 @@ def main():
             "WORKSPACE_MCP_PERMISSIONS ignored because %s was provided on the CLI",
             " and ".join(_conflicts),
         )
+    if args.tool_allowlist is None:
+        _env_allowlist = os.getenv("WORKSPACE_MCP_TOOL_ALLOWLIST", "").strip()
+        if _env_allowlist:
+            _parsed_allowlist = [
+                t.strip() for t in _env_allowlist.split(",") if t.strip()
+            ]
+            if not _parsed_allowlist:
+                _exit_with_env_error(
+                    "WORKSPACE_MCP_TOOL_ALLOWLIST",
+                    _env_allowlist,
+                    "comma-separated tool names",
+                )
+            args.tool_allowlist = _parsed_allowlist
     if args.transport is None:
         _env_transport = os.getenv("WORKSPACE_MCP_TRANSPORT", "").strip().lower()
         if _env_transport:
@@ -584,6 +615,38 @@ def main():
         tools_to_import = tool_imports.keys()
         # Don't filter individual tools when importing all
         set_enabled_tool_names(None)
+
+    # Optional final filter: narrow registered tools to an explicit allowlist.
+    # Applies on top of tier / services / read-only / permissions selection.
+    if args.tool_allowlist:
+        from core.tool_registry import get_enabled_tools
+
+        allowlist = {t.strip() for t in args.tool_allowlist if t.strip()}
+        if not allowlist:
+            safe_print(
+                "❌ --tool-allowlist / WORKSPACE_MCP_TOOL_ALLOWLIST produced an "
+                "empty set of tool names"
+            )
+            sys.exit(1)
+        current_enabled = get_enabled_tools()
+        if current_enabled is None:
+            # No prior tool filter (e.g. default mode or --tools only).
+            # The allowlist itself becomes the enabled set.
+            set_enabled_tool_names(allowlist)
+        else:
+            narrowed = current_enabled & allowlist
+            if not narrowed:
+                safe_print(
+                    "❌ --tool-allowlist filtered out every tool. "
+                    "Allowlist: %s. Available before allowlist: %s"
+                    % (sorted(allowlist), sorted(current_enabled))
+                )
+                sys.exit(1)
+            set_enabled_tool_names(narrowed)
+        logger.info(
+            "Tool allowlist applied: %d tool(s) will be registered",
+            len(allowlist),
+        )
 
     wrap_server_tool_method(server)
 

--- a/main.py
+++ b/main.py
@@ -630,22 +630,23 @@ def main():
             sys.exit(1)
         current_enabled = get_enabled_tools()
         if current_enabled is None:
-            # No prior tool filter (e.g. default mode or --tools only).
-            # The allowlist itself becomes the enabled set.
-            set_enabled_tool_names(allowlist)
+            # No prior tier filter (default mode or --tools-only). The
+            # allowlist becomes the enabled set; whether every name maps to
+            # an actually-imported tool is validated post-registration below.
+            applied = allowlist
         else:
-            narrowed = current_enabled & allowlist
-            if not narrowed:
+            applied = current_enabled & allowlist
+            if not applied:
                 safe_print(
                     "❌ --tool-allowlist filtered out every tool. "
                     "Allowlist: %s. Available before allowlist: %s"
                     % (sorted(allowlist), sorted(current_enabled))
                 )
                 sys.exit(1)
-            set_enabled_tool_names(narrowed)
+        set_enabled_tool_names(applied)
         logger.info(
-            "Tool allowlist applied: %d tool(s) will be registered",
-            len(allowlist),
+            "Tool allowlist applied: %d tool name(s) requested",
+            len(applied),
         )
 
     wrap_server_tool_method(server)
@@ -681,6 +682,34 @@ def main():
 
     # Filter tools based on tier configuration (if tier-based loading is enabled)
     filter_server_tools(server)
+
+    # Allowlist correctness: a name in the allowlist that doesn't belong to any
+    # imported service silently produces no registered tool. Validate post-filter
+    # so callers like `--tools gmail --tool-allowlist create_calendar_event`
+    # fail fast instead of starting empty.
+    if args.tool_allowlist:
+        from core.tool_registry import get_tool_components
+
+        registered = set(get_tool_components(server).keys())
+        if not registered:
+            safe_print(
+                "❌ --tool-allowlist / WORKSPACE_MCP_TOOL_ALLOWLIST resulted in "
+                "zero registered tools. Check that allowlist names match tools "
+                "provided by the services imported via --tools / --tool-tier. "
+                "Requested: %s" % sorted(allowlist)
+            )
+            sys.exit(1)
+        missing = allowlist - registered
+        if missing:
+            logger.warning(
+                "Allowlist names not registered (no matching imported tool): %s",
+                sorted(missing),
+            )
+        logger.info(
+            "Tool allowlist: %d tool(s) registered: %s",
+            len(registered),
+            sorted(registered),
+        )
 
     summary_parts = [f"{len(loaded)}/{len(tool_imports)} services"]
     if args.tool_tier is not None:

--- a/main.py
+++ b/main.py
@@ -638,9 +638,9 @@ def main():
             applied = current_enabled & allowlist
             if not applied:
                 safe_print(
-                    "❌ --tool-allowlist filtered out every tool. "
-                    "Allowlist: %s. Available before allowlist: %s"
-                    % (sorted(allowlist), sorted(current_enabled))
+                    f"❌ --tool-allowlist filtered out every tool. "
+                    f"Allowlist: {sorted(allowlist)}. "
+                    f"Available before allowlist: {sorted(current_enabled)}"
                 )
                 sys.exit(1)
         set_enabled_tool_names(applied)
@@ -693,17 +693,28 @@ def main():
         registered = set(get_tool_components(server).keys())
         if not registered:
             safe_print(
-                "❌ --tool-allowlist / WORKSPACE_MCP_TOOL_ALLOWLIST resulted in "
-                "zero registered tools. Check that allowlist names match tools "
-                "provided by the services imported via --tools / --tool-tier. "
-                "Requested: %s" % sorted(allowlist)
+                f"❌ --tool-allowlist / WORKSPACE_MCP_TOOL_ALLOWLIST resulted in "
+                f"zero registered tools. Check that allowlist names match tools "
+                f"provided by the services imported via --tools / --tool-tier. "
+                f"Requested: {sorted(allowlist)}"
             )
             sys.exit(1)
-        missing = allowlist - registered
+        # Two distinct cases for an allowlisted name that didn't register:
+        #   1. Tier/service selection dropped it before registration (`applied`).
+        #      Expected — the user asked for a narrowed set.
+        #   2. It survived intersection but matches no imported tool (`registered`).
+        #      Likely a typo or wrong tier.
+        missing = applied - registered
         if missing:
             logger.warning(
                 "Allowlist names not registered (no matching imported tool): %s",
                 sorted(missing),
+            )
+        filtered = allowlist - applied
+        if filtered:
+            logger.info(
+                "Allowlist names dropped by tier/service selection: %s",
+                sorted(filtered),
             )
         logger.info(
             "Tool allowlist: %d tool(s) registered: %s",

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -1,0 +1,94 @@
+"""Tests for the favicon HTTP routes and directory resolution.
+
+The favicon feature lets operators drop favicon.ico / favicon.png /
+apple-touch-icon.png into a pre-mounted persistent-storage directory and
+have the server serve them at the corresponding root paths.
+"""
+import os
+import sys
+
+import pytest
+from starlette.responses import FileResponse
+from starlette.responses import JSONResponse
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("MCP_ENABLE_OAUTH21", "false")
+os.environ.setdefault("WORKSPACE_MCP_STATELESS_MODE", "false")
+
+
+@pytest.fixture
+def clean_favicon_env(monkeypatch):
+    for var in (
+        "WORKSPACE_MCP_FAVICON_DIR",
+        "WORKSPACE_MCP_CREDENTIALS_DIR",
+        "GOOGLE_MCP_CREDENTIALS_DIR",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+def test_favicon_dir_explicit_override(clean_favicon_env, monkeypatch, tmp_path):
+    from core.server import _resolve_favicon_dir
+
+    monkeypatch.setenv("WORKSPACE_MCP_FAVICON_DIR", str(tmp_path))
+    assert _resolve_favicon_dir() == str(tmp_path)
+
+
+def test_favicon_dir_falls_back_to_workspace_creds(
+    clean_favicon_env, monkeypatch, tmp_path
+):
+    from core.server import _resolve_favicon_dir
+
+    monkeypatch.setenv("WORKSPACE_MCP_CREDENTIALS_DIR", str(tmp_path))
+    assert _resolve_favicon_dir() == str(tmp_path)
+
+
+def test_favicon_dir_falls_back_to_google_creds(
+    clean_favicon_env, monkeypatch, tmp_path
+):
+    from core.server import _resolve_favicon_dir
+
+    monkeypatch.setenv("GOOGLE_MCP_CREDENTIALS_DIR", str(tmp_path))
+    assert _resolve_favicon_dir() == str(tmp_path)
+
+
+def test_favicon_dir_explicit_wins_over_creds(
+    clean_favicon_env, monkeypatch, tmp_path
+):
+    from core.server import _resolve_favicon_dir
+
+    favicon_dir = tmp_path / "favicons"
+    favicon_dir.mkdir()
+    creds_dir = tmp_path / "creds"
+    creds_dir.mkdir()
+    monkeypatch.setenv("WORKSPACE_MCP_FAVICON_DIR", str(favicon_dir))
+    monkeypatch.setenv("WORKSPACE_MCP_CREDENTIALS_DIR", str(creds_dir))
+    assert _resolve_favicon_dir() == str(favicon_dir)
+
+
+@pytest.mark.asyncio
+async def test_serve_favicon_returns_404_when_missing(
+    clean_favicon_env, monkeypatch, tmp_path
+):
+    from core.server import _serve_favicon_file
+
+    monkeypatch.setenv("WORKSPACE_MCP_FAVICON_DIR", str(tmp_path))
+    response = await _serve_favicon_file("favicon.ico", "image/vnd.microsoft.icon")
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_serve_favicon_returns_file_when_present(
+    clean_favicon_env, monkeypatch, tmp_path
+):
+    from core.server import _serve_favicon_file
+
+    monkeypatch.setenv("WORKSPACE_MCP_FAVICON_DIR", str(tmp_path))
+    ico_path = tmp_path / "favicon.ico"
+    ico_path.write_bytes(b"\x00\x00\x01\x00")  # minimal ICO header bytes
+    response = await _serve_favicon_file("favicon.ico", "image/vnd.microsoft.icon")
+    assert isinstance(response, FileResponse)
+    assert response.media_type == "image/vnd.microsoft.icon"
+    assert response.headers.get("cache-control") == "public, max-age=86400"

--- a/tests/test_server_icon.py
+++ b/tests/test_server_icon.py
@@ -85,3 +85,52 @@ def test_blank_env_treated_as_unset(reload_server_module, monkeypatch):
 
     assert server_mod._server_icons is None
     assert server_mod._server_website_url is None
+
+
+def test_data_uri_icon_accepted(reload_server_module, monkeypatch):
+    monkeypatch.setenv(
+        "WORKSPACE_MCP_SERVER_ICON_URL",
+        "data:image/png;base64,iVBORw0KGgo=",
+    )
+    import core.server as server_mod
+    importlib.reload(server_mod)
+
+    icons = server_mod._server_icons
+    assert icons is not None and len(icons) == 1
+    assert icons[0].src.startswith("data:image/png;base64,")
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "http://example.com/icon.png",  # plain http
+        "javascript:alert(1)",
+        "file:///etc/passwd",
+        "ftp://example.com/icon.png",
+        "example.com/icon.png",
+    ],
+)
+def test_icon_url_rejects_unsupported_schemes(
+    reload_server_module, monkeypatch, bad_url
+):
+    monkeypatch.setenv("WORKSPACE_MCP_SERVER_ICON_URL", bad_url)
+    import core.server as server_mod
+    importlib.reload(server_mod)
+
+    assert server_mod._server_icons is None
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "http://example.com",
+        "javascript:alert(1)",
+        "example.com",
+    ],
+)
+def test_website_url_rejects_non_https(reload_server_module, monkeypatch, bad_url):
+    monkeypatch.setenv("WORKSPACE_MCP_SERVER_WEBSITE_URL", bad_url)
+    import core.server as server_mod
+    importlib.reload(server_mod)
+
+    assert server_mod._server_website_url is None

--- a/tests/test_server_icon.py
+++ b/tests/test_server_icon.py
@@ -1,0 +1,87 @@
+"""Tests for the WORKSPACE_MCP_SERVER_ICON_* environment variables.
+
+These cover the icon-construction helper in isolation; full server boot
+with the icon attached is covered indirectly by smoke tests.
+"""
+import os
+import sys
+import importlib
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("MCP_ENABLE_OAUTH21", "false")
+os.environ.setdefault("WORKSPACE_MCP_STATELESS_MODE", "false")
+
+
+@pytest.fixture
+def reload_server_module(monkeypatch):
+    """Reload core.server with a clean env so module-level vars re-evaluate."""
+    for var in (
+        "WORKSPACE_MCP_SERVER_ICON_URL",
+        "WORKSPACE_MCP_SERVER_ICON_MIME",
+        "WORKSPACE_MCP_SERVER_ICON_SIZES",
+        "WORKSPACE_MCP_SERVER_WEBSITE_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    yield
+
+
+def test_no_icon_when_env_unset(reload_server_module):
+    import core.server as server_mod
+    importlib.reload(server_mod)
+    assert server_mod._server_icons is None
+
+
+def test_icon_built_from_url_only(reload_server_module, monkeypatch):
+    monkeypatch.setenv(
+        "WORKSPACE_MCP_SERVER_ICON_URL", "https://example.com/icon.png"
+    )
+    import core.server as server_mod
+    importlib.reload(server_mod)
+
+    icons = server_mod._server_icons
+    assert icons is not None
+    assert len(icons) == 1
+    assert icons[0].src == "https://example.com/icon.png"
+    assert icons[0].mimeType is None
+    assert icons[0].sizes is None
+
+
+def test_icon_built_with_mime_and_sizes(reload_server_module, monkeypatch):
+    monkeypatch.setenv(
+        "WORKSPACE_MCP_SERVER_ICON_URL", "https://example.com/icon.png"
+    )
+    monkeypatch.setenv("WORKSPACE_MCP_SERVER_ICON_MIME", "image/png")
+    monkeypatch.setenv(
+        "WORKSPACE_MCP_SERVER_ICON_SIZES", "48x48, 96x96 , 256x256"
+    )
+    import core.server as server_mod
+    importlib.reload(server_mod)
+
+    icons = server_mod._server_icons
+    assert icons is not None and len(icons) == 1
+    icon = icons[0]
+    assert icon.src == "https://example.com/icon.png"
+    assert icon.mimeType == "image/png"
+    assert icon.sizes == ["48x48", "96x96", "256x256"]
+
+
+def test_website_url_from_env(reload_server_module, monkeypatch):
+    monkeypatch.setenv("WORKSPACE_MCP_SERVER_WEBSITE_URL", "https://example.com")
+    import core.server as server_mod
+    importlib.reload(server_mod)
+
+    assert server_mod._server_website_url == "https://example.com"
+
+
+def test_blank_env_treated_as_unset(reload_server_module, monkeypatch):
+    monkeypatch.setenv("WORKSPACE_MCP_SERVER_ICON_URL", "   ")
+    monkeypatch.setenv("WORKSPACE_MCP_SERVER_WEBSITE_URL", "  ")
+    import core.server as server_mod
+    importlib.reload(server_mod)
+
+    assert server_mod._server_icons is None
+    assert server_mod._server_website_url is None

--- a/tests/test_tool_allowlist.py
+++ b/tests/test_tool_allowlist.py
@@ -97,3 +97,55 @@ def test_env_parsing_rejects_empty():
     raw = "   ,  ,   "
     parsed = [t.strip() for t in raw.split(",") if t.strip()]
     assert parsed == []
+
+
+def test_post_import_validation_detects_zero_registered():
+    """Allowlist name absent from imported services must fail post-registration.
+
+    Reproduces `--tools gmail --tool-allowlist create_calendar_event` where the
+    allowlist promotes to the enabled set but no calendar tools are imported.
+    """
+    from core.tool_registry import get_tool_components
+
+    class _FakeProvider:
+        def __init__(self, names):
+            self._components = {f"tool:{n}@1": object() for n in names}
+
+    class _FakeServer:
+        def __init__(self, names):
+            self.local_provider = _FakeProvider(names)
+
+    # Imported gmail-only universe; allowlist asks for a calendar tool.
+    server = _FakeServer(["send_gmail_message", "get_gmail_attachment_content"])
+    allowlist = {"create_calendar_event"}
+    set_enabled_tools(allowlist)
+
+    # Simulate post-filter step: a real filter would drop everything not in
+    # the allowlist, leaving zero registered.
+    registered_after_filter = {
+        n for n in get_tool_components(server).keys() if n in allowlist
+    }
+    assert registered_after_filter == set()
+    _reset_registry()
+
+
+def test_post_import_validation_reports_missing_names():
+    """Allowlist names that don't map to imported tools should be reportable."""
+    from core.tool_registry import get_tool_components
+
+    class _FakeProvider:
+        def __init__(self, names):
+            self._components = {f"tool:{n}@1": object() for n in names}
+
+    class _FakeServer:
+        def __init__(self, names):
+            self.local_provider = _FakeProvider(names)
+
+    server = _FakeServer(["send_gmail_message", "get_gmail_attachment_content"])
+    allowlist = {"send_gmail_message", "create_calendar_event"}
+    registered = set(get_tool_components(server).keys()) & allowlist
+    missing = allowlist - registered
+
+    assert registered == {"send_gmail_message"}
+    assert missing == {"create_calendar_event"}
+    _reset_registry()

--- a/tests/test_tool_allowlist.py
+++ b/tests/test_tool_allowlist.py
@@ -12,16 +12,35 @@ os.environ.setdefault("MCP_ENABLE_OAUTH21", "false")
 os.environ.setdefault("WORKSPACE_MCP_STATELESS_MODE", "false")
 
 from core.tool_registry import (  # noqa: E402
+    filter_server_tools,
     get_enabled_tools,
+    get_tool_components,
     set_enabled_tools,
 )
 
 
-def _reset_registry():
+def _reset_registry() -> None:
     set_enabled_tools(None)
 
 
-def test_allowlist_narrows_existing_enabled_set():
+class _FakeProvider:
+    def __init__(self, names: list[str]) -> None:
+        self._components: dict[str, object] = {
+            f"tool:{n}@1": object() for n in names
+        }
+
+    def remove_tool(self, tool_name: str) -> None:
+        for key in list(self._components):
+            if key.startswith("tool:") and key.split(":", 1)[1].rsplit("@", 1)[0] == tool_name:
+                del self._components[key]
+
+
+class _FakeServer:
+    def __init__(self, names: list[str]) -> None:
+        self.local_provider = _FakeProvider(names)
+
+
+def test_allowlist_narrows_existing_enabled_set() -> None:
     """Allowlist intersects with the set produced by tier/services."""
     _reset_registry()
     set_enabled_tools(
@@ -46,7 +65,7 @@ def test_allowlist_narrows_existing_enabled_set():
     _reset_registry()
 
 
-def test_allowlist_becomes_enabled_set_when_no_prior_filter():
+def test_allowlist_becomes_enabled_set_when_no_prior_filter() -> None:
     """When no tier/services filter is set, allowlist alone defines enabled set."""
     _reset_registry()
     assert get_enabled_tools() is None
@@ -58,7 +77,7 @@ def test_allowlist_becomes_enabled_set_when_no_prior_filter():
     _reset_registry()
 
 
-def test_allowlist_intersection_drops_tools_not_in_tier():
+def test_allowlist_intersection_drops_tools_not_in_tier() -> None:
     """Tools requested in allowlist but absent from tier selection are dropped."""
     _reset_registry()
     set_enabled_tools({"search_gmail_messages", "send_gmail_message"})
@@ -73,7 +92,7 @@ def test_allowlist_intersection_drops_tools_not_in_tier():
     _reset_registry()
 
 
-def test_empty_intersection_is_detectable_by_caller():
+def test_empty_intersection_is_detectable_by_caller() -> None:
     """If allowlist intersected with current produces nothing, caller can detect."""
     _reset_registry()
     set_enabled_tools({"search_gmail_messages"})
@@ -86,66 +105,55 @@ def test_empty_intersection_is_detectable_by_caller():
     _reset_registry()
 
 
-def test_env_parsing_splits_on_comma_and_trims():
+def test_env_parsing_splits_on_comma_and_trims() -> None:
     """Mimics the env-parsing branch added in main.py."""
     raw = "  send_gmail_message , get_gmail_attachment_content ,  "
     parsed = [t.strip() for t in raw.split(",") if t.strip()]
     assert parsed == ["send_gmail_message", "get_gmail_attachment_content"]
 
 
-def test_env_parsing_rejects_empty():
+def test_env_parsing_rejects_empty() -> None:
     raw = "   ,  ,   "
     parsed = [t.strip() for t in raw.split(",") if t.strip()]
     assert parsed == []
 
 
-def test_post_import_validation_detects_zero_registered():
+def test_post_import_validation_detects_zero_registered() -> None:
     """Allowlist name absent from imported services must fail post-registration.
 
     Reproduces `--tools gmail --tool-allowlist create_calendar_event` where the
     allowlist promotes to the enabled set but no calendar tools are imported.
+    Drives the real `filter_server_tools` so the production filter is exercised.
     """
-    from core.tool_registry import get_tool_components
-
-    class _FakeProvider:
-        def __init__(self, names):
-            self._components = {f"tool:{n}@1": object() for n in names}
-
-    class _FakeServer:
-        def __init__(self, names):
-            self.local_provider = _FakeProvider(names)
-
-    # Imported gmail-only universe; allowlist asks for a calendar tool.
     server = _FakeServer(["send_gmail_message", "get_gmail_attachment_content"])
     allowlist = {"create_calendar_event"}
     set_enabled_tools(allowlist)
 
-    # Simulate post-filter step: a real filter would drop everything not in
-    # the allowlist, leaving zero registered.
-    registered_after_filter = {
-        n for n in get_tool_components(server).keys() if n in allowlist
-    }
+    filter_server_tools(server)
+
+    registered_after_filter = set(get_tool_components(server).keys())
     assert registered_after_filter == set()
     _reset_registry()
 
 
-def test_post_import_validation_reports_missing_names():
+def test_post_import_validation_reports_missing_names() -> None:
     """Allowlist names that don't map to imported tools should be reportable."""
-    from core.tool_registry import get_tool_components
-
-    class _FakeProvider:
-        def __init__(self, names):
-            self._components = {f"tool:{n}@1": object() for n in names}
-
-    class _FakeServer:
-        def __init__(self, names):
-            self.local_provider = _FakeProvider(names)
-
     server = _FakeServer(["send_gmail_message", "get_gmail_attachment_content"])
     allowlist = {"send_gmail_message", "create_calendar_event"}
-    registered = set(get_tool_components(server).keys()) & allowlist
+    set_enabled_tools(allowlist)
+
+    filter_server_tools(server)
+
+    registered = set(get_tool_components(server).keys())
     missing = allowlist - registered
 
     assert registered == {"send_gmail_message"}
     assert missing == {"create_calendar_event"}
     _reset_registry()
+
+
+def test_env_parsing_rejects_mixed_empty_entries() -> None:
+    """Mixed empty entries like 'a,,b' should be detectable so the env var can fail fast."""
+    raw = "send_gmail_message,,get_gmail_attachment_content"
+    tokens = [t.strip() for t in raw.split(",")]
+    assert any(not t for t in tokens)

--- a/tests/test_tool_allowlist.py
+++ b/tests/test_tool_allowlist.py
@@ -1,0 +1,99 @@
+"""Tests for the --tool-allowlist CLI flag and WORKSPACE_MCP_TOOL_ALLOWLIST env var.
+
+These tests focus on the parsing and narrowing logic; full end-to-end startup
+is covered by the existing tier / permissions tests.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("MCP_ENABLE_OAUTH21", "false")
+os.environ.setdefault("WORKSPACE_MCP_STATELESS_MODE", "false")
+
+from core.tool_registry import (  # noqa: E402
+    get_enabled_tools,
+    set_enabled_tools,
+)
+
+
+def _reset_registry():
+    set_enabled_tools(None)
+
+
+def test_allowlist_narrows_existing_enabled_set():
+    """Allowlist intersects with the set produced by tier/services."""
+    _reset_registry()
+    set_enabled_tools(
+        {
+            "search_gmail_messages",
+            "get_gmail_message_content",
+            "send_gmail_message",
+            "get_gmail_attachment_content",
+            "draft_gmail_message",
+        }
+    )
+
+    allowlist = {"send_gmail_message", "get_gmail_attachment_content"}
+    current = get_enabled_tools()
+    narrowed = current & allowlist
+    set_enabled_tools(narrowed)
+
+    assert get_enabled_tools() == {
+        "send_gmail_message",
+        "get_gmail_attachment_content",
+    }
+    _reset_registry()
+
+
+def test_allowlist_becomes_enabled_set_when_no_prior_filter():
+    """When no tier/services filter is set, allowlist alone defines enabled set."""
+    _reset_registry()
+    assert get_enabled_tools() is None
+
+    allowlist = {"send_gmail_message", "get_gmail_attachment_content"}
+    set_enabled_tools(allowlist)
+
+    assert get_enabled_tools() == allowlist
+    _reset_registry()
+
+
+def test_allowlist_intersection_drops_tools_not_in_tier():
+    """Tools requested in allowlist but absent from tier selection are dropped."""
+    _reset_registry()
+    set_enabled_tools({"search_gmail_messages", "send_gmail_message"})
+
+    # User asks for send + attachment, but attachment isn't in the tier.
+    allowlist = {"send_gmail_message", "get_gmail_attachment_content"}
+    current = get_enabled_tools()
+    narrowed = current & allowlist
+    set_enabled_tools(narrowed)
+
+    assert get_enabled_tools() == {"send_gmail_message"}
+    _reset_registry()
+
+
+def test_empty_intersection_is_detectable_by_caller():
+    """If allowlist intersected with current produces nothing, caller can detect."""
+    _reset_registry()
+    set_enabled_tools({"search_gmail_messages"})
+
+    allowlist = {"send_gmail_message"}  # not in tier
+    current = get_enabled_tools()
+    narrowed = current & allowlist
+
+    assert narrowed == set()
+    _reset_registry()
+
+
+def test_env_parsing_splits_on_comma_and_trims():
+    """Mimics the env-parsing branch added in main.py."""
+    raw = "  send_gmail_message , get_gmail_attachment_content ,  "
+    parsed = [t.strip() for t in raw.split(",") if t.strip()]
+    assert parsed == ["send_gmail_message", "get_gmail_attachment_content"]
+
+
+def test_env_parsing_rejects_empty():
+    raw = "   ,  ,   "
+    parsed = [t.strip() for t in raw.split(",") if t.strip()]
+    assert parsed == []

--- a/tests/test_tool_allowlist.py
+++ b/tests/test_tool_allowlist.py
@@ -153,7 +153,11 @@ def test_post_import_validation_reports_missing_names() -> None:
 
 
 def test_env_parsing_rejects_mixed_empty_entries() -> None:
-    """Mixed empty entries like 'a,,b' should be detectable so the env var can fail fast."""
+    """Mixed empty entries like 'a,,b' should be detectable so the env var can fail fast.
+
+    Mirrors the validation in main.py: split on ',' (no `if t.strip()` filter)
+    so an empty middle token surfaces as a rejectable entry.
+    """
     raw = "send_gmail_message,,get_gmail_attachment_content"
-    tokens = [t.strip() for t in raw.split(",")]
-    assert any(not t for t in tokens)
+    raw_tokens = raw.split(",")
+    assert any(not t.strip() for t in raw_tokens)


### PR DESCRIPTION
## Description

Threads two pieces of optional branding metadata — the server icon and a website URL — from environment variables into the FastMCP constructor, so they appear in the MCP `initialize` response and any public icon endpoints FastMCP exposes.

Both default to off. Existing deployments see no change.

### Motivation

FastMCP already accepts `icons=` and `website_url=` arguments and forwards them through to MCP clients that render server metadata. We just don't wire those parameters up in `core/server.py` — they're hardcoded absent. For self-hosted teams the immediate consequence is that compatible clients render their server with the literal name `google_workspace` and a generic icon, with no way to brand the deployment without forking.

This change makes both fields environment-configurable, matching the existing pattern of "everything that's deployment-specific is an env var."

### What this adds

```bash
WORKSPACE_MCP_SERVER_ICON_URL     # https:// or data: URI
WORKSPACE_MCP_SERVER_ICON_MIME    # e.g. "image/png" (optional)
WORKSPACE_MCP_SERVER_ICON_SIZES   # e.g. "48x48,96x96,256x256" (optional)
WORKSPACE_MCP_SERVER_WEBSITE_URL  # https:// URL
```

When `WORKSPACE_MCP_SERVER_ICON_URL` is set, a single `mcp.types.Icon` is constructed with the optional MIME type and size list and passed to `SecureFastMCP(icons=[...])`. When `WORKSPACE_MCP_SERVER_WEBSITE_URL` is set, it's passed as `website_url=`. When neither is set, the constructor call is byte-identical to the previous behaviour.

### Implementation notes

- Icon construction is in a small private helper `_build_server_icons()` in `core/server.py`. Returns `None` when no icon URL is configured.
- **URL scheme validation:** `WORKSPACE_MCP_SERVER_ICON_URL` is restricted to `https://` and `data:`; `WORKSPACE_MCP_SERVER_WEBSITE_URL` is restricted to `https://`. Anything else is rejected with a WARNING and the value is treated as unset, rather than advertised to MCP clients.
- **Log hygiene:** the info log records only the scheme (`scheme=https` / `scheme=data`), not the raw URL — important because a `data:` URI can embed the entire icon payload.
- `mcp.types.Icon` is imported lazily inside the helper. `mcp` is already a hard dependency (FastMCP imports it), so this is only to keep the import next to its usage.
- Blank-string env values (`"   "`) are treated as unset.
- Multiple icons aren't supported via env vars; the MCP spec allows a list but in practice clients pick one. If a future need arises, a JSON-encoded env var could be layered on without breaking the simple case.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

`tests/test_server_icon.py` covers:
- no icon when env unset (default behaviour preserved)
- icon built from `https://` URL only
- icon built with MIME type and sizes list
- `data:` URI accepted
- `https://` website_url propagation
- whitespace-only env values treated as unset
- icon URL rejects non-https/non-data schemes (`http://`, `javascript:`, `file://`, `ftp://`, scheme-less)
- website URL rejects non-https schemes

The tests reload `core.server` between cases to re-evaluate the module-level env reads, which matches how the deployment actually loads its config (at process start).

```
$ python -m pytest tests/test_server_icon.py -v
============================== 14 passed in 0.93s ==============================
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Backwards compatibility

Strictly additive. The unset path keeps the call signature unchanged relative to `main`, so existing deployments behave identically.

## Client support caveat

Whether the icon is actually rendered depends on the MCP client. Some clients already render server icons (the field is part of the current MCP spec); others may not yet. This PR makes the server side correct; client adoption is on each client's roadmap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure server icon and website URL via environment variables (HTTPS/data: validation).
  * Favicon endpoints added for common paths, serving from a configurable directory with caching and 404 JSON when missing.
  * New CLI flag / env var to allowlist which tools are enabled, with validation and runtime checks.

* **Tests**
  * Expanded test coverage for icon/website parsing, favicon behavior, and tool-allowlist logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->