### PR TITLE
feat(drive): add create_drive_shortcut tool

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -27,6 +27,7 @@ drive:
     - get_drive_file_download_url
     - create_drive_file
     - create_drive_folder
+    - create_drive_shortcut
     - import_to_google_doc
     - get_drive_shareable_link
   extended:

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -1180,6 +1180,76 @@ async def create_drive_file(
     return confirmation_message
 
 
+SHORTCUT_MIME_TYPE = "application/vnd.google-apps.shortcut"
+
+
+@server.tool(
+    title="Create Drive Shortcut",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("create_drive_shortcut", service_type="drive")
+@require_google_service("drive", "drive_file")
+async def create_drive_shortcut(
+    service,
+    user_google_email: str,
+    target_id: str,
+    shortcut_name: str,
+    parent_folder_id: Optional[str] = None,
+) -> str:
+    """
+    Creates a Google Drive shortcut pointing to an existing file or folder, supporting shared drives.
+
+    A shortcut is a lightweight link to a target item; it does not duplicate the target's
+    content. Useful for surfacing the same file in multiple folders without copying it.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        target_id (str): The ID of the file or folder the shortcut points to. Required.
+        shortcut_name (str): The name for the new shortcut.
+        parent_folder_id (Optional[str]): The ID of the parent folder for the shortcut. Defaults to My Drive root if omitted. For shared drives, use a folder ID within that shared drive.
+
+    Returns:
+        str: Confirmation message with the shortcut name, ID, and link.
+    """
+    logger.info(
+        f"[create_drive_shortcut] Invoked. Email: '{user_google_email}', "
+        f"Name: '{shortcut_name}', Target: '{target_id}', Parent: '{parent_folder_id}'"
+    )
+
+    file_metadata = {
+        "name": shortcut_name,
+        "mimeType": SHORTCUT_MIME_TYPE,
+        "shortcutDetails": {"targetId": target_id},
+    }
+    if parent_folder_id:
+        file_metadata["parents"] = [parent_folder_id]
+
+    created_shortcut = await asyncio.to_thread(
+        service.files()
+        .create(
+            body=file_metadata,
+            fields="id, name, webViewLink, shortcutDetails",
+            supportsAllDrives=True,
+        )
+        .execute,
+        num_retries=GOOGLE_API_WRITE_RETRIES,
+    )
+
+    link = created_shortcut.get("webViewLink", "No link available")
+    confirmation_message = (
+        f"Successfully created shortcut '{created_shortcut.get('name', shortcut_name)}' "
+        f"(ID: {created_shortcut.get('id', 'N/A')}) pointing to target '{target_id}' "
+        f"for {user_google_email}. Link: {link}"
+    )
+    logger.info(f"Successfully created shortcut. Link: {link}")
+    return confirmation_message
+
+
 # Mapping of file extensions to source MIME types for Google Docs conversion
 GOOGLE_DOCS_IMPORT_FORMATS = {
     ".md": "text/markdown",

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 from gdrive.drive_helpers import build_drive_list_params
 from gdrive.drive_tools import (
+    create_drive_shortcut,
     get_drive_file_permissions,
     import_to_google_doc,
     list_drive_items,
@@ -1567,3 +1568,84 @@ def test_resolve_file_type_mime_empty_raises():
 
     with pytest.raises(ValueError, match="cannot be empty"):
         resolve_file_type_mime("   ")
+
+
+# ---------------------------------------------------------------------------
+# create_drive_shortcut
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_drive_shortcut_builds_shortcut_body():
+    """The create body carries the shortcut MIME type and targetId."""
+    mock_service = Mock()
+    mock_service.files().create().execute.return_value = {
+        "id": "shortcut123",
+        "name": "Link to Report",
+        "webViewLink": "https://drive.google.com/file/d/shortcut123/view",
+        "shortcutDetails": {"targetId": "target456"},
+    }
+
+    result = await _unwrap(create_drive_shortcut)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        target_id="target456",
+        shortcut_name="Link to Report",
+        parent_folder_id="folder789",
+    )
+
+    create_kwargs = mock_service.files.return_value.create.call_args.kwargs
+    body = create_kwargs["body"]
+    assert body["mimeType"] == "application/vnd.google-apps.shortcut"
+    assert body["shortcutDetails"] == {"targetId": "target456"}
+    assert body["name"] == "Link to Report"
+    assert body["parents"] == ["folder789"]
+    assert create_kwargs["supportsAllDrives"] is True
+
+    assert "Successfully created shortcut" in result
+    assert "shortcut123" in result
+    assert "target456" in result
+
+
+@pytest.mark.asyncio
+async def test_create_drive_shortcut_omits_parents_when_no_parent():
+    """When parent_folder_id is None, 'parents' is omitted from the body."""
+    mock_service = Mock()
+    mock_service.files().create().execute.return_value = {
+        "id": "shortcut123",
+        "name": "Link to Report",
+        "webViewLink": "https://drive.google.com/file/d/shortcut123/view",
+    }
+
+    await _unwrap(create_drive_shortcut)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        target_id="target456",
+        shortcut_name="Link to Report",
+    )
+
+    body = mock_service.files.return_value.create.call_args.kwargs["body"]
+    assert "parents" not in body
+
+
+@pytest.mark.asyncio
+async def test_create_drive_shortcut_uses_google_api_retries():
+    """Shortcut creation uses googleapiclient's built-in write retry handling."""
+    mock_service = Mock()
+    mock_service.files().create().execute.return_value = {
+        "id": "shortcut123",
+        "name": "Link to Report",
+        "webViewLink": "https://drive.google.com/file/d/shortcut123/view",
+    }
+
+    await _unwrap(create_drive_shortcut)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        target_id="target456",
+        shortcut_name="Link to Report",
+    )
+
+    execute_kwargs = (
+        mock_service.files.return_value.create.return_value.execute.call_args.kwargs
+    )
+    assert execute_kwargs["num_retries"] == 3


### PR DESCRIPTION
## Description

Surfacing one Drive file in more than one folder — without duplicating its bytes — is the canonical use case for a Drive **shortcut**. Since Drive removed multi-parenting (Sept 2020), a file has a single parent, so a shortcut is the supported "appears here too / live pointer to the canonical file" mechanism. Today `gdrive/drive_tools.py` can *resolve/chase* existing shortcuts but has no `@server.tool` that **creates** one — `create_drive_file` always uploads media with the upload mime == `body.mimeType`, so it can't produce a metadata-only shortcut.

This adds a `create_drive_shortcut` tool.

Closes #819

## Implementation

`create_drive_shortcut(target_id, shortcut_name, parent_folder_id=None, user_google_email=...)` performs a metadata-only `files.create`:

```python
body = {
    "name": shortcut_name,
    "mimeType": "application/vnd.google-apps.shortcut",
    "shortcutDetails": {"targetId": target_id},
}
# parents added only when parent_folder_id is provided
```

It mirrors the existing `create_drive_file` / `create_drive_folder` pattern exactly:
- Same decorator stack (`@server.tool` + `ToolAnnotations`, `@handle_http_errors(..., service_type="drive")`, `@require_google_service("drive", "drive_file")`).
- `service` obtained via the auth middleware; `user_google_email` first param.
- `supportsAllDrives=True`, `num_retries=GOOGLE_API_WRITE_RETRIES`, off-loop via `asyncio.to_thread`.
- `fields="id, name, webViewLink, shortcutDetails"`.
- Returns the same confirmation-string shape (name, ID, link).
- `parents` is omitted when `parent_folder_id` is `None` (defaults to My Drive root), so the body stays clean rather than carrying `parents: [None]`.

**Tier:** registered under `drive` → `core` in `core/tool_tiers.yaml`, matching the sibling create tools (`create_drive_file`, `create_drive_folder`). Reachable at `core`/`extended`/`complete` (not `complete`-only).

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

What I ran locally:
- `python3 -m py_compile gdrive/drive_tools.py tests/gdrive/test_drive_tools.py` — clean.
- `uvx ruff check` and `uvx ruff format --check` on the changed files — clean / already formatted.
- `uv run --extra test pytest tests/gdrive/` — 85 passed (3 new `create_drive_shortcut` tests covering body construction, `parents` omission when no parent, and write-retry handling).

What I did **not** run: credentialed integration tests that hit live Google Drive — I don't have OAuth credentials for that. The new tests mock the Drive `service` (no live calls), consistent with the existing `tests/gdrive` suite. Real end-to-end conversion relies on CI / a maintainer with credentials.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Opened as a **draft**. Commit is DCO signed-off (`git commit -s`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create Google Drive shortcuts: New tool enables users to create shortcuts to existing Drive files and folders. Supports optional parent folder assignment for organizational flexibility.

* **Tests**
  * Added comprehensive test coverage for the new Drive shortcut creation tool, including validation of shortcut properties and API integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/taylorwilsdon/google_workspace_mcp/pull/821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->