### PR TITLE
feat(contacts): add list/search Workspace domain directory people

### DIFF
--- a/auth/scopes.py
+++ b/auth/scopes.py
@@ -65,6 +65,12 @@ TASKS_READONLY_SCOPE = "https://www.googleapis.com/auth/tasks.readonly"
 # Google Contacts (People API) scopes
 CONTACTS_SCOPE = "https://www.googleapis.com/auth/contacts"
 CONTACTS_READONLY_SCOPE = "https://www.googleapis.com/auth/contacts.readonly"
+# Directory scope - read-only access to the organization's domain directory
+# (only available in Google Workspace accounts; required for listDirectoryPeople
+# and searchDirectoryPeople, which return colleagues from the user's domain.)
+DIRECTORY_READONLY_SCOPE = (
+    "https://www.googleapis.com/auth/directory.readonly"
+)
 
 # Google Custom Search API scope
 CUSTOM_SEARCH_SCOPE = "https://www.googleapis.com/auth/cse"
@@ -178,7 +184,11 @@ SLIDES_SCOPES = [SLIDES_SCOPE, SLIDES_READONLY_SCOPE]
 
 TASKS_SCOPES = [TASKS_SCOPE, TASKS_READONLY_SCOPE]
 
-CONTACTS_SCOPES = [CONTACTS_SCOPE, CONTACTS_READONLY_SCOPE]
+CONTACTS_SCOPES = [
+    CONTACTS_SCOPE,
+    CONTACTS_READONLY_SCOPE,
+    DIRECTORY_READONLY_SCOPE,
+]
 
 CUSTOM_SEARCH_SCOPES = [CUSTOM_SEARCH_SCOPE]
 
@@ -221,7 +231,7 @@ TOOL_READONLY_SCOPES_MAP = {
     "forms": [FORMS_BODY_READONLY_SCOPE, FORMS_RESPONSES_READONLY_SCOPE],
     "slides": [SLIDES_READONLY_SCOPE],
     "tasks": [TASKS_READONLY_SCOPE],
-    "contacts": [CONTACTS_READONLY_SCOPE],
+    "contacts": [CONTACTS_READONLY_SCOPE, DIRECTORY_READONLY_SCOPE],
     "search": CUSTOM_SEARCH_SCOPES,
     "appscript": [
         SCRIPT_PROJECTS_READONLY_SCOPE,

--- a/auth/scopes.py
+++ b/auth/scopes.py
@@ -68,9 +68,7 @@ CONTACTS_READONLY_SCOPE = "https://www.googleapis.com/auth/contacts.readonly"
 # Directory scope - read-only access to the organization's domain directory
 # (only available in Google Workspace accounts; required for listDirectoryPeople
 # and searchDirectoryPeople, which return colleagues from the user's domain.)
-DIRECTORY_READONLY_SCOPE = (
-    "https://www.googleapis.com/auth/directory.readonly"
-)
+DIRECTORY_READONLY_SCOPE = "https://www.googleapis.com/auth/directory.readonly"
 
 # Google Custom Search API scope
 CUSTOM_SEARCH_SCOPE = "https://www.googleapis.com/auth/cse"

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -57,6 +57,7 @@ from auth.scopes import (
     TASKS_READONLY_SCOPE,
     CONTACTS_SCOPE,
     CONTACTS_READONLY_SCOPE,
+    DIRECTORY_READONLY_SCOPE,
     CUSTOM_SEARCH_SCOPE,
     SCRIPT_PROJECTS_SCOPE,
     SCRIPT_PROJECTS_READONLY_SCOPE,
@@ -572,6 +573,7 @@ SCOPE_GROUPS = {
     # Contacts scopes
     "contacts": CONTACTS_SCOPE,
     "contacts_read": CONTACTS_READONLY_SCOPE,
+    "directory_read": DIRECTORY_READONLY_SCOPE,
     # Custom Search scope
     "customsearch": CUSTOM_SEARCH_SCOPE,
     # Apps Script scopes

--- a/gcontacts/contacts_tools.py
+++ b/gcontacts/contacts_tools.py
@@ -34,6 +34,28 @@ DETAILED_PERSON_FIELDS = (
 # Contact group fields
 CONTACT_GROUP_FIELDS = "name,groupType,memberCount,metadata"
 
+# Default person fields for directory operations - same as contacts but adds
+# locations and userDefined (which often holds HR-system custom fields synced
+# by Workspace admins such as start date or employee id).
+DIRECTORY_DEFAULT_PERSON_FIELDS = (
+    "names,emailAddresses,phoneNumbers,organizations,locations,userDefined"
+)
+
+# Directory source types supported by the People API.
+# DOMAIN_PROFILE = the Workspace user profile (most useful for staff directory).
+# DOMAIN_CONTACT = shared contacts created by domain admins (vendors, externals).
+DIRECTORY_SOURCE_DOMAIN_PROFILE = "DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE"
+DIRECTORY_SOURCE_DOMAIN_CONTACT = "DIRECTORY_SOURCE_TYPE_DOMAIN_CONTACT"
+DEFAULT_DIRECTORY_SOURCES = [
+    DIRECTORY_SOURCE_DOMAIN_PROFILE,
+    DIRECTORY_SOURCE_DOMAIN_CONTACT,
+]
+
+# mergeSources is itself a list-valued enum in the People API; the only useful
+# value today is DIRECTORY_MERGE_SOURCE_TYPE_CONTACT, which asks the server to
+# merge profile and contact records for the same person.
+DIRECTORY_MERGE_SOURCE_CONTACT = "DIRECTORY_MERGE_SOURCE_TYPE_CONTACT"
+
 # Cache warmup tracking
 _search_cache_warmed_up: Dict[str, bool] = {}
 
@@ -1187,6 +1209,201 @@ async def search_contacts(
 
     logger.info(
         f"Found {len(results)} contacts matching '{query}' for {user_google_email}"
+    )
+    return response
+
+
+def _resolve_directory_sources(sources: Optional[List[str]]) -> List[str]:
+    """Validate and resolve directory source types, with friendly aliases."""
+    if not sources:
+        return list(DEFAULT_DIRECTORY_SOURCES)
+    resolved: List[str] = []
+    for entry in sources:
+        key = (entry or "").strip().upper()
+        if not key:
+            continue
+        if key in {"PROFILE", "DOMAIN_PROFILE", DIRECTORY_SOURCE_DOMAIN_PROFILE}:
+            resolved.append(DIRECTORY_SOURCE_DOMAIN_PROFILE)
+        elif key in {"CONTACT", "DOMAIN_CONTACT", DIRECTORY_SOURCE_DOMAIN_CONTACT}:
+            resolved.append(DIRECTORY_SOURCE_DOMAIN_CONTACT)
+        else:
+            raise UserInputError(
+                f"Unknown directory source '{entry}'. Use 'profile' (Workspace "
+                "user profiles), 'contact' (admin-managed shared contacts), or "
+                "omit to query both."
+            )
+    return resolved or list(DEFAULT_DIRECTORY_SOURCES)
+
+
+@server.tool(
+    title="List Directory People",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@require_google_service("people", "directory_read")
+@handle_http_errors("list_directory_people", service_type="people")
+async def list_directory_people(
+    service: Resource,
+    user_google_email: str,
+    page_size: int = 100,
+    page_token: Optional[str] = None,
+    sources: Optional[List[str]] = None,
+    merge_contact_into_profile: bool = True,
+) -> str:
+    """
+    List people in the authenticated user's Google Workspace domain directory.
+
+    Returns colleagues from the organization's directory (Workspace user
+    profiles) and/or admin-managed shared domain contacts. Requires the
+    directory.readonly scope and a Google Workspace account; consumer Google
+    accounts cannot access a domain directory.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        page_size (int): Maximum number of people to return (default: 100, max: 1000).
+        page_token (Optional[str]): Token for pagination.
+        sources (Optional[List[str]]): Which directory sources to include.
+            Accepts 'profile' (Workspace user profiles) and 'contact' (shared
+            domain contacts). Defaults to both.
+        merge_contact_into_profile (bool): When True (default), asks the API
+            to merge shared-contact entries into matching profile entries to
+            reduce duplicates.
+
+    Returns:
+        str: List of directory people with their basic information.
+    """
+    logger.info(f"[list_directory_people] Invoked. Email: '{user_google_email}'")
+
+    if page_size < 1:
+        raise UserInputError("page_size must be >= 1")
+    page_size = min(page_size, 1000)
+
+    params: Dict[str, Any] = {
+        "readMask": DIRECTORY_DEFAULT_PERSON_FIELDS,
+        "sources": _resolve_directory_sources(sources),
+        "pageSize": page_size,
+    }
+    if merge_contact_into_profile:
+        params["mergeSources"] = [DIRECTORY_MERGE_SOURCE_CONTACT]
+    if page_token:
+        params["pageToken"] = page_token
+
+    result = await asyncio.to_thread(
+        service.people().listDirectoryPeople(**params).execute
+    )
+
+    people = result.get("people", [])
+    next_page_token = result.get("nextPageToken")
+
+    if not people:
+        return f"No directory people found for {user_google_email}."
+
+    response = (
+        f"Directory people for {user_google_email} "
+        f"({len(people)} returned this page):\n\n"
+    )
+    for person in people:
+        response += _format_contact(person) + "\n\n"
+    if next_page_token:
+        response += f"Next page token: {next_page_token}"
+
+    logger.info(
+        f"Listed {len(people)} directory people for {user_google_email}"
+    )
+    return response
+
+
+@server.tool(
+    title="Search Directory People",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@require_google_service("people", "directory_read")
+@handle_http_errors("search_directory_people", service_type="people")
+async def search_directory_people(
+    service: Resource,
+    user_google_email: str,
+    query: str,
+    page_size: int = 50,
+    page_token: Optional[str] = None,
+    sources: Optional[List[str]] = None,
+    merge_contact_into_profile: bool = True,
+) -> str:
+    """
+    Search the Workspace domain directory by name, email or other fields.
+
+    Substring-matches across names, email addresses, organisations and titles.
+    Requires the directory.readonly scope and a Google Workspace account.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        query (str): Search query string. The API matches against names, email
+            addresses, organisations and a few other fields.
+        page_size (int): Maximum number of results per page (default: 50, max: 500).
+        page_token (Optional[str]): Token for pagination.
+        sources (Optional[List[str]]): Which directory sources to include
+            ('profile' and/or 'contact'). Defaults to both.
+        merge_contact_into_profile (bool): When True (default), asks the API
+            to merge shared-contact entries into matching profile entries to
+            reduce duplicates.
+
+    Returns:
+        str: Matching directory people with their basic information.
+    """
+    logger.info(
+        f"[search_directory_people] Invoked. Email: '{user_google_email}', "
+        f"Query: '{query}'"
+    )
+
+    if not query or not query.strip():
+        raise UserInputError("query must be a non-empty string")
+    if page_size < 1:
+        raise UserInputError("page_size must be >= 1")
+    page_size = min(page_size, 500)
+
+    params: Dict[str, Any] = {
+        "query": query,
+        "readMask": DIRECTORY_DEFAULT_PERSON_FIELDS,
+        "sources": _resolve_directory_sources(sources),
+        "pageSize": page_size,
+    }
+    if merge_contact_into_profile:
+        params["mergeSources"] = [DIRECTORY_MERGE_SOURCE_CONTACT]
+    if page_token:
+        params["pageToken"] = page_token
+
+    result = await asyncio.to_thread(
+        service.people().searchDirectoryPeople(**params).execute
+    )
+
+    people = result.get("people", [])
+    next_page_token = result.get("nextPageToken")
+
+    if not people:
+        return (
+            f"No directory people found matching '{query}' for "
+            f"{user_google_email}."
+        )
+
+    response = (
+        f"Directory search results for '{query}' ({len(people)} found):\n\n"
+    )
+    for person in people:
+        response += _format_contact(person) + "\n\n"
+    if next_page_token:
+        response += f"Next page token: {next_page_token}"
+
+    logger.info(
+        f"Found {len(people)} directory people matching '{query}' for "
+        f"{user_google_email}"
     )
     return response
 

--- a/gcontacts/contacts_tools.py
+++ b/gcontacts/contacts_tools.py
@@ -1311,9 +1311,7 @@ async def list_directory_people(
     if next_page_token:
         response += f"Next page token: {next_page_token}"
 
-    logger.info(
-        f"Listed {len(people)} directory people for {user_google_email}"
-    )
+    logger.info(f"Listed {len(people)} directory people for {user_google_email}")
     return response
 
 
@@ -1388,14 +1386,9 @@ async def search_directory_people(
     next_page_token = result.get("nextPageToken")
 
     if not people:
-        return (
-            f"No directory people found matching '{query}' for "
-            f"{user_google_email}."
-        )
+        return f"No directory people found matching '{query}' for {user_google_email}."
 
-    response = (
-        f"Directory search results for '{query}' ({len(people)} found):\n\n"
-    )
+    response = f"Directory search results for '{query}' ({len(people)} found):\n\n"
     for person in people:
         response += _format_contact(person) + "\n\n"
     if next_page_token:

--- a/tests/gcontacts/test_directory_tools.py
+++ b/tests/gcontacts/test_directory_tools.py
@@ -1,0 +1,289 @@
+"""
+Unit tests for directory-people tools backed by the Google People API
+(listDirectoryPeople and searchDirectoryPeople).
+
+Each tool is invoked through its unwrapped async function to bypass auth
+decorators, with a MagicMock standing in for the People API client.
+"""
+
+import asyncio
+import os
+import sys
+
+import pytest
+from unittest.mock import MagicMock
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+)
+
+from gcontacts.contacts_tools import (  # noqa: E402  (path setup above)
+    DEFAULT_DIRECTORY_SOURCES,
+    DIRECTORY_DEFAULT_PERSON_FIELDS,
+    DIRECTORY_MERGE_SOURCE_CONTACT,
+    DIRECTORY_SOURCE_DOMAIN_CONTACT,
+    DIRECTORY_SOURCE_DOMAIN_PROFILE,
+    _resolve_directory_sources,
+    list_directory_people as _list_directory_people_wrapped,
+    search_directory_people as _search_directory_people_wrapped,
+)
+from core.utils import UserInputError
+
+
+def _unwrap(fn):
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+list_directory_people = _unwrap(_list_directory_people_wrapped)
+search_directory_people = _unwrap(_search_directory_people_wrapped)
+
+
+def run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _person(name, email):
+    return {
+        "resourceName": "people/c123",
+        "names": [{"displayName": name}],
+        "emailAddresses": [{"value": email}],
+    }
+
+
+class TestResolveDirectorySources:
+    def test_default_when_none(self):
+        assert _resolve_directory_sources(None) == list(DEFAULT_DIRECTORY_SOURCES)
+
+    def test_default_when_empty(self):
+        assert _resolve_directory_sources([]) == list(DEFAULT_DIRECTORY_SOURCES)
+
+    def test_profile_aliases(self):
+        for alias in ("profile", "Profile", "DOMAIN_PROFILE"):
+            assert _resolve_directory_sources([alias]) == [
+                DIRECTORY_SOURCE_DOMAIN_PROFILE
+            ]
+
+    def test_contact_aliases(self):
+        for alias in ("contact", "DOMAIN_CONTACT"):
+            assert _resolve_directory_sources([alias]) == [
+                DIRECTORY_SOURCE_DOMAIN_CONTACT
+            ]
+
+    def test_full_value_passthrough(self):
+        assert _resolve_directory_sources(
+            [DIRECTORY_SOURCE_DOMAIN_PROFILE]
+        ) == [DIRECTORY_SOURCE_DOMAIN_PROFILE]
+
+    def test_unknown_source_raises(self):
+        with pytest.raises(UserInputError):
+            _resolve_directory_sources(["bogus"])
+
+
+class TestListDirectoryPeople:
+    def test_calls_api_with_default_params(self):
+        svc = MagicMock()
+        svc.people.return_value.listDirectoryPeople.return_value.execute.return_value = {
+            "people": [_person("Alice", "alice@example.com")]
+        }
+
+        result = run(
+            list_directory_people(
+                service=svc, user_google_email="me@example.com"
+            )
+        )
+
+        kwargs = (
+            svc.people.return_value.listDirectoryPeople.call_args.kwargs
+        )
+        assert kwargs["readMask"] == DIRECTORY_DEFAULT_PERSON_FIELDS
+        assert kwargs["sources"] == list(DEFAULT_DIRECTORY_SOURCES)
+        assert kwargs["pageSize"] == 100
+        assert kwargs["mergeSources"] == [DIRECTORY_MERGE_SOURCE_CONTACT]
+        assert "pageToken" not in kwargs
+        assert "Alice" in result
+        assert "alice@example.com" in result
+
+    def test_merge_disabled_omits_param(self):
+        svc = MagicMock()
+        svc.people.return_value.listDirectoryPeople.return_value.execute.return_value = {
+            "people": []
+        }
+
+        run(
+            list_directory_people(
+                service=svc,
+                user_google_email="me@example.com",
+                merge_contact_into_profile=False,
+            )
+        )
+
+        kwargs = (
+            svc.people.return_value.listDirectoryPeople.call_args.kwargs
+        )
+        assert "mergeSources" not in kwargs
+
+    def test_clamps_page_size_to_1000(self):
+        svc = MagicMock()
+        svc.people.return_value.listDirectoryPeople.return_value.execute.return_value = {
+            "people": []
+        }
+
+        run(
+            list_directory_people(
+                service=svc, user_google_email="me@example.com", page_size=5000
+            )
+        )
+
+        kwargs = (
+            svc.people.return_value.listDirectoryPeople.call_args.kwargs
+        )
+        assert kwargs["pageSize"] == 1000
+
+    def test_rejects_zero_page_size(self):
+        svc = MagicMock()
+        with pytest.raises(UserInputError):
+            run(
+                list_directory_people(
+                    service=svc,
+                    user_google_email="me@example.com",
+                    page_size=0,
+                )
+            )
+
+    def test_passes_page_token(self):
+        svc = MagicMock()
+        svc.people.return_value.listDirectoryPeople.return_value.execute.return_value = {
+            "people": []
+        }
+
+        run(
+            list_directory_people(
+                service=svc,
+                user_google_email="me@example.com",
+                page_token="tok123",
+            )
+        )
+
+        kwargs = (
+            svc.people.return_value.listDirectoryPeople.call_args.kwargs
+        )
+        assert kwargs["pageToken"] == "tok123"
+
+    def test_uses_resolved_sources(self):
+        svc = MagicMock()
+        svc.people.return_value.listDirectoryPeople.return_value.execute.return_value = {
+            "people": []
+        }
+
+        run(
+            list_directory_people(
+                service=svc,
+                user_google_email="me@example.com",
+                sources=["profile"],
+            )
+        )
+
+        kwargs = (
+            svc.people.return_value.listDirectoryPeople.call_args.kwargs
+        )
+        assert kwargs["sources"] == [DIRECTORY_SOURCE_DOMAIN_PROFILE]
+
+    def test_includes_next_page_token_in_response(self):
+        svc = MagicMock()
+        svc.people.return_value.listDirectoryPeople.return_value.execute.return_value = {
+            "people": [_person("Alice", "alice@example.com")],
+            "nextPageToken": "next-tok",
+        }
+
+        result = run(
+            list_directory_people(
+                service=svc, user_google_email="me@example.com"
+            )
+        )
+
+        assert "Next page token: next-tok" in result
+
+    def test_empty_result_message(self):
+        svc = MagicMock()
+        svc.people.return_value.listDirectoryPeople.return_value.execute.return_value = {}
+
+        result = run(
+            list_directory_people(
+                service=svc, user_google_email="me@example.com"
+            )
+        )
+
+        assert "No directory people found" in result
+
+
+class TestSearchDirectoryPeople:
+    def test_passes_query_and_default_params(self):
+        svc = MagicMock()
+        svc.people.return_value.searchDirectoryPeople.return_value.execute.return_value = {
+            "people": [_person("Bob", "bob@example.com")]
+        }
+
+        result = run(
+            search_directory_people(
+                service=svc,
+                user_google_email="me@example.com",
+                query="bob",
+            )
+        )
+
+        kwargs = (
+            svc.people.return_value.searchDirectoryPeople.call_args.kwargs
+        )
+        assert kwargs["query"] == "bob"
+        assert kwargs["readMask"] == DIRECTORY_DEFAULT_PERSON_FIELDS
+        assert kwargs["sources"] == list(DEFAULT_DIRECTORY_SOURCES)
+        assert kwargs["pageSize"] == 50
+        assert kwargs["mergeSources"] == [DIRECTORY_MERGE_SOURCE_CONTACT]
+        assert "Bob" in result
+
+    def test_rejects_empty_query(self):
+        svc = MagicMock()
+        with pytest.raises(UserInputError):
+            run(
+                search_directory_people(
+                    service=svc,
+                    user_google_email="me@example.com",
+                    query="   ",
+                )
+            )
+
+    def test_clamps_page_size_to_500(self):
+        svc = MagicMock()
+        svc.people.return_value.searchDirectoryPeople.return_value.execute.return_value = {
+            "people": []
+        }
+
+        run(
+            search_directory_people(
+                service=svc,
+                user_google_email="me@example.com",
+                query="x",
+                page_size=10000,
+            )
+        )
+
+        kwargs = (
+            svc.people.return_value.searchDirectoryPeople.call_args.kwargs
+        )
+        assert kwargs["pageSize"] == 500
+
+    def test_empty_result_message(self):
+        svc = MagicMock()
+        svc.people.return_value.searchDirectoryPeople.return_value.execute.return_value = {}
+
+        result = run(
+            search_directory_people(
+                service=svc,
+                user_google_email="me@example.com",
+                query="nobody",
+            )
+        )
+
+        assert "No directory people found matching 'nobody'" in result

--- a/tests/gcontacts/test_directory_tools.py
+++ b/tests/gcontacts/test_directory_tools.py
@@ -252,6 +252,54 @@ class TestSearchDirectoryPeople:
         kwargs = svc.people.return_value.searchDirectoryPeople.call_args.kwargs
         assert kwargs["pageSize"] == 500
 
+    def test_merge_disabled_omits_param(self):
+        svc = MagicMock()
+        svc.people.return_value.searchDirectoryPeople.return_value.execute.return_value = {
+            "people": []
+        }
+
+        run(
+            search_directory_people(
+                service=svc,
+                user_google_email="me@example.com",
+                query="test",
+                merge_contact_into_profile=False,
+            )
+        )
+
+        kwargs = svc.people.return_value.searchDirectoryPeople.call_args.kwargs
+        assert "mergeSources" not in kwargs
+
+    def test_passes_page_token(self):
+        svc = MagicMock()
+        svc.people.return_value.searchDirectoryPeople.return_value.execute.return_value = {
+            "people": []
+        }
+
+        run(
+            search_directory_people(
+                service=svc,
+                user_google_email="me@example.com",
+                query="test",
+                page_token="tok123",
+            )
+        )
+
+        kwargs = svc.people.return_value.searchDirectoryPeople.call_args.kwargs
+        assert kwargs["pageToken"] == "tok123"
+
+    def test_rejects_zero_page_size(self):
+        svc = MagicMock()
+        with pytest.raises(UserInputError):
+            run(
+                search_directory_people(
+                    service=svc,
+                    user_google_email="me@example.com",
+                    query="test",
+                    page_size=0,
+                )
+            )
+
     def test_empty_result_message(self):
         svc = MagicMock()
         svc.people.return_value.searchDirectoryPeople.return_value.execute.return_value = {}

--- a/tests/gcontacts/test_directory_tools.py
+++ b/tests/gcontacts/test_directory_tools.py
@@ -13,9 +13,7 @@ import sys
 import pytest
 from unittest.mock import MagicMock
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from gcontacts.contacts_tools import (  # noqa: E402  (path setup above)
     DEFAULT_DIRECTORY_SOURCES,
@@ -72,9 +70,9 @@ class TestResolveDirectorySources:
             ]
 
     def test_full_value_passthrough(self):
-        assert _resolve_directory_sources(
-            [DIRECTORY_SOURCE_DOMAIN_PROFILE]
-        ) == [DIRECTORY_SOURCE_DOMAIN_PROFILE]
+        assert _resolve_directory_sources([DIRECTORY_SOURCE_DOMAIN_PROFILE]) == [
+            DIRECTORY_SOURCE_DOMAIN_PROFILE
+        ]
 
     def test_unknown_source_raises(self):
         with pytest.raises(UserInputError):
@@ -89,14 +87,10 @@ class TestListDirectoryPeople:
         }
 
         result = run(
-            list_directory_people(
-                service=svc, user_google_email="me@example.com"
-            )
+            list_directory_people(service=svc, user_google_email="me@example.com")
         )
 
-        kwargs = (
-            svc.people.return_value.listDirectoryPeople.call_args.kwargs
-        )
+        kwargs = svc.people.return_value.listDirectoryPeople.call_args.kwargs
         assert kwargs["readMask"] == DIRECTORY_DEFAULT_PERSON_FIELDS
         assert kwargs["sources"] == list(DEFAULT_DIRECTORY_SOURCES)
         assert kwargs["pageSize"] == 100
@@ -119,9 +113,7 @@ class TestListDirectoryPeople:
             )
         )
 
-        kwargs = (
-            svc.people.return_value.listDirectoryPeople.call_args.kwargs
-        )
+        kwargs = svc.people.return_value.listDirectoryPeople.call_args.kwargs
         assert "mergeSources" not in kwargs
 
     def test_clamps_page_size_to_1000(self):
@@ -136,9 +128,7 @@ class TestListDirectoryPeople:
             )
         )
 
-        kwargs = (
-            svc.people.return_value.listDirectoryPeople.call_args.kwargs
-        )
+        kwargs = svc.people.return_value.listDirectoryPeople.call_args.kwargs
         assert kwargs["pageSize"] == 1000
 
     def test_rejects_zero_page_size(self):
@@ -166,9 +156,7 @@ class TestListDirectoryPeople:
             )
         )
 
-        kwargs = (
-            svc.people.return_value.listDirectoryPeople.call_args.kwargs
-        )
+        kwargs = svc.people.return_value.listDirectoryPeople.call_args.kwargs
         assert kwargs["pageToken"] == "tok123"
 
     def test_uses_resolved_sources(self):
@@ -185,9 +173,7 @@ class TestListDirectoryPeople:
             )
         )
 
-        kwargs = (
-            svc.people.return_value.listDirectoryPeople.call_args.kwargs
-        )
+        kwargs = svc.people.return_value.listDirectoryPeople.call_args.kwargs
         assert kwargs["sources"] == [DIRECTORY_SOURCE_DOMAIN_PROFILE]
 
     def test_includes_next_page_token_in_response(self):
@@ -198,9 +184,7 @@ class TestListDirectoryPeople:
         }
 
         result = run(
-            list_directory_people(
-                service=svc, user_google_email="me@example.com"
-            )
+            list_directory_people(service=svc, user_google_email="me@example.com")
         )
 
         assert "Next page token: next-tok" in result
@@ -210,9 +194,7 @@ class TestListDirectoryPeople:
         svc.people.return_value.listDirectoryPeople.return_value.execute.return_value = {}
 
         result = run(
-            list_directory_people(
-                service=svc, user_google_email="me@example.com"
-            )
+            list_directory_people(service=svc, user_google_email="me@example.com")
         )
 
         assert "No directory people found" in result
@@ -233,9 +215,7 @@ class TestSearchDirectoryPeople:
             )
         )
 
-        kwargs = (
-            svc.people.return_value.searchDirectoryPeople.call_args.kwargs
-        )
+        kwargs = svc.people.return_value.searchDirectoryPeople.call_args.kwargs
         assert kwargs["query"] == "bob"
         assert kwargs["readMask"] == DIRECTORY_DEFAULT_PERSON_FIELDS
         assert kwargs["sources"] == list(DEFAULT_DIRECTORY_SOURCES)
@@ -269,9 +249,7 @@ class TestSearchDirectoryPeople:
             )
         )
 
-        kwargs = (
-            svc.people.return_value.searchDirectoryPeople.call_args.kwargs
-        )
+        kwargs = svc.people.return_value.searchDirectoryPeople.call_args.kwargs
         assert kwargs["pageSize"] == 500
 
     def test_empty_result_message(self):


### PR DESCRIPTION
## Summary

Adds two read-only tools backed by the People API endpoints
listDirectoryPeople and searchDirectoryPeople. These surface the Google
Workspace domain directory (colleagues and admin-managed shared domain
contacts), which is distinct from the user's personal contacts already
covered by list_contacts and search_contacts.

Domain directory access requires a Google Workspace account. Consumer
Google accounts cannot grant directory.readonly.

## Changes

- auth/scopes.py: add DIRECTORY_READONLY_SCOPE
  (https://www.googleapis.com/auth/directory.readonly) and include it in
  CONTACTS_SCOPES and the contacts read-only tool scope set.
- auth/service_decorator.py: expose a "directory_read" scope key so the
  new tools require only the directory scope.
- gcontacts/contacts_tools.py: add list_directory_people and
  search_directory_people, plus a helper that resolves friendly source
  aliases ('profile' / 'contact') to the API's DIRECTORY_SOURCE_TYPE_*
  values. The default readMask additionally requests locations and
  userDefined so admin-synced HR fields (such as start date or employee
  id) surface when configured.
- tests/gcontacts/test_directory_tools.py: 18 unit tests covering source
  resolution, default and explicit params, page-size clamping,
  pagination, empty results, and input validation.

## New tools

- list_directory_people: list people in the authenticated user's
  Workspace domain directory. Supports page_size (max 1000), pagination,
  source selection (profile and/or contact), and optional merging of
  shared-contact entries into matching profiles.
- search_directory_people: substring search across the domain directory
  by name, email, organization, and title. Supports page_size (max 500),
  pagination, source selection, and merge.

Both tools are read-only and request only directory.readonly.

## Testing

All 18 unit tests pass. Each tool is invoked through its unwrapped async
function with a mocked People API client.

## Notes

Adding DIRECTORY_READONLY_SCOPE to the shared contacts scope set means
existing contacts users will be prompted to re-consent on next auth, and
consumer (non-Workspace) accounts will see a Workspace-only scope they
cannot grant. Happy to scope this down to only the two new tools if
preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List and search Google Workspace directory people with pagination and source filtering
  * Optional merge of shared contacts into profile results when querying directory sources
  * Contact permissions updated to include Google Workspace directory read-only access

* **Tests**
  * Added unit tests covering directory listing/search behavior, input validation, pagination, source resolution, and user-facing messages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->