### PR TITLE
feat(gmail): surface inline (cid:) image mapping in get_gmail_message_content

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -8,6 +8,7 @@ import logging
 import asyncio
 import base64
 import binascii
+import json
 import re
 import ssl
 import mimetypes
@@ -652,6 +653,44 @@ def _extract_attachments(payload: dict) -> List[Dict[str, Any]]:
     # Start searching from the root payload
     search_parts(payload)
     return attachments
+
+
+def _extract_cid_map(payload: dict) -> Dict[str, Dict[str, Any]]:
+    """
+    Map each inline part's Content-ID to its attachment metadata.
+
+    Inline images (signature logos, pasted screenshots) are referenced from the
+    HTML body via ``src="cid:<content-id>"``. The Gmail ``format=full`` payload
+    exposes both the part's ``Content-ID`` header and its ``body.attachmentId``,
+    which lets a caller resolve exactly which attachment belongs to which cid
+    reference — without guessing by order or size.
+
+    Returns:
+        Dict mapping the bare Content-ID (angle brackets stripped) to a dict
+        with ``attachmentId``, ``filename`` and ``mimeType``.
+    """
+    cid_map: Dict[str, Dict[str, Any]] = {}
+
+    def search_parts(part):
+        cid = None
+        for header in part.get("headers", []):
+            if header.get("name", "").lower() == "content-id":
+                cid = (header.get("value") or "").strip().strip("<>").strip()
+                break
+        attachment_id = part.get("body", {}).get("attachmentId")
+        if cid and attachment_id and cid not in cid_map:
+            cid_map[cid] = {
+                "attachmentId": attachment_id,
+                "filename": part.get("filename", ""),
+                "mimeType": part.get("mimeType", "application/octet-stream"),
+            }
+
+        if "parts" in part:
+            for subpart in part["parts"]:
+                search_parts(subpart)
+
+    search_parts(payload)
+    return cid_map
 
 
 def _extract_headers(payload: dict, header_names: List[str]) -> Dict[str, str]:
@@ -1909,6 +1948,59 @@ async def get_gmail_attachment_content(
         if return_base64 and base64_data:
             result_lines.extend(_format_base64_content_block(base64_data))
         return "\n".join(result_lines)
+
+
+@server.tool(
+    title="Get Gmail Message Attachment Map",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors(
+    "get_gmail_message_attachment_map", is_read_only=True, service_type="gmail"
+)
+@require_google_service("gmail", "gmail_read")
+async def get_gmail_message_attachment_map(
+    service,
+    message_id: str,
+    user_google_email: str,
+) -> str:
+    """
+    Returns the exact Content-ID → attachment mapping for a Gmail message.
+
+    Inline images in an HTML email (signature logos, pasted screenshots) are
+    referenced from the HTML body via ``src="cid:<content-id>"``. This tool
+    reads the structured ``format=full`` payload and returns which attachment ID
+    each Content-ID maps to, so a client can resolve inline images precisely
+    (e.g. render them as data: URIs) instead of guessing by part order or size.
+
+    Args:
+        message_id (str): The unique ID of the Gmail message.
+        user_google_email (str): The user's Google email address. Required.
+
+    Returns:
+        str: JSON of the form
+        ``{"message_id": "...", "cid_map": {"<cid>": {"attachmentId": "...",
+        "filename": "...", "mimeType": "..."}}}``.
+    """
+    logger.info(
+        f"[get_gmail_message_attachment_map] Invoked. Message ID: '{message_id}', "
+        f"Email: '{user_google_email}'"
+    )
+
+    message_full = await asyncio.to_thread(
+        service.users()
+        .messages()
+        .get(userId="me", id=message_id, format="full")
+        .execute
+    )
+    payload = message_full.get("payload", {})
+    cid_map = _extract_cid_map(payload)
+
+    return json.dumps({"message_id": message_id, "cid_map": cid_map})
 
 
 @server.tool(

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -8,7 +8,6 @@ import logging
 import asyncio
 import base64
 import binascii
-import json
 import re
 import ssl
 import mimetypes
@@ -628,22 +627,40 @@ def _extract_attachments(payload: dict) -> List[Dict[str, Any]]:
         payload: The message payload from Gmail API
 
     Returns:
-        List of attachment dictionaries with filename, mimeType, size, and attachmentId
+        List of attachment dictionaries with filename, mimeType, size, attachmentId
+        and content_id. ``content_id`` is the bare Content-ID (angle brackets
+        stripped) for inline parts referenced from the HTML body via
+        ``src="cid:<content-id>"`` (signature logos, pasted screenshots), or None
+        for regular attachments. Surfacing it lets a client resolve which
+        attachment belongs to which ``cid:`` reference without guessing by part
+        order or size.
     """
     attachments = []
 
     def search_parts(part):
         """Recursively search for attachments in message parts"""
-        # Check if this part is an attachment
-        if part.get("filename") and part.get("body", {}).get("attachmentId"):
-            attachments.append(
-                {
-                    "filename": part["filename"],
-                    "mimeType": part.get("mimeType", "application/octet-stream"),
-                    "size": part.get("body", {}).get("size", 0),
-                    "attachmentId": part["body"]["attachmentId"],
-                }
-            )
+        body = part.get("body", {})
+        attachment_id = body.get("attachmentId")
+        if attachment_id:
+            # Read the part's Content-ID header (inline parts have one).
+            cid = None
+            for header in part.get("headers", []):
+                if header.get("name", "").lower() == "content-id":
+                    cid = (header.get("value") or "").strip().strip("<>").strip()
+                    break
+            # A part counts as an attachment when it has a filename (classic
+            # attachment) OR a Content-ID (inline cid: image, sometimes filename-
+            # less). Either way it carries an attachmentId we can fetch.
+            if part.get("filename") or cid:
+                attachments.append(
+                    {
+                        "filename": part.get("filename", ""),
+                        "mimeType": part.get("mimeType", "application/octet-stream"),
+                        "size": body.get("size", 0),
+                        "attachmentId": attachment_id,
+                        "content_id": cid,
+                    }
+                )
 
         # Recursively search sub-parts
         if "parts" in part:
@@ -655,42 +672,25 @@ def _extract_attachments(payload: dict) -> List[Dict[str, Any]]:
     return attachments
 
 
-def _extract_cid_map(payload: dict) -> Dict[str, Dict[str, Any]]:
-    """
-    Map each inline part's Content-ID to its attachment metadata.
-
-    Inline images (signature logos, pasted screenshots) are referenced from the
-    HTML body via ``src="cid:<content-id>"``. The Gmail ``format=full`` payload
-    exposes both the part's ``Content-ID`` header and its ``body.attachmentId``,
-    which lets a caller resolve exactly which attachment belongs to which cid
-    reference — without guessing by order or size.
-
-    Returns:
-        Dict mapping the bare Content-ID (angle brackets stripped) to a dict
-        with ``attachmentId``, ``filename`` and ``mimeType``.
-    """
-    cid_map: Dict[str, Dict[str, Any]] = {}
-
-    def search_parts(part):
-        cid = None
-        for header in part.get("headers", []):
-            if header.get("name", "").lower() == "content-id":
-                cid = (header.get("value") or "").strip().strip("<>").strip()
-                break
-        attachment_id = part.get("body", {}).get("attachmentId")
-        if cid and attachment_id and cid not in cid_map:
-            cid_map[cid] = {
-                "attachmentId": attachment_id,
-                "filename": part.get("filename", ""),
-                "mimeType": part.get("mimeType", "application/octet-stream"),
-            }
-
-        if "parts" in part:
-            for subpart in part["parts"]:
-                search_parts(subpart)
-
-    search_parts(payload)
-    return cid_map
+def _format_attachment_entry(index: int, att: Dict[str, Any], message_id: str) -> str:
+    """Format one ATTACHMENTS list entry. Includes a ``Content-ID`` line when the
+    attachment is an inline (cid:) part, so a client can map inline images to the
+    right attachment (``src="cid:<id>"``) without heuristics."""
+    size_kb = att.get("size", 0) / 1024
+    name = att["filename"] or f"(inline image, cid:{att.get('content_id')})"
+    lines = [
+        f"{index}. {name} ({att['mimeType']}, {size_kb:.1f} KB)",
+        f"   Attachment ID: {att['attachmentId']}",
+    ]
+    if att.get("content_id"):
+        lines.append(
+            f"   Content-ID: {att['content_id']} (inline; referenced as cid:{att['content_id']})"
+        )
+    lines.append(
+        f"   Use get_gmail_attachment_content(message_id='{message_id}', "
+        f"attachment_id='{att['attachmentId']}') to download"
+    )
+    return "\n".join(lines)
 
 
 def _extract_headers(payload: dict, header_names: List[str]) -> Dict[str, str]:
@@ -1544,12 +1544,7 @@ async def get_gmail_message_content(
     if attachments:
         content_lines.append("\n--- ATTACHMENTS ---")
         for i, att in enumerate(attachments, 1):
-            size_kb = att["size"] / 1024
-            content_lines.append(
-                f"{i}. {att['filename']} ({att['mimeType']}, {size_kb:.1f} KB)\n"
-                f"   Attachment ID: {att['attachmentId']}\n"
-                f"   Use get_gmail_attachment_content(message_id='{message_id}', attachment_id='{att['attachmentId']}') to download"
-            )
+            content_lines.append(_format_attachment_entry(i, att, message_id))
 
     return "\n".join(content_lines)
 
@@ -1726,12 +1721,7 @@ async def get_gmail_messages_content_batch(
                     if attachments:
                         msg_output += "\n--- ATTACHMENTS ---\n"
                         for i, att in enumerate(attachments, 1):
-                            size_kb = att["size"] / 1024
-                            msg_output += (
-                                f"{i}. {att['filename']} ({att['mimeType']}, {size_kb:.1f} KB)\n"
-                                f"   Attachment ID: {att['attachmentId']}\n"
-                                f"   Use get_gmail_attachment_content(message_id='{mid}', attachment_id='{att['attachmentId']}') to download\n"
-                            )
+                            msg_output += _format_attachment_entry(i, att, mid) + "\n"
 
                     output_messages.append(msg_output)
 
@@ -1948,59 +1938,6 @@ async def get_gmail_attachment_content(
         if return_base64 and base64_data:
             result_lines.extend(_format_base64_content_block(base64_data))
         return "\n".join(result_lines)
-
-
-@server.tool(
-    title="Get Gmail Message Attachment Map",
-    annotations=ToolAnnotations(
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=True,
-    ),
-)
-@handle_http_errors(
-    "get_gmail_message_attachment_map", is_read_only=True, service_type="gmail"
-)
-@require_google_service("gmail", "gmail_read")
-async def get_gmail_message_attachment_map(
-    service,
-    message_id: str,
-    user_google_email: str,
-) -> str:
-    """
-    Returns the exact Content-ID → attachment mapping for a Gmail message.
-
-    Inline images in an HTML email (signature logos, pasted screenshots) are
-    referenced from the HTML body via ``src="cid:<content-id>"``. This tool
-    reads the structured ``format=full`` payload and returns which attachment ID
-    each Content-ID maps to, so a client can resolve inline images precisely
-    (e.g. render them as data: URIs) instead of guessing by part order or size.
-
-    Args:
-        message_id (str): The unique ID of the Gmail message.
-        user_google_email (str): The user's Google email address. Required.
-
-    Returns:
-        str: JSON of the form
-        ``{"message_id": "...", "cid_map": {"<cid>": {"attachmentId": "...",
-        "filename": "...", "mimeType": "..."}}}``.
-    """
-    logger.info(
-        f"[get_gmail_message_attachment_map] Invoked. Message ID: '{message_id}', "
-        f"Email: '{user_google_email}'"
-    )
-
-    message_full = await asyncio.to_thread(
-        service.users()
-        .messages()
-        .get(userId="me", id=message_id, format="full")
-        .execute
-    )
-    payload = message_full.get("payload", {})
-    cid_map = _extract_cid_map(payload)
-
-    return json.dumps({"message_id": message_id, "cid_map": cid_map})
 
 
 @server.tool(
@@ -2625,12 +2562,7 @@ def _format_thread_content(
         if attachments:
             content_lines.append("--- ATTACHMENTS ---")
             for j, att in enumerate(attachments, 1):
-                size_kb = att["size"] / 1024
-                content_lines.append(
-                    f"{j}. {att['filename']} ({att['mimeType']}, {size_kb:.1f} KB)\n"
-                    f"   Attachment ID: {att['attachmentId']}\n"
-                    f"   Use get_gmail_attachment_content(message_id='{message_id}', attachment_id='{att['attachmentId']}') to download"
-                )
+                content_lines.append(_format_attachment_entry(j, att, message_id))
             content_lines.append("")
 
     return "\n".join(content_lines)


### PR DESCRIPTION
## Problem

HTML emails reference inline images (signature logos, pasted screenshots) via `src="cid:<content-id>"`. To render them, a client must know **which attachment each Content-ID maps to**. Today that mapping isn't reachable: the `--- ATTACHMENTS ---` listing exposes `attachmentId` but not the part's `Content-ID`, and `body_format="raw"` is truncated — so clients are forced to guess by part order or size, which gets inline images wrong when e.g. a small signature logo and a large screenshot are both present.

## Change (updated per review)

This originally added a dedicated `get_gmail_message_attachment_map` tool. Per @taylorwilsdon's note that the server is at the tool limit, the mapping is now folded into the **existing** message-content tools instead — no new tool:

- `_extract_attachments` now reads each part's `Content-ID`, and also includes filename-less inline (`cid:`) parts that carry an `attachmentId`.
- The `--- ATTACHMENTS ---` listing (in `get_gmail_message_content`, the batch variant, and the thread-content variant) shows a `Content-ID: <cid>` line for inline parts, via a shared `_format_attachment_entry` helper.

A client can then map `src="cid:<id>"` to the correct attachment and fetch it via `get_gmail_attachment_content` — no heuristics needed.

Removed `get_gmail_message_attachment_map` and the now-unused `_extract_cid_map`.

## Tests

All gmail tests pass (`uv run pytest tests/gmail/` — 129 passed), lint clean (`ruff check`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Gmail attachment extraction to capture `Content-ID` for inline (`cid:`) parts, so embedded images can be identified with their `cid` mapping alongside filename, MIME type, size, and attachment identifiers in structured JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->