### PR TITLE
fix(gmail): thread reply drafts and quote the original by default

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2426,9 +2426,9 @@ async def draft_gmail_message(
     quote_original: Annotated[
         bool,
         Field(
-            description="Whether to include the original message as a quoted reply. Requires thread_id. Defaults to false.",
+            description="Whether to include the original message as a quoted reply (only applies when thread_id is set). Defaults to true, matching the Gmail UI which quotes the conversation when you reply. Set false for a bare reply with no quoted history.",
         ),
-    ] = False,
+    ] = True,
 ) -> str:
     """
     Creates a draft email in the user's Gmail account. Supports both new drafts and reply drafts with optional attachments.
@@ -2464,8 +2464,9 @@ async def draft_gmail_message(
             Non-benign failures such as quota/rate-limit or API errors raise ToolError and abort
             the draft.
         quote_original (bool): Whether to include the original message as a quoted reply.
-            Requires thread_id to be provided. When enabled, fetches the original message
-            and appends it below the signature. Defaults to False.
+            Only applies when thread_id is provided. When enabled, fetches the original
+            message and appends it below the signature. Defaults to True, matching the
+            Gmail UI (which quotes the conversation on reply). Set False for a bare reply.
 
     Returns:
         str: Confirmation message with the created draft's ID.
@@ -2602,9 +2603,16 @@ async def draft_gmail_message(
             f"{details}"
         )
 
-    # Create a draft instead of sending. Keep reply threading in the raw
-    # headers; setting message.threadId here can create Gmail UI-hidden drafts.
-    draft_body = {"message": {"raw": raw_message}}
+    # Create a draft instead of sending. For a reply, the draft must carry the
+    # thread's threadId (like send_gmail_message does) or Gmail starts a brand-new
+    # thread and the draft shows up detached from the conversation. Threading by raw
+    # In-Reply-To/References headers alone is not enough for drafts. Per the Gmail API
+    # threading rules, the threadId is honored because the derived Subject (Re: ...)
+    # and References headers already match the target thread.
+    draft_message = {"raw": raw_message}
+    if thread_id:
+        draft_message["threadId"] = thread_id
+    draft_body = {"message": draft_message}
 
     # Create the draft
     created_draft = await asyncio.to_thread(

--- a/tests/gmail/test_draft_gmail_message.py
+++ b/tests/gmail/test_draft_gmail_message.py
@@ -387,6 +387,7 @@ async def test_draft_gmail_message_builds_threaded_html_reply_as_multipart_alter
         body_format="html",
         thread_id="thread123",
         include_signature=False,
+        quote_original=False,
     )
 
     create_kwargs = (
@@ -524,6 +525,45 @@ async def test_draft_gmail_message_fetches_thread_once_when_quoting_reply():
 
 
 @pytest.mark.asyncio
+async def test_draft_reply_threads_and_quotes_by_default():
+    """A reply draft must (1) carry the threadId so Gmail nests it in the
+    conversation and (2) quote the original by default, mirroring the Gmail UI."""
+    mock_service = Mock()
+    mock_service.users().drafts().create().execute.return_value = {"id": "draft_thr"}
+    mock_service.users().threads().get().execute.return_value = {
+        "messages": [
+            _thread_message(
+                "<msg1@example.com>",
+                from_value="Alice Example <alice@example.com>",
+                text="Original plain text",
+                html="<p>Original html</p>",
+            )
+        ]
+    }
+
+    await _unwrap(draft_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        to="recipient@example.com",
+        subject="Meeting tomorrow",
+        body="Thanks!",
+        thread_id="thread123",
+        include_signature=False,
+        # quote_original omitted -> should default to True
+    )
+
+    create_kwargs = (
+        mock_service.users.return_value.drafts.return_value.create.call_args.kwargs
+    )
+    # (1) the draft is attached to the thread
+    assert create_kwargs["body"]["message"]["threadId"] == "thread123"
+    # (2) the original message is quoted in the body by default
+    raw_message = create_kwargs["body"]["message"]["raw"]
+    raw_text = base64.urlsafe_b64decode(raw_message).decode("utf-8", errors="ignore")
+    assert "Original plain text" in raw_text
+
+
+@pytest.mark.asyncio
 async def test_draft_gmail_message_autofills_reply_headers_from_thread():
     mock_service = Mock()
     mock_service.users().drafts().create().execute.return_value = {"id": "draft_reply"}
@@ -541,6 +581,7 @@ async def test_draft_gmail_message_autofills_reply_headers_from_thread():
         body="Thanks for the update.",
         thread_id="thread123",
         include_signature=False,
+        quote_original=False,
     )
 
     # Verify threads().get() was called with correct parameters
@@ -565,7 +606,9 @@ async def test_draft_gmail_message_autofills_reply_headers_from_thread():
         "References: <msg1@example.com> <msg2@example.com> <msg3@example.com>"
         in raw_text
     )
-    assert "threadId" not in create_kwargs["body"]["message"]
+    # The draft must carry the threadId so Gmail nests it in the conversation
+    # instead of starting a new thread.
+    assert create_kwargs["body"]["message"]["threadId"] == "thread123"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Reply drafts created by `draft_gmail_message` don't behave like the Gmail UI — they end up **detached from the conversation** and **without the quoted history**. Two fixes:

### 1. Drafts weren't threaded
`draft_gmail_message` built the draft as `{"message": {"raw": ...}}` and deliberately omitted `message.threadId`, relying on raw `In-Reply-To`/`References` headers alone:

```python
# Keep reply threading in the raw headers; setting message.threadId here can
# create Gmail UI-hidden drafts.
draft_body = {"message": {"raw": raw_message}}
```

For drafts that isn't enough — Gmail assigns a **new thread**, so the draft shows up as a standalone message instead of nested in the conversation (`send_gmail_message` already sets `threadId`, which is why sends thread but drafts don't). The "UI-hidden draft" risk only occurs when the `Subject`/`References` don't match the thread; this tool already derives the `Re:` subject and the `References`/`In-Reply-To` chain from the thread, so per [Gmail's threading rules](https://developers.google.com/gmail/api/guides/threads) setting `threadId` nests the draft correctly.

Now: `threadId` is set on the draft message when `thread_id` is provided.

### 2. Drafts weren't quoting the original
`quote_original` defaulted to `false`, so reply drafts came out bare. The Gmail UI always quotes the conversation on reply. Changed the default to `true` (pass `quote_original=false` for a bare reply). It's a no-op for non-thread drafts.

## Tests
- Updated the test that asserted the old no-`threadId` behavior to assert `threadId` is now set.
- Marked the two structural/header tests that target non-quoting behavior with explicit `quote_original=False`.
- Added a test that a default reply both **threads** (`threadId` set) and **quotes** (original text in the body).

Full `tests/gmail/test_draft_gmail_message.py` passes (30 tests).

> Note: #2 changes a default. Happy to split it out or keep it opt-in if you'd prefer the bare-reply default — the threading fix (#1) stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Draft replies now automatically include quotes of the original message by default when replying within a thread, aligning with standard email behavior.

* **Bug Fixes**
  * Resolved issue where draft replies could become hidden or detached from their original thread conversation by ensuring proper thread linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->