### PR TITLE
Add OAuth consent-page branding via env vars

### DIFF
--- a/.env.oauth21
+++ b/.env.oauth21
@@ -60,3 +60,15 @@ OAUTH2_ENABLE_LEGACY_AUTH=true
 #   otherwise from GOOGLE_OAUTH_CLIENT_SECRET.
 # - For stable decryption across client-secret rotations, set
 #   FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY explicitly.
+#
+# ---------------------------------------------------------------------------
+# OAuth Consent Page Branding (optional)
+#
+# FastMCP's OAuth proxy renders the consent screen from the server's name, icon,
+# and website. These env vars set those fields; unset leaves FastMCP's defaults
+# (its name and logo). The icon accepts a hosted URL or an inline data: URI and is
+# displayed at 64px wide — provide a ~64px image (or ~128px for retina sharpness).
+#
+# WORKSPACE_MCP_BRAND_NAME="My Workspace MCP"
+# WORKSPACE_MCP_BRAND_ICON_URL=https://example.com/logo.png   # shown at 64px wide
+# WORKSPACE_MCP_BRAND_WEBSITE_URL=https://example.com

--- a/auth/oauth_config.py
+++ b/auth/oauth_config.py
@@ -39,6 +39,13 @@ class OAuthConfig:
         self.client_id = os.getenv("GOOGLE_OAUTH_CLIENT_ID")
         self.client_secret = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET")
 
+        # Branding for the OAuth consent page. FastMCP's OAuth proxy renders the
+        # server's name / icon / website on the consent screen; these env vars feed
+        # those server fields. All optional — unset leaves the upstream defaults.
+        self.brand_name = os.getenv("WORKSPACE_MCP_BRAND_NAME")
+        self.brand_icon_url = os.getenv("WORKSPACE_MCP_BRAND_ICON_URL")
+        self.brand_website_url = os.getenv("WORKSPACE_MCP_BRAND_WEBSITE_URL")
+
         # OAuth 2.1 configuration
         self.oauth21_enabled = (
             os.getenv("MCP_ENABLE_OAUTH21", "false").lower() == "true"

--- a/core/server.py
+++ b/core/server.py
@@ -16,7 +16,7 @@ from auth.auth_info_middleware import AuthInfoMiddleware
 from auth.google_auth import handle_auth_callback, start_auth_flow, check_client_secrets
 from auth.mcp_session_middleware import MCPSessionMiddleware
 from auth.oauth21_session_store import set_auth_provider
-from auth.oauth_config import is_oauth21_enabled, is_external_oauth21_provider
+from auth.oauth_config import is_oauth21_enabled, is_external_oauth21_provider, get_oauth_config
 from auth.oauth_responses import (
     create_error_response,
     create_success_response,
@@ -32,7 +32,7 @@ from core.config import (
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
 from fastmcp import FastMCP
 from fastmcp.server.auth.providers.google import GoogleProvider
-from mcp.types import ToolAnnotations
+from mcp.types import ToolAnnotations, Icon
 from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
 from starlette.middleware import Middleware
@@ -277,10 +277,19 @@ if USER_GOOGLE_EMAIL:
 When using Google Workspace tools, always use `{USER_GOOGLE_EMAIL}` as the `user_google_email` parameter. Do not ask the user for their email address."""
     logger.info(f"Server instructions configured for user: {USER_GOOGLE_EMAIL}")
 
+# Branding for the OAuth consent page: FastMCP's OAuth proxy renders the server's
+# name / icon / website on the consent screen (auth/oauth_config reads the env vars).
+_brand_config = get_oauth_config()
+_brand_icons = (
+    [Icon(src=_brand_config.brand_icon_url)] if _brand_config.brand_icon_url else None
+)
+
 server = SecureFastMCP(
-    name="google_workspace",
+    name=_brand_config.brand_name or "google_workspace",
     auth=None,
     instructions=_server_instructions,
+    website_url=_brand_config.brand_website_url,
+    icons=_brand_icons,
 )
 
 # Add the AuthInfo middleware to inject authentication into FastMCP context

--- a/tests/auth/test_branding.py
+++ b/tests/auth/test_branding.py
@@ -1,0 +1,51 @@
+"""Tests for OAuth consent-page branding config (WORKSPACE_MCP_BRAND_*).
+
+These env vars feed the FastMCP server's name / icon / website, which FastMCP's
+OAuth proxy renders on the consent screen (see core/server.py).
+"""
+
+from mcp.types import Icon
+
+from auth.oauth_config import OAuthConfig
+
+
+class TestBrandingConfig:
+    def test_brand_env_vars_are_read(self, monkeypatch):
+        monkeypatch.setenv("WORKSPACE_MCP_BRAND_NAME", "Example Workspace")
+        monkeypatch.setenv(
+            "WORKSPACE_MCP_BRAND_ICON_URL", "https://example.com/logo.png"
+        )
+        monkeypatch.setenv("WORKSPACE_MCP_BRAND_WEBSITE_URL", "https://example.com")
+
+        cfg = OAuthConfig()
+
+        assert cfg.brand_name == "Example Workspace"
+        assert cfg.brand_icon_url == "https://example.com/logo.png"
+        assert cfg.brand_website_url == "https://example.com"
+
+    def test_brand_defaults_to_none_when_unset(self, monkeypatch):
+        for var in (
+            "WORKSPACE_MCP_BRAND_NAME",
+            "WORKSPACE_MCP_BRAND_ICON_URL",
+            "WORKSPACE_MCP_BRAND_WEBSITE_URL",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        cfg = OAuthConfig()
+
+        assert cfg.brand_name is None
+        assert cfg.brand_icon_url is None
+        assert cfg.brand_website_url is None
+
+    def test_icon_built_from_brand_icon_url(self, monkeypatch):
+        # Mirrors core/server.py: an Icon is constructed from the configured URL (or
+        # data URI) and handed to FastMCP, replacing the default consent-page logo.
+        monkeypatch.setenv(
+            "WORKSPACE_MCP_BRAND_ICON_URL", "data:image/svg+xml;base64,ABC123"
+        )
+        cfg = OAuthConfig()
+
+        icons = [Icon(src=cfg.brand_icon_url)] if cfg.brand_icon_url else None
+
+        assert icons is not None
+        assert icons[0].src == "data:image/svg+xml;base64,ABC123"


### PR DESCRIPTION
## Description

In OAuth 2.1 mode the server runs behind FastMCP's `GoogleProvider` / OAuth proxy, whose **consent screen** is rendered from the server's name, icon, and website — defaulting to FastMCP's own name and logo. Self-hosted / enterprise deployments often want their own identity on that page, but `workspace-mcp` constructs the server with a fixed name and no icon, so there's currently no way to set them.

This adds three **optional** environment variables that brand the consent page, using FastMCP's **supported** server fields — no FastMCP patching and no UI fork:

| Env var | Effect |
| --- | --- |
| `WORKSPACE_MCP_BRAND_NAME` | Server name shown on the consent page |
| `WORKSPACE_MCP_BRAND_ICON_URL` | Logo — hosted URL or inline `data:` URI, displayed at 64px wide |
| `WORKSPACE_MCP_BRAND_WEBSITE_URL` | Website link on the consent page |

The values are read in `OAuthConfig` and passed to `SecureFastMCP` as `name` / `icons` / `website_url`, which FastMCP's consent page picks up automatically (`fastmcp.name`, `fastmcp.icons[0].src`, `fastmcp.website_url`). All optional — unset preserves the current upstream defaults. No new dependencies.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

`pytest tests/auth/test_branding.py` → 3 passing (config reads the env vars; defaults to `None` when unset; an `Icon` is built from the configured URL/`data:` URI). Manually verified in OAuth 2.1 mode: set `WORKSPACE_MCP_BRAND_ICON_URL` / `_NAME`, authorized an MCP client, and confirmed the consent page shows the custom name + logo.

Full suite: 1215 passed / 2 skipped; the only failures are pre-existing `tests/gcontacts/test_contacts_integration.py` ordering-flakes (they pass in isolation), unrelated to this change.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

- **Scope.** This covers the **consent page** (name + logo + website), which FastMCP renders from server metadata. The OAuth **error** pages and page **colors** are currently hardcoded in FastMCP with no configuration hook, so they're intentionally out of scope here — branding those would require a change in FastMCP itself. Happy to follow up upstream there separately.
- **Logo sizing.** FastMCP's `.logo` CSS displays the icon at **64px wide**, so a ~64px source (or ~128px for retina sharpness) is recommended. A `data:` URI keeps the logo self-contained with no hosting.
- **CSP.** FastMCP's default consent CSP already allows `img-src https: data:`, so both hosted and inline logos work with no CSP changes.
- **Backwards compatible.** Behavior is unchanged when the vars are unset; the default server name (`google_workspace`) and FastMCP's default logo are preserved.
