### PR TITLE
feat(core): --only-tools — exact tool allowlist that derives minimal OAuth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,14 @@ uv run workspace-cli call search_gmail_messages query="is:unread" max_results=5
 
 Install globally with `uv tool install .` from this repo. ⚠️ Don't use `uvx workspace-cli` - an abandoned PyPI package squats that name.
 
+**🎯 Exact Tool Selection**
+
+```bash
+uv run main.py --only-tools send_gmail_message manage_drive_access
+```
+
+**`--only-tools`** takes an exact (and possibly cross-service) tool allowlist and *also* derives the **minimal** OAuth scopes those tools need — the smallest possible consent screen for a purpose-built endpoint. Mutually exclusive with `--tools`, `--tool-tier`, `--permissions`, `--read-only`, and `--disabled-tools` (just omit a tool from the list rather than disabling it). See [docs/only-tools.md](docs/only-tools.md), including how it differs from the subtractive `--disabled-tools`.
+
 ## Deployment & Advanced Configuration
 
 Everything you need to run this in production lives in two places. The [documentation](https://workspacemcp.com/docs?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=deploy-docs) covers auth modes and server configuration:

--- a/auth/scopes.py
+++ b/auth/scopes.py
@@ -12,6 +12,19 @@ logger = logging.getLogger(__name__)
 # Global variable to store enabled tools (set by main.py)
 _ENABLED_TOOLS = None
 
+# Explicit OAuth scope override (set by main.py for --only-tools).
+# When not None, get_scopes_for_tools() returns exactly BASE_SCOPES + these
+# scopes, bypassing the service-granular TOOL_SCOPES_MAP entirely.
+_EXPLICIT_SCOPES = None
+
+
+def set_explicit_scopes(scopes):
+    """Set an explicit OAuth scope set, or None to clear."""
+    global _EXPLICIT_SCOPES
+    _EXPLICIT_SCOPES = set(scopes) if scopes is not None else None
+    if _EXPLICIT_SCOPES is not None:
+        logger.info("Explicit scope set active: %d scopes", len(_EXPLICIT_SCOPES))
+
 # Individual OAuth Scope Constants
 USERINFO_EMAIL_SCOPE = "https://www.googleapis.com/auth/userinfo.email"
 USERINFO_PROFILE_SCOPE = "https://www.googleapis.com/auth/userinfo.profile"
@@ -302,6 +315,11 @@ def get_scopes_for_tools(enabled_tools=None):
     Returns:
         List of unique scopes for the enabled tools plus base scopes.
     """
+    # Explicit per-tool scope override (--only-tools): exact union of the
+    # selected tools' required scopes plus base identity scopes.
+    if _EXPLICIT_SCOPES is not None:
+        return list(set(BASE_SCOPES) | _EXPLICIT_SCOPES)
+
     # Granular permissions mode overrides both full and read-only scope maps.
     # Lazy import with guard to avoid circular dependency during module init
     # (SCOPES = get_scopes_for_tools() runs at import time before auth.permissions

--- a/auth/scopes.py
+++ b/auth/scopes.py
@@ -25,6 +25,7 @@ def set_explicit_scopes(scopes):
     if _EXPLICIT_SCOPES is not None:
         logger.info("Explicit scope set active: %d scopes", len(_EXPLICIT_SCOPES))
 
+
 # Individual OAuth Scope Constants
 USERINFO_EMAIL_SCOPE = "https://www.googleapis.com/auth/userinfo.email"
 USERINFO_PROFILE_SCOPE = "https://www.googleapis.com/auth/userinfo.profile"
@@ -255,8 +256,11 @@ def set_enabled_tools(enabled_tools):
     """
     global _ENABLED_TOOLS
     _ENABLED_TOOLS = enabled_tools
+    # enabled_tools may be None (the default / "all services" state) — guard the
+    # count so clearing the override doesn't raise.
     # Debug level: the startup screen already reports the loaded service count.
-    logger.debug(f"Scope management active for {len(enabled_tools)} services")
+    count = len(enabled_tools) if enabled_tools is not None else 0
+    logger.debug(f"Scope management active for {count} services")
 
 
 # Global variable to store read-only mode (set by main.py)

--- a/core/tool_tier_loader.py
+++ b/core/tool_tier_loader.py
@@ -148,6 +148,23 @@ class ToolTierLoader:
 
         return services
 
+    def get_all_tool_names(self) -> Set[str]:
+        """
+        Get the union of every tool name across all services and tiers.
+
+        Returns:
+            Set of all tool names defined anywhere in the configuration.
+        """
+        config = self._load_config()
+        all_tools: Set[str] = set()
+
+        for service_config in config.values():
+            for tier_tools in service_config.values():
+                if tier_tools:  # Handle empty lists / None
+                    all_tools.update(tier_tools)
+
+        return all_tools
+
 
 def get_tools_for_tier(
     tier: TierLevel, services: Optional[List[str]] = None

--- a/docs/only-tools.md
+++ b/docs/only-tools.md
@@ -1,0 +1,81 @@
+# Exact tool selection: `--only-tools`
+
+This server already ships three ways to decide which tools (and which OAuth
+scopes) a running instance exposes, plus a per-tool block list:
+
+- **`--tool-tier core|extended|complete`** — fixed, *cumulative* tiers. Each tier
+  is a curated superset of the previous one across every service.
+- **`--permissions service:level ...`** — *cumulative* permission **levels** per
+  service (e.g. `gmail:readonly` ⊂ `gmail:organize` ⊂ `gmail:drafts` ⊂
+  `gmail:send` ⊂ `gmail:full`). A level maps to a set of scopes, and any tool
+  whose required scopes aren't all covered is dropped.
+- **`--tools gmail drive ...`** — whole **services**. All or nothing per service.
+- **`--disabled-tools tool_name ...`** — subtractive per-tool block list that
+  composes with all of the above; scopes are untouched.
+
+These are the right tool most of the time. But they share one structural limit,
+and `--only-tools` exists to fill exactly that gap.
+
+## The gap this flag fills
+
+None of the built-in selectors can **expose an arbitrary, disjoint subset of
+tools with a minimal grant**. Tiers and permission levels are cumulative
+ladders; `--tools` is whole services; `--disabled-tools` subtracts tools but
+leaves the scope grant defined by the other selectors. There is no built-in way
+to say "expose *exactly* these four tools, drawn from three different services,
+and request *only* the scopes those four tools need." You always end up
+over-granting scopes or over-exposing tools.
+
+## What `--only-tools` does
+
+```bash
+--only-tools send_gmail_message manage_drive_access
+```
+
+`--only-tools` takes an explicit list of **tool names** and does two things:
+
+1. **Allowlist the tools.** Only the named tools are registered; everything else
+   is removed. The list can be an arbitrary, disjoint subset that crosses
+   service boundaries.
+2. **Derive the minimal scope union.** The server inspects exactly those tools'
+   declared Google scopes (`_required_google_scopes`) and requests **only** that
+   union plus the base identity scopes (`userinfo.email`, `openid`). It bypasses
+   the service-granular scope maps entirely.
+
+So `--only-tools` **narrows both layers at once**: the tool surface *and* the
+OAuth grant. The token you mint can do nothing beyond what those specific tools
+require. This is the tightest possible grant for a given set of tools.
+
+Unknown tool names are rejected with an error at startup, so a typo fails loud
+instead of silently shipping a smaller surface than intended.
+
+`--only-tools` is **mutually exclusive** with `--tools`, `--tool-tier`,
+`--permissions`, `--read-only`, and `--disabled-tools` (CLI flag or their
+`WORKSPACE_MCP_*` env vars) — it is a self-contained selector that picks both
+tools and scopes on its own, so combining it with another selector is
+contradictory and rejected with an error. In particular, disabling one of its
+tools with `--disabled-tools` would drop that tool from the surface while still
+requesting its scope, defeating the minimal grant; just omit the tool from the
+`--only-tools` list instead.
+
+**When to use it:** you want a purpose-built endpoint that does a few specific
+things and nothing else, with the smallest OAuth consent screen possible. An
+agent that only sends email and shares Drive files, for example, should never be
+granted read access to your whole mailbox.
+
+## `--only-tools` vs `--disabled-tools`
+
+The two flags work at different layers, and the difference is the OAuth grant:
+
+| | `--only-tools` | `--disabled-tools` |
+| --- | --- | --- |
+| Direction | allowlist (exact set) | blocklist (subtract from any selection) |
+| Combines with other selectors | no — self-contained | yes — that's the point |
+| Effect on requested scopes | **derives the minimal union** from the named tools | **none** — the grant is whatever the other selectors chose |
+| Enforcement layer | scope layer *and* tool layer | tool layer only |
+
+A tool removed by `--disabled-tools` is gone from the MCP surface, but if its
+scope is shared with a surviving tool the token can still perform the underlying
+action through any path outside this server. Only `--only-tools` (or a
+permission level that genuinely excludes the scope) narrows what the *token*
+can do.

--- a/docs/only-tools.md
+++ b/docs/only-tools.md
@@ -39,8 +39,8 @@ over-granting scopes or over-exposing tools.
    service boundaries.
 2. **Derive the minimal scope union.** The server inspects exactly those tools'
    declared Google scopes (`_required_google_scopes`) and requests **only** that
-   union plus the base identity scopes (`userinfo.email`, `openid`). It bypasses
-   the service-granular scope maps entirely.
+   union plus the base identity scopes (`userinfo.email`, `userinfo.profile`,
+   `openid`). It bypasses the service-granular scope maps entirely.
 
 So `--only-tools` **narrows both layers at once**: the tool surface *and* the
 OAuth grant. The token you mint can do nothing beyond what those specific tools

--- a/main.py
+++ b/main.py
@@ -741,6 +741,11 @@ def main():
     from auth.scopes import set_enabled_tools, set_read_only, set_explicit_scopes
 
     set_enabled_tools(list(tools_to_import))
+    # Clear any explicit-scope override left from a prior in-process run; only the
+    # --only-tools branch below sets it. Without this reset, a second main() call
+    # in the same process (tests, or an embedded re-init) that does NOT use
+    # --only-tools would reuse the stale exact-scope grant and request wrong scopes.
+    set_explicit_scopes(None)
     if args.read_only:
         set_read_only(True)
 

--- a/main.py
+++ b/main.py
@@ -511,7 +511,9 @@ def main():
                     "WORKSPACE_MCP_TOOL_TIER", _env_tier, "core, extended, or complete"
                 )
             args.tool_tier = _env_tier
-    # Subtractive, so it needs no conflict handling against the allowlist flags.
+    # Subtractive, so it needs no conflict handling against the allowlist flags —
+    # except --only-tools, which derives scopes from its exact list and rejects
+    # the combination below.
     disabled_tools = resolve_disabled_tools(args.disabled_tools)
     set_disabled_tools(disabled_tools)
     if not args.read_only and not _cli_has_permissions:
@@ -595,12 +597,15 @@ def main():
         or args.tool_tier is not None
         or args.permissions is not None
         or args.read_only
+        or disabled_tools
     ):
         print(
             "Error: --only-tools cannot be combined with --tools, --tool-tier, "
-            "--permissions, or --read-only "
+            "--permissions, --read-only, or --disabled-tools "
             "(via CLI flag or WORKSPACE_MCP_* env var). "
-            "--only-tools is an exact per-tool allowlist and selects scopes on its own.",
+            "--only-tools is an exact per-tool allowlist and selects scopes on its "
+            "own — disabling one of its tools would drop it from the surface while "
+            "still requesting its scope, so just omit it from --only-tools instead.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/main.py
+++ b/main.py
@@ -462,6 +462,17 @@ def main():
             "Mutually exclusive with --read-only and --tools."
         ),
     )
+    parser.add_argument(
+        "--only-tools",
+        nargs="+",
+        metavar="TOOL_NAME",
+        help=(
+            "Expose exactly the named tools (per-tool-name allowlist) and request "
+            "only the OAuth scopes those specific tools require. "
+            "Example: --only-tools send_gmail_message manage_drive_access. "
+            "Mutually exclusive with --tools, --tool-tier, --permissions, and --read-only."
+        ),
+    )
     args = parser.parse_args()
 
     # Env var fallbacks for plugin users who configure via userConfig.
@@ -579,6 +590,20 @@ def main():
             file=sys.stderr,
         )
         sys.exit(1)
+    if args.only_tools is not None and (
+        args.tools is not None
+        or args.tool_tier is not None
+        or args.permissions is not None
+        or args.read_only
+    ):
+        print(
+            "Error: --only-tools cannot be combined with --tools, --tool-tier, "
+            "--permissions, or --read-only "
+            "(via CLI flag or WORKSPACE_MCP_* env var). "
+            "--only-tools is an exact per-tool allowlist and selects scopes on its own.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     validate_streamable_http_auth(args.transport)
     resolve_callback_port_for_transport(args.transport)
@@ -638,7 +663,23 @@ def main():
 
     # Determine which tools to import based on arguments
     perms = None
-    if args.permissions:
+    if args.only_tools is not None:
+        from core.tool_tier_loader import ToolTierLoader
+
+        requested = list(dict.fromkeys(args.only_tools))  # de-dup, keep order
+        loader = ToolTierLoader()
+        known_tools = loader.get_all_tool_names()  # the new public helper
+        unknown = [t for t in requested if t not in known_tools]
+        if unknown:
+            print(
+                f"Error: unknown tool name(s) for --only-tools: {', '.join(unknown)}. "
+                f"Each must be a registered tool name (see core/tool_tiers.yaml).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        tools_to_import = sorted(loader.get_services_for_tools(requested))
+        set_enabled_tool_names(set(requested))
+    elif args.permissions:
         # Granular permissions mode — parse and activate before tool selection
         from auth.permissions import parse_permissions_arg, set_permissions
 
@@ -697,7 +738,7 @@ def main():
 
     wrap_server_tool_method(server)
 
-    from auth.scopes import set_enabled_tools, set_read_only
+    from auth.scopes import set_enabled_tools, set_read_only, set_explicit_scopes
 
     set_enabled_tools(list(tools_to_import))
     if args.read_only:
@@ -729,6 +770,32 @@ def main():
     for tool, exc in failed:
         ui.step(f"{tool.title()} failed to load", state="fail")
         ui.detail(str(exc))
+
+    if args.only_tools is not None:
+        from core.tool_registry import get_tool_components
+
+        components = get_tool_components(server)
+        minimal_scopes = set()
+        missing = []
+        for name in args.only_tools:
+            obj = components.get(name)
+            if obj is None:
+                missing.append(name)
+                continue
+            fn = getattr(obj, "fn", obj)
+            minimal_scopes.update(getattr(fn, "_required_google_scopes", []) or [])
+        if missing:
+            print(
+                f"Error: --only-tools selected tool(s) did not register: "
+                f"{', '.join(missing)}.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        set_explicit_scopes(minimal_scopes)
+        safe_print(
+            f"🎯 only-tools: {len(args.only_tools)} tools, "
+            f"{len(minimal_scopes)} minimal scopes"
+        )
 
     if perms:
         ui.blank()

--- a/main.py
+++ b/main.py
@@ -744,16 +744,21 @@ def main():
 
     wrap_server_tool_method(server)
 
+    from auth.permissions import set_permissions as set_permissions_mode
     from auth.scopes import set_enabled_tools, set_read_only, set_explicit_scopes
 
     set_enabled_tools(list(tools_to_import))
-    # Clear any explicit-scope override left from a prior in-process run; only the
-    # --only-tools branch below sets it. Without this reset, a second main() call
-    # in the same process (tests, or an embedded re-init) that does NOT use
-    # --only-tools would reuse the stale exact-scope grant and request wrong scopes.
+    # Clear any state left from a prior in-process run (tests, or an embedded
+    # re-init); each mode below is only (re)enabled by its own flag on THIS run.
+    # Without these resets a later run inherits the earlier run's filters:
+    # filter_server_tools() would apply a stale read-only / permissions mode and
+    # could remove tools the current flags selected — under --only-tools that
+    # turns into a spurious startup failure, and the explicit-scope override
+    # would make a non---only-tools run request the earlier narrow grant.
     set_explicit_scopes(None)
-    if args.read_only:
-        set_read_only(True)
+    set_read_only(bool(args.read_only))
+    if not args.permissions:
+        set_permissions_mode(None)
 
     loaded = []
     failed = []

--- a/main.py
+++ b/main.py
@@ -470,7 +470,8 @@ def main():
             "Expose exactly the named tools (per-tool-name allowlist) and request "
             "only the OAuth scopes those specific tools require. "
             "Example: --only-tools send_gmail_message manage_drive_access. "
-            "Mutually exclusive with --tools, --tool-tier, --permissions, and --read-only."
+            "Mutually exclusive with --tools, --tool-tier, --permissions, "
+            "--read-only, and --disabled-tools."
         ),
     )
     args = parser.parse_args()
@@ -673,12 +674,12 @@ def main():
 
         requested = list(dict.fromkeys(args.only_tools))  # de-dup, keep order
         loader = ToolTierLoader()
-        known_tools = loader.get_all_tool_names()  # the new public helper
+        known_tools = loader.get_all_tool_names()
         unknown = [t for t in requested if t not in known_tools]
         if unknown:
             print(
                 f"Error: unknown tool name(s) for --only-tools: {', '.join(unknown)}. "
-                f"Each must be a registered tool name (see core/tool_tiers.yaml).",
+                f"Each must be a tool name listed in core/tool_tiers.yaml.",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -787,23 +788,40 @@ def main():
         components = get_tool_components(server)
         minimal_scopes = set()
         missing = []
-        for name in args.only_tools:
+        scopeless = []
+        for name in requested:
             obj = components.get(name)
             if obj is None:
                 missing.append(name)
                 continue
             fn = getattr(obj, "fn", obj)
-            minimal_scopes.update(getattr(fn, "_required_google_scopes", []) or [])
+            tool_scopes = getattr(fn, "_required_google_scopes", []) or []
+            if not tool_scopes:
+                scopeless.append(name)
+            minimal_scopes.update(tool_scopes)
         if missing:
             print(
-                f"Error: --only-tools selected tool(s) did not register: "
-                f"{', '.join(missing)}.",
+                f"Error: --only-tools selected tool(s) are not available: "
+                f"{', '.join(missing)}. They validated against core/tool_tiers.yaml "
+                f"but were removed by another startup filter — for example, "
+                f"start_google_auth is unavailable when OAuth 2.1 is enabled.",
                 file=sys.stderr,
             )
             sys.exit(1)
+        if scopeless:
+            # A selected tool declaring no scopes usually means the decorator
+            # metadata moved out from under us — the derived grant would then be
+            # smaller than the tools need and every call would fail at runtime.
+            logger.warning(
+                "--only-tools: %d selected tool(s) declare no Google scopes "
+                "(%s); the derived OAuth grant will not include anything for "
+                "them. If these tools normally need scopes, this is a bug.",
+                len(scopeless),
+                ", ".join(scopeless),
+            )
         set_explicit_scopes(minimal_scopes)
         safe_print(
-            f"🎯 only-tools: {len(args.only_tools)} tools, "
+            f"🎯 only-tools: {len(requested)} tools, "
             f"{len(minimal_scopes)} minimal scopes"
         )
 

--- a/tests/test_only_tools.py
+++ b/tests/test_only_tools.py
@@ -1,0 +1,222 @@
+"""
+Unit tests for the --only-tools CLI flag.
+
+The flag is a per-tool-name allowlist that ALSO requests only those specific
+tools' Google OAuth scopes. It is exercised across three layers:
+
+- core/tool_tier_loader.py: ToolTierLoader.get_all_tool_names() — the union of
+  every tool name across all services/tiers, used to validate requested names.
+- auth/scopes.py: set_explicit_scopes() / _EXPLICIT_SCOPES — when set,
+  get_scopes_for_tools() returns exactly BASE_SCOPES + the explicit scopes,
+  bypassing the service-granular maps.
+- main.py: argparse wiring, the mutual-exclusivity guard, the unknown-tool
+  validation, and the selection branch that resolves services and sets the
+  enabled-tool allowlist.
+
+The post-import scope-union step (reading each registered tool's
+_required_google_scopes off a live FastMCP server) needs a fully-registered
+server, so it is integration-level and covered by a manual smoke test rather
+than here.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Keep these tests independent of a developer's local .env. Importing main loads
+# .env, and OAuth 2.1 mode changes tool schemas at decoration time. Mirrors
+# tests/test_main_permissions_tier.py.
+os.environ["MCP_ENABLE_OAUTH21"] = "false"
+os.environ["WORKSPACE_MCP_STATELESS_MODE"] = "false"
+
+import main  # noqa: E402
+
+from auth.scopes import (  # noqa: E402
+    BASE_SCOPES,
+    GMAIL_SEND_SCOPE,
+    get_scopes_for_tools,
+    set_explicit_scopes,
+)
+from core.tool_tier_loader import ToolTierLoader  # noqa: E402
+import core.tool_registry as tool_registry  # noqa: E402
+
+
+# A couple of tool names that genuinely exist in core/tool_tiers.yaml. We assert
+# their presence rather than hard-coding the full list so the test does not break
+# every time a tool is added or moved between tiers.
+KNOWN_TOOLS = ["send_gmail_message", "search_gmail_messages", "manage_drive_access"]
+
+
+class TestGetAllToolNames:
+    """ToolTierLoader.get_all_tool_names() — the validation source of truth."""
+
+    def test_returns_non_empty_set(self):
+        names = ToolTierLoader().get_all_tool_names()
+        assert isinstance(names, set)
+        assert len(names) > 0
+
+    def test_includes_known_tools(self):
+        """Expectations derived from the real tool_tiers.yaml, not hard-coded."""
+        names = ToolTierLoader().get_all_tool_names()
+        for tool in KNOWN_TOOLS:
+            assert tool in names, f"{tool} should be defined in tool_tiers.yaml"
+
+    def test_is_union_across_all_tiers(self):
+        """The union must cover core + extended + complete for every service."""
+        loader = ToolTierLoader()
+        all_names = loader.get_all_tool_names()
+        # The 'complete' tier (which get_tools_up_to_tier walks through every
+        # tier to build) must be a subset of the full union.
+        complete = set(loader.get_tools_up_to_tier("complete"))
+        assert complete == all_names
+
+
+class TestExplicitScopeOverride:
+    """auth/scopes.py: set_explicit_scopes() short-circuits get_scopes_for_tools()."""
+
+    def setup_method(self):
+        set_explicit_scopes(None)
+
+    def teardown_method(self):
+        # Reset module-global state so other tests don't see a leaked override.
+        set_explicit_scopes(None)
+
+    def test_override_returns_base_plus_exactly_that_scope(self):
+        set_explicit_scopes({GMAIL_SEND_SCOPE})
+        scopes = get_scopes_for_tools()
+
+        expected = set(BASE_SCOPES) | {GMAIL_SEND_SCOPE}
+        assert set(scopes) == expected
+
+    def test_override_ignores_enabled_tool_list(self):
+        """When explicit scopes are set, the passed-in tool list is bypassed."""
+        set_explicit_scopes({GMAIL_SEND_SCOPE})
+        # Asking for 'drive' tools must NOT leak any drive scope.
+        scopes = set(get_scopes_for_tools(["drive", "calendar"]))
+        assert scopes == set(BASE_SCOPES) | {GMAIL_SEND_SCOPE}
+
+    def test_override_returns_unique_scopes(self):
+        set_explicit_scopes({GMAIL_SEND_SCOPE})
+        scopes = get_scopes_for_tools()
+        assert len(scopes) == len(set(scopes))
+
+    def test_clearing_override_reverts_to_normal_behavior(self):
+        set_explicit_scopes({GMAIL_SEND_SCOPE})
+        assert set(get_scopes_for_tools(["drive"])) == set(BASE_SCOPES) | {
+            GMAIL_SEND_SCOPE
+        }
+
+        set_explicit_scopes(None)
+        reverted = get_scopes_for_tools(["drive"])
+        # Normal path adds the drive service scopes on top of base; at minimum it
+        # must no longer be the explicit-only set.
+        assert set(reverted) != set(BASE_SCOPES) | {GMAIL_SEND_SCOPE}
+        assert len(reverted) > len(BASE_SCOPES)
+
+
+class TestSelectionBranch:
+    """main.py selection logic for --only-tools.
+
+    The mutual-exclusivity guard and the unknown-tool validation both run early
+    in main.main() and sys.exit(1) before any server is started, so they are
+    driven the same way tests/test_main_permissions_tier.py drives the
+    permissions/tools guard: monkeypatch sys.argv + expect SystemExit.
+
+    The happy-path *continuation* (importing modules and running the server) is
+    not reachable as a unit, so the resolution it performs is asserted directly
+    against the same helpers main.py calls: ToolTierLoader.get_services_for_tools
+    and the enabled-tool registry.
+    """
+
+    def setup_method(self):
+        tool_registry.set_enabled_tools(None)
+
+    def teardown_method(self):
+        tool_registry.set_enabled_tools(None)
+
+    def test_selection_resolves_services_and_allowlist(self):
+        """--only-tools send_gmail_message manage_drive_access resolves to the
+        gmail + drive services, and the enabled allowlist is exactly that set."""
+        requested = ["send_gmail_message", "manage_drive_access"]
+        loader = ToolTierLoader()
+
+        # Service resolution — the same call main.py makes for tools_to_import.
+        services = loader.get_services_for_tools(requested)
+        assert services == {"gmail", "drive"}
+
+        # Enabled-tool allowlist — main.py calls set_enabled_tool_names(set(...)),
+        # an alias for core.tool_registry.set_enabled_tools.
+        main.set_enabled_tool_names(set(requested))
+        assert tool_registry.get_enabled_tools() == set(requested)
+        assert tool_registry.is_tool_enabled("send_gmail_message")
+        assert tool_registry.is_tool_enabled("manage_drive_access")
+        assert not tool_registry.is_tool_enabled("search_gmail_messages")
+
+    def test_set_enabled_tool_names_is_registry_alias(self):
+        """main.set_enabled_tool_names must be core.tool_registry.set_enabled_tools."""
+        assert main.set_enabled_tool_names is tool_registry.set_enabled_tools
+
+    def test_unknown_tool_name_exits(self, monkeypatch, capsys):
+        monkeypatch.setattr(main, "configure_safe_logging", lambda: None)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["main.py", "--only-tools", "send_gmail_message", "not_a_real_tool"],
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main.main()
+
+        assert exc.value.code == 1
+        assert "unknown tool name" in capsys.readouterr().err.lower()
+
+    def test_combined_with_read_only_exits(self, monkeypatch, capsys):
+        monkeypatch.setattr(main, "configure_safe_logging", lambda: None)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["main.py", "--only-tools", "send_gmail_message", "--read-only"],
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main.main()
+
+        assert exc.value.code == 1
+        assert "--only-tools cannot be combined" in capsys.readouterr().err
+
+    def test_combined_with_tool_tier_exits(self, monkeypatch, capsys):
+        monkeypatch.setattr(main, "configure_safe_logging", lambda: None)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "main.py",
+                "--only-tools",
+                "send_gmail_message",
+                "--tool-tier",
+                "core",
+            ],
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main.main()
+
+        assert exc.value.code == 1
+        assert "--only-tools cannot be combined" in capsys.readouterr().err
+
+    def test_combined_with_tools_exits(self, monkeypatch, capsys):
+        monkeypatch.setattr(main, "configure_safe_logging", lambda: None)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["main.py", "--only-tools", "send_gmail_message", "--tools", "gmail"],
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main.main()
+
+        assert exc.value.code == 1
+        assert "--only-tools cannot be combined" in capsys.readouterr().err

--- a/tests/test_only_tools.py
+++ b/tests/test_only_tools.py
@@ -39,9 +39,12 @@ from auth.scopes import (  # noqa: E402
     GMAIL_SEND_SCOPE,
     get_scopes_for_tools,
     set_explicit_scopes,
+    set_enabled_tools as set_enabled_scope_tools,
+    set_read_only,
 )
 from core.tool_tier_loader import ToolTierLoader  # noqa: E402
 import core.tool_registry as tool_registry  # noqa: E402
+import auth.permissions as permissions  # noqa: E402
 
 
 # A couple of tool names that genuinely exist in core/tool_tiers.yaml. We assert
@@ -77,12 +80,20 @@ class TestGetAllToolNames:
 class TestExplicitScopeOverride:
     """auth/scopes.py: set_explicit_scopes() short-circuits get_scopes_for_tools()."""
 
-    def setup_method(self):
+    def _reset_scope_globals(self):
+        # Clear every global get_scopes_for_tools() consults, so the "normal path"
+        # tests genuinely exercise service-scope derivation instead of a leaked
+        # permissions / read-only short-circuit from another test.
         set_explicit_scopes(None)
+        set_read_only(False)
+        set_enabled_scope_tools(None)
+        permissions.set_permissions(None)
+
+    def setup_method(self):
+        self._reset_scope_globals()
 
     def teardown_method(self):
-        # Reset module-global state so other tests don't see a leaked override.
-        set_explicit_scopes(None)
+        self._reset_scope_globals()
 
     def test_override_returns_base_plus_exactly_that_scope(self):
         set_explicit_scopes({GMAIL_SEND_SCOPE})
@@ -133,6 +144,9 @@ class TestSelectionBranch:
 
     def _reset(self):
         tool_registry.set_enabled_tools(None)
+        # main() applies the disabled-tools block list before the only-tools
+        # guard exits, so a rejected run still leaves it set globally.
+        tool_registry.set_disabled_tools(set())
         set_explicit_scopes(None)
         set_enabled_scope_tools(None)
         set_read_only(False)
@@ -220,6 +234,47 @@ class TestSelectionBranch:
             sys,
             "argv",
             ["main.py", "--only-tools", "send_gmail_message", "--tools", "gmail"],
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main.main()
+
+        assert exc.value.code == 1
+        assert "--only-tools cannot be combined" in capsys.readouterr().err
+
+    def test_combined_with_disabled_tools_exits(self, monkeypatch, capsys):
+        # --only-tools derives a minimal grant from its exact list; layering
+        # --disabled-tools on top would drop a tool from the surface while still
+        # requesting its scope. Reject the combination instead of leaking scope.
+        monkeypatch.setattr(main, "configure_safe_logging", lambda: None)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "main.py",
+                "--only-tools",
+                "send_gmail_message",
+                "manage_drive_access",
+                "--disabled-tools",
+                "manage_drive_access",
+            ],
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main.main()
+
+        assert exc.value.code == 1
+        assert "--only-tools cannot be combined" in capsys.readouterr().err
+
+    def test_combined_with_disabled_tools_env_var_exits(self, monkeypatch, capsys):
+        # The block list also arrives via WORKSPACE_MCP_DISABLED_TOOLS; the guard
+        # must see the resolved set, not just the CLI flag.
+        monkeypatch.setattr(main, "configure_safe_logging", lambda: None)
+        monkeypatch.setenv("WORKSPACE_MCP_DISABLED_TOOLS", "manage_drive_access")
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["main.py", "--only-tools", "send_gmail_message"],
         )
 
         with pytest.raises(SystemExit) as exc:

--- a/tests/test_only_tools.py
+++ b/tests/test_only_tools.py
@@ -341,6 +341,44 @@ class TestSelectionBranch:
             GMAIL_SEND_SCOPE
         }
 
+    def test_stale_filter_modes_cleared_before_tool_filtering(self, monkeypatch):
+        """Read-only / permissions mode from a prior in-process run must not
+        survive into this run's filter_server_tools (CodeRabbit finding on the
+        re-scope). Before the fix, set_read_only was enable-only and permissions
+        mode was never cleared, so a later --only-tools run inherited the stale
+        filters, filter_server_tools removed its selected write tools, and the
+        fail-closed availability check exited with no conflicting current flag.
+
+        Stops at filter_server_tools: the stale modes must already be gone by
+        the time it runs, and stopping there keeps the (destructive) removal
+        from touching the process-global server.
+        """
+        from auth.scopes import is_read_only_mode
+
+        # Simulate the leftovers of an earlier `--read-only --permissions ...` run.
+        set_read_only(True)
+        permissions.set_permissions({"gmail": "readonly"})
+
+        class _StopBeforeFiltering(Exception):
+            pass
+
+        def _stop(*_a, **_k):
+            raise _StopBeforeFiltering()
+
+        monkeypatch.setattr(main, "configure_safe_logging", lambda: None)
+        monkeypatch.setattr(main, "resolve_callback_port_for_transport", lambda t: None)
+        monkeypatch.setattr(main, "validate_streamable_http_auth", lambda t: None)
+        monkeypatch.setattr(main, "filter_server_tools", _stop)
+        monkeypatch.setattr(
+            sys, "argv", ["main.py", "--only-tools", "send_gmail_message"]
+        )
+
+        with pytest.raises(_StopBeforeFiltering):
+            main.main()
+
+        assert not is_read_only_mode()
+        assert permissions.get_permissions() is None
+
 
 class TestScopeDerivationEndToEnd:
     """The headline feature: the post-registration scope union.

--- a/tests/test_only_tools.py
+++ b/tests/test_only_tools.py
@@ -10,16 +10,15 @@ tools' Google OAuth scopes. It is exercised across three layers:
   get_scopes_for_tools() returns exactly BASE_SCOPES + the explicit scopes,
   bypassing the service-granular maps.
 - main.py: argparse wiring, the mutual-exclusivity guard, the unknown-tool
-  validation, and the selection branch that resolves services and sets the
-  enabled-tool allowlist.
-
-The post-import scope-union step (reading each registered tool's
-_required_google_scopes off a live FastMCP server) needs a fully-registered
-server, so it is integration-level and covered by a manual smoke test rather
-than here.
+  validation, the selection branch that resolves services and sets the
+  enabled-tool allowlist, and the post-registration scope-union derivation
+  (driven through a real main() run stopped just after the union is applied —
+  see TestScopeDerivationEndToEnd).
 """
 
+import json
 import os
+import subprocess
 import sys
 
 import pytest
@@ -32,10 +31,26 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 os.environ["MCP_ENABLE_OAUTH21"] = "false"
 os.environ["WORKSPACE_MCP_STATELESS_MODE"] = "false"
 
+# Selection env vars main() folds into args.* before the --only-tools guard runs.
+# A value leaked from the developer's shell (e.g. WORKSPACE_MCP_DISABLED_TOOLS)
+# would trip the mutual-exclusivity guard and turn an unrelated test's expected
+# error into the guard's error. Scrubbed here AND per-test via _scrub_selection_env.
+SELECTION_ENV_VARS = [
+    "WORKSPACE_MCP_TOOLS",
+    "WORKSPACE_MCP_TOOL_TIER",
+    "WORKSPACE_MCP_PERMISSIONS",
+    "WORKSPACE_MCP_READ_ONLY",
+    "WORKSPACE_MCP_DISABLED_TOOLS",
+]
+for _var in SELECTION_ENV_VARS:
+    os.environ.pop(_var, None)
+
 import main  # noqa: E402
 
 from auth.scopes import (  # noqa: E402
     BASE_SCOPES,
+    DRIVE_FILE_SCOPE,
+    GMAIL_READONLY_SCOPE,
     GMAIL_SEND_SCOPE,
     get_scopes_for_tools,
     set_explicit_scopes,
@@ -157,6 +172,16 @@ class TestSelectionBranch:
 
     def teardown_method(self):
         self._reset()
+
+    @pytest.fixture(autouse=True)
+    def _scrub_selection_env(self, monkeypatch):
+        # main() folds these env vars into args.* before the guards run, so a
+        # value leaked from the developer's shell would change WHICH guard
+        # fires (e.g. WORKSPACE_MCP_DISABLED_TOOLS turns the unknown-tool error
+        # into the mutual-exclusivity error). Tests that want one set it
+        # explicitly after this scrub.
+        for var in SELECTION_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
 
     def test_selection_resolves_services_and_allowlist(self):
         """--only-tools send_gmail_message manage_drive_access resolves to the
@@ -315,3 +340,76 @@ class TestSelectionBranch:
         assert set(get_scopes_for_tools(["drive"])) != set(BASE_SCOPES) | {
             GMAIL_SEND_SCOPE
         }
+
+
+class TestScopeDerivationEndToEnd:
+    """The headline feature: the post-registration scope union.
+
+    main() reads each selected tool's ``_required_google_scopes`` off the live
+    FastMCP registry and calls ``set_explicit_scopes`` with exactly that union.
+    If those decorator internals ever move (a rename of ``.fn`` or of the scope
+    attribute), the union silently collapses to the empty set and the OAuth
+    grant shrinks to BASE_SCOPES — consent still succeeds, then every tool call
+    fails at runtime. Only a test that drives a REAL main() run can catch that.
+
+    Runs in a subprocess (same idiom as the streamable-http decoration boot
+    test) because the run registers every tool and then *removes* all but the
+    selected ones from the process-global server — an irreversible mutation
+    that would poison any later test using the shared registry in-process.
+    """
+
+    def test_derived_grant_is_exactly_the_selected_tools_union(self):
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        code = """
+import json, os, sys
+import main
+
+def _stop(*_a, **_k):
+    # Runs INSIDE main() right after the scope union is applied
+    # (set_transport_mode is the next hook), before any server binds a port.
+    # Dump the state and hard-exit here: main() wraps its run in a broad
+    # except Exception, so an exception-based sentinel would be swallowed.
+    from auth.scopes import get_scopes_for_tools
+    from core.tool_registry import get_tool_components
+
+    sys.stdout.write(json.dumps({
+        "scopes": sorted(get_scopes_for_tools()),
+        "surface": sorted(get_tool_components(main.server)),
+    }) + "\\n")
+    sys.stdout.flush()
+    os._exit(0)
+
+main.set_transport_mode = _stop
+sys.argv = ["main.py", "--only-tools", "send_gmail_message", "manage_drive_access"]
+main.main()
+raise SystemExit("main() was not stopped by the sentinel")
+"""
+        env = {
+            **os.environ,
+            "MCP_ENABLE_OAUTH21": "false",
+            "WORKSPACE_MCP_STATELESS_MODE": "false",
+        }
+        for var in SELECTION_ENV_VARS:
+            env.pop(var, None)
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"main() run failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+
+        # The surface is exactly the selected tools — nothing else survived.
+        assert payload["surface"] == ["manage_drive_access", "send_gmail_message"]
+
+        # The grant is exactly base identity + the two tools' declared scopes.
+        # Pinned literally on purpose: if a tool's declaration changes, the
+        # consent screen changes, and this failing is the announcement.
+        assert payload["scopes"] == sorted(
+            set(BASE_SCOPES)
+            | {GMAIL_SEND_SCOPE, GMAIL_READONLY_SCOPE, DRIVE_FILE_SCOPE}
+        )

--- a/tests/test_only_tools.py
+++ b/tests/test_only_tools.py
@@ -131,11 +131,18 @@ class TestSelectionBranch:
     and the enabled-tool registry.
     """
 
-    def setup_method(self):
+    def _reset(self):
         tool_registry.set_enabled_tools(None)
+        set_explicit_scopes(None)
+        set_enabled_scope_tools(None)
+        set_read_only(False)
+        permissions.set_permissions(None)
+
+    def setup_method(self):
+        self._reset()
 
     def teardown_method(self):
-        tool_registry.set_enabled_tools(None)
+        self._reset()
 
     def test_selection_resolves_services_and_allowlist(self):
         """--only-tools send_gmail_message manage_drive_access resolves to the
@@ -220,3 +227,36 @@ class TestSelectionBranch:
 
         assert exc.value.code == 1
         assert "--only-tools cannot be combined" in capsys.readouterr().err
+
+    def test_only_tools_override_does_not_leak_across_runs(self, monkeypatch):
+        """A prior --only-tools run leaves an explicit-scope override on the module
+        global; a later non---only-tools run in the same process must clear it
+        (main() resets it), so get_scopes_for_tools() stops short-circuiting on the
+        stale exact-scope grant."""
+        # Simulate the leftover override from an earlier --only-tools invocation.
+        set_explicit_scopes({GMAIL_SEND_SCOPE})
+        assert set(get_scopes_for_tools(["drive"])) == set(BASE_SCOPES) | {
+            GMAIL_SEND_SCOPE
+        }
+
+        class _StopBeforeServer(Exception):
+            pass
+
+        def _stop(*_a, **_k):
+            raise _StopBeforeServer()
+
+        monkeypatch.setattr(main, "configure_safe_logging", lambda: None)
+        monkeypatch.setattr(main, "resolve_callback_port_for_transport", lambda t: None)
+        monkeypatch.setattr(main, "validate_streamable_http_auth", lambda t: None)
+        # Stop main() right after the scope-setup, before it launches a server.
+        monkeypatch.setattr(main, "filter_server_tools", _stop)
+        monkeypatch.setattr(sys, "argv", ["main.py", "--tools", "gmail"])
+
+        with pytest.raises(_StopBeforeServer):
+            main.main()
+
+        # The override is gone: the normal service-scope path runs instead of the
+        # stale explicit grant.
+        assert set(get_scopes_for_tools(["drive"])) != set(BASE_SCOPES) | {
+            GMAIL_SEND_SCOPE
+        }


### PR DESCRIPTION
## What this adds

`--only-tools` — an exact per-tool allowlist that **also derives the minimal OAuth scope set** from the named tools:

```bash
uv run main.py --only-tools send_gmail_message manage_drive_access
```

1. **Allowlist the tools.** Only the named tools are registered; everything else is removed. The list can be an arbitrary, disjoint subset that crosses service boundaries.
2. **Derive the minimal scope union.** The server reads exactly those tools' declared `_required_google_scopes` and requests only that union plus the base identity scopes. The example above yields a consent screen of `gmail.send` + `gmail.readonly` + `drive.file` and nothing else.

None of the existing selectors can do this: tiers and permission levels are cumulative ladders, `--tools` is whole services, and `--disabled-tools` subtracts tools without narrowing the grant. There is no way today to say "expose exactly these four tools, drawn from three services, and request only the scopes those four need" — you always over-grant scopes or over-expose tools. Full write-up in `docs/only-tools.md`, including an `--only-tools` vs `--disabled-tools` comparison.

**Why we need it:** we run this server behind a gateway as two endpoints with separately-revocable Google grants — a broad read+safe-write endpoint, and a narrow "commit actions" endpoint (send mail, post chat, share files) whose token deliberately holds only the handful of scopes those tools require. `--only-tools` is what makes the narrow endpoint's consent screen minimal. This has been running in production since July.

## Re-scope note (previous reviewers)

This PR originally bundled a second flag, `--exclude-tools` (subtractive blocklist, scopes untouched). Upstream has since shipped `--disabled-tools` (#990), which covers that ground — so **the blocklist half of this PR is withdrawn in favor of the built-in flag**, and the branch was rebuilt on current `main` carrying only the allowlist work. The force-push replacing the old branch content is that re-scope.

`--only-tools` is mutually exclusive with `--tools`, `--tool-tier`, `--permissions`, `--read-only`, and `--disabled-tools` (CLI or env forms): it derives its grant from its exact list, so disabling one of its tools would remove it from the surface while still requesting its scope, silently defeating the minimal grant. The guard checks the resolved block list, so `WORKSPACE_MCP_DISABLED_TOOLS` is caught too. Just omit the tool from the list instead.

## Safety properties

- **Unknown names fail at startup** (validated against `core/tool_tiers.yaml`), so a typo fails loud instead of shipping a smaller surface than intended.
- **A selected tool removed by another startup filter fails at startup** with a message naming the common case (`start_google_auth` under OAuth 2.1). The post-registration check sees every removal, so the surface can never silently diverge from the grant.
- **A selected tool declaring no scopes logs a warning** — the tripwire for decorator-metadata drift, where the derived grant would otherwise silently collapse.
- A stale explicit-scope override from a prior `--only-tools` run is cleared on every startup, so a later non-`--only-tools` run in the same process can't inherit the narrow grant.

## Tests

23 tests in `tests/test_only_tools.py`, including an end-to-end pin that drives a **real `main()` run in a subprocess** (stopped just before the server binds) and asserts both layers literally: the surviving tool surface is exactly the selected tools, and the derived grant is exactly base + `gmail.send` + `gmail.readonly` + `drive.file`. Verified to fail against a simulated rename of the scope attribute. The suite also scrubs the five `WORKSPACE_MCP_*` selection env vars so a value in a developer's shell can't change which startup guard fires. Full suite: 1709 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
