### PR TITLE
feat(logging): honor WORKSPACE_MCP_LOG_DIR env var for file logging directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ uv run main.py --transport streamable-http --tools gmail drive calendar
 | `MCP_ENABLE_OAUTH21` | | `true` to enable OAuth 2.1 multi-user support |
 | `EXTERNAL_OAUTH21_PROVIDER` | | `true` for external OAuth flow with bearer tokens |
 | `WORKSPACE_MCP_STATELESS_MODE` | | `true` for stateless container-friendly operation |
+| `WORKSPACE_MCP_LOG_DIR` | | Directory for `mcp_server_debug.log` — defaults to `~/.google_workspace_mcp/logs` |
 | `GOOGLE_OAUTH_REDIRECT_URI` | | Override OAuth callback URL — default auto-constructed |
 | `OAUTH_CUSTOM_REDIRECT_URIS` | | Comma-separated additional redirect URIs |
 | `OAUTH_ALLOWED_ORIGINS` | | Comma-separated additional CORS origins |

--- a/core/log_formatter.py
+++ b/core/log_formatter.py
@@ -193,7 +193,7 @@ def _resolve_log_dir() -> str:
     return os.path.join(os.path.expanduser("~"), ".google_workspace_mcp", "logs")
 
 
-def configure_file_logging(logger_name: str = None) -> bool:
+def configure_file_logging(logger_name: str | None = None) -> bool:
     """
     Configure file logging based on stateless mode setting.
 

--- a/core/log_formatter.py
+++ b/core/log_formatter.py
@@ -157,12 +157,30 @@ def setup_enhanced_logging(
         root_logger.addHandler(console_handler)
 
 
+def _resolve_log_dir() -> str:
+    """Resolve the directory used for file logging.
+
+    Priority:
+    1. ``WORKSPACE_MCP_LOG_DIR`` (preferred)
+    2. ``~/.google_workspace_mcp/logs`` (default)
+
+    Tilde expansion is applied to env-var values so paths like ``~/logs`` work.
+    """
+    env_log_dir = os.getenv("WORKSPACE_MCP_LOG_DIR")
+    if env_log_dir:
+        return os.path.expanduser(env_log_dir)
+    return os.path.join(os.path.expanduser("~"), ".google_workspace_mcp", "logs")
+
+
 def configure_file_logging(logger_name: str = None) -> bool:
     """
     Configure file logging based on stateless mode setting.
 
     In stateless mode, file logging is completely disabled to avoid filesystem writes.
     In normal mode, sets up detailed file logging to 'mcp_server_debug.log'.
+
+    The log directory defaults to ``~/.google_workspace_mcp/logs`` and may be
+    overridden via the ``WORKSPACE_MCP_LOG_DIR`` environment variable.
 
     Args:
         logger_name: Optional name for the logger (defaults to root logger)
@@ -185,7 +203,7 @@ def configure_file_logging(logger_name: str = None) -> bool:
         target_logger = logging.getLogger(logger_name)
 
         # Write logs to user-specific directory, not the package directory
-        log_dir = os.path.join(os.path.expanduser("~"), ".google_workspace_mcp", "logs")
+        log_dir = _resolve_log_dir()
         os.makedirs(log_dir, mode=0o700, exist_ok=True)
         log_file_path = os.path.join(log_dir, "mcp_server_debug.log")
 

--- a/tests/core/test_log_formatter.py
+++ b/tests/core/test_log_formatter.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -11,7 +12,7 @@ from core.log_formatter import SuppressStatelessTransportTerminationFilter
 
 
 @pytest.fixture(autouse=True)
-def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Ensure each test starts with the relevant env vars unset."""
     monkeypatch.delenv("WORKSPACE_MCP_LOG_DIR", raising=False)
     monkeypatch.delenv("WORKSPACE_MCP_STATELESS_MODE", raising=False)

--- a/tests/core/test_log_formatter.py
+++ b/tests/core/test_log_formatter.py
@@ -22,7 +22,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 def test_resolve_log_dir_defaults_to_home_workspace_mcp_logs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(os.path, "expanduser", lambda p: "/home/user" if p == "~" else p)
+    monkeypatch.setattr(
+        os.path, "expanduser", lambda p: "/home/user" if p == "~" else p
+    )
 
     resolved = log_formatter._resolve_log_dir()
 
@@ -88,7 +90,9 @@ def test_configure_file_logging_disabled_in_stateless_mode(
     monkeypatch.setenv("WORKSPACE_MCP_LOG_DIR", str(tmp_path))
     monkeypatch.setenv("WORKSPACE_MCP_STATELESS_MODE", "true")
 
-    assert log_formatter.configure_file_logging("tests.log_formatter.stateless") is False
+    assert (
+        log_formatter.configure_file_logging("tests.log_formatter.stateless") is False
+    )
     assert not (tmp_path / "mcp_server_debug.log").exists()
 
 

--- a/tests/core/test_log_formatter.py
+++ b/tests/core/test_log_formatter.py
@@ -1,0 +1,79 @@
+"""Tests for ``core.log_formatter`` log-directory resolution."""
+
+import logging
+import os
+
+import pytest
+
+from core import log_formatter
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Ensure each test starts with the relevant env vars unset."""
+    monkeypatch.delenv("WORKSPACE_MCP_LOG_DIR", raising=False)
+    monkeypatch.delenv("WORKSPACE_MCP_STATELESS_MODE", raising=False)
+    yield
+
+
+def test_resolve_log_dir_defaults_to_home_workspace_mcp_logs(monkeypatch):
+    monkeypatch.setattr(os.path, "expanduser", lambda p: "/home/user" if p == "~" else p)
+
+    resolved = log_formatter._resolve_log_dir()
+
+    assert resolved == os.path.join("/home/user", ".google_workspace_mcp", "logs")
+
+
+def test_resolve_log_dir_honors_workspace_mcp_log_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("WORKSPACE_MCP_LOG_DIR", str(tmp_path))
+
+    resolved = log_formatter._resolve_log_dir()
+
+    assert resolved == str(tmp_path)
+
+
+def test_resolve_log_dir_expands_user_home_in_env_value(monkeypatch):
+    monkeypatch.setenv("WORKSPACE_MCP_LOG_DIR", "~/custom-logs")
+    monkeypatch.setattr(
+        os.path,
+        "expanduser",
+        lambda p: "/home/user/custom-logs" if p == "~/custom-logs" else p,
+    )
+
+    resolved = log_formatter._resolve_log_dir()
+
+    assert resolved == "/home/user/custom-logs"
+
+
+def test_configure_file_logging_writes_into_override_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("WORKSPACE_MCP_LOG_DIR", str(tmp_path))
+
+    logger_name = "tests.log_formatter.override"
+    target_logger = logging.getLogger(logger_name)
+    # Drop any prior handlers so we don't leak state between tests
+    for handler in list(target_logger.handlers):
+        target_logger.removeHandler(handler)
+
+    try:
+        assert log_formatter.configure_file_logging(logger_name) is True
+        expected_path = tmp_path / "mcp_server_debug.log"
+        assert expected_path.exists()
+        file_handlers = [
+            h for h in target_logger.handlers if isinstance(h, logging.FileHandler)
+        ]
+        assert any(
+            os.path.abspath(h.baseFilename) == os.path.abspath(str(expected_path))
+            for h in file_handlers
+        )
+    finally:
+        for handler in list(target_logger.handlers):
+            handler.close()
+            target_logger.removeHandler(handler)
+
+
+def test_configure_file_logging_disabled_in_stateless_mode(monkeypatch, tmp_path):
+    monkeypatch.setenv("WORKSPACE_MCP_LOG_DIR", str(tmp_path))
+    monkeypatch.setenv("WORKSPACE_MCP_STATELESS_MODE", "true")
+
+    assert log_formatter.configure_file_logging("tests.log_formatter.stateless") is False
+    assert not (tmp_path / "mcp_server_debug.log").exists()


### PR DESCRIPTION
## Summary

`configure_file_logging()` in `core/log_formatter.py` hardcoded the log
directory to `~/.google_workspace_mcp/logs`, so `mcp_server_debug.log`
was always written there even when `WORKSPACE_MCP_CREDENTIALS_DIR` was
set to keep state outside the default tree. This PR adds a new optional
`WORKSPACE_MCP_LOG_DIR` env var to override the log directory, with the
existing default preserved when the var is unset.

## Why this matters

Users who set `WORKSPACE_MCP_CREDENTIALS_DIR` to relocate credentials
(e.g., to `~/.config/<app>/credentials`) reasonably expect logs to follow
the same convention. Today they don't, and there's no other way to
relocate the log file short of patching the code or symlinking the
default path.

The new env var also matches the existing per-concern env-var pattern
already used by `WORKSPACE_MCP_CREDENTIALS_DIR` and
`WORKSPACE_MCP_STATELESS_MODE`.

## Changes

- `core/log_formatter.py`: new `_resolve_log_dir()` helper reads
  `WORKSPACE_MCP_LOG_DIR` and falls back to the previous hardcoded
  default. Tilde expansion is applied so values like \`~/logs\` work.
- `tests/core/test_log_formatter.py`: new test module with 5 tests
  covering the default path, the override path, tilde expansion, the
  file-handler attachment, and stateless mode still skipping file logging.
- `README.md`: documents the new env var in the environment variable
  reference table.

## Backward compatibility

Behavior is unchanged for anyone who doesn't set the new env var — the
default still resolves to \`~/.google_workspace_mcp/logs\`.

## Test plan

- [x] \`uv run pytest tests/core/test_log_formatter.py -v\` — 5/5 pass
- [x] \`uv run pytest tests/core/ -q\` — 79/79 pass (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WORKSPACE_MCP_LOG_DIR environment variable to customize debug log directory (supports ~ expansion; defaults to ~/.google_workspace_mcp/logs).

* **Documentation**
  * Updated the environment variable reference to document the new log directory setting.

* **Tests**
  * Added tests covering log-directory resolution, ~ expansion, file logging behavior, stateless-mode disabling, and suppression rules for specific termination log messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->