### PR TITLE
fix(helm): drop deprecated Ingress APIs and require Kubernetes >= 1.25

### DIFF
--- a/helm-chart/workspace-mcp/Chart.yaml
+++ b/helm-chart/workspace-mcp/Chart.yaml
@@ -2,8 +2,11 @@ apiVersion: v2
 name: workspace-mcp
 description: A Helm chart for Google Workspace MCP Server - Comprehensive Google Workspace integration for AI assistants
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.2.0"
+# Drops support for Kubernetes < 1.25; the chart now only emits GA APIs
+# (networking.k8s.io/v1 Ingress, policy/v1 PDB, autoscaling/v2 HPA).
+kubeVersion: ">=1.25.0-0"
 keywords:
   - mcp
   - google

--- a/helm-chart/workspace-mcp/templates/ingress.yaml
+++ b/helm-chart/workspace-mcp/templates/ingress.yaml
@@ -1,16 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "workspace-mcp.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class")) }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -21,8 +12,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
@@ -41,19 +32,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
-            {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
The Ingress template branched on `networking.k8s.io/v1beta1` and `extensions/v1beta1` — both removed in Kubernetes 1.22 — and injected the deprecated `kubernetes.io/ingress.class` annotation. This collapses it to the GA `networking.k8s.io/v1` API (`ingressClassName` + always-rendered `pathType`) and adds `kubeVersion: ">=1.25.0-0"` so the removed versions can no longer be targeted. Remaining chart APIs were already GA (`policy/v1` PDB, `autoscaling/v2` HPA).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

> Breaking only for clusters older than 1.25, which are already EOL and could not use the modern Ingress backend that was the default path.

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

Manual `helm template`/`helm lint`:
- `helm lint` passes.
- `--kube-version 1.35.0` renders `networking.k8s.io/v1` with `ingressClassName` and `pathType`.
- `--kube-version 1.24.0` is now correctly rejected by the `kubeVersion` constraint.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Chart version bumped `0.1.0` → `0.2.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Kubernetes version requirement to 1.25.0
  * Simplified Ingress configuration for improved compatibility with modern Kubernetes environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->