### PR TITLE
fix(gdocs): emit NORMAL_TEXT reset for body paragraphs + spacers in markdown_to_docs_requests

### DIFF
--- a/gdocs/docs_markdown_writer.py
+++ b/gdocs/docs_markdown_writer.py
@@ -70,9 +70,13 @@ def _emit_requests(tokens, requests, tab_id, start_index):
             cursor[0] += len(text)
             requests.append(_build_heading_style(range_start, cursor[0], level, tab_id))
             requests.extend(inline_styles)
-            # Blank spacer paragraph between top-level blocks for visual spacing
+            # Blank spacer paragraph between top-level blocks for visual spacing.
+            # Reset the spacer to NORMAL_TEXT so the next block's inserts don't
+            # inherit HEADING_N from the heading paragraph above.
+            spacer_start = cursor[0]
             requests.append(_build_insert_text(cursor[0], "\n", tab_id))
             cursor[0] += 1
+            requests.append(_build_normal_text_style(spacer_start, cursor[0], tab_id))
             i += 3
             continue
 
@@ -125,9 +129,12 @@ def _emit_requests(tokens, requests, tab_id, start_index):
                     }
                 }
             )
-            # Blank spacer paragraph between top-level blocks for visual spacing
+            # Blank spacer paragraph between top-level blocks for visual spacing.
+            # Reset to NORMAL_TEXT so the next block doesn't inherit list style.
+            spacer_start = cursor[0]
             requests.append(_build_insert_text(cursor[0], "\n", tab_id))
             cursor[0] += 1
+            requests.append(_build_normal_text_style(spacer_start, cursor[0], tab_id))
             i = j + 1
             continue
 
@@ -141,6 +148,9 @@ def _emit_requests(tokens, requests, tab_id, start_index):
             text = content if content.endswith("\n") else content + "\n"
             requests.append(_build_insert_text(cursor[0], text, tab_id))
             cursor[0] += len(text)
+            # Reset the fenced code paragraph(s) to NORMAL_TEXT so they don't
+            # inherit a surrounding heading style.
+            requests.append(_build_normal_text_style(start_idx, cursor[0], tab_id))
             # Style the code characters but not the paragraph-ending newline.
             code_end = cursor[0] - 1
             _append_text_style(
@@ -152,8 +162,10 @@ def _emit_requests(tokens, requests, tab_id, start_index):
                 tab_id,
             )
             # Blank spacer paragraph between top-level blocks for visual spacing
+            spacer_start = cursor[0]
             requests.append(_build_insert_text(cursor[0], "\n", tab_id))
             cursor[0] += 1
+            requests.append(_build_normal_text_style(spacer_start, cursor[0], tab_id))
             i += 1
             continue
 
@@ -205,16 +217,23 @@ def _emit_requests(tokens, requests, tab_id, start_index):
                     }
                 }
             )
-            # Blank spacer paragraph between top-level blocks for visual spacing
+            # Reset namedStyleType to NORMAL_TEXT across the blockquote so
+            # quoted paragraphs don't inherit a surrounding heading style.
+            requests.append(_build_normal_text_style(quote_start, quote_end, tab_id))
+            # Blank spacer paragraph between top-level blocks for visual spacing.
+            spacer_start = cursor[0]
             requests.append(_build_insert_text(cursor[0], "\n", tab_id))
             cursor[0] += 1
+            requests.append(_build_normal_text_style(spacer_start, cursor[0], tab_id))
             i = j + 1
             continue
 
         if tok.type == "hr":
-            # Emit a blank paragraph as a visual separator
+            # Emit a blank paragraph as a visual separator, reset to NORMAL_TEXT.
+            hr_start = cursor[0]
             requests.append(_build_insert_text(cursor[0], "\n", tab_id))
             cursor[0] += 1
+            requests.append(_build_normal_text_style(hr_start, cursor[0], tab_id))
             i += 1
             continue
 
@@ -225,14 +244,21 @@ def _emit_requests(tokens, requests, tab_id, start_index):
                 inline_tok.children or [], cursor[0], tab_id
             )
             text += "\n"
+            range_start = cursor[0]
             requests.append(_build_insert_text(cursor[0], text, tab_id))
             cursor[0] += len(text)
+            # Reset the inserted paragraph to NORMAL_TEXT so it doesn't
+            # inherit a surrounding heading/blockquote/list style when this
+            # converter targets a mid-document index.
+            requests.append(_build_normal_text_style(range_start, cursor[0], tab_id))
             requests.extend(inline_styles)
             # Blank spacer paragraph between top-level blocks for visual spacing.
             # Only top-level paragraphs receive spacers - list-item paragraphs
             # and blockquote paragraphs dispatch inside their own branches.
+            spacer_start = cursor[0]
             requests.append(_build_insert_text(cursor[0], "\n", tab_id))
             cursor[0] += 1
+            requests.append(_build_normal_text_style(spacer_start, cursor[0], tab_id))
             i += 3  # skip paragraph_open, inline, paragraph_close
             continue
 
@@ -405,6 +431,30 @@ def _build_heading_style(
         "updateParagraphStyle": {
             "range": rng,
             "paragraphStyle": {"namedStyleType": f"HEADING_{level}"},
+            "fields": "namedStyleType",
+        }
+    }
+
+
+def _build_normal_text_style(start: int, end: int, tab_id: Optional[str]) -> dict:
+    """Build updateParagraphStyle resetting a range to NORMAL_TEXT.
+
+    Without this, new paragraphs created by insertText at a position that
+    happens to lie inside a non-NORMAL paragraph (a heading, blockquote, etc.)
+    inherit the surrounding namedStyleType. When this converter targets a
+    mid-document index — e.g. via the section-edit tools — the first inserted
+    paragraph often lands at the boundary of a deleted heading and inherits
+    HEADING_N. Emitting an explicit NORMAL_TEXT reset for every body paragraph,
+    fence block, and inter-block spacer fixes that without affecting the
+    heading paragraphs (which immediately re-style via _build_heading_style).
+    """
+    rng = {"startIndex": start, "endIndex": end}
+    if tab_id:
+        rng["tabId"] = tab_id
+    return {
+        "updateParagraphStyle": {
+            "range": rng,
+            "paragraphStyle": {"namedStyleType": "NORMAL_TEXT"},
             "fields": "namedStyleType",
         }
     }

--- a/tests/gdocs/test_docs_markdown_writer.py
+++ b/tests/gdocs/test_docs_markdown_writer.py
@@ -61,15 +61,16 @@ def test_h1_emits_insert_and_heading_style():
     assert inserts[0]["insertText"]["text"] == "My Title\n"
     assert inserts[1]["insertText"]["text"] == "\n"
     assert inserts[1]["insertText"]["location"]["index"] == 1 + len("My Title\n")
-    assert len(styles) == 1
-    assert (
-        styles[0]["updateParagraphStyle"]["paragraphStyle"]["namedStyleType"]
-        == "HEADING_1"
-    )
-    # Range should cover the heading text (not the spacer)
-    rng = styles[0]["updateParagraphStyle"]["range"]
-    assert rng["startIndex"] == 1
-    assert rng["endIndex"] == 1 + len("My Title\n")
+    # Two paragraphStyle requests: HEADING_1 for the heading text and a
+    # NORMAL_TEXT reset for the trailing spacer (so the next block doesn't
+    # inherit HEADING_1 when this converter targets a mid-document index).
+    assert len(styles) == 2
+    heading_style = styles[0]["updateParagraphStyle"]
+    assert heading_style["paragraphStyle"]["namedStyleType"] == "HEADING_1"
+    assert heading_style["range"]["startIndex"] == 1
+    assert heading_style["range"]["endIndex"] == 1 + len("My Title\n")
+    spacer_style = styles[1]["updateParagraphStyle"]
+    assert spacer_style["paragraphStyle"]["namedStyleType"] == "NORMAL_TEXT"
 
 
 def test_h2_h3_h4_h5_h6_all_emit_correct_named_style():
@@ -77,10 +78,21 @@ def test_h2_h3_h4_h5_h6_all_emit_correct_named_style():
         hashes = "#" * level
         md = f"{hashes} Heading L{level}"
         requests = markdown_to_docs_requests(md)
-        styles = [r for r in requests if "updateParagraphStyle" in r]
-        assert len(styles) == 1
+        # Filter to heading-style requests (the spacer NORMAL_TEXT reset is
+        # also emitted but is not under test here).
+        heading_styles = [
+            r
+            for r in requests
+            if "updateParagraphStyle" in r
+            and r["updateParagraphStyle"]["paragraphStyle"]
+            .get("namedStyleType", "")
+            .startswith("HEADING_")
+        ]
+        assert len(heading_styles) == 1
         assert (
-            styles[0]["updateParagraphStyle"]["paragraphStyle"]["namedStyleType"]
+            heading_styles[0]["updateParagraphStyle"]["paragraphStyle"][
+                "namedStyleType"
+            ]
             == f"HEADING_{level}"
         )
 
@@ -339,3 +351,47 @@ def test_paragraph_between_blocks_has_spacers_around_it():
     texts = [r["insertText"]["text"] for r in inserts]
     # Heading, spacer, paragraph, spacer
     assert texts == ["Title\n", "\n", "Body text\n", "\n"]
+
+
+def test_body_paragraph_emits_normal_text_reset():
+    """Section-edit tools target mid-document indices. When the converter
+    runs at a position that previously held a HEADING_N paragraph, the
+    inserted body paragraphs would inherit HEADING_N unless an explicit
+    NORMAL_TEXT style reset is emitted. Verify the reset is present.
+    """
+    requests = markdown_to_docs_requests("Plain body paragraph.")
+    normal_resets = [
+        r
+        for r in requests
+        if "updateParagraphStyle" in r
+        and r["updateParagraphStyle"]["paragraphStyle"].get("namedStyleType")
+        == "NORMAL_TEXT"
+    ]
+    # One reset for the body paragraph itself + one for the trailing spacer.
+    assert len(normal_resets) == 2
+    # The first reset covers the body text range; the second the spacer.
+    body_reset = normal_resets[0]["updateParagraphStyle"]["range"]
+    assert body_reset["startIndex"] == 1
+    assert body_reset["endIndex"] == 1 + len("Plain body paragraph.\n")
+
+
+def test_heading_followed_by_body_has_normal_reset_between():
+    """End-to-end: a heading followed by a body paragraph should produce a
+    NORMAL_TEXT reset on the spacer between them AND on the body paragraph
+    range. Together these guarantee the body paragraph keeps NORMAL_TEXT
+    even when inserted into a doc with surrounding HEADING_N style.
+    """
+    requests = markdown_to_docs_requests("# Heading\n\nBody paragraph.")
+    para_styles = [r for r in requests if "updateParagraphStyle" in r]
+    named_types = [
+        r["updateParagraphStyle"]["paragraphStyle"].get("namedStyleType")
+        for r in para_styles
+    ]
+    # Expected order: HEADING_1, NORMAL_TEXT (spacer after heading),
+    # NORMAL_TEXT (body paragraph), NORMAL_TEXT (spacer after body).
+    assert named_types == [
+        "HEADING_1",
+        "NORMAL_TEXT",
+        "NORMAL_TEXT",
+        "NORMAL_TEXT",
+    ]


### PR DESCRIPTION
## Description

`markdown_to_docs_requests` emits explicit `updateParagraphStyle HEADING_N` for headings but **no explicit style for body paragraphs or inter-block spacers**. When the output is applied at a doc index where the boundary paragraph carries a `namedStyleType` other than `NORMAL_TEXT` (e.g. `HEADING_1`), the newly inserted body paragraphs and spacers inherit that style — every body line renders as a heading.

## Minimal repro

```python
# Document already contains one HEADING_1 paragraph at index 1.
requests = markdown_to_docs_requests("Plain body paragraph.", start_index=1)
# Before this fix: the inserted paragraph renders as HEADING_1 (inherits from the boundary).
# After this fix: the inserted paragraph renders as NORMAL_TEXT (explicit reset emitted).
```

Harmless when targeting the start of a fresh doc (index 1 of an empty body is `NORMAL_TEXT`), but surfaces clearly when the converter is driven against a mid-document index — for example by `manage_doc_tab(content_markdown=...)` against an existing tab that ends with a heading, or by any future tool that wants to splice markdown into an existing doc.

## Fix

- New `_build_normal_text_style(start, end, tab_id)` helper.
- `paragraph_open`, `fence`, `blockquote_open`, `hr`, and every inter-block spacer (including the one after `heading_open`, `bullet_list`, `ordered_list`) now emit an explicit `updateParagraphStyle(NORMAL_TEXT)` after their `insertText`.
- The existing `_build_heading_style` calls still fire after their spacer reset, so heading paragraphs continue to render correctly.

## Tests

Two existing tests adjusted to expect the additional NORMAL_TEXT resets:
- `test_h1_emits_insert_and_heading_style`
- `test_h2_h3_h4_h5_h6_all_emit_correct_named_style`

Two new regression tests:
- `test_body_paragraph_emits_normal_text_reset` — verifies the body paragraph + spacer both carry a NORMAL_TEXT reset.
- `test_heading_followed_by_body_has_normal_reset_between` — verifies the full sequence (`HEADING_1`, `NORMAL_TEXT` spacer, `NORMAL_TEXT` body, `NORMAL_TEXT` spacer) for a mixed heading+body markdown input.

`pytest tests/gdocs/test_docs_markdown_writer.py`: **28 passed**.
Full suite on this branch (`upstream/main` + this fix): **1221 passed, 2 deselected, 0 failures**.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Tests added
- [x] Existing tests updated + passing
- [x] Verified live: a doc with H1 sections produced clean H1/body/H1 output after running `markdown_to_docs_requests` at a mid-document index (was: every body paragraph rendering as H1 before the fix).

## Checklist

- [x] My code follows the style guidelines of this project (`ruff check`, `ruff format --check` both clean)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

Discovered while building section-addressable markdown editing tools (#852 — depends on this fix to render cleanly). Independently useful: any caller of `markdown_to_docs_requests` that targets a non-empty doc benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)