### PR TITLE
fix(auth): longer-lived refresh tokens (FastMCP 3.4.0) + fix proxied/embedded OAuth consent 403

### DIFF
--- a/core/server.py
+++ b/core/server.py
@@ -590,6 +590,24 @@ def configure_server_for_http():
                         "OAuth 2.1: restricting DCR client redirect URIs to allowlist: %s",
                         allowed_client_redirect_uris,
                     )
+                # Consent mode for the OAuth proxy. Defaults to "external" because
+                # Google's own consent screen already gates authorization. The
+                # built-in consent screen sets a __Host-* SameSite=Lax binding
+                # cookie that must round-trip through the Google redirect; behind a
+                # reverse proxy or inside an embedded OAuth webview (e.g. Perplexity)
+                # that cookie is not returned, producing a 403 "Authorization
+                # session mismatch" on the IdP callback. "external" skips the
+                # built-in consent + binding check while keeping Google's consent.
+                # Override with WORKSPACE_MCP_AUTH_CONSENT=true|remember|external|false.
+                _consent_raw = os.getenv(
+                    "WORKSPACE_MCP_AUTH_CONSENT", "external"
+                ).strip().lower()
+                if _consent_raw in ("external", "remember"):
+                    require_authorization_consent = _consent_raw
+                elif _consent_raw in ("false", "0", "no", "off"):
+                    require_authorization_consent = False
+                else:
+                    require_authorization_consent = True
                 provider = GoogleProvider(
                     client_id=config.client_id,
                     client_secret=config.client_secret,
@@ -600,6 +618,7 @@ def configure_server_for_http():
                     client_storage=client_storage,
                     jwt_signing_key=jwt_signing_key,
                     allowed_client_redirect_uris=allowed_client_redirect_uris,
+                    require_authorization_consent=require_authorization_consent,
                 )
                 if provider.client_registration_options is not None:
                     # Keep protocol-level auth limited to base identity scopes, but

--- a/core/server.py
+++ b/core/server.py
@@ -600,14 +600,24 @@ def configure_server_for_http():
                 # built-in consent + binding check while keeping Google's consent.
                 # Override with WORKSPACE_MCP_AUTH_CONSENT=true|remember|external|false.
                 _consent_raw = os.getenv(
-                    "WORKSPACE_MCP_AUTH_CONSENT", "external"
+                    "WORKSPACE_MCP_AUTH_CONSENT", ""
                 ).strip().lower()
-                if _consent_raw in ("external", "remember"):
+                if not _consent_raw:
+                    # Unset or blank (e.g. WORKSPACE_MCP_AUTH_CONSENT=) -> default.
+                    require_authorization_consent = "external"
+                elif _consent_raw in ("external", "remember"):
                     require_authorization_consent = _consent_raw
                 elif _consent_raw in ("false", "0", "no", "off"):
                     require_authorization_consent = False
-                else:
+                elif _consent_raw in ("true", "1", "yes", "on"):
                     require_authorization_consent = True
+                else:
+                    logger.warning(
+                        "Invalid WORKSPACE_MCP_AUTH_CONSENT=%r; defaulting to "
+                        "'external'.",
+                        _consent_raw,
+                    )
+                    require_authorization_consent = "external"
                 provider = GoogleProvider(
                     client_id=config.client_id,
                     client_secret=config.client_secret,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
  "fastapi>=0.115.12",
- "fastmcp>=3.2.4",
+ "fastmcp>=3.4.0",
  "google-api-python-client>=2.168.0",
  "google-auth-httplib2>=0.2.0",
  "google-auth-oauthlib>=1.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -510,35 +510,63 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.2.4"
+version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/519739e98daf92ebc64580e9d3320649bf9a1612c029a913dd88c3474d73/fastmcp-3.4.0.tar.gz", hash = "sha256:29055fb6816f4862c615aabaf0112ae8feb8b469740db13403a0ce5b799ec1dc", size = 28754939, upload-time = "2026-06-03T02:32:40.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/72/9f9bbfc3a8d26870dbdbbd633cd1c6f42b8d3bec379426c760676d936e86/fastmcp-3.4.0-py3-none-any.whl", hash = "sha256:34523083d6149400a0655a8aa769eb34f85b1ce6dac6d66efb07503ebbe5f44b", size = 8017, upload-time = "2026-06-03T02:32:38.05Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/b0/4da6078c2d6aa0a38a8b1ae0271e1ed400f9e2cd1b3b46e6453fb1fe2b75/fastmcp_slim-3.4.0.tar.gz", hash = "sha256:faa0ccf16e85ec4b9f79c006fed3546b866d7e6dba3f60cd32cd98e84753a496", size = 575895, upload-time = "2026-06-03T02:32:18.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/66/cc283d4efd3faf325c26f51cfb43a118270ea732e70dda509f49d80ea625/fastmcp_slim-3.4.0-py3-none-any.whl", hash = "sha256:17cd0a1535972d3748d8c2416f0826dfc86c18df7a6cbc38602373277d44baa6", size = 748849, upload-time = "2026-06-03T02:32:17.435Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "griffelib" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
     { name = "opentelemetry-api" },
     { name = "packaging" },
-    { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "rich" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
 ]
 
 [[package]]
@@ -2197,7 +2225,7 @@ wheels = [
 
 [[package]]
 name = "workspace-mcp"
-version = "1.21.0"
+version = "1.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -2280,7 +2308,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=45.0.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastapi", specifier = ">=0.115.12" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
+    { name = "fastmcp", specifier = ">=3.4.0" },
     { name = "google-api-python-client", specifier = ">=2.168.0" },
     { name = "google-auth-httplib2", specifier = ">=0.2.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.2" },


### PR DESCRIPTION
## Summary

Two related OAuth/login robustness improvements, motivated by self-hosting this server behind a reverse proxy and connecting it from remote MCP clients (Perplexity, Claude web).

### 1. `chore`: bump FastMCP `3.2.4 → 3.4.0` (longer-lived refresh tokens)

`OAuthProxy` in 3.4.0:
- Raises the default FastMCP-issued **refresh-token lifetime from 30 days to 1 year** (`DEFAULT_REFRESH_TOKEN_EXPIRY_SECONDS`).
- Fixes refresh tokens **collapsing to the ~1h access-token TTL** when the upstream IdP (Google) returns no `refresh_token` on a refresh exchange — observed in practice as MCP refresh tokens stored with ~30–70 min expiry, forcing frequent re-login.
- Adds configurable `fallback_refresh_token_expiry_seconds` on `GoogleProvider`.

No code changes required beyond the version bump; the existing `GoogleProvider(...)` call is signature-compatible.

### 2. `fix(auth)`: default OAuth proxy consent to `"external"` to fix callback 403

When `require_authorization_consent=True` (current default), the built-in consent screen sets a `__Host-*` `SameSite=Lax` binding cookie that must round-trip through the Google redirect back to `/oauth2callback`. Behind a reverse proxy, or inside an **embedded OAuth webview** (e.g. Perplexity's connector flow), that cookie is not returned, so the callback rejects with:

> 403 — Authorization session mismatch. This can happen if you followed a link from another person or your session expired.

This makes the server effectively unusable from such clients. This change defaults `require_authorization_consent` to `"external"` (consent is still fully gated by **Google's own consent screen**, which already runs with `prompt=consent`), and makes it overridable:

```
WORKSPACE_MCP_AUTH_CONSENT = true | remember | external | false   # default: external
```

**Note for maintainers:** this changes a security-relevant default. If you'd rather keep `True` as the default and only expose the env override, I'm happy to adjust — just say the word. The env knob alone already lets self-hosters opt in.

## Testing

- Container builds on `v1.21.1` + these two commits.
- `/health` → healthy; `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource/mcp` → 200.
- Startup logs: `Built-in consent screen disabled; consent is handled externally.`
- OAuth 2.1 GoogleProvider initialises with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth 2.1 authorization consent behavior can be controlled via an environment variable, giving admins configurable consent flows for Google sign-in.

* **Chores**
  * Updated runtime dependency requirement for fastmcp to a newer minimum version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->