### PR TITLE
enh: inline binary upload for create_drive_file

### DIFF
--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -921,8 +921,14 @@ async def create_drive_file(
     )
 
     has_existing_content_source = content is not None or fileUrl is not None
-    if not has_existing_content_source and base64_content is None and mime_type != FOLDER_MIME_TYPE:
-        raise ValueError("You must provide one of 'content', 'fileUrl', or 'base64_content'.")
+    if (
+        not has_existing_content_source
+        and base64_content is None
+        and mime_type != FOLDER_MIME_TYPE
+    ):
+        raise ValueError(
+            "You must provide one of 'content', 'fileUrl', or 'base64_content'."
+        )
     if base64_content is not None and has_existing_content_source:
         raise ValueError("'base64_content' cannot be used with 'content' or 'fileUrl'.")
     if content_mime_type is not None and base64_content is None:

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 import io
 import base64
+import binascii
 
 from typing import Optional, List, Dict, Any
 from tempfile import NamedTemporaryFile, SpooledTemporaryFile
@@ -895,10 +896,12 @@ async def create_drive_file(
     folder_id: str = "root",
     mime_type: str = "text/plain",
     fileUrl: Optional[str] = None,  # Now explicitly Optional
+    base64_content: Optional[str] = None,
+    content_mime_type: Optional[str] = None,
 ) -> str:
     """
     Creates a new file in Google Drive, supporting creation within shared drives.
-    Accepts either direct content or a fileUrl to fetch the content from.
+    Accepts direct text content, inline base64 bytes, or a fileUrl to fetch content from.
 
     Args:
         user_google_email (str): The user's Google email address. Required.
@@ -907,6 +910,8 @@ async def create_drive_file(
         folder_id (str): The ID of the parent folder. Defaults to 'root'. For shared drives, this must be a folder ID within the shared drive.
         mime_type (str): The MIME type of the file. Defaults to 'text/plain'.
         fileUrl (Optional[str]): If provided, fetches the file content from this URL. Supports file://, http://, and https:// protocols.
+        base64_content (Optional[str]): Standard base64-encoded file bytes.
+        content_mime_type (Optional[str]): MIME type for base64_content uploads.
 
     Returns:
         str: Confirmation message of the successful file creation with file link.
@@ -915,8 +920,22 @@ async def create_drive_file(
         f"[create_drive_file] Invoked. Email: '{user_google_email}', File Name: {file_name}, Folder ID: {folder_id}, fileUrl: {fileUrl}"
     )
 
-    if content is None and fileUrl is None and mime_type != FOLDER_MIME_TYPE:
-        raise Exception("You must provide either 'content' or 'fileUrl'.")
+    has_existing_content_source = content is not None or fileUrl is not None
+    if not has_existing_content_source and base64_content is None and mime_type != FOLDER_MIME_TYPE:
+        raise ValueError("You must provide one of 'content', 'fileUrl', or 'base64_content'.")
+    if base64_content is not None and has_existing_content_source:
+        raise ValueError("'base64_content' cannot be used with 'content' or 'fileUrl'.")
+    if content_mime_type is not None and base64_content is None:
+        raise ValueError("'content_mime_type' can only be used with 'base64_content'.")
+    if base64_content is not None and not content_mime_type:
+        raise ValueError("'content_mime_type' is required when using 'base64_content'.")
+
+    file_data = None
+    if base64_content is not None:
+        try:
+            file_data = base64.b64decode(base64_content, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError("'base64_content' must be valid standard base64.") from exc
 
     # Create folder (no content or media_body). Prefer create_drive_folder for new code.
     if mime_type == FOLDER_MIME_TYPE:
@@ -924,7 +943,6 @@ async def create_drive_file(
             service, user_google_email, file_name, folder_id
         )
 
-    file_data = None
     resolved_folder_id = await resolve_folder_id(service, folder_id)
 
     file_metadata = {
@@ -933,8 +951,28 @@ async def create_drive_file(
         "mimeType": mime_type,
     }
 
-    # Prefer fileUrl if both are provided
-    if fileUrl:
+    if base64_content is not None:
+        file_metadata["mimeType"] = content_mime_type
+        media = MediaIoBaseUpload(
+            io.BytesIO(file_data),
+            mimetype=content_mime_type,
+            resumable=True,
+            chunksize=UPLOAD_CHUNK_SIZE_BYTES,
+        )
+
+        created_file = await asyncio.to_thread(
+            service.files()
+            .create(
+                body=file_metadata,
+                media_body=media,
+                fields="id, name, webViewLink",
+                supportsAllDrives=True,
+            )
+            .execute,
+            num_retries=GOOGLE_API_WRITE_RETRIES,
+        )
+    # Prefer fileUrl if both legacy sources are provided.
+    elif fileUrl:
         logger.info(f"[create_drive_file] Fetching file from URL: {fileUrl}")
 
         # Check if this is a file:// URL

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -920,7 +920,7 @@ async def create_drive_file(
         f"[create_drive_file] Invoked. Email: '{user_google_email}', File Name: {file_name}, Folder ID: {folder_id}, fileUrl: {fileUrl}"
     )
 
-    has_existing_content_source = content is not None or fileUrl is not None
+    has_existing_content_source = content is not None or bool(fileUrl)
     if (
         not has_existing_content_source
         and base64_content is None

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -6,6 +6,7 @@ Tests create_drive_folder with mocked API responses, plus coverage for
 and `file_type` filtering behaviors.
 """
 
+import base64
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
 import io
@@ -16,6 +17,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 from gdrive.drive_helpers import build_drive_list_params
 from gdrive.drive_tools import (
+    create_drive_file,
     get_drive_file_permissions,
     import_to_google_doc,
     import_to_google_sheets,
@@ -36,6 +38,100 @@ def _unwrap(tool):
     while hasattr(fn, "__wrapped__"):
         fn = fn.__wrapped__
     return fn
+
+
+# ---------------------------------------------------------------------------
+# create_drive_file — inline base64 upload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+async def test_create_drive_file_uploads_base64_content(mock_resolve_folder):
+    """Inline base64 bytes are decoded and uploaded with the provided MIME type."""
+    payload = b"%PDF-1.7\nbinary\x00data"
+    mock_resolve_folder.return_value = "folder123"
+    mock_service = Mock()
+    mock_service.files().create().execute.return_value = {
+        "id": "pdf123",
+        "name": "report.pdf",
+        "webViewLink": "https://drive.google.com/file/d/pdf123",
+    }
+
+    result = await _unwrap(create_drive_file)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        file_name="report.pdf",
+        folder_id="target-folder",
+        base64_content=base64.b64encode(payload).decode("ascii"),
+        content_mime_type="application/pdf",
+    )
+
+    create_kwargs = mock_service.files.return_value.create.call_args.kwargs
+    assert create_kwargs["body"] == {
+        "name": "report.pdf",
+        "parents": ["folder123"],
+        "mimeType": "application/pdf",
+    }
+    assert create_kwargs["supportsAllDrives"] is True
+    media = create_kwargs["media_body"]
+    assert media.mimetype() == "application/pdf"
+    assert media.getbytes(0, len(payload)) == payload
+    assert "Successfully created file 'report.pdf'" in result
+
+
+@pytest.mark.asyncio
+async def test_create_drive_file_rejects_mixed_base64_and_text_content():
+    """create_drive_file accepts exactly one content source."""
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="base64_content"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="report.pdf",
+            content="text",
+            base64_content=base64.b64encode(b"pdf").decode("ascii"),
+            content_mime_type="application/pdf",
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_drive_file_requires_mime_type_for_base64_content():
+    """Inline base64 uploads require an explicit source MIME type."""
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="content_mime_type"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="report.pdf",
+            base64_content=base64.b64encode(b"pdf").decode("ascii"),
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+async def test_create_drive_file_rejects_invalid_base64_content(mock_resolve_folder):
+    """Invalid inline base64 fails before calling Drive create."""
+    mock_resolve_folder.return_value = "folder123"
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="base64_content"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="report.pdf",
+            base64_content="not valid base64 !!!",
+            content_mime_type="application/pdf",
+        )
+
+    mock_resolve_folder.assert_not_called()
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -134,6 +134,39 @@ async def test_create_drive_file_rejects_invalid_base64_content(mock_resolve_fol
     mock_service.files.return_value.create.return_value.execute.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_create_drive_file_rejects_content_mime_type_without_base64():
+    """content_mime_type only applies to base64_content uploads."""
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="content_mime_type"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="report.pdf",
+            content="text",
+            content_mime_type="application/pdf",
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_drive_file_rejects_empty_file_url():
+    """An empty fileUrl is treated as no content source and rejected early."""
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="content"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="report.pdf",
+            fileUrl="",
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # get_drive_file_permissions — owners
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #860  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Drive file creation now enables uploading files from base64-encoded content, with customizable MIME type assignment and comprehensive validation checks.

* **Tests**
  * Comprehensive test suite added covering base64-encoded uploads, parameter validation, error handling, and Drive API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->