### PR TITLE
feat(gdrive): add copy_doc_as_snapshot for rollback-friendly Doc snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,6 +778,7 @@ cp .env.oauth21 .env
 | <sub>`get_drive_shareable_link`</sub> | <sub>Core</sub> | <sub>Get shareable links for a file</sub> |
 | <sub>`list_drive_items`</sub> | <sub>Extended</sub> | <sub>List folder contents or shared drives</sub> |
 | <sub>`copy_drive_file`</sub> | <sub>Extended</sub> | <sub>Copy existing files (templates) with optional renaming</sub> |
+| <sub>`copy_doc_as_snapshot`</sub> | <sub>Extended</sub> | <sub>Create a sibling-file snapshot of a Google Doc as a rollback point before destructive edits; idempotent via `files.list` dedup pre-check</sub> |
 | <sub>`update_drive_file`</sub> | <sub>Extended</sub> | <sub>Update metadata, move files, or replace Google Apps content</sub> |
 | <sub>`manage_drive_access`</sub> | <sub>Extended</sub> | <sub>Grant, update, revoke permissions, and transfer ownership</sub> |
 | <sub>`set_drive_file_permissions`</sub> | <sub>Extended</sub> | <sub>Set link sharing and file-level sharing settings</sub> |

--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -34,6 +34,7 @@ drive:
   extended:
     - list_drive_items
     - copy_drive_file
+    - copy_doc_as_snapshot
     - update_drive_file
     - manage_drive_access
     - set_drive_file_permissions

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -7,6 +7,7 @@ This module provides MCP tools for interacting with Google Drive API.
 import asyncio
 import logging
 import io
+import re
 import base64
 
 from typing import Optional, List, Dict, Any
@@ -26,6 +27,7 @@ from core.attachment_storage import get_attachment_storage, get_attachment_url
 from core.utils import (
     GOOGLE_API_WRITE_RETRIES,
     IMAGE_MIME_TYPES,
+    UserInputError,
     encode_image_content,
     extract_office_xml_text,
     extract_pdf_text,
@@ -2629,4 +2631,175 @@ async def set_drive_file_permissions(
         output_parts.append("  - No changes (already configured)")
     output_parts.extend(["", f"View link: {file_metadata.get('webViewLink', 'N/A')}"])
 
+    return "\n".join(output_parts)
+
+
+@server.tool(
+    title="Copy Doc as Snapshot",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("copy_doc_as_snapshot", is_read_only=False, service_type="drive")
+@require_google_service("drive", "drive_file")
+async def copy_doc_as_snapshot(
+    service,
+    user_google_email: str,
+    document_id: str,
+    name: Optional[str] = None,
+    folder_id: Optional[str] = None,
+    timestamp: Optional[str] = None,
+) -> str:
+    """Create a snapshot copy of a Google Doc as a sibling file.
+
+    Why this tool exists: Drive API revisions for native Docs cannot be
+    pinned (keepForever is binary-file-only and silently no-ops on native
+    Docs) or named (no name field on the Revision resource for native
+    files). Instead, this tool creates an independent copy via Drive
+    files.copy — a full-fidelity snapshot the owner can compare with via
+    Tools > Compare Documents, revert from, or trash after the edit lands.
+
+    Idempotency: before creating the snapshot, calls files.list to look
+    for an existing file with the computed name in the target folder. If
+    found, returns the existing snapshot's ID instead of creating a
+    duplicate. Agents that retry the same call (with the same timestamp)
+    get the same snapshot back.
+
+    Comments and suggestions are NOT carried to the snapshot. Drive UI's
+    "Make a copy" offers checkboxes for those; files.copy API does not
+    expose them. If the human expects thread fidelity, they should use
+    the Drive UI instead.
+
+    Failure modes the caller MUST handle:
+      - 403 storageQuotaExceeded — user is over Drive quota
+      - 403 insufficientFilePermissions — folder-write or restricted-copy
+        (source's viewersCanCopyContent set to false by owner)
+      - 404 — source not accessible via the granted scope
+
+    If this tool returns an error, the safety net was NOT created — do
+    NOT proceed with the destructive edit assuming rollback is available.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        document_id (str): ID of the Google Doc (or full URL). Required.
+        name (Optional[str]): Snapshot file name. Defaults to
+            "{original_title}.snapshot.{timestamp}". If both name and
+            timestamp are None, raises UserInputError.
+        folder_id (Optional[str]): Parent folder ID. Defaults to the
+            source file's first parent (or root if no parent).
+        timestamp (Optional[str]): Compact ISO 8601 UTC timestamp
+            (YYYYMMDDTHHMMSSZ). Required if name is None; ignored if
+            name is given. Agents supply this because this MCP runs
+            stateless.
+
+    Returns:
+        Multi-line confirmation per copy_drive_file convention, plus a
+        ready-to-paste comment string the caller can attach to the
+        source doc for human-visible rollback.
+    """
+    logger.info(
+        f"[copy_doc_as_snapshot] Invoked. Email: '{user_google_email}', "
+        f"Doc ID: '{document_id}', Name: '{name}', Folder: '{folder_id}'"
+    )
+
+    url_match = re.search(r"/d/([\w-]+)", document_id)
+    if url_match:
+        document_id = url_match.group(1)
+
+    resolved_doc_id, doc_metadata = await resolve_drive_item(
+        service, document_id, extra_fields="name, webViewLink, mimeType, parents"
+    )
+    document_id = resolved_doc_id
+    original_title = doc_metadata.get("name", "Unknown Doc")
+    source_webview = doc_metadata.get("webViewLink", "N/A")
+
+    if name is None:
+        if timestamp is None:
+            raise UserInputError(
+                "Either `name` or `timestamp` must be provided. Pass the "
+                "current UTC time as a compact ISO 8601 string "
+                "(YYYYMMDDTHHMMSSZ, e.g. 20260612T194401Z)."
+            )
+        snapshot_name = f"{original_title}.snapshot.{timestamp}"
+    else:
+        snapshot_name = name
+
+    # Resolve target folder. Default: first parent of the source, or root.
+    if folder_id:
+        resolved_folder_id = await resolve_folder_id(service, folder_id)
+    else:
+        source_parents = doc_metadata.get("parents") or []
+        resolved_folder_id = source_parents[0] if source_parents else "root"
+
+    # Dedup pre-check: if a file with this name already exists in the target
+    # folder (and isn't trashed), return its ID instead of creating a dup.
+    # Escape single quotes in the name per Drive query-language spec.
+    safe_name = snapshot_name.replace("\\", "\\\\").replace("'", "\\'")
+    query_parts = [f"name = '{safe_name}'", "trashed = false"]
+    if resolved_folder_id != "root":
+        query_parts.append(f"'{resolved_folder_id}' in parents")
+    list_response = await asyncio.to_thread(
+        service.files()
+        .list(
+            q=" and ".join(query_parts),
+            spaces="drive",
+            fields="files(id, name, webViewLink, mimeType)",
+            pageSize=1,
+            supportsAllDrives=True,
+            includeItemsFromAllDrives=True,
+        )
+        .execute
+    )
+    existing = list_response.get("files") or []
+    if existing:
+        existing_snapshot = existing[0]
+        output_parts = [
+            f"Snapshot already exists for '{original_title}' (returned existing).",
+            "",
+            f"Original file ID: {document_id}",
+            f"Snapshot file ID: {existing_snapshot.get('id', 'N/A')}",
+            f"Snapshot name: {existing_snapshot.get('name', snapshot_name)}",
+            f"Location: {resolved_folder_id}",
+            "",
+            f"View snapshot: {existing_snapshot.get('webViewLink', 'N/A')}",
+            f"View source: {source_webview}",
+            "",
+            "For human-visible rollback, paste this comment on the source:",
+            f'  "Snapshot before agent edit: {existing_snapshot.get("webViewLink", "N/A")}"',
+        ]
+        return "\n".join(output_parts)
+
+    # Create the snapshot.
+    copy_body: dict[str, Any] = {"name": snapshot_name}
+    if resolved_folder_id != "root":
+        copy_body["parents"] = [resolved_folder_id]
+
+    snapshot = await asyncio.to_thread(
+        service.files()
+        .copy(
+            fileId=document_id,
+            body=copy_body,
+            supportsAllDrives=True,
+            fields="id, name, webViewLink, mimeType, parents",
+        )
+        .execute
+    )
+
+    output_parts = [
+        f"Successfully created snapshot of '{original_title}'",
+        "",
+        f"Original file ID: {document_id}",
+        f"Snapshot file ID: {snapshot.get('id', 'N/A')}",
+        f"Snapshot name: {snapshot.get('name', snapshot_name)}",
+        f"Location: {resolved_folder_id}",
+        "",
+        f"View snapshot: {snapshot.get('webViewLink', 'N/A')}",
+        f"View source: {source_webview}",
+        "",
+        "For human-visible rollback, paste this comment on the source:",
+        f'  "Snapshot before agent edit: {snapshot.get("webViewLink", "N/A")}"',
+    ]
     return "\n".join(output_parts)

--- a/tests/gdrive/test_copy_doc_as_snapshot.py
+++ b/tests/gdrive/test_copy_doc_as_snapshot.py
@@ -1,0 +1,183 @@
+"""
+Tests for copy_doc_as_snapshot — Drive files.copy wrapper used as a
+safety-net snapshot before agent edits to a Google Doc.
+
+Mocking convention: unittest.mock + per-file _unwrap helper, matching
+tests/gdocs/test_advanced_doc_formatting.py:21-26.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from core.utils import UserInputError
+from gdrive import drive_tools
+
+
+def _unwrap(tool):
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _doc_metadata(name="My Doc", parents=("folder-abc",), webview="https://docs/x"):
+    return (
+        "doc-123",
+        {
+            "name": name,
+            "webViewLink": webview,
+            "mimeType": "application/vnd.google-apps.document",
+            "parents": list(parents),
+        },
+    )
+
+
+class TestCopyDocAsSnapshot:
+    @pytest.mark.asyncio
+    async def test_creates_snapshot_when_no_existing(self):
+        fn = _unwrap(drive_tools.copy_doc_as_snapshot)
+        mock_service = Mock()
+
+        # files.list returns empty (no existing snapshot).
+        mock_service.files().list.return_value = Mock(
+            execute=Mock(return_value={"files": []})
+        )
+        # files.copy returns the new file.
+        mock_service.files().copy.return_value = Mock(
+            execute=Mock(
+                return_value={
+                    "id": "snap-001",
+                    "name": "My Doc.snapshot.20260612T194401Z",
+                    "webViewLink": "https://docs/snap",
+                    "mimeType": "application/vnd.google-apps.document",
+                    "parents": ["folder-abc"],
+                }
+            )
+        )
+
+        with (
+            patch(
+                "gdrive.drive_tools.resolve_drive_item",
+                return_value=_doc_metadata(),
+            ),
+            patch(
+                "gdrive.drive_tools.resolve_folder_id",
+                side_effect=lambda _svc, fid: fid,
+            ),
+        ):
+            result = await fn(
+                mock_service,
+                "user@example.com",
+                "doc-123",
+                timestamp="20260612T194401Z",
+            )
+
+        # files.copy was called with the right body.
+        copy_args = mock_service.files().copy.call_args
+        assert copy_args.kwargs["fileId"] == "doc-123"
+        assert copy_args.kwargs["supportsAllDrives"] is True
+        body = copy_args.kwargs["body"]
+        assert body["name"] == "My Doc.snapshot.20260612T194401Z"
+        assert body["parents"] == ["folder-abc"]
+
+        assert "Successfully created snapshot" in result
+        assert "snap-001" in result
+        assert "Snapshot before agent edit" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_existing_snapshot_without_creating(self):
+        fn = _unwrap(drive_tools.copy_doc_as_snapshot)
+        mock_service = Mock()
+
+        # files.list returns an existing file with the target name.
+        mock_service.files().list.return_value = Mock(
+            execute=Mock(
+                return_value={
+                    "files": [
+                        {
+                            "id": "snap-existing",
+                            "name": "My Doc.snapshot.20260612T194401Z",
+                            "webViewLink": "https://docs/existing",
+                            "mimeType": "application/vnd.google-apps.document",
+                        }
+                    ]
+                }
+            )
+        )
+
+        with (
+            patch(
+                "gdrive.drive_tools.resolve_drive_item",
+                return_value=_doc_metadata(),
+            ),
+            patch(
+                "gdrive.drive_tools.resolve_folder_id",
+                side_effect=lambda _svc, fid: fid,
+            ),
+        ):
+            result = await fn(
+                mock_service,
+                "user@example.com",
+                "doc-123",
+                timestamp="20260612T194401Z",
+            )
+
+        # files.copy must NOT be called.
+        mock_service.files().copy.assert_not_called()
+        assert "already exists" in result
+        assert "snap-existing" in result
+
+    @pytest.mark.asyncio
+    async def test_requires_name_or_timestamp(self):
+        fn = _unwrap(drive_tools.copy_doc_as_snapshot)
+        mock_service = Mock()
+        with (
+            patch(
+                "gdrive.drive_tools.resolve_drive_item",
+                return_value=_doc_metadata(),
+            ),
+            patch(
+                "gdrive.drive_tools.resolve_folder_id",
+                side_effect=lambda _svc, fid: fid,
+            ),
+            pytest.raises(UserInputError, match="name.*or.*timestamp"),
+        ):
+            await fn(mock_service, "user@example.com", "doc-123")
+
+    @pytest.mark.asyncio
+    async def test_custom_name_used_verbatim(self):
+        fn = _unwrap(drive_tools.copy_doc_as_snapshot)
+        mock_service = Mock()
+        mock_service.files().list.return_value = Mock(
+            execute=Mock(return_value={"files": []})
+        )
+        mock_service.files().copy.return_value = Mock(
+            execute=Mock(
+                return_value={
+                    "id": "snap-custom",
+                    "name": "manual-name",
+                    "webViewLink": "https://docs/custom",
+                }
+            )
+        )
+
+        with (
+            patch(
+                "gdrive.drive_tools.resolve_drive_item",
+                return_value=_doc_metadata(),
+            ),
+            patch(
+                "gdrive.drive_tools.resolve_folder_id",
+                side_effect=lambda _svc, fid: fid,
+            ),
+        ):
+            await fn(
+                mock_service,
+                "user@example.com",
+                "doc-123",
+                name="manual-name",
+            )
+
+        body = mock_service.files().copy.call_args.kwargs["body"]
+        assert body["name"] == "manual-name"


### PR DESCRIPTION
## Description

Adds `copy_doc_as_snapshot` — a wrapper around Drive `files.copy` that creates a sibling-file snapshot of a Google Doc as a rollback point before destructive edits.

**Signature:**
```python
async def copy_doc_as_snapshot(
    service,
    user_google_email: str,
    document_id: str,
    name: Optional[str] = None,
    folder_id: Optional[str] = None,
    timestamp: Optional[str] = None,
) -> str
```

## Motivation

Drive API revisions for native Docs cannot be pinned (`Revision.keepForever` is binary-file-only and silently no-ops on native Docs) or named (no `name` field on the Revision resource for native files; the Docs UI's "Name current version" uses an internal endpoint). The only real safety net for native files via public API is `files.copy` — an independent sibling that survives indefinitely.

## Design highlights

- **Idempotent retries** via a `files.list` dedup pre-check on the computed name in the target folder. If a snapshot with the same name already exists (from a previous retry), the existing ID is returned and no `files.copy` call is made. Drive permits duplicate names, so without this an agent retry storm creates a junk drawer.
- **Default name pattern**: `{original_title}.snapshot.{compact-ISO-UTC}`. The timestamp is caller-supplied (the MCP runs stateless); either `name` or `timestamp` must be provided. Compact ISO 8601 (`YYYYMMDDTHHMMSSZ`) avoids `:` for cross-platform safety. *Why caller-supplied not server-side `datetime.utcnow()`*: retries within the same second produce different timestamps, which would break the dedup pre-check.
- **`supportsAllDrives=True`** (matches existing `copy_drive_file` precedent at `gdrive/drive_tools.py:2387`).
- **Multi-line return** matching `copy_drive_file` convention, plus a ready-to-paste comment string the caller can attach to the source doc for human-visible rollback ("Snapshot before agent edit: <link>").

## Failure modes documented

The docstring is explicit that the caller MUST handle:

- `403 storageQuotaExceeded` — owner over Drive quota
- `403 insufficientFilePermissions` — folder unwritable, or source has `viewersCanCopyContent=false`
- `404` — source not accessible via the granted scope

If the tool returns an error, the safety net was NOT created — the caller must not proceed with the destructive edit assuming rollback is available.

## What the snapshot does NOT carry

Drive UI's "Make a copy" offers checkboxes to copy comments and suggestions. The `files.copy` API does not (verified: no `copyComments` / `copyRequestingUser` parameter). Snapshots are content-only. The docstring surfaces this.

## README catalog entry added

```
| <sub>`copy_doc_as_snapshot`</sub> | <sub>Extended</sub> | <sub>Create a sibling-file snapshot of a Google Doc as a rollback point before destructive edits; idempotent via `files.list` dedup pre-check</sub> |
```

## Tests

Four mocked unit tests in `tests/gdrive/test_copy_doc_as_snapshot.py`:

- creates snapshot when no existing match; verifies `files.copy` body (`name`, `parents`, `supportsAllDrives=True`)
- returns existing snapshot ID when `files.list` dedup hits (no `files.copy` call) — idempotent retry semantics
- requires `name` or `timestamp` (raises `UserInputError` otherwise)
- custom `name` passed through verbatim

Full suite on this branch (`upstream/main` + this feature): **1223 passed, 2 deselected**, no regressions.

## Style

- Bare `service` (no `: Any`), explicit `is_read_only=False` — both per `drive_tools.py` file-local convention (matches `copy_drive_file:2387`).
- Registered in `core/tool_tiers.yaml` under `drive: extended` (matches `copy_drive_file` precedent).
- README Drive table updated.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Tests added that prove the feature works
- [x] Existing tests pass
- [x] Verified live: snapshot created on a real Doc, then a second call with the same `timestamp` returned the same snapshot ID without creating a duplicate (dedup pre-check confirmed).

## Checklist

- [x] My code follows the style guidelines of this project (`ruff check`, `ruff format --check` both clean)
- [x] Self-reviewed
- [x] No new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

🤖 Generated with [Claude Code](https://claude.com/claude-code)