### PR TITLE
ci(helm): publish chart to GHCR as OCI artifact

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,109 @@
+name: Helm Chart Publish to GHCR
+
+on:
+  push:
+    tags:
+      - 'chart-v*'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'helm-chart/**'
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  REGISTRY: ghcr.io
+  CHART_DIR: helm-chart/workspace-mcp
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Helm lint
+        run: helm lint ${{ env.CHART_DIR }}
+
+      - name: Helm template (render)
+        # OAuth secrets are `required` by the chart; supply throwaway values so
+        # rendering validates the templates without real credentials.
+        run: |
+          helm template workspace-mcp ${{ env.CHART_DIR }} \
+            --set secrets.googleOAuth.clientId=ci-render \
+            --set secrets.googleOAuth.clientSecret=ci-render \
+            > /dev/null
+
+  publish:
+    # Lint runs on every event; publishing only happens off a chart-v* tag
+    # (or a manual dispatch).
+    if: github.event_name != 'pull_request'
+    needs: lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Read chart metadata
+        id: chart
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          name=$(helm show chart "${CHART_DIR}" | awk '/^name:/ {print $2; exit}')
+          version=$(helm show chart "${CHART_DIR}" | awk '/^version:/ {print $2; exit}')
+          owner=$(echo "${REPO_OWNER}" | tr '[:upper:]' '[:lower:]')
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "repo=oci://${REGISTRY}/${owner}/charts" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag matches chart version
+        # Only enforced for tag pushes; chart-v0.3.0 must match Chart.yaml's 0.3.0.
+        if: github.event_name == 'push'
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          CHART_VERSION: ${{ steps.chart.outputs.version }}
+        run: |
+          tag_version="${REF_NAME#chart-v}"
+          if [ "${tag_version}" != "${CHART_VERSION}" ]; then
+            echo "::error::Tag ${REF_NAME} (version ${tag_version}) does not match Chart.yaml version ${CHART_VERSION}." \
+              "Bump ${CHART_DIR}/Chart.yaml or retag."
+            exit 1
+          fi
+
+      - name: Log in to GitHub Container Registry
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "${GHCR_TOKEN}" \
+            | helm registry login "${REGISTRY}" \
+                --username "${GHCR_USER}" \
+                --password-stdin
+
+      - name: Package chart
+        run: helm package "${CHART_DIR}" --destination dist
+
+      - name: Push chart to GHCR
+        run: |
+          chart="dist/${{ steps.chart.outputs.name }}-${{ steps.chart.outputs.version }}.tgz"
+          helm push "${chart}" "${{ steps.chart.outputs.repo }}"
+          {
+            echo "Published \`${{ steps.chart.outputs.name }}\` version \`${{ steps.chart.outputs.version }}\`"
+            echo ""
+            echo "    helm install workspace-mcp ${{ steps.chart.outputs.repo }}/${{ steps.chart.outputs.name }} --version ${{ steps.chart.outputs.version }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -25,10 +25,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Helm lint
         run: helm lint ${{ env.CHART_DIR }}
@@ -43,9 +45,9 @@ jobs:
             > /dev/null
 
   publish:
-    # Lint runs on every event; publishing only happens off a chart-v* tag
-    # (or a manual dispatch).
-    if: github.event_name != 'pull_request'
+    # Lint runs on every event; publishing only happens off a chart-v* tag push,
+    # so the tag/Chart.yaml version check below always applies.
+    if: github.event_name == 'push'
     needs: lint
     runs-on: ubuntu-latest
     permissions:
@@ -54,10 +56,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Read chart metadata
         id: chart

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -9,7 +9,6 @@ on:
       - main
     paths:
       - 'helm-chart/**'
-  workflow_dispatch:
 
 permissions: {}
 
@@ -33,20 +32,25 @@ jobs:
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Helm lint
-        run: helm lint ${{ env.CHART_DIR }}
+        # OAuth secrets are `required` by the chart; supply throwaway values so
+        # linting can render the templates without real credentials.
+        run: |
+          helm lint "${CHART_DIR}" \
+            --set secrets.googleOAuth.clientId=ci-render \
+            --set secrets.googleOAuth.clientSecret=ci-render
 
       - name: Helm template (render)
         # OAuth secrets are `required` by the chart; supply throwaway values so
         # rendering validates the templates without real credentials.
         run: |
-          helm template workspace-mcp ${{ env.CHART_DIR }} \
+          helm template workspace-mcp "${CHART_DIR}" \
             --set secrets.googleOAuth.clientId=ci-render \
             --set secrets.googleOAuth.clientSecret=ci-render \
             > /dev/null
 
   publish:
-    # Lint runs on every event; publishing only happens off a chart-v* tag push,
-    # so the tag/Chart.yaml version check below always applies.
+    # Lint runs on pull requests; publishing only happens off a chart-v* tag
+    # push, so the tag/Chart.yaml version check below always applies.
     if: github.event_name == 'push'
     needs: lint
     runs-on: ubuntu-latest
@@ -71,13 +75,14 @@ jobs:
           name=$(helm show chart "${CHART_DIR}" | awk '/^name:/ {print $2; exit}')
           version=$(helm show chart "${CHART_DIR}" | awk '/^version:/ {print $2; exit}')
           owner=$(echo "${REPO_OWNER}" | tr '[:upper:]' '[:lower:]')
-          echo "name=${name}" >> "$GITHUB_OUTPUT"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "repo=oci://${REGISTRY}/${owner}/charts" >> "$GITHUB_OUTPUT"
+          {
+            echo "name=${name}"
+            echo "version=${version}"
+            echo "repo=oci://${REGISTRY}/${owner}/charts"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Verify tag matches chart version
-        # Only enforced for tag pushes; chart-v0.3.0 must match Chart.yaml's 0.3.0.
-        if: github.event_name == 'push'
+        # chart-v0.3.0 must match Chart.yaml's 0.3.0.
         env:
           REF_NAME: ${{ github.ref_name }}
           CHART_VERSION: ${{ steps.chart.outputs.version }}
@@ -103,11 +108,15 @@ jobs:
         run: helm package "${CHART_DIR}" --destination dist
 
       - name: Push chart to GHCR
+        env:
+          CHART_NAME: ${{ steps.chart.outputs.name }}
+          CHART_VERSION: ${{ steps.chart.outputs.version }}
+          CHART_REPO: ${{ steps.chart.outputs.repo }}
         run: |
-          chart="dist/${{ steps.chart.outputs.name }}-${{ steps.chart.outputs.version }}.tgz"
-          helm push "${chart}" "${{ steps.chart.outputs.repo }}"
+          chart="dist/${CHART_NAME}-${CHART_VERSION}.tgz"
+          helm push "${chart}" "${CHART_REPO}"
           {
-            echo "Published \`${{ steps.chart.outputs.name }}\` version \`${{ steps.chart.outputs.version }}\`"
+            echo "Published \`${CHART_NAME}\` version \`${CHART_VERSION}\`"
             echo ""
-            echo "    helm install workspace-mcp ${{ steps.chart.outputs.repo }}/${{ steps.chart.outputs.name }} --version ${{ steps.chart.outputs.version }}"
+            echo "    helm install workspace-mcp ${CHART_REPO}/${CHART_NAME} --version ${CHART_VERSION}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/helm-chart/workspace-mcp/README.md
+++ b/helm-chart/workspace-mcp/README.md
@@ -22,6 +22,18 @@ helm install workspace-mcp ./helm-chart/workspace-mcp \
   --set secrets.googleOAuth.clientSecret="your-client-secret"
 ```
 
+### Install from the GHCR OCI registry
+
+Released chart versions are published as OCI artifacts to GitHub Packages. No
+`helm repo add` is needed:
+
+```bash
+helm install workspace-mcp oci://ghcr.io/taylorwilsdon/charts/workspace-mcp \
+  --version 0.3.0 \
+  --set secrets.googleOAuth.clientId="your-client-id.apps.googleusercontent.com" \
+  --set secrets.googleOAuth.clientSecret="your-client-secret"
+```
+
 ## Configuration
 
 The following table lists the configurable parameters and their default values:


### PR DESCRIPTION
## Description
Adds a CI flow to publish the `workspace-mcp` Helm chart to GitHub Packages (GHCR) as an OCI artifact, mirroring the existing Docker → GHCR flow.

- **`.github/workflows/helm-publish.yml`**
  - **PRs touching `helm-chart/**`**: `helm lint` + `helm template` (rendered with throwaway OAuth values, since the chart `required`s them) — validation only, no publish.
  - **Push a `chart-v<version>` tag** (e.g. `chart-v0.3.0`): packages the chart and runs `helm push` to `oci://ghcr.io/<owner>/charts`, so the artifact lands at `ghcr.io/<owner>/charts/workspace-mcp`.
  - A guard fails the run if the tag version doesn't match `Chart.yaml`'s `version`.
- **`helm-chart/workspace-mcp/README.md`**: documents installing the published chart straight from the OCI registry (no `helm repo add`).

The chart keeps its own version (`0.3.0`), independent of the app release tags, so chart releases are cut by pushing a `chart-v*` tag.

### Releasing
```bash
# bump version: in helm-chart/workspace-mcp/Chart.yaml, then:
git tag chart-v0.3.0
git push origin chart-v0.3.0
```

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

Validated locally against the chart: `helm lint` passes; `helm template` renders with dummy OAuth values; `helm package` produces `workspace-mcp-0.3.0.tgz`; the tag↔version guard was simulated for matching and mismatching tags.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
- Publish path is `oci://ghcr.io/<owner>/charts` (→ `charts/workspace-mcp`), kept separate from the Docker image package to avoid collision.
- Trigger is `chart-v*` tags so chart and app releases stay decoupled; happy to switch to version-change detection on `main` or to reuse the `v*.*.*` app tags if you'd prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated publishing of the Helm chart to an OCI registry for easier distribution.

* **Documentation**
  * Added instructions for installing the Helm chart directly from the OCI registry, including version and OAuth configuration examples.

* **Chores**
  * Added continuous validation for Helm chart changes and automated publication when a chart release is created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
