### PR TITLE
feat(drive): replace non-native file content in place (PDF, images, .md)

### DIFF
--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -514,6 +514,33 @@ TEXT_BASED_IMPORT_MIME_TYPES = {
     "application/rtf",
 }
 
+# Target MIME types whose bytes can be safely built from an in-memory UTF-8
+# `content` string on the raw-media (no-conversion) replacement path. This is
+# distinct from TEXT_BASED_IMPORT_MIME_TYPES (which gates source formats fed to
+# Drive's conversion engine). Any `text/*` type qualifies; these non-text MIME
+# types are textual payloads that are also safe to encode from a string.
+TEXT_BASED_RAW_MIME_TYPES = {
+    "application/json",
+    "application/xml",
+    "application/rtf",
+    "application/x-yaml",
+    "application/yaml",
+    "image/svg+xml",
+}
+
+
+def _is_text_based_target(mime_type: Optional[str]) -> bool:
+    """True when a target MIME type's bytes can be built from a UTF-8 string.
+
+    Used by the raw-media replacement path to decide whether in-memory
+    ``content`` is acceptable, or whether the caller must supply binary bytes
+    via ``file_path``/``file_url``.
+    """
+    if not mime_type:
+        return False
+    base = mime_type.split(";", 1)[0].strip().lower()
+    return base.startswith("text/") or base in TEXT_BASED_RAW_MIME_TYPES
+
 
 def _detect_source_format(
     file_name: str,
@@ -661,3 +688,92 @@ async def _resolve_import_media(
         chunksize=UPLOAD_CHUNK_SIZE_BYTES,
     )
     return media, source_mime_type, remote_file_data
+
+
+async def _resolve_raw_media(
+    *,
+    tool_name: str,
+    mime_type: str,
+    content: Optional[str],
+    file_path: Optional[str],
+    file_url: Optional[str],
+) -> Tuple[MediaIoBaseUpload, Optional[BinaryIO]]:
+    """
+    Resolve a content source into a raw (no-conversion) ``MediaIoBaseUpload``.
+
+    Unlike :func:`_resolve_import_media`, the bytes are uploaded with the
+    *target* ``mime_type`` and stored verbatim by Drive — no format conversion.
+    Used to replace the bytes of a non-native Drive file (PDF, PNG, ZIP, ...)
+    in place, preserving its fileId, sharing, comments, and links.
+
+    Exactly one of ``content``, ``file_path``, or ``file_url`` must be provided.
+    ``content`` is only valid when ``mime_type`` is text-based (see
+    :func:`_is_text_based_target`); binary targets require ``file_path`` or
+    ``file_url``.
+
+    Returns ``(media, closeable)``; when the source is a remote URL,
+    ``closeable`` is the download stream the caller must close after upload
+    (else ``None``).
+    """
+    source_count = sum(1 for x in (content, file_path, file_url) if x is not None)
+    if source_count == 0:
+        raise ValueError(
+            "You must provide one of: 'content', 'file_path', or 'file_url'."
+        )
+    if source_count > 1:
+        raise ValueError("Provide only one of: 'content', 'file_path', or 'file_url'.")
+
+    file_data: bytes
+    remote_file_data: Optional[BinaryIO] = None
+
+    if content is not None:
+        if not _is_text_based_target(mime_type):
+            raise ValueError(
+                f"[{tool_name}] 'content' (a text string) cannot replace a binary "
+                f"target of type '{mime_type}'. Provide 'file_path' or 'file_url' "
+                f"with the raw bytes instead."
+            )
+        file_data = content.encode("utf-8")
+        logger.info(
+            f"[{tool_name}] Using content for raw upload: {len(file_data)} bytes"
+        )
+
+    elif file_path is not None:
+        parsed_url = urlparse(file_path)
+        if parsed_url.scheme == "file":
+            raw_path = parsed_url.path or ""
+            netloc = parsed_url.netloc
+            if netloc and netloc.lower() != "localhost":
+                raw_path = f"//{netloc}{raw_path}"
+            actual_path = url2pathname(raw_path)
+        elif parsed_url.scheme == "":
+            actual_path = file_path
+        else:
+            raise ValueError(
+                f"file_path should be a local path or file:// URL, got: {file_path}"
+            )
+
+        path_obj = validate_file_path(actual_path)
+        if not path_obj.exists():
+            raise FileNotFoundError(f"File not found: {actual_path}")
+        if not path_obj.is_file():
+            raise ValueError(f"Path is not a file: {actual_path}")
+
+        file_data = await asyncio.to_thread(path_obj.read_bytes)
+        logger.info(
+            f"[{tool_name}] Read local file for raw upload: {len(file_data)} bytes"
+        )
+
+    else:  # file_url is not None
+        parsed_url = urlparse(file_url)
+        if parsed_url.scheme not in ("http", "https"):
+            raise ValueError(f"file_url must be http:// or https://, got: {file_url}")
+        remote_file_data, _remote_content_type = await _download_url_to_bytes(file_url)
+
+    media = MediaIoBaseUpload(
+        remote_file_data if remote_file_data is not None else io.BytesIO(file_data),
+        mimetype=mime_type,  # Target format stored verbatim — no conversion
+        resumable=True,
+        chunksize=UPLOAD_CHUNK_SIZE_BYTES,
+    )
+    return media, remote_file_data

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -45,6 +45,7 @@ from gdrive.drive_helpers import (
     GOOGLE_SLIDES_MIME_TYPE,
     UPLOAD_CHUNK_SIZE_BYTES,
     _resolve_import_media,
+    _resolve_raw_media,
     _stream_url_with_validation,
     build_drive_list_params,
     check_public_link_permission,
@@ -1729,10 +1730,17 @@ async def update_drive_file(
     Updates metadata, properties, and/or content of a Google Drive file.
 
     Providing one of ``content``, ``file_path``, or ``file_url`` replaces the file's
-    content in place. The source is uploaded with its source MIME type so the Drive
-    API applies the same format conversion as import_to_google_doc (markdown headings,
-    tables, bold, etc.) while preserving the existing file ID, sharing, comments, and
-    links. Metadata and content can be updated in a single call.
+    content in place, preserving the existing fileId, sharing, comments, and links.
+
+    - For native Google files (Docs/Sheets/Slides), the source is uploaded with its
+      *source* MIME type so Drive applies the same format conversion as
+      import_to_google_doc (markdown headings, tables, bold, etc.).
+    - For any other type (PDF, PNG, ZIP, CSV-as-file, etc.), the bytes are uploaded
+      raw with the file's *target* MIME type and stored verbatim — no conversion.
+      Binary targets must be supplied via ``file_path`` or ``file_url``; a ``content``
+      string is accepted only for text-based targets (text/*, application/json, etc.).
+
+    Metadata and content can be updated in a single call.
 
     Args:
         user_google_email (str): The user's Google email address. Required.
@@ -1747,11 +1755,15 @@ async def update_drive_file(
         writers_can_share (Optional[bool]): Whether editors can share the file.
         copy_requires_writer_permission (Optional[bool]): Whether copying requires writer permission.
         properties (Optional[dict]): Custom key-value properties for the file.
-        content (Optional[str]): New text content for text-based formats (markdown, TXT, HTML).
-        file_path (Optional[str]): Local file path for binary formats (DOCX, ODT). Supports file:// URLs.
+        content (Optional[str]): New text content. For native targets, text-based source
+            formats (markdown, TXT, HTML); for non-native targets, only text-based types
+            (text/*, application/json, etc.) — binary targets require file_path/file_url.
+        file_path (Optional[str]): Local file path. Required for binary non-native targets
+            (PDF, PNG, ZIP) and binary source formats (DOCX, ODT). Supports file:// URLs.
         file_url (Optional[str]): Remote http(s) URL to fetch new content from.
         source_format (Optional[str]): Source format hint for conversion
             (md, markdown, docx, txt, html, rtf, odt). Auto-detected when omitted.
+            Ignored for non-native raw replacement (bytes stored verbatim).
             Provide at most one of content/file_path/file_url.
 
     Returns:
@@ -1821,33 +1833,36 @@ async def update_drive_file(
     if update_body:
         query_params["body"] = update_body
 
-    # Replacement content is uploaded with its source MIME type so Drive converts it
-    # into the file's existing type — the same engine import_to_google_doc uses.
+    # Replacement content. Native targets (Docs/Sheets/Slides) are uploaded with
+    # their *source* MIME type so Drive converts them (the import_to_google_doc
+    # engine). Non-native targets (PDF, images, etc.) are uploaded as raw media
+    # with the *target* MIME type, replacing the bytes in place while preserving
+    # the fileId, sharing, comments, and links.
     replacing_content = any(x is not None for x in (content, file_path, file_url))
     remote_file_data = None
     if replacing_content:
         target_mime_type = mime_type or current_file.get("mimeType")
         format_map = IMPORT_FORMATS_BY_GOOGLE_MIME_TYPE.get(target_mime_type)
-        if format_map is None:
-            supported_targets = ", ".join(
-                mime for mime in IMPORT_FORMATS_BY_GOOGLE_MIME_TYPE
+        if format_map is not None:
+            # Native target: upload-with-conversion (unchanged path).
+            media, _source_mime_type, remote_file_data = await _resolve_import_media(
+                tool_name="update_drive_file",
+                file_name=name or current_file.get("name", ""),
+                content=content,
+                file_path=file_path,
+                file_url=file_url,
+                source_format=source_format,
+                format_map=format_map,
             )
-            raise ValueError(
-                "Content replacement with conversion is only supported for native "
-                f"Google Docs, Sheets, and Slides files. Current target MIME type: "
-                f"{target_mime_type or 'unknown'}. Supported target MIME types: "
-                f"{supported_targets}."
+        else:
+            # Non-native target: replace bytes in place, no conversion.
+            media, remote_file_data = await _resolve_raw_media(
+                tool_name="update_drive_file",
+                mime_type=target_mime_type,
+                content=content,
+                file_path=file_path,
+                file_url=file_url,
             )
-
-        media, _source_mime_type, remote_file_data = await _resolve_import_media(
-            tool_name="update_drive_file",
-            file_name=name or current_file.get("name", ""),
-            content=content,
-            file_path=file_path,
-            file_url=file_url,
-            source_format=source_format,
-            format_map=format_map,
-        )
         query_params["media_body"] = media
 
     # Perform the update
@@ -1913,9 +1928,17 @@ async def update_drive_file(
         changes.append(f"   • Updated custom properties: {properties}")
     if replacing_content:
         source = "content" if content is not None else (file_path or file_url)
-        changes.append(
-            f"   • Replaced content from {source} (converted to {updated_file.get('mimeType', current_file.get('mimeType', 'file type'))})"
+        result_mime = updated_file.get(
+            "mimeType", current_file.get("mimeType", "file type")
         )
+        if IMPORT_FORMATS_BY_GOOGLE_MIME_TYPE.get(target_mime_type) is not None:
+            changes.append(
+                f"   • Replaced content from {source} (converted to {result_mime})"
+            )
+        else:
+            changes.append(
+                f"   • Replaced content from {source} (stored as {result_mime}, in place)"
+            )
 
     if changes:
         output_parts.append("")

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -1899,26 +1899,137 @@ async def test_update_drive_file_replaces_sheet_content_with_sheet_formats(
 
 @pytest.mark.asyncio
 @patch("gdrive.drive_tools.resolve_drive_item", new_callable=AsyncMock)
-async def test_update_drive_file_rejects_content_replacement_for_unsupported_targets(
+async def test_update_drive_file_rejects_string_content_for_binary_target(
     mock_resolve_item,
 ):
-    """Non-Google Apps files fail before an ambiguous conversion upload."""
+    """A `content` string cannot replace a binary target (PDF): fail before upload."""
     mock_resolve_item.return_value = (
         "pdf123",
         {"name": "Report.pdf", "mimeType": "application/pdf"},
     )
     mock_service = Mock()
 
-    with pytest.raises(ValueError, match="only supported for native Google Docs"):
+    with pytest.raises(ValueError, match="cannot replace a binary target"):
         await _unwrap(update_drive_file)(
             service=mock_service,
             user_google_email="user@example.com",
             file_id="pdf123",
             content="# Replacement",
-            source_format="md",
         )
 
     mock_service.files.return_value.update.return_value.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_helpers.validate_file_path")
+@patch("gdrive.drive_tools.resolve_drive_item", new_callable=AsyncMock)
+async def test_update_drive_file_replaces_pdf_via_file_path(
+    mock_resolve_item, mock_validate_path
+):
+    """A PDF's bytes are replaced in place from a local file_path, no conversion."""
+    mock_resolve_item.return_value = (
+        "pdf123",
+        {"name": "Report.pdf", "mimeType": "application/pdf"},
+    )
+
+    fake_path = Mock()
+    fake_path.exists.return_value = True
+    fake_path.is_file.return_value = True
+    fake_path.read_bytes.return_value = b"%PDF-1.7 fake bytes"
+    mock_validate_path.return_value = fake_path
+
+    mock_service = Mock()
+    mock_service.files().update().execute.return_value = {
+        "id": "pdf123",
+        "name": "Report.pdf",
+        "mimeType": "application/pdf",
+        "webViewLink": "https://drive.google.com/file/d/pdf123",
+    }
+
+    result = await _unwrap(update_drive_file)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        file_id="pdf123",
+        file_path="/tmp/Report.pdf",
+    )
+
+    update_kwargs = mock_service.files.return_value.update.call_args.kwargs
+    assert update_kwargs["fileId"] == "pdf123"
+    assert update_kwargs["media_body"].mimetype() == "application/pdf"
+    assert "body" not in update_kwargs  # content-only: no metadata body
+    execute_kwargs = (
+        mock_service.files.return_value.update.return_value.execute.call_args.kwargs
+    )
+    assert execute_kwargs["num_retries"] == 3
+    assert "Replaced content" in result
+    assert "in place" in result
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_helpers._download_url_to_bytes", new_callable=AsyncMock)
+@patch("gdrive.drive_tools.resolve_drive_item", new_callable=AsyncMock)
+async def test_update_drive_file_replaces_image_via_file_url(
+    mock_resolve_item, mock_download
+):
+    """An image's bytes are replaced in place from a remote file_url, no conversion."""
+    mock_resolve_item.return_value = (
+        "img123",
+        {"name": "logo.png", "mimeType": "image/png"},
+    )
+
+    spool = io.BytesIO(b"\x89PNG\r\n\x1a\n fake image bytes")
+    mock_download.return_value = (spool, "image/png")
+
+    mock_service = Mock()
+    mock_service.files().update().execute.return_value = {
+        "id": "img123",
+        "name": "logo.png",
+        "mimeType": "image/png",
+        "webViewLink": "https://drive.google.com/file/d/img123",
+    }
+
+    result = await _unwrap(update_drive_file)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        file_id="img123",
+        file_url="https://example.com/logo.png",
+    )
+
+    update_kwargs = mock_service.files.return_value.update.call_args.kwargs
+    assert update_kwargs["fileId"] == "img123"
+    assert update_kwargs["media_body"].mimetype() == "image/png"
+    mock_download.assert_awaited_once_with("https://example.com/logo.png")
+    assert spool.closed is True  # remote stream closed after upload
+    assert "Replaced content" in result
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_drive_item", new_callable=AsyncMock)
+async def test_update_drive_file_replaces_text_target_via_content(mock_resolve_item):
+    """A text/* target accepts an in-memory `content` string for raw replacement."""
+    mock_resolve_item.return_value = (
+        "txt123",
+        {"name": "notes.txt", "mimeType": "text/plain"},
+    )
+
+    mock_service = Mock()
+    mock_service.files().update().execute.return_value = {
+        "id": "txt123",
+        "name": "notes.txt",
+        "mimeType": "text/plain",
+        "webViewLink": "https://drive.google.com/file/d/txt123",
+    }
+
+    result = await _unwrap(update_drive_file)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        file_id="txt123",
+        content="hello world",
+    )
+
+    update_kwargs = mock_service.files.return_value.update.call_args.kwargs
+    assert update_kwargs["media_body"].mimetype() == "text/plain"
+    assert "Replaced content" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
update_drive_file previously routed all content replacement through the import/conversion path, gated to native Google types (Docs/Sheets/Slides), and raised ValueError for anything else. This meant binary files like PDFs could not get a new version while preserving their fileId, sharing, comments, and links — even though the Drive API supports it.

Add a raw-media replacement path: when the target MIME type is non-native, upload the bytes verbatim via files().update(media_body=...) with the file's own MIME type (no conversion), preserving the fileId. Native types keep the existing conversion behavior unchanged.

- New _resolve_raw_media + _is_text_based_target helpers in drive_helpers.py, reusing validate_file_path and _download_url_to_bytes (SSRF + size limits).
- content string accepted only for text-based targets (text/*, application/ json, etc.); binary targets require file_path/file_url.
- Response message and docstring distinguish "converted to" vs "stored in place"; source_format is ignored on the raw path.
- Tests: redefined rejection test (string content on binary target) plus new cases for PDF via file_path, image via file_url, and text/* via content.

Verified live against Drive: PDF and text/markdown files each produced a second revision under the same fileId with no unwanted conversion.

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Add any other context about the pull request here.

---

**⚠️ IMPORTANT:** This repository requires that you enable "Allow edits from maintainers" when creating your pull request. This allows maintainers to make small fixes and improvements directly to your branch, speeding up the review process.

To enable this setting:
1. When creating the PR, check the "Allow edits from maintainers" checkbox
2. If you've already created the PR, you can enable this in the PR sidebar under "Allow edits from maintainers"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drive file content can now be replaced directly for non-native file types (PDF, images, etc.) with byte-for-byte updates, eliminating format conversion limitations.

* **Documentation**
  * Clarified supported content replacement options for different file types and input sources.

* **Tests**
  * Expanded coverage for file replacement scenarios across multiple file types and data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->