### PR TITLE
fix: coerce JSON-string array args for batch_update_form/presentation

### DIFF
--- a/gforms/forms_tools.py
+++ b/gforms/forms_tools.py
@@ -14,7 +14,7 @@ from mcp.types import ToolAnnotations
 
 from auth.service_decorator import require_google_service
 from core.server import server
-from core.utils import handle_http_errors
+from core.utils import handle_http_errors, DictList
 
 logger = logging.getLogger(__name__)
 
@@ -507,7 +507,7 @@ async def batch_update_form(
     service,
     user_google_email: str,
     form_id: str,
-    requests: List[Dict[str, Any]],
+    requests: DictList,
 ) -> str:
     """
     Apply batch updates to a Google Form.

--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -12,7 +12,7 @@ from mcp.types import ToolAnnotations
 
 from auth.service_decorator import require_google_service
 from core.server import server
-from core.utils import handle_http_errors
+from core.utils import handle_http_errors, DictList
 from core.comments import create_comment_tools
 from gslides.slides_helpers import (
     validate_batch_update_requests,
@@ -249,7 +249,7 @@ async def batch_update_presentation(
     service,
     user_google_email: str,
     presentation_id: str,
-    requests: List[Dict[str, Any]],
+    requests: DictList,
 ) -> str:
     """
     Apply batch updates to a Google Slides presentation.

--- a/tests/gforms/test_forms_tools.py
+++ b/tests/gforms/test_forms_tools.py
@@ -4,20 +4,63 @@ Unit tests for Google Forms MCP tools
 Tests the batch_update_form tool with mocked API responses
 """
 
+import inspect
 import pytest
 from unittest.mock import Mock
 import sys
 import os
 
+from pydantic import TypeAdapter
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from core.utils import DictList
 
 # Import internal implementation functions (not decorated tool wrappers)
 from gforms.forms_tools import (
     _batch_update_form_impl,
     _serialize_form_item,
+    batch_update_form,
     get_form,
     set_publish_settings,
 )
+
+
+def _raw(fn):
+    """Unwrap the FastMCP tool + decorators to the original async function."""
+    fn = getattr(fn, "fn", fn)
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _requests_adapter() -> TypeAdapter:
+    """TypeAdapter for the wired ``requests`` annotation on batch_update_form."""
+    annotation = (
+        inspect.signature(_raw(batch_update_form)).parameters["requests"].annotation
+    )
+    return TypeAdapter(annotation)
+
+
+class TestBatchUpdateFormRequestsCoercion:
+    """The ``requests`` param must accept both a native list and a JSON-encoded
+    string of a list — some MCP clients serialise array args as strings."""
+
+    def test_requests_annotation_is_dictlist(self):
+        annotation = (
+            inspect.signature(_raw(batch_update_form)).parameters["requests"].annotation
+        )
+        assert annotation is DictList
+
+    def test_requests_accepts_native_list(self):
+        value = [{"createItem": {"item": {"title": "Q1"}, "location": {"index": 0}}}]
+        assert _requests_adapter().validate_python(value) == value
+
+    def test_requests_coerces_json_array_string(self):
+        value = [{"createItem": {"item": {"title": "Q1"}, "location": {"index": 0}}}]
+        import json as _json
+
+        assert _requests_adapter().validate_python(_json.dumps(value)) == value
 
 
 @pytest.mark.asyncio

--- a/tests/test_slides_tools.py
+++ b/tests/test_slides_tools.py
@@ -1,8 +1,10 @@
+import inspect
 from unittest.mock import Mock
 
 import pytest
+from pydantic import TypeAdapter
 
-from core.utils import UserInputError
+from core.utils import DictList, UserInputError
 from gslides.slides_tools import (
     _describe_elements,
     _extract_shape_text,
@@ -17,6 +19,38 @@ def _unwrap(tool):
     while hasattr(fn, "__wrapped__"):
         fn = fn.__wrapped__
     return fn
+
+
+class TestBatchUpdatePresentationRequestsCoercion:
+    """The ``requests`` param must accept both a native list and a JSON-encoded
+    string of a list — some MCP clients serialise array args as strings."""
+
+    @staticmethod
+    def _adapter() -> TypeAdapter:
+        annotation = (
+            inspect.signature(_unwrap(batch_update_presentation))
+            .parameters["requests"]
+            .annotation
+        )
+        return TypeAdapter(annotation)
+
+    def test_requests_annotation_is_dictlist(self):
+        annotation = (
+            inspect.signature(_unwrap(batch_update_presentation))
+            .parameters["requests"]
+            .annotation
+        )
+        assert annotation is DictList
+
+    def test_requests_accepts_native_list(self):
+        value = [{"createSlide": {"objectId": "s1"}}]
+        assert self._adapter().validate_python(value) == value
+
+    def test_requests_coerces_json_array_string(self):
+        import json as _json
+
+        value = [{"createSlide": {"objectId": "s1"}}]
+        assert self._adapter().validate_python(_json.dumps(value)) == value
 
 
 def _build_slides_service(presentation=None, batch_update_response=None):


### PR DESCRIPTION
## Description

`batch_update_form` (gforms) and `batch_update_presentation` (gslides) still type their `requests` parameter as the bare `List[Dict[str, Any]]`. When an MCP client serialises that array argument as a JSON string instead of a native array, Pydantic raises `Input should be a valid list` and the tool can't be used for its primary purpose (adding/updating form items, slide elements).

The repo already solved this everywhere else: `core.utils.DictList` is an `Annotated[List[dict], BeforeValidator(_coerce_json_str_to_list)]` that `json.loads` a string before validation. gmail/calendar/sheets/etc. all use it — Forms and Slides were just missed in that migration.

This swaps both `requests` params to `DictList`. Native lists are unchanged; a stringified array (`'[{"createItem": ...}]'`) now coerces cleanly.

Fixes #853.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Added `TestBatchUpdateFormRequestsCoercion` and `TestBatchUpdatePresentationRequestsCoercion`, mirroring the existing `tests/gmail/test_manage_gmail_filter.py::TestJsonDictValidation` pattern. Each asserts the wired annotation (resolved through the FastMCP tool wrapper via `inspect.signature`) is `DictList`, that a native list validates unchanged, and that a JSON-array string coerces to the equivalent list.

```
tests/gforms/test_forms_tools.py::TestBatchUpdateFormRequestsCoercion ... 3 passed
tests/test_slides_tools.py::TestBatchUpdatePresentationRequestsCoercion ... 3 passed
```

(Note: `tests/gforms/test_forms_tools.py::test_set_publish_settings_builds_publish_state_body` fails on a clean checkout of `main` as well — it's a pre-existing `updateMask` assertion unrelated to this change, so I've left it untouched.)

## Checklist
- [x] My code follows the style guidelines of this project (`ruff check` + `ruff format` clean)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced parameter type handling for batch update operations across Forms and Slides tools to improve internal consistency.

* **Tests**
  * Added comprehensive test coverage for parameter validation and coercion in batch update requests, verifying support for multiple input format handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->