### PR TITLE
Add /healthz and /healthz/ready HTTP probes for Kubernetes

### DIFF
--- a/core/health.py
+++ b/core/health.py
@@ -1,0 +1,15 @@
+"""HTTP health endpoints for container and Kubernetes deployments."""
+
+from threading import Event
+
+_mcp_tools_ready = Event()
+
+
+def mark_mcp_tools_ready() -> None:
+    """Record that MCP tools are loaded and the server can accept tool traffic."""
+    _mcp_tools_ready.set()
+
+
+def mcp_tools_ready() -> bool:
+    """Return whether mark_mcp_tools_ready has been called."""
+    return _mcp_tools_ready.is_set()

--- a/core/server.py
+++ b/core/server.py
@@ -30,6 +30,7 @@ from core.config import (
     get_oauth_redirect_uri as get_oauth_redirect_uri_for_current_mode,
 )
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
+from starlette.responses import PlainTextResponse
 from fastmcp import FastMCP
 from fastmcp.server.auth.providers.google import GoogleProvider
 from mcp.types import ToolAnnotations
@@ -643,6 +644,22 @@ def configure_server_for_http():
 def get_auth_provider() -> Optional[GoogleProvider]:
     """Gets the global authentication provider instance."""
     return _auth_provider
+
+
+@server.custom_route("/healthz", methods=["GET"])
+async def healthz_liveness(request: Request):
+    """Liveness: HTTP server is accepting connections."""
+    return PlainTextResponse("OK\n")
+
+
+@server.custom_route("/healthz/ready", methods=["GET"])
+async def healthz_readiness(request: Request):
+    """Readiness: MCP tool surface is loaded and configured."""
+    from core.health import mcp_tools_ready
+
+    if not mcp_tools_ready():
+        return PlainTextResponse("MCP tools not ready\n", status_code=503)
+    return PlainTextResponse("OK\n")
 
 
 @server.custom_route("/", methods=["GET"])

--- a/helm-chart/workspace-mcp/README.md
+++ b/helm-chart/workspace-mcp/README.md
@@ -44,6 +44,11 @@ The following table lists the configurable parameters and their default values:
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `512Mi` |
 | `autoscaling.enabled` | Enable HPA | `false` |
+| `healthCheck.livenessPath` | HTTP liveness probe path | `/healthz` |
+| `healthCheck.readinessPath` | HTTP readiness probe (MCP tools loaded) | `/healthz/ready` |
+| `healthCheck.startupPath` | HTTP startup probe path | `/healthz` |
+
+Streamable HTTP mode exposes `/healthz` (process up) and `/healthz/ready` (tool registry configured). The JSON `/health` endpoint remains available for compatibility.
 
 ## Google OAuth Setup
 

--- a/helm-chart/workspace-mcp/templates/deployment.yaml
+++ b/helm-chart/workspace-mcp/templates/deployment.yaml
@@ -38,9 +38,17 @@ spec:
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           {{- if .Values.healthCheck.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.healthCheck.startupPath | default .Values.healthCheck.livenessPath | default "/healthz" }}
+              port: http
+            initialDelaySeconds: {{ .Values.healthCheck.startupInitialDelaySeconds | default 2 }}
+            periodSeconds: {{ .Values.healthCheck.startupPeriodSeconds | default 3 }}
+            timeoutSeconds: {{ .Values.healthCheck.timeoutSeconds }}
+            failureThreshold: {{ .Values.healthCheck.startupFailureThreshold | default 20 }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.healthCheck.path }}
+              path: {{ .Values.healthCheck.livenessPath | default "/healthz" }}
               port: http
             initialDelaySeconds: {{ .Values.healthCheck.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthCheck.periodSeconds }}
@@ -49,7 +57,7 @@ spec:
             failureThreshold: {{ .Values.healthCheck.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.healthCheck.path }}
+              path: {{ .Values.healthCheck.readinessPath | default "/healthz/ready" }}
               port: http
             initialDelaySeconds: {{ .Values.healthCheck.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthCheck.periodSeconds }}

--- a/helm-chart/workspace-mcp/values.yaml
+++ b/helm-chart/workspace-mcp/values.yaml
@@ -130,12 +130,20 @@ command:
 # Health check configuration
 healthCheck:
   enabled: true
+  # Legacy JSON status endpoint (still supported)
   path: /health
-  initialDelaySeconds: 30
-  periodSeconds: 30
-  timeoutSeconds: 10
+  # Kubernetes-style probes (streamable-http)
+  livenessPath: /healthz
+  readinessPath: /healthz/ready
+  startupPath: /healthz
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
   successThreshold: 1
-  failureThreshold: 3
+  failureThreshold: 6
+  startupInitialDelaySeconds: 2
+  startupPeriodSeconds: 3
+  startupFailureThreshold: 20
 
 # Pod disruption budget
 podDisruptionBudget:

--- a/main.py
+++ b/main.py
@@ -665,6 +665,10 @@ def main():
     # Filter tools based on tier configuration (if tier-based loading is enabled)
     filter_server_tools(server)
 
+    from core.health import mark_mcp_tools_ready
+
+    mark_mcp_tools_ready()
+
     summary_parts = [f"{len(loaded)}/{len(tool_imports)} services"]
     if args.tool_tier is not None:
         tier_desc = f"tier={args.tool_tier}"

--- a/tests/core/test_healthz_routes.py
+++ b/tests/core/test_healthz_routes.py
@@ -1,0 +1,53 @@
+import pytest
+from starlette.requests import Request
+
+from core.health import mark_mcp_tools_ready, mcp_tools_ready
+from core.server import healthz_liveness, healthz_readiness
+
+
+def _build_request(path: str) -> Request:
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "server": ("localhost", 8080),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+@pytest.mark.asyncio
+async def test_healthz_liveness_always_ok():
+    response = await healthz_liveness(_build_request("/healthz"))
+    assert response.status_code == 200
+    assert response.body == b"OK\n"
+
+
+@pytest.mark.asyncio
+async def test_healthz_ready_before_tools_loaded():
+    # Reset readiness for isolated test run order.
+    import core.health as health_module
+
+    health_module._mcp_tools_ready.clear()
+    assert not mcp_tools_ready()
+
+    response = await healthz_readiness(_build_request("/healthz/ready"))
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_healthz_ready_after_tools_loaded():
+    mark_mcp_tools_ready()
+    response = await healthz_readiness(_build_request("/healthz/ready"))
+    assert response.status_code == 200
+    assert response.body == b"OK\n"


### PR DESCRIPTION
## Summary

Streamable HTTP deployments already expose `/health` (JSON status), but many Kubernetes configurations expect conventional probe paths. This change adds:

- **`GET /healthz`** — liveness: HTTP server is up
- **`GET /healthz/ready`** — readiness: MCP tool modules are imported, filtered, and ready (503 until startup completes)

The existing `/health` endpoint is unchanged.

## Helm chart

When `healthCheck.enabled` is true, the deployment now uses:

- **startupProbe** → `/healthz`
- **livenessProbe** → `/healthz`
- **readinessProbe** → `/healthz/ready`

Defaults are tuned for faster feedback than the previous single `/health` probe on both liveness and readiness.

## Test plan

- [x] `uv run pytest tests/core/test_healthz_routes.py`
- [ ] Deploy with `streamable-http` and verify:
  - `curl -sf http://localhost:8080/healthz`
  - `curl -sf http://localhost:8080/healthz/ready` (after startup)
- [ ] `helm template` / install chart and confirm probes use the new paths

## Notes for operators

Readiness flips to OK after tool import and `filter_server_tools()` complete — before `server.run()` binds the port. Startup probes should pass once the process is listening; readiness gates traffic that requires a working MCP tool surface.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated HTTP health check endpoints (`/healthz` for liveness, `/healthz/ready` for readiness) with support for Kubernetes health probes.
  * Readiness endpoint now properly tracks when MCP tools finish loading and returns service unavailable status until ready.

* **Documentation**
  * Updated Helm chart configuration documentation for health check paths and probe timing settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->