### PR TITLE
fix(calendar): preserve start/end in _modify_event_impl when not explicitly changed

### DIFF
--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -1062,6 +1062,10 @@ async def _modify_event_impl(
                 "attendees": event_body.get("attendees"),
                 "colorId": event_body.get("colorId"),
                 "recurrence": recurrence,
+                # start/end are required by events.update(); carry them over when
+                # not explicitly changed (e.g. updating only attachments/attendees)
+                "start": event_body.get("start"),
+                "end": event_body.get("end"),
             },
         )
 


### PR DESCRIPTION
## Problem

`events.update()` requires both `start` and `end` fields in the request body. When `manage_event` is called without providing `start_time`/`end_time` (e.g. updating only `attendees` or `attachments`), neither field is populated in `event_body`, so the existing event's times are not carried over. This causes the Google Calendar API to return a 400 error:

```
Missing end time.
```

## Root cause

`_preserve_existing_fields` in `_modify_event_impl` preserves `summary`, `description`, `location`, `attendees`, `colorId`, and `recurrence` from the existing event — but not `start` or `end`.

## Fix

Add `"start"` and `"end"` to the `_preserve_existing_fields` call. When `event_body` already has values for these keys (because the caller provided `start_time`/`end_time`), `event_body.get("start")` returns those values and they are preserved as-is. When the caller omitted them, `event_body.get("start")` returns `None`, and `_preserve_existing_fields` copies the existing event's values — which is the desired behaviour.

```python
_preserve_existing_fields(
    event_body,
    existing_event,
    {
        ...
        "start": event_body.get("start"),   # carry over when not explicitly changed
        "end": event_body.get("end"),        # carry over when not explicitly changed
    },
)
```

## Reproduction

Call `manage_event` with `event_id` and `attendees` but no `start_time`/`end_time`. Without this fix, the Google API returns 400 "Missing end time."

## Notes

- No new parameters, no behaviour change when `start_time`/`end_time` are provided
- Minimal diff: 4 lines added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where calendar event dates could be unintentionally omitted when updating events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->