### PR TITLE
auth: log structured context on token verification failures

### DIFF
--- a/auth/auth_info_middleware.py
+++ b/auth/auth_info_middleware.py
@@ -197,7 +197,7 @@ class AuthInfoMiddleware(Middleware):
                                             f"token={_token_fingerprint(token_str)} "
                                             f"provider={type(auth_provider).__name__}"
                                         )
-                                except Exception:
+                                except Exception as e:
                                     logger.error(
                                         f"[AuthInfoMiddleware] Token verification raised exception "
                                         f"reason=verify_token_exception "

--- a/auth/auth_info_middleware.py
+++ b/auth/auth_info_middleware.py
@@ -17,6 +17,13 @@ from auth.oauth_types import WorkspaceAccessToken
 logger = logging.getLogger(__name__)
 
 
+def _token_fingerprint(token: str) -> str:
+    """Return a safe, short fingerprint of a bearer token for logging."""
+    if not token:
+        return "none"
+    return f"{token[:8]}…(len={len(token)})"
+
+
 class AuthInfoMiddleware(Middleware):
     """
     Middleware to extract authentication information from JWT tokens
@@ -184,11 +191,18 @@ class AuthInfoMiddleware(Middleware):
                                         auth_via = "bearer_token"
                                     else:
                                         logger.error(
-                                            "Failed to verify Google OAuth token"
+                                            f"[AuthInfoMiddleware] Token verification returned None "
+                                            f"reason=verify_token_returned_none "
+                                            f"token={_token_fingerprint(token_str)} "
+                                            f"provider={type(auth_provider).__name__}"
                                         )
                                 except Exception as e:
                                     logger.error(
-                                        f"Error verifying Google OAuth token: {e}"
+                                        f"[AuthInfoMiddleware] Token verification raised exception "
+                                        f"reason=verify_token_exception "
+                                        f"token={_token_fingerprint(token_str)} "
+                                        f"exc_type={type(e).__name__} "
+                                        f"exc={e}"
                                     )
                             else:
                                 logger.warning(
@@ -331,6 +345,28 @@ class AuthInfoMiddleware(Middleware):
             )
             logger.debug(
                 f"Context state after auth: authenticated_user_email={auth_email}"
+            )
+        else:
+            try:
+                auth_header = (get_http_headers() or {}).get("authorization", "")
+            except Exception:
+                auth_header = ""
+            if auth_header.startswith("Bearer "):
+                bearer = auth_header[7:]
+                token_fp = _token_fingerprint(bearer)
+                token_kind = (
+                    "google_oauth" if bearer.startswith("ya29.") else "jwt_or_other"
+                )
+            else:
+                token_fp = "none"
+                token_kind = "no_bearer"
+            session_id = getattr(context.fastmcp_context, "session_id", None)
+            logger.warning(
+                f"[AuthInfoMiddleware] No authenticated user resolved "
+                f"reason=all_auth_paths_failed "
+                f"token={token_fp} "
+                f"token_kind={token_kind} "
+                f"session_id={session_id}"
             )
 
     async def on_call_tool(self, context: MiddlewareContext, call_next):

--- a/auth/auth_info_middleware.py
+++ b/auth/auth_info_middleware.py
@@ -197,13 +197,12 @@ class AuthInfoMiddleware(Middleware):
                                             f"token={_token_fingerprint(token_str)} "
                                             f"provider={type(auth_provider).__name__}"
                                         )
-                                except Exception as e:
+                                except Exception:
                                     logger.error(
                                         f"[AuthInfoMiddleware] Token verification raised exception "
                                         f"reason=verify_token_exception "
                                         f"token={_token_fingerprint(token_str)} "
-                                        f"exc_type={type(e).__name__} "
-                                        f"exc={e}"
+                                        f"exc_type={type(e).__name__}"
                                     )
                             else:
                                 logger.warning(


### PR DESCRIPTION
## Summary

Adds structured failure-path logging in `AuthInfoMiddleware` so requests that fail authentication produce a single grep-able log line with token fingerprint, token kind, and session_id. Today, when the OAuth layer rejects a request, downstream operators see only repeated client reconnects with no in-log signal of which auth path failed — particularly painful for mobile clients where refresh-token rotation races and OS keychain evictions cause silent re-registration cycles.

Three changes to `auth/auth_info_middleware.py`:

1. Add `_token_fingerprint()` helper that returns `first8…(len=N)` — safe to log, useful for correlating across log lines without exposing the full bearer.
2. Replace the generic `\"Failed to verify Google OAuth token\"` error with a structured line including `reason=verify_token_returned_none`, the provider class name, and the token fingerprint. Same treatment for the exception branch (`reason=verify_token_exception` + `exc_type`).
3. Add a terminal `else` branch in `_process_request_for_auth` that emits one `WARNING` with `reason=all_auth_paths_failed` when no auth path resolved a user. Includes a derived `token_kind` (`google_oauth` for `ya29.*`, `jwt_or_other` otherwise, or `no_bearer`).

No behavioral change — only logging.

## Test plan

- [ ] Syntax: `python3 -c \"import ast; ast.parse(open('auth/auth_info_middleware.py').read())\"` passes
- [ ] Send a request with no Authorization header → expect `reason=all_auth_paths_failed token_kind=no_bearer`
- [ ] Send a request with `Authorization: Bearer FAKE` → expect `reason=all_auth_paths_failed token_kind=jwt_or_other token=FAKE…(len=4)`
- [ ] Send a request with a malformed `ya29.*` token → expect `reason=verify_token_returned_none` (or `verify_token_exception` depending on provider behavior)
- [ ] Send a valid token → existing `✓ Authenticated via …` line still fires, no new warnings

## Why

Debugging repeated mobile OAuth reconnects against a self-hosted gws-mcp instance, the only visible signal in logs is `POST /mcp 401` with no information about which auth path failed or which client triggered it. This patch closes that gap with three small additions — token fingerprint, provider class, and a single terminal warning — without any behavioral change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved authentication failure logging with safer token identification and more structured diagnostic details (including OAuth verification outcomes and exception metadata).
  * Consolidated authentication-failure warnings into a single, consistent message to simplify troubleshooting across auth paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->