### PR TITLE
test: add UPDATE_GOLDEN flag to regenerate schema snapshots

### DIFF
--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -48,7 +48,7 @@ Key architectural pillars:
 
    * Unit tests for every tool; integration tests for high‑risk flows (email send, file upload).
    * Mock Google APIs with `httpretty` + canned fixtures – do **not** hit live services in CI.
-   * Contract tests: regenerate FastMCP OpenAI‑schema and diff against committed goldens.
+   * Contract tests: tool schemas are diffed against committed goldens. When a schema change is intentional, regenerate the snapshots with `UPDATE_GOLDEN=1 uv run pytest` and commit the updated golden files.
 
 # 🚦 Low‑Value Feedback to Skip
 

--- a/tests/gcontacts/test_contacts_tools_v2.py
+++ b/tests/gcontacts/test_contacts_tools_v2.py
@@ -11,19 +11,17 @@ Covers:
 - Internal PBX type
 """
 
-import json
 import os
-from difflib import unified_diff
 from pathlib import Path
 import sys
 import warnings
-
-import pytest
 
 from core.server import server
 from core.tool_registry import get_tool_components
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from tests.golden_utils import assert_matches_golden
 
 from gcontacts.contacts_tools import (
     EmailInput,
@@ -744,7 +742,6 @@ class TestBuildPersonBodyBatch:
 class TestContactsToolSchemaGolden:
     def test_contacts_tool_schema_matches_golden(self):
         generated = _schema_subset()
-        golden = json.loads(SCHEMA_GOLDEN_PATH.read_text())
 
         manage_contact_props = generated["manage_contact"]["properties"]
         manage_contact_defs = generated["manage_contact"]["$defs"]
@@ -776,16 +773,4 @@ class TestContactsToolSchemaGolden:
             "$ref": "#/$defs/PhoneInput"
         }
 
-        if generated != golden:
-            expected = json.dumps(golden, indent=2, sort_keys=True).splitlines()
-            actual = json.dumps(generated, indent=2, sort_keys=True).splitlines()
-            diff = "\n".join(
-                unified_diff(
-                    expected,
-                    actual,
-                    fromfile=str(SCHEMA_GOLDEN_PATH),
-                    tofile="generated",
-                    lineterm="",
-                )
-            )
-            pytest.fail(f"Contacts tool schema drifted from golden:\n{diff}")
+        assert_matches_golden(generated, SCHEMA_GOLDEN_PATH, "Contacts")

--- a/tests/gdocs/test_strikethrough.py
+++ b/tests/gdocs/test_strikethrough.py
@@ -4,8 +4,6 @@ Tests for strikethrough text style support.
 Covers the helpers, validation, and batch manager integration.
 """
 
-import json
-from difflib import unified_diff
 from pathlib import Path
 import pytest
 from unittest.mock import AsyncMock, Mock
@@ -15,6 +13,7 @@ from core.tool_registry import get_tool_components
 from gdocs import docs_tools
 from gdocs.docs_helpers import build_text_style, create_format_text_request
 from gdocs.managers.validation_manager import ValidationManager
+from tests.golden_utils import assert_matches_golden
 
 SCHEMA_GOLDEN_PATH = (
     Path(__file__).with_name("golden").joinpath("docs_tool_schemas.json")
@@ -201,7 +200,6 @@ class TestPublicToolWiring:
 class TestDocsToolSchemaGolden:
     def test_docs_tool_schema_matches_golden(self):
         generated = _schema_subset()
-        golden = json.loads(SCHEMA_GOLDEN_PATH.read_text())
 
         assert "strikethrough" in generated["modify_doc_text"]["properties"], (
             "modify_doc_text schema is missing the strikethrough parameter"
@@ -219,16 +217,4 @@ class TestDocsToolSchemaGolden:
             is False
         )
 
-        if generated != golden:
-            expected = json.dumps(golden, indent=2, sort_keys=True).splitlines()
-            actual = json.dumps(generated, indent=2, sort_keys=True).splitlines()
-            diff = "\n".join(
-                unified_diff(
-                    expected,
-                    actual,
-                    fromfile=str(SCHEMA_GOLDEN_PATH),
-                    tofile="generated",
-                    lineterm="",
-                )
-            )
-            pytest.fail(f"Docs tool schema drifted from golden:\n{diff}")
+        assert_matches_golden(generated, SCHEMA_GOLDEN_PATH, "Docs")

--- a/tests/golden_utils.py
+++ b/tests/golden_utils.py
@@ -40,10 +40,10 @@ def assert_matches_golden(generated: Any, golden_path: Path, label: str) -> None
     message (e.g. "Contacts").
     """
     if UPDATE_GOLDEN:
-        golden_path.write_text(_serialize(generated))
+        golden_path.write_text(_serialize(generated), encoding="utf-8")
         return
 
-    golden = json.loads(golden_path.read_text())
+    golden = json.loads(golden_path.read_text(encoding="utf-8"))
     if generated != golden:
         expected = json.dumps(golden, indent=2, sort_keys=True).splitlines()
         actual = json.dumps(generated, indent=2, sort_keys=True).splitlines()

--- a/tests/golden_utils.py
+++ b/tests/golden_utils.py
@@ -1,0 +1,63 @@
+"""Shared helpers for golden-file (schema snapshot) tests.
+
+A golden test regenerates some output (e.g. a tool's JSON schema) and compares
+it against a committed snapshot file, failing on any drift. This catches
+*accidental* changes to a tool's public contract.
+
+When a schema change is *intentional*, the snapshot must be refreshed. Set the
+``UPDATE_GOLDEN=1`` environment variable to rewrite the golden files instead of
+asserting against them, then review the resulting diff in git before committing::
+
+    UPDATE_GOLDEN=1 uv run pytest tests/gcontacts/test_contacts_tools_v2.py
+
+Default runs (without the variable) only compare and fail on drift.
+"""
+
+import json
+import os
+from difflib import unified_diff
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+#: When this env var is "1", golden tests rewrite their snapshot instead of asserting.
+UPDATE_GOLDEN = os.environ.get("UPDATE_GOLDEN") == "1"
+
+
+def _serialize(data: Any) -> str:
+    """Serialize ``data`` in the canonical golden-file format (stable across runs)."""
+    return json.dumps(data, indent=2, sort_keys=True) + "\n"
+
+
+def assert_matches_golden(generated: Any, golden_path: Path, label: str) -> None:
+    """Compare ``generated`` against the golden file at ``golden_path``.
+
+    In ``UPDATE_GOLDEN=1`` mode the golden file is rewritten with ``generated``
+    and the function returns without asserting. Otherwise the parsed golden is
+    compared against ``generated`` and a unified diff is raised via
+    ``pytest.fail`` on any mismatch. ``label`` names the schema in the failure
+    message (e.g. "Contacts").
+    """
+    if UPDATE_GOLDEN:
+        golden_path.write_text(_serialize(generated))
+        return
+
+    golden = json.loads(golden_path.read_text())
+    if generated != golden:
+        expected = json.dumps(golden, indent=2, sort_keys=True).splitlines()
+        actual = json.dumps(generated, indent=2, sort_keys=True).splitlines()
+        diff = "\n".join(
+            unified_diff(
+                expected,
+                actual,
+                fromfile=str(golden_path),
+                tofile="generated",
+                lineterm="",
+            )
+        )
+        pytest.fail(
+            f"{label} tool schema drifted from golden:\n{diff}\n\n"
+            "If this change is intentional, regenerate the snapshot with:\n"
+            "    UPDATE_GOLDEN=1 uv run pytest"
+        )


### PR DESCRIPTION
## Description
Adds an opt-in `UPDATE_GOLDEN=1` environment flag so the schema **golden-file tests can regenerate their snapshots**, instead of forcing contributors to hand-edit the JSON.

### Why this is needed
Two tests assert a generated tool schema against a committed snapshot and fail on any drift:
- `tests/gcontacts/test_contacts_tools_v2.py` → `golden/contacts_tool_schemas.json`
- `tests/gdocs/test_strikethrough.py` → `golden/docs_tool_schemas.json`

These guards are valuable — they catch *accidental* changes to a tool's public contract. But there was **no supported way to update a snapshot after an intentional schema change**. Any PR that legitimately changes a contacts/docs tool schema (adding a field, a parameter, etc.) makes these tests fail, and the only recourse is to manually reconstruct the exact `json.dumps(..., indent=2, sort_keys=True)` output by hand — easy to get subtly wrong, and the failure message gave no guidance.

This was hit in practice while adding a `birthday` field to the contacts tool: the schema-golden test failed and had to be regenerated manually.

### What this does
- Adds a shared helper `tests/golden_utils.assert_matches_golden(generated, golden_path, label)`.
- `UPDATE_GOLDEN=1` → the helper **rewrites** the golden file (canonical `indent=2, sort_keys=True` + trailing newline) and returns.
- Default (unset) → it compares and fails on drift exactly as before, now with a hint:
  ```
  If this change is intentional, regenerate the snapshot with:
      UPDATE_GOLDEN=1 uv run pytest
  ```
- Refactors both existing golden tests onto the helper. The per-test structural assertions are unchanged.

Workflow for an intentional schema change becomes:
```bash
UPDATE_GOLDEN=1 uv run pytest    # rewrites snapshots
git diff                         # review the schema change deliberately
```
This is the standard snapshot pattern (pytest-snapshot's `--snapshot-update`, Jest's `-u`, Rust insta's `INSTA_UPDATE`). The diff still surfaces in code review, so the guardrail isn't weakened — it just stops being a manual transcription chore.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update / developer tooling (test-only; no runtime change)

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

Verified locally:
- Default mode: both golden tests pass unchanged (`90 passed` for the two files; `1199 passed, 2 skipped` full suite).
- `UPDATE_GOLDEN=1` regenerates the snapshots **byte-identically** when the schema is unchanged (no spurious diff).
- Drift detection still works: perturbing a golden file fails the test in default mode and prints the `UPDATE_GOLDEN` hint; rerunning with the flag restores it.
- `ruff check` and `ruff format --check` pass on all changed files (no unused imports left behind).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Test-only change — no runtime/production code is touched. Independent of (and complementary to) the birthday feature in #833, which is what surfaced the gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a shared golden-file comparison helper and updated multiple test suites to use it, streamlining snapshot checks and reducing duplication.

* **Chores / Documentation**
  * Updated repository instructions for regenerating and diffing golden snapshots, clarifying how to update snapshots when changes are intentional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->