### PR TITLE
fix: add httplib2 socket timeout to prevent indefinite hangs (#835)

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -89,13 +89,7 @@ DEFAULT_CREDENTIALS_DIR = get_default_credentials_dir()
 def _build_authorized_http(
     credentials: Credentials, timeout: int = 30
 ) -> google_auth_httplib2.AuthorizedHttp:
-    """Return an httplib2.Http wrapped with credentials and a socket timeout.
-
-    Issue #835: googleapiclient.discovery.build() with credentials=credentials
-    creates an httplib2.Http() with no timeout (default None), causing
-    indefinite hangs on stalled TCP. We explicitly construct an
-    AuthorizedHttp with a timeout and pass it as the *http* argument.
-    """
+    """Return credentialed HTTP with an explicit socket timeout."""
     http = httplib2.Http(timeout=timeout)
     return google_auth_httplib2.AuthorizedHttp(credentials, http=http)
 

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -17,6 +17,8 @@ from google.auth.transport.requests import Request
 from google.auth.exceptions import RefreshError
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
+import httplib2
+import google_auth_httplib2
 from auth.scopes import SCOPES, get_current_scopes, has_required_scopes  # noqa
 from auth.oauth21_session_store import get_oauth21_session_store
 from auth.credential_store import get_credential_store
@@ -82,6 +84,21 @@ def get_default_credentials_dir():
 
 
 DEFAULT_CREDENTIALS_DIR = get_default_credentials_dir()
+
+
+def _build_authorized_http(
+    credentials: Credentials, timeout: int = 30
+) -> google_auth_httplib2.AuthorizedHttp:
+    """Return an httplib2.Http wrapped with credentials and a socket timeout.
+
+    Issue #835: googleapiclient.discovery.build() with credentials=credentials
+    creates an httplib2.Http() with no timeout (default None), causing
+    indefinite hangs on stalled TCP. We explicitly construct an
+    AuthorizedHttp with a timeout and pass it as the *http* argument.
+    """
+    http = httplib2.Http(timeout=timeout)
+    return google_auth_httplib2.AuthorizedHttp(credentials, http=http)
+
 
 # Session credentials now handled by OAuth21SessionStore - no local cache needed
 # Centralized Client Secrets Path Logic
@@ -1193,7 +1210,7 @@ def get_user_info(
     try:
         # Using googleapiclient discovery to get user info
         # Requires 'google-api-python-client' library
-        service = build("oauth2", "v2", credentials=credentials)
+        service = build("oauth2", "v2", http=_build_authorized_http(credentials))
         user_info = service.userinfo().get().execute()
         logger.info(f"Successfully fetched user info: {user_info.get('email')}")
         return user_info
@@ -1344,7 +1361,7 @@ async def get_authenticated_google_service(
         raise GoogleAuthenticationError(auth_response)
 
     try:
-        service = build(service_name, version, credentials=credentials)
+        service = build(service_name, version, http=_build_authorized_http(credentials))
         log_user_email = user_google_email
 
         # Try to get email from credentials if needed for validation

--- a/tests/auth/test_httplib2_timeout.py
+++ b/tests/auth/test_httplib2_timeout.py
@@ -15,7 +15,9 @@ def test_build_authorized_http_uses_explicit_timeout():
     mock_authorized = MagicMock()
 
     with (
-        patch("auth.google_auth.httplib2.Http", return_value=mock_http) as mock_http_cls,
+        patch(
+            "auth.google_auth.httplib2.Http", return_value=mock_http
+        ) as mock_http_cls,
         patch(
             "auth.google_auth.google_auth_httplib2.AuthorizedHttp",
             return_value=mock_authorized,
@@ -77,7 +79,9 @@ async def test_get_authenticated_google_service_builds_service_with_authorized_h
     monkeypatch.setattr("auth.google_auth.get_fastmcp_session_id", lambda: None)
     monkeypatch.setattr("auth.google_auth.get_fastmcp_context", None)
     monkeypatch.setattr("auth.google_auth.asyncio.to_thread", fake_to_thread)
-    monkeypatch.setattr("auth.google_auth.get_credentials", lambda **kwargs: credentials)
+    monkeypatch.setattr(
+        "auth.google_auth.get_credentials", lambda **kwargs: credentials
+    )
     monkeypatch.setattr(
         "auth.google_auth._build_authorized_http", lambda creds: authorized_http
     )

--- a/tests/auth/test_httplib2_timeout.py
+++ b/tests/auth/test_httplib2_timeout.py
@@ -1,0 +1,46 @@
+"""Regression tests for Issue #835 — httplib2 socket timeout."""
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from auth.google_auth import _build_authorized_http  # noqa: E402
+
+
+def test_build_authorized_http_uses_explicit_timeout():
+    """_build_authorized_http must construct httplib2.Http with a timeout."""
+    mock_credentials = MagicMock()
+    mock_http = MagicMock()
+    mock_authorized = MagicMock()
+
+    with (
+        patch("auth.google_auth.httplib2.Http", return_value=mock_http) as mock_http_cls,
+        patch(
+            "auth.google_auth.google_auth_httplib2.AuthorizedHttp",
+            return_value=mock_authorized,
+        ) as mock_auth_http_cls,
+    ):
+        result = _build_authorized_http(mock_credentials, timeout=42)
+
+    mock_http_cls.assert_called_once_with(timeout=42)
+    mock_auth_http_cls.assert_called_once_with(mock_credentials, http=mock_http)
+    assert result is mock_authorized
+
+
+def test_build_authorized_http_default_timeout_is_30():
+    """Default timeout should be 30 seconds."""
+    mock_credentials = MagicMock()
+    mock_http = MagicMock()
+
+    with (
+        patch("auth.google_auth.httplib2.Http", return_value=mock_http) as mock_http_cls,
+        patch(
+            "auth.google_auth.google_auth_httplib2.AuthorizedHttp",
+        ) as mock_auth_http_cls,
+    ):
+        _build_authorized_http(mock_credentials)
+
+    mock_http_cls.assert_called_once_with(timeout=30)
+    mock_auth_http_cls.assert_called_once_with(mock_credentials, http=mock_http)

--- a/tests/auth/test_httplib2_timeout.py
+++ b/tests/auth/test_httplib2_timeout.py
@@ -1,16 +1,15 @@
-"""Regression tests for Issue #835 — httplib2 socket timeout."""
+"""Regression tests for Issue #835 httplib2 socket timeout."""
 
-import os
-import sys
-from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+import pytest
 
-from auth.google_auth import _build_authorized_http  # noqa: E402
+from auth.google_auth import _build_authorized_http, get_authenticated_google_service
+from auth.google_auth import get_user_info
 
 
 def test_build_authorized_http_uses_explicit_timeout():
-    """_build_authorized_http must construct httplib2.Http with a timeout."""
     mock_credentials = MagicMock()
     mock_http = MagicMock()
     mock_authorized = MagicMock()
@@ -30,12 +29,10 @@ def test_build_authorized_http_uses_explicit_timeout():
 
 
 def test_build_authorized_http_default_timeout_is_30():
-    """Default timeout should be 30 seconds."""
     mock_credentials = MagicMock()
-    mock_http = MagicMock()
 
     with (
-        patch("auth.google_auth.httplib2.Http", return_value=mock_http) as mock_http_cls,
+        patch("auth.google_auth.httplib2.Http") as mock_http_cls,
         patch(
             "auth.google_auth.google_auth_httplib2.AuthorizedHttp",
         ) as mock_auth_http_cls,
@@ -43,4 +40,58 @@ def test_build_authorized_http_default_timeout_is_30():
         _build_authorized_http(mock_credentials)
 
     mock_http_cls.assert_called_once_with(timeout=30)
-    mock_auth_http_cls.assert_called_once_with(mock_credentials, http=mock_http)
+    mock_auth_http_cls.assert_called_once_with(
+        mock_credentials, http=mock_http_cls.return_value
+    )
+
+
+def test_get_user_info_builds_service_with_authorized_http(monkeypatch):
+    credentials = SimpleNamespace(valid=True)
+    authorized_http = object()
+    service = MagicMock()
+    service.userinfo.return_value.get.return_value.execute.return_value = {
+        "email": "user@example.com"
+    }
+
+    monkeypatch.setattr(
+        "auth.google_auth._build_authorized_http", lambda creds: authorized_http
+    )
+    build = MagicMock(return_value=service)
+    monkeypatch.setattr("auth.google_auth.build", build)
+
+    assert get_user_info(credentials) == {"email": "user@example.com"}
+    build.assert_called_once_with("oauth2", "v2", http=authorized_http)
+
+
+@pytest.mark.asyncio
+async def test_get_authenticated_google_service_builds_service_with_authorized_http(
+    monkeypatch,
+):
+    async def fake_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    credentials = SimpleNamespace(valid=True, id_token=None)
+    authorized_http = object()
+    service = MagicMock()
+
+    monkeypatch.setattr("auth.google_auth.get_fastmcp_session_id", lambda: None)
+    monkeypatch.setattr("auth.google_auth.get_fastmcp_context", None)
+    monkeypatch.setattr("auth.google_auth.asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr("auth.google_auth.get_credentials", lambda **kwargs: credentials)
+    monkeypatch.setattr(
+        "auth.google_auth._build_authorized_http", lambda creds: authorized_http
+    )
+    build = MagicMock(return_value=service)
+    monkeypatch.setattr("auth.google_auth.build", build)
+
+    result, user_email = await get_authenticated_google_service(
+        service_name="gmail",
+        version="v1",
+        tool_name="test_tool",
+        user_google_email="user@example.com",
+        required_scopes=["scope.a"],
+    )
+
+    assert result is service
+    assert user_email == "user@example.com"
+    build.assert_called_once_with("gmail", "v1", http=authorized_http)


### PR DESCRIPTION
Closes: #835 

## Problem

`googleapiclient.discovery.build()` with `credentials=credentials` internally creates an `httplib2.Http()` with no socket timeout (default `None`). On stalled or flaky network connections, this causes indefinite hangs rather than a clean timeout error.

Issue #835 reports this as a hard hang during service initialization.

## Changes

### `auth/google_auth.py`

- Added `_build_authorized_http(credentials, timeout=30)` helper that explicitly constructs an `httplib2.Http(timeout=30)` and wraps it with `google_auth_httplib2.AuthorizedHttp`
- Updated `get_user_info()` to pass `http=_build_authorized_http(credentials)` instead of `credentials=credentials`
- Updated `_get_google_service()` (the main service builder) with the same fix

### Dependencies

`google-auth-httplib2>=0.2.0` and `httplib2` are already declared in `pyproject.toml` and locked in `uv.lock` — no new dependencies.

### Tests

- `tests/auth/test_httplib2_timeout.py`: two focused unit tests verifying:
  1. Explicit timeout value is forwarded to `httplib2.Http`
  2. Default timeout is 30 seconds

## Verification

```bash
uv run pytest tests/auth/test_httplib2_timeout.py -v
# 2 passed

uv run pytest tests/auth/ -v
# 127 passed
```

Fixes #835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Google API authentication now uses an explicit socket timeout to prevent indefinite request hangs. A 30-second default is applied and custom timeout values are supported.

* **Tests**
  * Added regression tests verifying explicit timeout propagation, the 30-second default behavior, and that authenticated Google requests are built using the timed HTTP transport.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->