### PR TITLE
feat(helm): add persistent volume support

### DIFF
--- a/helm-chart/workspace-mcp/Chart.yaml
+++ b/helm-chart/workspace-mcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: workspace-mcp
 description: A Helm chart for Google Workspace MCP Server - Comprehensive Google Workspace integration for AI assistants
 type: application
-version: 0.1.0
+version: 0.3.0
 appVersion: "1.2.0"
 keywords:
   - mcp

--- a/helm-chart/workspace-mcp/templates/deployment.yaml
+++ b/helm-chart/workspace-mcp/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "workspace-mcp.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
@@ -111,6 +115,13 @@ spec:
             - name: tmp
               mountPath: /tmp
               readOnly: false
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              {{- with .Values.persistence.subPath }}
+              subPath: {{ . }}
+              {{- end }}
+            {{- end }}
       volumes:
         - name: credentials
           emptyDir:
@@ -118,6 +129,11 @@ spec:
         - name: tmp
           emptyDir:
             sizeLimit: 100Mi
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "workspace-mcp.fullname" .) }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/workspace-mcp/templates/deployment.yaml
+++ b/helm-chart/workspace-mcp/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.persistence.enabled (eq .Values.persistence.accessMode "ReadWriteOnce") (or .Values.autoscaling.enabled (gt (int .Values.replicaCount) 1)) }}
+{{- fail "persistence.accessMode=ReadWriteOnce can only attach to one pod: set replicaCount=1 and autoscaling.enabled=false, or use a ReadWriteMany volume." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm-chart/workspace-mcp/templates/pvc.yaml
+++ b/helm-chart/workspace-mcp/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "workspace-mcp.fullname" . }}
+  labels:
+    {{- include "workspace-mcp.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/helm-chart/workspace-mcp/values.yaml
+++ b/helm-chart/workspace-mcp/values.yaml
@@ -71,6 +71,25 @@ tolerations: []
 
 affinity: {}
 
+# Deployment update strategy. Leave empty for the default RollingUpdate.
+# Set type: Recreate when persistence uses a ReadWriteOnce volume — a rolling
+# update would deadlock with the new pod waiting on the PVC the old pod holds.
+strategy: {}
+  # type: Recreate
+
+# Persistent storage, e.g. for the OAuth proxy disk backend so tokens survive
+# a restart. When disabled the pod runs fully on emptyDir (ephemeral).
+persistence:
+  enabled: false
+  # Mount an existing PVC instead of creating one from this chart.
+  existingClaim: ""
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  mountPath: /data
+  # subPath: ""
+  annotations: {}
+
 # Environment variables for the application
 env:
   # Server configuration


### PR DESCRIPTION
## Description
The chart runs entirely on `emptyDir`, so any on-disk state (e.g. the OAuth proxy `disk` storage backend) is lost on every restart. This adds opt-in persistence:

- New `templates/pvc.yaml`: creates a `PersistentVolumeClaim` when `persistence.enabled` is set and no `existingClaim` is given.
- `templates/deployment.yaml`: mounts the volume (honoring `mountPath`/`subPath`, using `existingClaim` or the chart-created PVC), adds a configurable `strategy` so `ReadWriteOnce` volumes can use `Recreate` (a rolling update would deadlock waiting on the PVC the old pod holds), and fails early if RWO persistence is combined with multiple replicas.
- `values.yaml`: new `persistence` and `strategy` blocks.

Persistence is **disabled by default** — rendered output is unchanged when off.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

Manual `helm template`/`helm lint`:
- `helm lint` passes.
- `persistence.enabled=true` + `strategy.type=Recreate` renders the PVC (`storageClassName`, `storage`), the `Recreate` strategy, and the volume mount.
- `persistence.existingClaim=...` mounts the claim and creates no PVC.
- Defaults (persistence off): 0 PVCs, no `strategy`, no extra volume.
- RWO + `replicaCount>1`/autoscaling is rejected with a clear message; RWX and single-replica pass.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Chart version bumped `0.1.0` → `0.3.0`. Independent of #858 (deprecated-API cleanup); if that merges first, the `Chart.yaml` version line may need a trivial rebase.