### PR TITLE
fix(auth): prevent refreshed credentials from clobbering broader scopes

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -1072,9 +1072,7 @@ def get_credentials(
                 )
                 return None
         else:
-            credentials, found_user_email = _find_any_credentials(
-                credentials_base_dir, preferred_user_email=user_google_email
-            )
+            credentials, found_user_email = _find_any_credentials(credentials_base_dir)
         if not credentials:
             logger.info(
                 f"[get_credentials] Single-user mode: No credentials found in {credentials_base_dir}"

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -113,10 +113,17 @@ else:
 
 def _find_any_credentials(
     base_dir: str = DEFAULT_CREDENTIALS_DIR,
+    preferred_user_email: Optional[str] = None,
 ) -> tuple[Optional[Credentials], Optional[str]]:
     """
     Find and load any valid credentials from the credentials directory.
     Used in single-user mode to bypass session-to-OAuth mapping.
+
+    Args:
+        preferred_user_email: When set, this user's stored credentials are
+            tried first so single-user mode doesn't accidentally select a
+            different (possibly expired) account when more than one credential
+            file exists.
 
     Returns:
         Tuple of (Credentials, user_email) or (None, None) if none exist.
@@ -131,18 +138,25 @@ def _find_any_credentials(
             )
             return None, None
 
-        # Return credentials for the first user found
-        first_user = users[0]
-        credentials = store.get_credential(first_user)
-        if credentials:
-            logger.info(
-                f"[single-user] Found credentials for {first_user} via credential store"
-            )
-            return credentials, first_user
-        else:
-            logger.warning(
-                f"[single-user] Could not load credentials for {first_user} via credential store"
-            )
+        # Prefer the explicitly requested user so single-user mode doesn't
+        # accidentally pick a different (possibly expired) account when more
+        # than one credential file exists.
+        ordered_users = list(users)
+        if preferred_user_email and preferred_user_email in ordered_users:
+            ordered_users.remove(preferred_user_email)
+            ordered_users.insert(0, preferred_user_email)
+
+        for candidate in ordered_users:
+            credentials = store.get_credential(candidate)
+            if credentials:
+                logger.info(
+                    f"[single-user] Found credentials for {candidate} via credential store"
+                )
+                return credentials, candidate
+            else:
+                logger.warning(
+                    f"[single-user] Could not load credentials for {candidate} via credential store"
+                )
 
     except Exception as e:
         logger.error(
@@ -151,6 +165,43 @@ def _find_any_credentials(
 
     logger.info("[single-user] No valid credentials found via credential store")
     return None, None
+
+
+def _store_credential_without_scope_shrink(
+    credential_store, user_email: str, credentials: Credentials
+) -> bool:
+    """Persist refreshed credentials without ever dropping scopes.
+
+    A stale, narrower-scoped credential (e.g. an in-memory session token issued
+    before the user granted additional scopes) must never overwrite a broader
+    credential already on file. The google-auth library does not update
+    ``credentials.scopes`` on refresh, so refreshing such a token and persisting
+    it permanently clobbers the freshly re-authorized scopes, forcing an endless
+    re-authentication loop for tools that need scopes added in a later grant. If
+    the stored credential has scopes the incoming one lacks, keep the broader
+    stored credential instead of overwriting it.
+
+    Returns True when the stored credential is at least as broad as before
+    (either freshly written or intentionally preserved), False if the underlying
+    write failed.
+    """
+    try:
+        existing = credential_store.get_credential(user_email)
+    except Exception:
+        existing = None
+
+    new_scopes = set(credentials.scopes or [])
+    existing_scopes = set(existing.scopes) if existing and existing.scopes else set()
+    missing = existing_scopes - new_scopes
+    if missing:
+        logger.warning(
+            f"[get_credentials] Not persisting refreshed credentials for {user_email}: "
+            f"refreshed token is missing scopes already on file ({sorted(missing)}). "
+            "Keeping the broader stored credential to avoid a scope-shrink clobber."
+        )
+        return True
+
+    return credential_store.store_credential(user_email, credentials)
 
 
 def save_credentials_to_session(session_id: str, credentials: Credentials):
@@ -942,8 +993,8 @@ def get_credentials(
                                     try:
                                         credential_store = get_credential_store()
                                         persist_succeeded = (
-                                            credential_store.store_credential(
-                                                user_email, credentials
+                                            _store_credential_without_scope_shrink(
+                                                credential_store, user_email, credentials
                                             )
                                         )
                                         if not persist_succeeded:
@@ -1021,7 +1072,9 @@ def get_credentials(
                 )
                 return None
         else:
-            credentials, found_user_email = _find_any_credentials(credentials_base_dir)
+            credentials, found_user_email = _find_any_credentials(
+                credentials_base_dir, preferred_user_email=user_google_email
+            )
         if not credentials:
             logger.info(
                 f"[get_credentials] Single-user mode: No credentials found in {credentials_base_dir}"
@@ -1111,8 +1164,8 @@ def get_credentials(
                 if not is_stateless_mode():
                     try:
                         credential_store = get_credential_store()
-                        persist_succeeded = credential_store.store_credential(
-                            user_google_email, credentials
+                        persist_succeeded = _store_credential_without_scope_shrink(
+                            credential_store, user_google_email, credentials
                         )
                     except Exception as persist_error:
                         persist_succeeded = False


### PR DESCRIPTION
## Problem

Tools that require a scope the user granted in a *later* authorization (e.g. the Google Chat message tools, which additionally need the People / `contacts` scope to resolve sender display names) can get stuck in an endless re-authentication loop. The user authorizes, the new broad-scoped token is written to the credential store, but the **very next call wipes the new scopes back out**, so the tool asks to authenticate again, forever.

## Root cause

`google.oauth2.credentials.Credentials.refresh()` does **not** update `credentials.scopes` (the scope list is set at authorization time). When a stale, narrower-scoped credential is still in memory — for example an OAuth 2.1 session token cached before the extra scope was granted — `get_credentials()` refreshes it and then persists it via `credential_store.store_credential()`. That write overwrites the freshly re-authorized, broader-scoped credential on file with the narrower one. The next request loads the now-narrowed credential, fails the scope check, and triggers re-auth again.

A second, related issue: in single-user mode `_find_any_credentials()` returns `users[0]` (the alphabetically first credential file) regardless of the requested account. When more than one credential file exists, an unrelated and possibly expired account can be selected instead of the one being requested.

## Fix

- Add `_store_credential_without_scope_shrink()` and use it at both refresh-persist sites. If the credential already on file has scopes the incoming (refreshed) credential lacks, the broader stored credential is kept instead of being overwritten. A refresh can no longer shrink the persisted scope set.
- `_find_any_credentials()` now accepts an optional `preferred_user_email` and tries that user's credential first, so single-user mode does not accidentally pick a different account when multiple credential files are present.

## Testing

Reproduced with the Google Chat `get_messages` / `search_messages` tools (which require both `chat` and `people` services): before the change, each call re-triggered People/`contacts` authentication and clobbered the stored token; after the change the contacts scope persists across calls, sender names resolve via the People API, and no re-auth loop occurs. Verified in single-user / streamable-http mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google credential selection by prioritizing the intended user email when multiple credentials are available, improving accuracy in single-user mode.
  * Enhanced token/credential refresh handling to avoid unintentionally reducing permissions during updates.
  * Added safer credential persistence behavior that preserves broader stored access when refreshed credentials would otherwise “shrink” scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->