### PR TITLE
feat(permissions): non-cumulative union mode for --permissions (closes #808)

### DIFF
--- a/auth/permissions.py
+++ b/auth/permissions.py
@@ -232,32 +232,6 @@ def get_scopes_for_permission(service: str, level: str) -> List[str]:
     return sorted(set(cumulative))
 
 
-def get_additive_scopes_for_level(service: str, level: str) -> List[str]:
-    """
-    Get only the scopes *added* at a given level (non-cumulative).
-
-    Unlike :func:`get_scopes_for_permission`, this returns just the additive
-    delta declared at the named level — it does not include scopes from
-    earlier levels. Used by union mode (``--permissions gmail:readonly+send``)
-    where the caller explicitly composes a scope set from selected level deltas.
-
-    Raises ValueError if service or level is unknown.
-    """
-    levels = SERVICE_PERMISSION_LEVELS.get(service)
-    if levels is None:
-        raise ValueError(f"Unknown service: '{service}'")
-
-    for level_name, level_scopes in levels:
-        if level_name == level:
-            return sorted(set(level_scopes))
-
-    valid = [name for name, _ in levels]
-    raise ValueError(
-        f"Unknown permission level '{level}' for service '{service}'. "
-        f"Valid levels: {valid}"
-    )
-
-
 def get_scopes_for_union(service: str, levels: FrozenSet[str]) -> List[str]:
     """
     Get the union of additive scopes for a set of levels (non-cumulative).
@@ -267,13 +241,22 @@ def get_scopes_for_union(service: str, levels: FrozenSet[str]) -> List[str]:
 
     Raises ValueError if any level is unknown.
     """
+    service_levels = SERVICE_PERMISSION_LEVELS.get(service)
+    if service_levels is None:
+        raise ValueError(f"Unknown service: '{service}'")
     if not levels:
         raise ValueError(f"Empty level set for service '{service}'")
 
-    combined: set = set()
-    for level in levels:
-        combined.update(get_additive_scopes_for_level(service, level))
-    return sorted(combined)
+    additive_scopes = dict(service_levels)
+    unknown = levels.difference(additive_scopes)
+    if unknown:
+        level = sorted(unknown)[0]
+        raise ValueError(
+            f"Unknown permission level '{level}' for service '{service}'. "
+            f"Valid levels: {list(additive_scopes)}"
+        )
+
+    return sorted({scope for level in levels for scope in additive_scopes[level]})
 
 
 def get_all_permission_scopes() -> List[str]:
@@ -286,7 +269,7 @@ def get_all_permission_scopes() -> List[str]:
     if _PERMISSIONS is None:
         return []
 
-    all_scopes: set = set()
+    all_scopes: set[str] = set()
     for service, value in _PERMISSIONS.items():
         if isinstance(value, frozenset):
             all_scopes.update(get_scopes_for_union(service, value))
@@ -295,7 +278,7 @@ def get_all_permission_scopes() -> List[str]:
     return list(all_scopes)
 
 
-def get_allowed_scopes_set() -> Optional[set]:
+def get_allowed_scopes_set() -> Optional[set[str]]:
     """
     Get the set of allowed scopes under permissions mode (for tool filtering).
 

--- a/auth/permissions.py
+++ b/auth/permissions.py
@@ -11,10 +11,21 @@ Usage:
 Gmail levels: readonly, organize, drafts, send, full
 Tasks levels: readonly, manage, full
 Other services: readonly, full (extensible by adding entries to SERVICE_PERMISSION_LEVELS)
+
+Non-cumulative (union) mode — separate levels with ``+`` to request only the
+additive scopes of the named levels, skipping the cumulative ladder:
+
+    --permissions gmail:readonly+send
+
+This grants exactly ``{gmail.readonly, gmail.send}`` — useful when a downstream
+allowlists a narrow tool set (e.g. read + send only) and wants the OAuth grant
+to match. Each level contributes only the scopes added at that level, not the
+scopes inherited from earlier levels. Level names must match those declared in
+``SERVICE_PERMISSION_LEVELS``.
 """
 
 import logging
-from typing import Dict, FrozenSet, List, Optional, Tuple
+from typing import Dict, FrozenSet, List, Optional, Tuple, Union
 
 from auth.scopes import (
     GMAIL_READONLY_SCOPE,
@@ -148,23 +159,33 @@ def is_action_denied(service: str, action: str) -> bool:
 
     Returns ``False`` when granular permissions mode is not active, when the
     service has no permission entry, or when the configured level does not
-    deny the action.
+    deny the action. In union mode (when the entry is a frozenset of level
+    names), the action is denied if *any* selected level denies it — most
+    restrictive wins, so explicitly including a level always carries that
+    level's exclusions.
     """
     if _PERMISSIONS is None:
         return False
     level = _PERMISSIONS.get(service)
     if level is None:
         return False
-    denied = SERVICE_DENIED_ACTIONS.get(service, {}).get(level, frozenset())
-    return action in denied
+    service_denied = SERVICE_DENIED_ACTIONS.get(service, {})
+    if isinstance(level, frozenset):
+        return any(action in service_denied.get(lvl, frozenset()) for lvl in level)
+    return action in service_denied.get(level, frozenset())
 
+
+# Type alias: a per-service permission value is either a single cumulative
+# level name (str) or a frozenset of level names for non-cumulative union mode.
+PermissionValue = Union[str, FrozenSet[str]]
 
 # Module-level state: parsed --permissions config
-# Dict mapping service_name -> level_name, e.g. {"gmail": "organize"}
-_PERMISSIONS: Optional[Dict[str, str]] = None
+# Dict mapping service_name -> level (cumulative str) or frozenset of level
+# names (union mode), e.g. {"gmail": "organize"} or {"gmail": frozenset({"readonly", "send"})}
+_PERMISSIONS: Optional[Dict[str, PermissionValue]] = None
 
 
-def set_permissions(permissions: Optional[Dict[str, str]]) -> None:
+def set_permissions(permissions: Optional[Dict[str, PermissionValue]]) -> None:
     """Set granular permissions from parsed --permissions argument."""
     global _PERMISSIONS
     _PERMISSIONS = permissions
@@ -172,7 +193,7 @@ def set_permissions(permissions: Optional[Dict[str, str]]) -> None:
         logger.info("Granular permissions set: %s", permissions)
 
 
-def get_permissions() -> Optional[Dict[str, str]]:
+def get_permissions() -> Optional[Dict[str, PermissionValue]]:
     """Return current permissions dict, or None if not using granular mode."""
     return _PERMISSIONS
 
@@ -211,18 +232,66 @@ def get_scopes_for_permission(service: str, level: str) -> List[str]:
     return sorted(set(cumulative))
 
 
+def get_additive_scopes_for_level(service: str, level: str) -> List[str]:
+    """
+    Get only the scopes *added* at a given level (non-cumulative).
+
+    Unlike :func:`get_scopes_for_permission`, this returns just the additive
+    delta declared at the named level — it does not include scopes from
+    earlier levels. Used by union mode (``--permissions gmail:readonly+send``)
+    where the caller explicitly composes a scope set from selected level deltas.
+
+    Raises ValueError if service or level is unknown.
+    """
+    levels = SERVICE_PERMISSION_LEVELS.get(service)
+    if levels is None:
+        raise ValueError(f"Unknown service: '{service}'")
+
+    for level_name, level_scopes in levels:
+        if level_name == level:
+            return sorted(set(level_scopes))
+
+    valid = [name for name, _ in levels]
+    raise ValueError(
+        f"Unknown permission level '{level}' for service '{service}'. "
+        f"Valid levels: {valid}"
+    )
+
+
+def get_scopes_for_union(service: str, levels: FrozenSet[str]) -> List[str]:
+    """
+    Get the union of additive scopes for a set of levels (non-cumulative).
+
+    Each level contributes only its own additive scopes — the caller is
+    responsible for including ``readonly`` if read access is desired.
+
+    Raises ValueError if any level is unknown.
+    """
+    if not levels:
+        raise ValueError(f"Empty level set for service '{service}'")
+
+    combined: set = set()
+    for level in levels:
+        combined.update(get_additive_scopes_for_level(service, level))
+    return sorted(combined)
+
+
 def get_all_permission_scopes() -> List[str]:
     """
     Get the combined scopes for all services at their configured permission levels.
 
+    Handles both cumulative (str) and union-mode (frozenset) entries.
     Only meaningful when is_permissions_mode() is True.
     """
     if _PERMISSIONS is None:
         return []
 
     all_scopes: set = set()
-    for service, level in _PERMISSIONS.items():
-        all_scopes.update(get_scopes_for_permission(service, level))
+    for service, value in _PERMISSIONS.items():
+        if isinstance(value, frozenset):
+            all_scopes.update(get_scopes_for_union(service, value))
+        else:
+            all_scopes.update(get_scopes_for_permission(service, value))
     return list(all_scopes)
 
 
@@ -245,21 +314,25 @@ def get_valid_levels(service: str) -> List[str]:
     return [name for name, _ in levels]
 
 
-def parse_permissions_arg(permissions_list: List[str]) -> Dict[str, str]:
+def parse_permissions_arg(permissions_list: List[str]) -> Dict[str, PermissionValue]:
     """
-    Parse --permissions arguments like ["gmail:organize", "drive:full"].
+    Parse --permissions arguments like ["gmail:organize", "drive:full"] or
+    ["gmail:readonly+send"] for non-cumulative union mode.
 
-    Returns dict mapping service -> level.
+    Returns dict mapping service -> level. The value is a ``str`` for the
+    cumulative ladder form (``gmail:organize``) or a ``frozenset[str]`` of
+    level names for the union form (``gmail:readonly+send``).
+
     Raises ValueError on parse errors (unknown service, invalid level, bad format).
     """
-    result: Dict[str, str] = {}
+    result: Dict[str, PermissionValue] = {}
     for entry in permissions_list:
         if ":" not in entry:
             raise ValueError(
                 f"Invalid permission format: '{entry}'. "
                 f"Expected 'service:level' (e.g., 'gmail:organize', 'drive:readonly')"
             )
-        service, level = entry.split(":", 1)
+        service, level_spec = entry.split(":", 1)
         if service in result:
             raise ValueError(f"Duplicate service in permissions: '{service}'")
         if service not in SERVICE_PERMISSION_LEVELS:
@@ -268,10 +341,27 @@ def parse_permissions_arg(permissions_list: List[str]) -> Dict[str, str]:
                 f"Valid services: {sorted(SERVICE_PERMISSION_LEVELS.keys())}"
             )
         valid = get_valid_levels(service)
-        if level not in valid:
-            raise ValueError(
-                f"Unknown level '{level}' for service '{service}'. "
-                f"Valid levels: {valid}"
-            )
-        result[service] = level
+
+        if "+" in level_spec:
+            parts = [p.strip() for p in level_spec.split("+")]
+            if any(not p for p in parts):
+                raise ValueError(
+                    f"Invalid union spec for service '{service}': '{level_spec}'. "
+                    f"Expected non-empty level names separated by '+' "
+                    f"(e.g., 'gmail:readonly+send')"
+                )
+            for part in parts:
+                if part not in valid:
+                    raise ValueError(
+                        f"Unknown level '{part}' for service '{service}'. "
+                        f"Valid levels: {valid}"
+                    )
+            result[service] = frozenset(parts)
+        else:
+            if level_spec not in valid:
+                raise ValueError(
+                    f"Unknown level '{level_spec}' for service '{service}'. "
+                    f"Valid levels: {valid}"
+                )
+            result[service] = level_spec
     return result

--- a/main.py
+++ b/main.py
@@ -7,7 +7,11 @@ import socket
 import sys
 from functools import partial
 from importlib import metadata, import_module
+from typing import TYPE_CHECKING
 from dotenv import load_dotenv
+
+if TYPE_CHECKING:
+    from auth.permissions import PermissionValue
 
 # Prevent any stray startup output on macOS (e.g. platform identifiers) from
 # corrupting the MCP JSON-RPC handshake on stdout. We capture anything written
@@ -205,8 +209,8 @@ def resolve_permissions_mode_selection(
 
 
 def narrow_permissions_to_services(
-    permissions: dict[str, str], services: list[str]
-) -> dict[str, str]:
+    permissions: dict[str, "PermissionValue"], services: list[str]
+) -> dict[str, "PermissionValue"]:
     """Restrict permission entries to the provided service list order."""
     return {
         service: permissions[service] for service in services if service in permissions
@@ -284,6 +288,10 @@ def main():
             "Example: --permissions gmail:organize drive:readonly. "
             "Gmail levels: readonly, organize, drafts, send, full (cumulative). "
             "Other services: readonly, full. "
+            "Non-cumulative union mode: join levels with '+' to request only "
+            "the additive scopes of the named levels "
+            "(e.g. --permissions gmail:readonly+send grants exactly "
+            "{gmail.readonly, gmail.send}). "
             "Mutually exclusive with --read-only and --tools."
         ),
     )

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -13,7 +13,11 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from auth.permissions import (
+    get_additive_scopes_for_level,
+    get_all_permission_scopes,
+    get_allowed_scopes_set,
     get_scopes_for_permission,
+    get_scopes_for_union,
     is_action_denied,
     parse_permissions_arg,
     set_permissions,
@@ -24,6 +28,8 @@ from auth.scopes import (
     GMAIL_LABELS_SCOPE,
     GMAIL_MODIFY_SCOPE,
     GMAIL_COMPOSE_SCOPE,
+    GMAIL_SEND_SCOPE,
+    GMAIL_SETTINGS_BASIC_SCOPE,
     DRIVE_READONLY_SCOPE,
     DRIVE_SCOPE,
     TASKS_READONLY_SCOPE,
@@ -199,3 +205,173 @@ class TestIsActionDenied:
         """A service with no SERVICE_DENIED_ACTIONS entry should allow all actions."""
         set_permissions({"gmail": "readonly"})
         assert is_action_denied("gmail", "delete") is False
+
+
+class TestParsePermissionsArgUnion:
+    """Tests for parse_permissions_arg() non-cumulative union syntax (level+level)."""
+
+    def test_simple_union(self):
+        result = parse_permissions_arg(["gmail:readonly+send"])
+        assert result == {"gmail": frozenset({"readonly", "send"})}
+
+    def test_three_level_union(self):
+        result = parse_permissions_arg(["gmail:readonly+organize+send"])
+        assert result == {"gmail": frozenset({"readonly", "organize", "send"})}
+
+    def test_union_deduplicates(self):
+        """Repeated levels in a union should collapse to a single set entry."""
+        result = parse_permissions_arg(["gmail:readonly+readonly"])
+        assert result == {"gmail": frozenset({"readonly"})}
+
+    def test_union_and_cumulative_mixed_across_services(self):
+        """Different services can use different modes in the same invocation."""
+        result = parse_permissions_arg(["gmail:readonly+send", "drive:full"])
+        assert result["gmail"] == frozenset({"readonly", "send"})
+        assert result["drive"] == "full"
+
+    def test_union_with_whitespace_around_levels(self):
+        result = parse_permissions_arg(["gmail:readonly + send"])
+        assert result == {"gmail": frozenset({"readonly", "send"})}
+
+    def test_union_empty_component_raises(self):
+        with pytest.raises(ValueError, match="Invalid union spec"):
+            parse_permissions_arg(["gmail:readonly+"])
+
+    def test_union_only_separator_raises(self):
+        with pytest.raises(ValueError, match="Invalid union spec"):
+            parse_permissions_arg(["gmail:+"])
+
+    def test_union_unknown_level_raises(self):
+        with pytest.raises(ValueError, match="Unknown level 'superadmin'"):
+            parse_permissions_arg(["gmail:readonly+superadmin"])
+
+    def test_union_unknown_service_raises(self):
+        with pytest.raises(ValueError, match="Unknown service"):
+            parse_permissions_arg(["fakesvc:readonly+full"])
+
+    def test_union_duplicate_service_raises(self):
+        with pytest.raises(ValueError, match="Duplicate service"):
+            parse_permissions_arg(["gmail:readonly+send", "gmail:full"])
+
+
+class TestGetAdditiveScopesForLevel:
+    """Tests for get_additive_scopes_for_level() — per-level deltas only."""
+
+    def test_gmail_readonly_returns_just_readonly_scope(self):
+        scopes = get_additive_scopes_for_level("gmail", "readonly")
+        assert scopes == [GMAIL_READONLY_SCOPE]
+
+    def test_gmail_send_returns_just_send_scope(self):
+        """send level's additive delta is gmail.send only — not the cumulative bundle."""
+        scopes = get_additive_scopes_for_level("gmail", "send")
+        assert scopes == [GMAIL_SEND_SCOPE]
+        assert GMAIL_READONLY_SCOPE not in scopes
+        assert GMAIL_LABELS_SCOPE not in scopes
+
+    def test_gmail_organize_returns_labels_and_modify_only(self):
+        scopes = get_additive_scopes_for_level("gmail", "organize")
+        assert set(scopes) == {GMAIL_LABELS_SCOPE, GMAIL_MODIFY_SCOPE}
+        assert GMAIL_READONLY_SCOPE not in scopes
+
+    def test_gmail_full_returns_just_settings_scope(self):
+        scopes = get_additive_scopes_for_level("gmail", "full")
+        assert scopes == [GMAIL_SETTINGS_BASIC_SCOPE]
+
+    def test_unknown_service_raises(self):
+        with pytest.raises(ValueError, match="Unknown service"):
+            get_additive_scopes_for_level("nonexistent", "readonly")
+
+    def test_unknown_level_raises(self):
+        with pytest.raises(ValueError, match="Unknown permission level"):
+            get_additive_scopes_for_level("gmail", "nonexistent")
+
+
+class TestGetScopesForUnion:
+    """Tests for get_scopes_for_union() — non-cumulative scope assembly."""
+
+    def test_readonly_plus_send_yields_exact_two_scopes(self):
+        """The canonical issue-#808 case: gmail:readonly+send → {readonly, send}."""
+        scopes = get_scopes_for_union("gmail", frozenset({"readonly", "send"}))
+        assert set(scopes) == {GMAIL_READONLY_SCOPE, GMAIL_SEND_SCOPE}
+
+    def test_send_alone_excludes_readonly(self):
+        """send level on its own contributes no readonly scope."""
+        scopes = get_scopes_for_union("gmail", frozenset({"send"}))
+        assert GMAIL_SEND_SCOPE in scopes
+        assert GMAIL_READONLY_SCOPE not in scopes
+
+    def test_readonly_plus_organize(self):
+        scopes = get_scopes_for_union("gmail", frozenset({"readonly", "organize"}))
+        assert set(scopes) == {
+            GMAIL_READONLY_SCOPE,
+            GMAIL_LABELS_SCOPE,
+            GMAIL_MODIFY_SCOPE,
+        }
+
+    def test_single_level_union_equals_additive(self):
+        """A union of one level should equal that level's additive scopes."""
+        single = get_scopes_for_union("gmail", frozenset({"readonly"}))
+        additive = get_additive_scopes_for_level("gmail", "readonly")
+        assert single == additive
+
+    def test_empty_union_raises(self):
+        with pytest.raises(ValueError, match="Empty level set"):
+            get_scopes_for_union("gmail", frozenset())
+
+    def test_unknown_level_raises(self):
+        with pytest.raises(ValueError, match="Unknown permission level"):
+            get_scopes_for_union("gmail", frozenset({"readonly", "bogus"}))
+
+
+class TestUnionModeIntegration:
+    """End-to-end: parse → set → resolve scopes via get_all_permission_scopes."""
+
+    def test_gmail_read_send_grants_exactly_two_scopes(self):
+        """Issue #808 acceptance: read+send must produce the exact downstream scope set."""
+        perms = parse_permissions_arg(["gmail:readonly+send"])
+        set_permissions(perms)
+        assert get_allowed_scopes_set() == {GMAIL_READONLY_SCOPE, GMAIL_SEND_SCOPE}
+
+    def test_mixed_union_and_cumulative_services_combine(self):
+        perms = parse_permissions_arg(["gmail:readonly+send", "drive:readonly"])
+        set_permissions(perms)
+        allowed = get_allowed_scopes_set()
+        assert GMAIL_READONLY_SCOPE in allowed
+        assert GMAIL_SEND_SCOPE in allowed
+        assert DRIVE_READONLY_SCOPE in allowed
+        assert GMAIL_LABELS_SCOPE not in allowed
+        assert DRIVE_SCOPE not in allowed
+
+    def test_all_permission_scopes_handles_both_modes(self):
+        perms = parse_permissions_arg(["gmail:organize", "drive:readonly"])
+        set_permissions(perms)
+        cumulative_only = set(get_all_permission_scopes())
+        assert GMAIL_READONLY_SCOPE in cumulative_only  # cumulative includes readonly
+        assert GMAIL_LABELS_SCOPE in cumulative_only
+
+        perms = parse_permissions_arg(["gmail:organize+full", "drive:readonly"])
+        set_permissions(perms)
+        union_only = set(get_all_permission_scopes())
+        assert GMAIL_LABELS_SCOPE in union_only
+        assert GMAIL_SETTINGS_BASIC_SCOPE in union_only
+        assert GMAIL_READONLY_SCOPE not in union_only  # union excludes readonly
+
+
+class TestIsActionDeniedUnion:
+    """Tests for is_action_denied() under union-mode permissions."""
+
+    def test_union_denies_if_any_selected_level_denies(self):
+        """tasks:readonly+manage should still deny delete (manage's exclusion)."""
+        set_permissions({"tasks": frozenset({"readonly", "manage"})})
+        assert is_action_denied("tasks", "delete") is True
+        assert is_action_denied("tasks", "clear_completed") is True
+
+    def test_union_without_denying_level_allows(self):
+        """A union that omits the denying level should not deny."""
+        set_permissions({"tasks": frozenset({"readonly", "full"})})
+        assert is_action_denied("tasks", "delete") is False
+
+    def test_union_irrelevant_actions_unaffected(self):
+        set_permissions({"tasks": frozenset({"readonly", "manage"})})
+        assert is_action_denied("tasks", "create") is False
+        assert is_action_denied("tasks", "update") is False

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -13,8 +13,6 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from auth.permissions import (
-    get_additive_scopes_for_level,
-    get_all_permission_scopes,
     get_allowed_scopes_set,
     get_scopes_for_permission,
     get_scopes_for_union,
@@ -29,7 +27,6 @@ from auth.scopes import (
     GMAIL_MODIFY_SCOPE,
     GMAIL_COMPOSE_SCOPE,
     GMAIL_SEND_SCOPE,
-    GMAIL_SETTINGS_BASIC_SCOPE,
     DRIVE_READONLY_SCOPE,
     DRIVE_SCOPE,
     TASKS_READONLY_SCOPE,
@@ -214,76 +211,19 @@ class TestParsePermissionsArgUnion:
         result = parse_permissions_arg(["gmail:readonly+send"])
         assert result == {"gmail": frozenset({"readonly", "send"})}
 
-    def test_three_level_union(self):
-        result = parse_permissions_arg(["gmail:readonly+organize+send"])
-        assert result == {"gmail": frozenset({"readonly", "organize", "send"})}
-
-    def test_union_deduplicates(self):
-        """Repeated levels in a union should collapse to a single set entry."""
-        result = parse_permissions_arg(["gmail:readonly+readonly"])
-        assert result == {"gmail": frozenset({"readonly"})}
-
     def test_union_and_cumulative_mixed_across_services(self):
         """Different services can use different modes in the same invocation."""
         result = parse_permissions_arg(["gmail:readonly+send", "drive:full"])
         assert result["gmail"] == frozenset({"readonly", "send"})
         assert result["drive"] == "full"
 
-    def test_union_with_whitespace_around_levels(self):
-        result = parse_permissions_arg(["gmail:readonly + send"])
-        assert result == {"gmail": frozenset({"readonly", "send"})}
-
     def test_union_empty_component_raises(self):
         with pytest.raises(ValueError, match="Invalid union spec"):
             parse_permissions_arg(["gmail:readonly+"])
 
-    def test_union_only_separator_raises(self):
-        with pytest.raises(ValueError, match="Invalid union spec"):
-            parse_permissions_arg(["gmail:+"])
-
     def test_union_unknown_level_raises(self):
         with pytest.raises(ValueError, match="Unknown level 'superadmin'"):
             parse_permissions_arg(["gmail:readonly+superadmin"])
-
-    def test_union_unknown_service_raises(self):
-        with pytest.raises(ValueError, match="Unknown service"):
-            parse_permissions_arg(["fakesvc:readonly+full"])
-
-    def test_union_duplicate_service_raises(self):
-        with pytest.raises(ValueError, match="Duplicate service"):
-            parse_permissions_arg(["gmail:readonly+send", "gmail:full"])
-
-
-class TestGetAdditiveScopesForLevel:
-    """Tests for get_additive_scopes_for_level() — per-level deltas only."""
-
-    def test_gmail_readonly_returns_just_readonly_scope(self):
-        scopes = get_additive_scopes_for_level("gmail", "readonly")
-        assert scopes == [GMAIL_READONLY_SCOPE]
-
-    def test_gmail_send_returns_just_send_scope(self):
-        """send level's additive delta is gmail.send only — not the cumulative bundle."""
-        scopes = get_additive_scopes_for_level("gmail", "send")
-        assert scopes == [GMAIL_SEND_SCOPE]
-        assert GMAIL_READONLY_SCOPE not in scopes
-        assert GMAIL_LABELS_SCOPE not in scopes
-
-    def test_gmail_organize_returns_labels_and_modify_only(self):
-        scopes = get_additive_scopes_for_level("gmail", "organize")
-        assert set(scopes) == {GMAIL_LABELS_SCOPE, GMAIL_MODIFY_SCOPE}
-        assert GMAIL_READONLY_SCOPE not in scopes
-
-    def test_gmail_full_returns_just_settings_scope(self):
-        scopes = get_additive_scopes_for_level("gmail", "full")
-        assert scopes == [GMAIL_SETTINGS_BASIC_SCOPE]
-
-    def test_unknown_service_raises(self):
-        with pytest.raises(ValueError, match="Unknown service"):
-            get_additive_scopes_for_level("nonexistent", "readonly")
-
-    def test_unknown_level_raises(self):
-        with pytest.raises(ValueError, match="Unknown permission level"):
-            get_additive_scopes_for_level("gmail", "nonexistent")
 
 
 class TestGetScopesForUnion:
@@ -299,20 +239,6 @@ class TestGetScopesForUnion:
         scopes = get_scopes_for_union("gmail", frozenset({"send"}))
         assert GMAIL_SEND_SCOPE in scopes
         assert GMAIL_READONLY_SCOPE not in scopes
-
-    def test_readonly_plus_organize(self):
-        scopes = get_scopes_for_union("gmail", frozenset({"readonly", "organize"}))
-        assert set(scopes) == {
-            GMAIL_READONLY_SCOPE,
-            GMAIL_LABELS_SCOPE,
-            GMAIL_MODIFY_SCOPE,
-        }
-
-    def test_single_level_union_equals_additive(self):
-        """A union of one level should equal that level's additive scopes."""
-        single = get_scopes_for_union("gmail", frozenset({"readonly"}))
-        additive = get_additive_scopes_for_level("gmail", "readonly")
-        assert single == additive
 
     def test_empty_union_raises(self):
         with pytest.raises(ValueError, match="Empty level set"):
@@ -342,20 +268,6 @@ class TestUnionModeIntegration:
         assert GMAIL_LABELS_SCOPE not in allowed
         assert DRIVE_SCOPE not in allowed
 
-    def test_all_permission_scopes_handles_both_modes(self):
-        perms = parse_permissions_arg(["gmail:organize", "drive:readonly"])
-        set_permissions(perms)
-        cumulative_only = set(get_all_permission_scopes())
-        assert GMAIL_READONLY_SCOPE in cumulative_only  # cumulative includes readonly
-        assert GMAIL_LABELS_SCOPE in cumulative_only
-
-        perms = parse_permissions_arg(["gmail:organize+full", "drive:readonly"])
-        set_permissions(perms)
-        union_only = set(get_all_permission_scopes())
-        assert GMAIL_LABELS_SCOPE in union_only
-        assert GMAIL_SETTINGS_BASIC_SCOPE in union_only
-        assert GMAIL_READONLY_SCOPE not in union_only  # union excludes readonly
-
 
 class TestIsActionDeniedUnion:
     """Tests for is_action_denied() under union-mode permissions."""
@@ -370,8 +282,3 @@ class TestIsActionDeniedUnion:
         """A union that omits the denying level should not deny."""
         set_permissions({"tasks": frozenset({"readonly", "full"})})
         assert is_action_denied("tasks", "delete") is False
-
-    def test_union_irrelevant_actions_unaffected(self):
-        set_permissions({"tasks": frozenset({"readonly", "manage"})})
-        assert is_action_denied("tasks", "create") is False
-        assert is_action_denied("tasks", "update") is False


### PR DESCRIPTION
## Description

Fixes https://github.com/taylorwilsdon/google_workspace_mcp/issues/808

### Problem

`--permissions` only supported cumulative levels. Requesting `gmail:send` therefore also granted labels, modify, and compose scopes, so downstream servers exposing only Gmail read and send tools could not request a matching least-privilege OAuth grant.

### Changes

- Add opt-in `+` syntax, for example `gmail:readonly+send`.
- Resolve union entries from only the additive scopes of the named levels.
- Keep the existing `service:level` cumulative behavior unchanged.
- Support mixed union and cumulative services in one invocation.
- Preserve per-level denied-action checks for union entries.
- Document the syntax in `--help`.

### User impact

`--permissions gmail:readonly+send` now grants exactly `gmail.readonly` and `gmail.send`, so OAuth scopes can match a narrow tool allowlist without broad Gmail write access.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Verification

- `uv run pytest tests/test_permissions.py tests/test_scopes.py -q` — 74 passed.
- `uv run pytest -q` — 1,159 passed and 2 skipped; three unrelated Windows-only assertions failed on POSIX mode bits and slash direction.
- `uv run ruff check auth/permissions.py main.py tests/test_permissions.py` — passed.
- `uv run ruff format --check auth/permissions.py main.py tests/test_permissions.py` — passed.
- `git diff --check upstream/main...HEAD` — passed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have enabled "Allow edits from maintainers" for this pull request

## Additional Notes

Union mode is opt-in. A single cumulative level such as `gmail:send` behaves exactly as before; callers that want read plus send without intermediate scopes must request `gmail:readonly+send`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added union mode for permission specifications using `+` syntax (for example, `gmail:readonly+send`).
  * Combined permission levels now provide non-cumulative, additive access scopes for more granular authorization control.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->