### PR TITLE
fix: normalize Unicode whitespace in saved attachment filenames (e.g. macOS U+202F)

### DIFF
--- a/core/attachment_storage.py
+++ b/core/attachment_storage.py
@@ -9,6 +9,7 @@ import base64
 import logging
 import os
 import re
+import unicodedata
 import uuid
 from pathlib import Path
 from typing import NamedTuple, Optional, Dict
@@ -46,6 +47,16 @@ def sanitize_attachment_filename(filename: Optional[str]) -> str:
     """Return a filesystem-safe attachment filename."""
     if not filename:
         return "attachment"
+
+    # Normalize Unicode space separators (category "Zs") to a plain ASCII space.
+    # macOS, for example, names screenshots with a NARROW NO-BREAK SPACE (U+202F)
+    # before "AM"/"PM" (e.g. "Screenshot 2026-05-28 at 3.44.08 PM.png"). MCP
+    # clients commonly normalize such characters to a regular space when they echo
+    # the returned file path back into a read/open call, which then no longer
+    # matches the name on disk. Saving with a normalized name keeps them in sync.
+    filename = "".join(
+        " " if unicodedata.category(ch) == "Zs" else ch for ch in filename
+    )
 
     sanitized = _WINDOWS_RESERVED_FILENAME_CHARS.sub("_", filename).rstrip(" .")
     if not sanitized:

--- a/core/attachment_storage.py
+++ b/core/attachment_storage.py
@@ -49,11 +49,6 @@ def sanitize_attachment_filename(filename: Optional[str]) -> str:
         return "attachment"
 
     # Normalize Unicode space separators (category "Zs") to a plain ASCII space.
-    # macOS, for example, names screenshots with a NARROW NO-BREAK SPACE (U+202F)
-    # before "AM"/"PM" (e.g. "Screenshot 2026-05-28 at 3.44.08 PM.png"). MCP
-    # clients commonly normalize such characters to a regular space when they echo
-    # the returned file path back into a read/open call, which then no longer
-    # matches the name on disk. Saving with a normalized name keeps them in sync.
     filename = "".join(
         " " if unicodedata.category(ch) == "Zs" else ch for ch in filename
     )

--- a/tests/core/test_attachment_storage.py
+++ b/tests/core/test_attachment_storage.py
@@ -1,0 +1,49 @@
+"""Tests for filename handling in core.attachment_storage."""
+
+import unicodedata
+
+from core.attachment_storage import sanitize_attachment_filename
+
+# Built via chr() so the source stays pure ASCII and the exact code points are
+# unambiguous (these characters are visually indistinguishable from a space).
+NARROW_NBSP = chr(0x202F)  # macOS screenshot time separator (NARROW NO-BREAK SPACE)
+
+
+class TestSanitizeAttachmentFilename:
+    """Unit tests for sanitize_attachment_filename."""
+
+    def test_plain_filename_unchanged(self):
+        assert sanitize_attachment_filename("report.pdf") == "report.pdf"
+
+    def test_empty_returns_default(self):
+        assert sanitize_attachment_filename("") == "attachment"
+
+    def test_none_returns_default(self):
+        assert sanitize_attachment_filename(None) == "attachment"
+
+    def test_reserved_characters_replaced(self):
+        assert sanitize_attachment_filename("a/b:c*d?.png") == "a_b_c_d_.png"
+
+    def test_windows_reserved_name_prefixed(self):
+        assert sanitize_attachment_filename("CON.txt") == "_CON.txt"
+
+    def test_regular_ascii_space_preserved(self):
+        assert sanitize_attachment_filename("my file.txt") == "my file.txt"
+
+    def test_narrow_no_break_space_normalized_to_ascii_space(self):
+        # macOS screenshots use U+202F (NARROW NO-BREAK SPACE) before "AM"/"PM".
+        # Clients that echo the saved path back into a read/open call often
+        # normalize U+202F to a regular space (U+0020); the saved name must use a
+        # regular space too, or that read fails with "file not found".
+        original = f"Screenshot 2026-05-28 at 3.44.08{NARROW_NBSP}PM.png"
+        result = sanitize_attachment_filename(original)
+        assert NARROW_NBSP not in result
+        assert result == "Screenshot 2026-05-28 at 3.44.08 PM.png"
+
+    def test_various_unicode_spaces_normalized(self):
+        # NO-BREAK SPACE, THIN SPACE, NARROW NO-BREAK SPACE, IDEOGRAPHIC SPACE --
+        # all Unicode "Zs" (space separator) code points.
+        for cp in (0x00A0, 0x2009, 0x202F, 0x3000):
+            sep = chr(cp)
+            assert unicodedata.category(sep) == "Zs"
+            assert sanitize_attachment_filename(f"a{sep}b.txt") == "a b.txt"


### PR DESCRIPTION
## Description
`download_chat_attachment` (and the Gmail attachment tools) save files under their original name via `sanitize_attachment_filename`. macOS names screenshots with a **NARROW NO-BREAK SPACE (U+202F)** between the time and "AM"/"PM" — e.g. `Screenshot 2026-05-28 at 3.44.08<U+202F>PM.png`. The file is saved correctly under that name and the tool returns that path.

The problem: MCP clients/agents that take the returned path and feed it back into a `read`/`open` call frequently **normalize U+202F to a regular ASCII space (U+0020)**. The normalized path no longer matches the on-disk name, so the follow-up read fails with "file not found" — even though the download succeeded. Directory listings (`ls`/glob) still show the file, which makes this especially confusing to debug.

Net effect: pasted-screenshot attachments are effectively unreadable for affected clients.

## Fix
Normalize all Unicode space separators (category `Zs` — U+00A0, U+2009, U+202F, U+3000, …) to a plain ASCII space in `sanitize_attachment_filename`, before the existing reserved-character handling. The saved name then uses a regular space, matching the path clients produce. Regular filenames are unaffected; tabs/newlines remain covered by the existing `\x00-\x1f` rule.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

Added `tests/core/test_attachment_storage.py` covering U+202F and other `Zs` separators, reserved chars, reserved names, and pass-through of ordinary names. `ruff check` and `ruff format --check` are clean on the changed files.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Repro: save an attachment whose `contentName` contains U+202F (any macOS screenshot), then read the returned path after a round-trip through a client that normalizes path strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attachment filenames with various Unicode space characters are now normalized to standard ASCII spaces, improving filename consistency and cross-system compatibility.

* **Tests**
  * Added comprehensive tests covering attachment filename sanitization, reserved-character handling, empty/default cases, and normalization of multiple Unicode space variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->