### PR TITLE
feat(drive): remote-safe uploads via resumable URLs for create/update

### DIFF
--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -5,6 +5,7 @@ This module provides MCP tools for interacting with Google Drive API.
 """
 
 import asyncio
+import json
 import logging
 import io
 import base64
@@ -876,6 +877,77 @@ async def create_drive_folder(
     )
 
 
+def _is_remote_transport() -> bool:
+    """True when the server is reachable over the network (streamable-http).
+
+    In that mode the client and server are different machines, so server-side
+    file ingestion (``file://`` paths, and by extension fetching bytes the client
+    holds) is misleading: those paths/URLs resolve on the *server*, not the caller.
+    """
+    return get_transport_mode() == "streamable-http"
+
+
+async def _initiate_resumable_upload_session(
+    service,
+    *,
+    mime_type: str,
+    file_metadata: Optional[Dict[str, Any]] = None,
+    file_id: Optional[str] = None,
+    content_length: Optional[int] = None,
+) -> str:
+    """Initiate a Drive resumable upload session and return the session URL.
+
+    ``file_id`` absent -> ``POST`` (create a new file); present -> ``PATCH`` (replace
+    the content of an existing file). The returned ``Location`` URL is pre-authorized:
+    the caller can ``PUT`` the bytes straight to Google with no Authorization header,
+    so the payload never flows through this server. Uses the request user's authorized
+    transport (``service._http``) for the initiation call only.
+    """
+    base = "https://www.googleapis.com/upload/drive/v3/files"
+    if file_id:
+        url = f"{base}/{file_id}?uploadType=resumable&supportsAllDrives=true"
+        method = "PATCH"
+    else:
+        url = f"{base}?uploadType=resumable&supportsAllDrives=true"
+        method = "POST"
+
+    headers = {
+        "Content-Type": "application/json; charset=UTF-8",
+        "X-Upload-Content-Type": mime_type,
+    }
+    if content_length is not None:
+        headers["X-Upload-Content-Length"] = str(content_length)
+
+    response, _ = await asyncio.to_thread(
+        service._http.request,
+        url,
+        method=method,
+        body=json.dumps(file_metadata or {}),
+        headers=headers,
+    )
+
+    status = int(response.status)
+    if status not in (200, 201):
+        raise Exception(
+            f"Failed to initiate resumable upload session (HTTP {status})."
+        )
+    upload_url = response.get("location")
+    if not upload_url:
+        raise Exception(
+            "Resumable upload session was created but Google returned no session URL."
+        )
+    return upload_url
+
+
+def _format_resumable_upload_instructions(upload_url: str, mime_type: str) -> str:
+    return (
+        f"Upload URL (no Authorization header required):\n{upload_url}\n\n"
+        f"Upload the bytes with a single PUT request, e.g.:\n"
+        f"  curl -X PUT -H 'Content-Type: {mime_type}' --data-binary @<file> '{upload_url}'\n\n"
+        f"The session is single-use and expires roughly one week after creation."
+    )
+
+
 @server.tool(
     title="Create Drive File",
     annotations=ToolAnnotations(
@@ -895,10 +967,22 @@ async def create_drive_file(
     folder_id: str = "root",
     mime_type: str = "text/plain",
     fileUrl: Optional[str] = None,  # Now explicitly Optional
+    return_upload_url: bool = False,
+    content_length: Optional[int] = None,
 ) -> str:
     """
     Creates a new file in Google Drive, supporting creation within shared drives.
-    Accepts either direct content or a fileUrl to fetch the content from.
+    Accepts direct text content, a fileUrl, or — for binary/large files — a
+    pre-authorized resumable upload URL.
+
+    Three ways to provide the bytes:
+    - ``content``: inline text. Works in every transport mode.
+    - ``fileUrl``: the server fetches the bytes. Only available in local (stdio)
+      mode; ``file://`` reads the *server's* filesystem, so it is rejected when the
+      server runs remotely (streamable-http).
+    - ``return_upload_url=True``: returns a resumable upload URL instead of creating
+      the file inline. The caller then PUTs the bytes straight to Google with no auth
+      header — the recommended way to upload binary/large files to a remote server.
 
     Args:
         user_google_email (str): The user's Google email address. Required.
@@ -906,14 +990,50 @@ async def create_drive_file(
         content (Optional[str]): If provided, the content to write to the file.
         folder_id (str): The ID of the parent folder. Defaults to 'root'. For shared drives, this must be a folder ID within the shared drive.
         mime_type (str): The MIME type of the file. Defaults to 'text/plain'.
-        fileUrl (Optional[str]): If provided, fetches the file content from this URL. Supports file://, http://, and https:// protocols.
+        fileUrl (Optional[str]): If provided, fetches the file content from this URL. Supports file://, http://, and https:// protocols. Unavailable in remote (streamable-http) mode.
+        return_upload_url (bool): If True, return a resumable upload URL for the new file instead of creating it from inline content.
+        content_length (Optional[int]): Exact byte length for the resumable upload, if known (sent as X-Upload-Content-Length).
 
     Returns:
-        str: Confirmation message of the successful file creation with file link.
+        str: Confirmation of the created file, or the resumable upload URL.
     """
     logger.info(
-        f"[create_drive_file] Invoked. Email: '{user_google_email}', File Name: {file_name}, Folder ID: {folder_id}, fileUrl: {fileUrl}"
+        f"[create_drive_file] Invoked. Email: '{user_google_email}', File Name: {file_name}, Folder ID: {folder_id}, fileUrl: {fileUrl}, return_upload_url: {return_upload_url}"
     )
+
+    # Resumable upload URL path: hand back a pre-authorized session URL and stop.
+    if return_upload_url:
+        if content is not None or fileUrl is not None:
+            raise ValueError(
+                "return_upload_url cannot be combined with 'content' or 'fileUrl'."
+            )
+        if mime_type == FOLDER_MIME_TYPE:
+            raise ValueError("return_upload_url is not applicable to folders.")
+        resolved_folder_id = await resolve_folder_id(service, folder_id)
+        upload_url = await _initiate_resumable_upload_session(
+            service,
+            mime_type=mime_type,
+            file_metadata={
+                "name": file_name,
+                "parents": [resolved_folder_id],
+                "mimeType": mime_type,
+            },
+            content_length=content_length,
+        )
+        logger.info(f"[create_drive_file] Returned resumable upload URL for '{file_name}'.")
+        return (
+            f"Resumable upload session created for new file '{file_name}' "
+            f"(folder '{folder_id}', for {user_google_email}).\n\n"
+            + _format_resumable_upload_instructions(upload_url, mime_type)
+        )
+
+    # fileUrl reads the server's filesystem / fetches server-side; misleading remotely.
+    if fileUrl is not None and _is_remote_transport():
+        raise ValueError(
+            "'fileUrl' is unavailable in remote (streamable-http) mode because it "
+            "resolves on the server, not the caller. Pass return_upload_url=True to "
+            "get a resumable upload URL to PUT your bytes to, or send text via 'content'."
+        )
 
     if content is None and fileUrl is None and mime_type != FOLDER_MIME_TYPE:
         raise Exception("You must provide either 'content' or 'fileUrl'.")
@@ -1724,6 +1844,8 @@ async def update_drive_file(
     file_path: Optional[str] = None,  # Local file path (DOCX, ODT, etc.)
     file_url: Optional[str] = None,  # Remote URL to fetch content from
     source_format: Optional[str] = None,  # Format hint (md, docx, txt, html, rtf, odt)
+    return_upload_url: bool = False,
+    content_length: Optional[int] = None,
 ) -> str:
     """
     Updates metadata, properties, and/or content of a Google Drive file.
@@ -1733,6 +1855,15 @@ async def update_drive_file(
     API applies the same format conversion as import_to_google_doc (markdown headings,
     tables, bold, etc.) while preserving the existing file ID, sharing, comments, and
     links. Metadata and content can be updated in a single call.
+
+    Content sources behave the same way as in ``create_drive_file``:
+    - ``content``: inline text, available in every transport mode.
+    - ``file_path``/``file_url``: server-side ingestion; only available in local
+      (stdio) mode, and rejected when the server runs remotely (streamable-http)
+      because they resolve on the server, not the caller.
+    - ``return_upload_url=True``: apply any metadata changes, then return a resumable
+      upload URL the caller PUTs the new bytes to directly (recommended for binary or
+      large content on a remote server).
 
     Args:
         user_google_email (str): The user's Google email address. Required.
@@ -1748,14 +1879,18 @@ async def update_drive_file(
         copy_requires_writer_permission (Optional[bool]): Whether copying requires writer permission.
         properties (Optional[dict]): Custom key-value properties for the file.
         content (Optional[str]): New text content for text-based formats (markdown, TXT, HTML).
-        file_path (Optional[str]): Local file path for binary formats (DOCX, ODT). Supports file:// URLs.
-        file_url (Optional[str]): Remote http(s) URL to fetch new content from.
+        file_path (Optional[str]): Local file path for binary formats (DOCX, ODT). Supports file:// URLs. Unavailable in remote (streamable-http) mode.
+        file_url (Optional[str]): Remote http(s) URL to fetch new content from. Unavailable in remote (streamable-http) mode.
         source_format (Optional[str]): Source format hint for conversion
             (md, markdown, docx, txt, html, rtf, odt). Auto-detected when omitted.
             Provide at most one of content/file_path/file_url.
+        return_upload_url (bool): If True, apply metadata changes and return a resumable
+            upload URL for replacing the file's content (instead of uploading inline).
+        content_length (Optional[int]): Exact byte length for the resumable upload, if known.
 
     Returns:
-        str: Confirmation message with details of the updates applied.
+        str: Confirmation message with details of the updates applied, or the
+            resumable upload URL.
     """
     logger.info(f"[update_drive_file] Updating file {file_id} for {user_google_email}")
 
@@ -1820,6 +1955,43 @@ async def update_drive_file(
     # Only include body if there are updates
     if update_body:
         query_params["body"] = update_body
+
+    # Remote-safe content replacement: hand back a pre-authorized resumable PUT URL.
+    if return_upload_url:
+        if any(x is not None for x in (content, file_path, file_url)):
+            raise ValueError(
+                "return_upload_url replaces content via a resumable PUT; do not also "
+                "pass 'content', 'file_path', or 'file_url'."
+            )
+        # Apply any metadata-only changes first, then return the upload URL.
+        if "body" in query_params or "addParents" in query_params or "removeParents" in query_params:
+            await asyncio.to_thread(
+                service.files().update(**query_params).execute, num_retries=0
+            )
+        upload_mime = (
+            mime_type or current_file.get("mimeType") or "application/octet-stream"
+        )
+        upload_url = await _initiate_resumable_upload_session(
+            service,
+            mime_type=upload_mime,
+            file_id=file_id,
+            content_length=content_length,
+        )
+        logger.info(f"[update_drive_file] Returned resumable upload URL for {file_id}.")
+        return (
+            f"Resumable upload session created to replace content of "
+            f"'{current_file.get('name', file_id)}' (ID {file_id}, for {user_google_email}).\n\n"
+            + _format_resumable_upload_instructions(upload_url, upload_mime)
+        )
+
+    # file_path/file_url ingest on the server is misleading when reached remotely.
+    if (file_path is not None or file_url is not None) and _is_remote_transport():
+        raise ValueError(
+            "'file_path'/'file_url' are unavailable in remote (streamable-http) mode "
+            "because they resolve on the server, not the caller. Pass "
+            "return_upload_url=True to get a resumable upload URL to PUT new content "
+            "to, or send text via 'content'."
+        )
 
     # Replacement content is uploaded with its source MIME type so Drive converts it
     # into the file's existing type — the same engine import_to_google_doc uses.

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -9,6 +9,7 @@ and `file_type` filtering behaviors.
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
 import io
+import json
 import sys
 import os
 
@@ -16,6 +17,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 from gdrive.drive_helpers import build_drive_list_params
 from gdrive.drive_tools import (
+    create_drive_file,
     get_drive_file_permissions,
     import_to_google_doc,
     import_to_google_sheets,
@@ -1943,3 +1945,130 @@ async def test_update_drive_file_metadata_only_uploads_no_media(mock_resolve_ite
     update_kwargs = mock_service.files.return_value.update.call_args.kwargs
     assert "media_body" not in update_kwargs
     assert "Successfully updated file" in result
+
+
+# ---------------------------------------------------------------------------
+# Resumable upload URLs + remote-mode guards (create_drive_file / update_drive_file)
+# ---------------------------------------------------------------------------
+
+
+def _resumable_response(status, location=None):
+    """Build a minimal httplib2-style (response, content) pair."""
+    response = Mock()
+    response.status = status
+    response.get = Mock(return_value=location)
+    return response, b""
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+async def test_create_drive_file_returns_resumable_upload_url(mock_resolve_folder):
+    """return_upload_url initiates a POST resumable session and returns the URL."""
+    upload_url = "https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable&upload_id=ABC"
+    mock_resolve_folder.return_value = "folder123"
+    mock_service = Mock()
+    mock_service._http.request.return_value = _resumable_response(200, upload_url)
+
+    result = await _unwrap(create_drive_file)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        file_name="report.pdf",
+        folder_id="target",
+        mime_type="application/pdf",
+        return_upload_url=True,
+        content_length=2048,
+    )
+
+    args, kwargs = mock_service._http.request.call_args
+    assert args[0].startswith("https://www.googleapis.com/upload/drive/v3/files?")
+    assert "uploadType=resumable" in args[0] and "supportsAllDrives=true" in args[0]
+    assert kwargs["method"] == "POST"
+    assert kwargs["headers"]["X-Upload-Content-Type"] == "application/pdf"
+    assert kwargs["headers"]["X-Upload-Content-Length"] == "2048"
+    assert json.loads(kwargs["body"]) == {
+        "name": "report.pdf",
+        "parents": ["folder123"],
+        "mimeType": "application/pdf",
+    }
+    assert upload_url in result
+
+
+@pytest.mark.asyncio
+async def test_create_drive_file_rejects_return_upload_url_with_content():
+    """return_upload_url is mutually exclusive with inline content/fileUrl."""
+    mock_service = Mock()
+    with pytest.raises(ValueError, match="cannot be combined"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="report.pdf",
+            content="hi",
+            return_upload_url=True,
+        )
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.get_transport_mode", return_value="streamable-http")
+async def test_create_drive_file_rejects_fileurl_in_remote_mode(mock_mode):
+    """fileUrl is refused when the server runs remotely (streamable-http)."""
+    mock_service = Mock()
+    with pytest.raises(ValueError, match="remote"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="report.pdf",
+            fileUrl="https://example.com/report.pdf",
+        )
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_drive_item", new_callable=AsyncMock)
+async def test_update_drive_file_returns_resumable_patch_url(mock_resolve_item):
+    """return_upload_url applies metadata then returns a PATCH resumable URL."""
+    upload_url = "https://www.googleapis.com/upload/drive/v3/files/file123?uploadType=resumable&upload_id=XYZ"
+    mock_resolve_item.return_value = (
+        "file123",
+        {"name": "Doc", "mimeType": "application/vnd.google-apps.document"},
+    )
+    mock_service = Mock()
+    mock_service._http.request.return_value = _resumable_response(200, upload_url)
+
+    result = await _unwrap(update_drive_file)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        file_id="file123",
+        name="Renamed",  # forces a metadata update call
+        return_upload_url=True,
+    )
+
+    # metadata-only update was applied (no media_body)
+    update_kwargs = mock_service.files.return_value.update.call_args.kwargs
+    assert "media_body" not in update_kwargs
+    # resumable session is a PATCH against the file id
+    args, kwargs = mock_service._http.request.call_args
+    assert args[0].startswith(
+        "https://www.googleapis.com/upload/drive/v3/files/file123?"
+    )
+    assert kwargs["method"] == "PATCH"
+    assert upload_url in result
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_drive_item", new_callable=AsyncMock)
+@patch("gdrive.drive_tools.get_transport_mode", return_value="streamable-http")
+async def test_update_drive_file_rejects_file_url_in_remote_mode(
+    mock_mode, mock_resolve_item
+):
+    """file_path/file_url content replacement is refused in remote mode."""
+    mock_resolve_item.return_value = (
+        "file123",
+        {"name": "Doc", "mimeType": "application/vnd.google-apps.document"},
+    )
+    mock_service = Mock()
+    with pytest.raises(ValueError, match="remote"):
+        await _unwrap(update_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_id="file123",
+            file_url="https://example.com/new.docx",
+        )


### PR DESCRIPTION
## Summary

Makes `create_drive_file` and `update_drive_file` **transport-mode aware** so file uploads behave correctly when the server is reached remotely (`streamable-http`), and adds a way to upload binary/large files without routing the bytes through the server.

### The problem
Today the upload inputs assume the client and server share a filesystem:
- `create_drive_file(fileUrl=…)` — `file://` reads the **server's** filesystem, not the caller's; the http(s) branch makes the server fetch arbitrary URLs (SSRF surface).
- `update_drive_file(file_path=…, file_url=…)` — same thing for content replacement.

On a remote deployment that's misleading to an agent: it points a tool at "a file" that only exists on the agent's machine.

### The change
- **Remote-mode guard.** In `streamable-http` mode, `fileUrl` (create) and `file_path`/`file_url` (update) are rejected with an actionable error. **`stdio` mode is unchanged** — local file ingestion still works there.
- **Resumable upload URLs.** Both tools gain `return_upload_url=True`, which initiates a [Drive resumable upload session](https://developers.google.com/workspace/drive/api/guides/manage-uploads#resumable) and returns the pre-authorized session URL. The caller then `PUT`s the bytes **straight to Google with no `Authorization` header** — the payload never flows through the server (or the model context).
  - `create_drive_file` → `POST` (new file)
  - `update_drive_file` → `PATCH` (replace an existing file's content, after applying any metadata changes)
- Inline text `content` and all of `update_drive_file`'s metadata operations (rename / move / star / trash / sharing / properties) are unaffected in every mode.
- Supports shared drives (`supportsAllDrives=true`). Optional `content_length` is forwarded as `X-Upload-Content-Length`.

Backward compatible — the new parameters default off.

## Tests

Adds unit tests for the resumable-URL path (create `POST` + update `PATCH`, headers/metadata/returned URL) and the remote-mode rejection of `fileUrl`/`file_url`. Full `tests/gdrive/test_drive_tools.py` passes (82 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resumable Google Drive uploads by returning pre-authorized resumable session instructions (with optional content length), for both creating new files and replacing existing file content.
  * Added safer behavior for remote/streamed scenarios by rejecting incompatible inputs (e.g., inline content/file URLs) when resumable session mode is used.

* **Tests**
  * Added async test coverage for resumable session initiation and returned upload/session URLs, including validation of argument combinations and remote-mode rejection cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->