### PR TITLE
feat(sheets): add data validation tools (set/clear + read dropdowns)

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -96,6 +96,7 @@ sheets:
     - manage_spreadsheet_comment
     - manage_conditional_formatting
     - manage_data_validation
+    - read_data_validation
 
 chat:
   core:

--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -95,6 +95,7 @@ sheets:
     - list_spreadsheet_comments
     - manage_spreadsheet_comment
     - manage_conditional_formatting
+    - manage_data_validation
 
 chat:
   core:

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -26,6 +26,7 @@ from gsheets.sheets_helpers import (
     _fetch_detailed_sheet_errors,
     _fetch_grid_metadata,
     _fetch_sheets_with_rules,
+    _format_a1_cell,
     _format_conditional_rules_section,
     _format_sheet_error_section,
     _parse_a1_range,
@@ -2592,3 +2593,130 @@ async def manage_data_validation(
         f"Applied data validation to '{result['range_name']}' in spreadsheet "
         f"{result['spreadsheet_id']} for {user_google_email}: {result['summary']}."
     )
+
+
+async def _read_data_validation_impl(
+    service,
+    spreadsheet_id: str,
+    range_name: str,
+) -> dict:
+    """Internal implementation for read_data_validation (decorator-free for tests)."""
+    metadata = await asyncio.to_thread(
+        service.spreadsheets()
+        .get(
+            spreadsheetId=spreadsheet_id,
+            ranges=[range_name],
+            fields="sheets(properties(title),data(startRow,startColumn,rowData(values(dataValidation))))",
+        )
+        .execute
+    )
+
+    cells = []
+    cells_checked = 0
+    for sheet in metadata.get("sheets", []):
+        title = sheet.get("properties", {}).get("title", "")
+        for data in sheet.get("data", []):
+            start_row = data.get("startRow", 0)
+            start_col = data.get("startColumn", 0)
+            for i, row in enumerate(data.get("rowData", [])):
+                for j, cell in enumerate(row.get("values", [])):
+                    cells_checked += 1
+                    dv = cell.get("dataValidation")
+                    if not dv:
+                        continue
+                    condition = dv.get("condition", {})
+                    cond_values = [
+                        v.get("userEnteredValue") for v in condition.get("values", [])
+                    ]
+                    cells.append(
+                        {
+                            "address": _format_a1_cell(
+                                title, start_row + i, start_col + j
+                            ),
+                            "type": condition.get("type", "UNKNOWN"),
+                            "values": cond_values,
+                            "strict": dv.get("strict", False),
+                            "show_dropdown": dv.get("showCustomUi", False),
+                            "input_message": dv.get("inputMessage"),
+                        }
+                    )
+
+    return {
+        "range_name": range_name,
+        "spreadsheet_id": spreadsheet_id,
+        "cells_checked": cells_checked,
+        "cells_with_validation": cells,
+    }
+
+
+@server.tool(
+    title="Read Data Validation",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("read_data_validation", is_read_only=True, service_type="sheets")
+@require_google_service("sheets", "sheets_read")
+async def read_data_validation(
+    service,
+    user_google_email: str,
+    spreadsheet_id: str,
+    range_name: str,
+) -> str:
+    """
+    Reads the data validation (dropdown) rules currently set on a Google Sheets range.
+
+    Use this to verify what validation a range actually has — for example, to confirm
+    a dropdown set with manage_data_validation landed correctly. Read-only; reports the
+    condition type, the list options or source range, strict vs warn, and whether the
+    dropdown chip is shown, per cell that has a rule.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        spreadsheet_id (str): The ID of the spreadsheet. Required.
+        range_name (str): A1-style range to inspect, optionally with a sheet name
+            (e.g., "Sheet1!C2:C100"). Required.
+
+    Returns:
+        str: A per-cell listing of the validation rules found, or a note that none are set.
+    """
+    logger.info(
+        "[read_data_validation] Email: '%s', Spreadsheet: %s, Range: %s",
+        user_google_email,
+        spreadsheet_id,
+        range_name,
+    )
+
+    result = await _read_data_validation_impl(
+        service=service,
+        spreadsheet_id=spreadsheet_id,
+        range_name=range_name,
+    )
+
+    found = result["cells_with_validation"]
+    if not found:
+        return (
+            f"No data validation found in '{range_name}' of spreadsheet "
+            f"{result['spreadsheet_id']} ({result['cells_checked']} cell(s) checked) "
+            f"for {user_google_email}."
+        )
+
+    lines = [
+        f"Data validation in '{range_name}' of spreadsheet {result['spreadsheet_id']} "
+        f"for {user_google_email} ({len(found)} of {result['cells_checked']} cell(s) have a rule):"
+    ]
+    for c in found:
+        if c["type"] == "ONE_OF_RANGE":
+            source = c["values"][0] if c["values"] else "(unknown)"
+            detail = f"dropdown sourced from {source}"
+        elif c["type"] == "ONE_OF_LIST":
+            detail = f"dropdown list {c['values']}"
+        else:
+            detail = f"{c['type']} {c['values']}"
+        mode = "strict (reject)" if c["strict"] else "warn-only"
+        chip = "chip shown" if c["show_dropdown"] else "no chip"
+        lines.append(f"  {c['address']}: {detail}; {mode}; {chip}")
+    return "\n".join(lines)

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -2438,3 +2438,157 @@ _comment_tools = create_comment_tools("spreadsheet", "spreadsheet_id")
 # Extract and register the functions
 list_spreadsheet_comments = _comment_tools["list_comments"]
 manage_spreadsheet_comment = _comment_tools["manage_comment"]
+
+
+async def _manage_data_validation_impl(
+    service,
+    spreadsheet_id: str,
+    range_name: str,
+    action: str = "set",
+    values: Optional[List[str]] = None,
+    source_range: Optional[str] = None,
+    strict: bool = True,
+    show_dropdown: bool = True,
+    input_message: Optional[str] = None,
+) -> dict:
+    """Internal implementation for manage_data_validation (decorator-free for tests)."""
+    action_normalized = (action or "").strip().lower()
+    if action_normalized not in ("set", "clear"):
+        raise UserInputError("action must be 'set' or 'clear'.")
+
+    if action_normalized == "set" and bool(values) == bool(source_range):
+        raise UserInputError(
+            "For action='set', provide exactly one of 'values' (a list of dropdown "
+            "options) or 'source_range' (an A1 range to source the options from)."
+        )
+
+    metadata = await asyncio.to_thread(
+        service.spreadsheets()
+        .get(
+            spreadsheetId=spreadsheet_id,
+            fields="sheets(properties(sheetId,title))",
+        )
+        .execute
+    )
+    sheets = metadata.get("sheets", [])
+    grid_range = _parse_a1_range(range_name, sheets)
+
+    if action_normalized == "clear":
+        # Omitting 'rule' from setDataValidation clears validation on the range.
+        dv_request = {"range": grid_range}
+        summary = "cleared data validation"
+    else:
+        if values:
+            condition = {
+                "type": "ONE_OF_LIST",
+                "values": [{"userEnteredValue": str(v)} for v in values],
+            }
+            summary = f"set a dropdown with {len(values)} option(s)"
+        else:
+            ref = source_range.strip()
+            if not ref.startswith("="):
+                ref = "=" + ref
+            condition = {
+                "type": "ONE_OF_RANGE",
+                "values": [{"userEnteredValue": ref}],
+            }
+            summary = f"set a dropdown sourced from {source_range}"
+
+        rule = {
+            "condition": condition,
+            "showCustomUi": show_dropdown,
+            "strict": strict,
+        }
+        if input_message:
+            rule["inputMessage"] = input_message
+        dv_request = {"range": grid_range, "rule": rule}
+
+    request_body = {"requests": [{"setDataValidation": dv_request}]}
+    await asyncio.to_thread(
+        service.spreadsheets()
+        .batchUpdate(spreadsheetId=spreadsheet_id, body=request_body)
+        .execute
+    )
+
+    return {
+        "range_name": range_name,
+        "spreadsheet_id": spreadsheet_id,
+        "summary": summary,
+    }
+
+
+@server.tool(
+    title="Manage Data Validation",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("manage_data_validation", service_type="sheets")
+@require_google_service("sheets", "sheets_write")
+async def manage_data_validation(
+    service,
+    user_google_email: str,
+    spreadsheet_id: str,
+    range_name: str,
+    action: str = "set",
+    values: Optional[StringList] = None,
+    source_range: Optional[str] = None,
+    strict: bool = True,
+    show_dropdown: bool = True,
+    input_message: Optional[str] = None,
+) -> str:
+    """
+    Sets or clears data validation (dropdowns) on a Google Sheets range.
+
+    Use this to add a dropdown to cells, either from a fixed list of options or
+    sourced from another range, or to remove validation. To run the dropdown,
+    pick action="set" with exactly one of `values` or `source_range`.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        spreadsheet_id (str): The ID of the spreadsheet. Required.
+        range_name (str): A1-style range to apply validation to, optionally with a
+            sheet name (e.g., "Sheet1!C2:C100"). If no sheet name, the first sheet
+            is used. Required.
+        action (str): "set" to apply a dropdown, "clear" to remove validation.
+            Defaults to "set".
+        values (Optional[List[str]]): The list of allowed dropdown options
+            (action="set" with a fixed list). Mutually exclusive with source_range.
+        source_range (Optional[str]): An A1 range whose cell values populate the
+            dropdown, e.g. "Lists!A1:A20" (the leading "=" is added if omitted).
+            Mutually exclusive with values.
+        strict (bool): If True, reject entries not in the list. If False, warn but
+            allow. Defaults to True.
+        show_dropdown (bool): Show the dropdown arrow chip in the cell. Defaults to True.
+        input_message (Optional[str]): Optional help tooltip shown on the cell.
+
+    Returns:
+        str: Confirmation of the applied or cleared validation.
+    """
+    logger.info(
+        "[manage_data_validation] Action: '%s', Email: '%s', Spreadsheet: %s, Range: %s",
+        action,
+        user_google_email,
+        spreadsheet_id,
+        range_name,
+    )
+
+    result = await _manage_data_validation_impl(
+        service=service,
+        spreadsheet_id=spreadsheet_id,
+        range_name=range_name,
+        action=action,
+        values=values,
+        source_range=source_range,
+        strict=strict,
+        show_dropdown=show_dropdown,
+        input_message=input_message,
+    )
+
+    return (
+        f"Applied data validation to '{result['range_name']}' in spreadsheet "
+        f"{result['spreadsheet_id']} for {user_google_email}: {result['summary']}."
+    )

--- a/tests/gsheets/test_manage_data_validation.py
+++ b/tests/gsheets/test_manage_data_validation.py
@@ -1,0 +1,110 @@
+import pytest
+from unittest.mock import Mock
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gsheets.sheets_tools import _manage_data_validation_impl
+from core.utils import UserInputError
+
+
+def create_mock_service():
+    mock_service = Mock()
+    mock_service.spreadsheets().get().execute = Mock(
+        return_value={
+            "sheets": [{"properties": {"sheetId": 0, "title": "Sheet1"}}]
+        }
+    )
+    mock_service.spreadsheets().batchUpdate().execute = Mock(return_value={})
+    return mock_service
+
+
+def _batch_body(mock_service):
+    call_args = mock_service.spreadsheets().batchUpdate.call_args
+    return call_args[1]["body"]
+
+
+@pytest.mark.asyncio
+async def test_set_list_dropdown_builds_one_of_list():
+    mock_service = create_mock_service()
+    result = await _manage_data_validation_impl(
+        service=mock_service,
+        spreadsheet_id="ss_123",
+        range_name="Sheet1!C2:C100",
+        values=["Open", "Won", "Lost"],
+    )
+    assert result["spreadsheet_id"] == "ss_123"
+    dv = _batch_body(mock_service)["requests"][0]["setDataValidation"]
+    assert dv["range"]["sheetId"] == 0
+    assert dv["rule"]["condition"]["type"] == "ONE_OF_LIST"
+    assert dv["rule"]["condition"]["values"] == [
+        {"userEnteredValue": "Open"},
+        {"userEnteredValue": "Won"},
+        {"userEnteredValue": "Lost"},
+    ]
+    assert dv["rule"]["showCustomUi"] is True
+    assert dv["rule"]["strict"] is True
+
+
+@pytest.mark.asyncio
+async def test_set_range_dropdown_adds_equals_prefix():
+    mock_service = create_mock_service()
+    await _manage_data_validation_impl(
+        service=mock_service,
+        spreadsheet_id="ss_123",
+        range_name="A1:A10",
+        source_range="Lists!A1:A20",
+    )
+    dv = _batch_body(mock_service)["requests"][0]["setDataValidation"]
+    assert dv["rule"]["condition"]["type"] == "ONE_OF_RANGE"
+    assert dv["rule"]["condition"]["values"] == [
+        {"userEnteredValue": "=Lists!A1:A20"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_clear_omits_rule():
+    mock_service = create_mock_service()
+    await _manage_data_validation_impl(
+        service=mock_service,
+        spreadsheet_id="ss_123",
+        range_name="Sheet1!C2:C100",
+        action="clear",
+    )
+    dv = _batch_body(mock_service)["requests"][0]["setDataValidation"]
+    assert "rule" not in dv
+    assert dv["range"]["sheetId"] == 0
+
+
+@pytest.mark.asyncio
+async def test_set_requires_exactly_one_source():
+    mock_service = create_mock_service()
+    # neither values nor source_range
+    with pytest.raises(UserInputError):
+        await _manage_data_validation_impl(
+            service=mock_service,
+            spreadsheet_id="ss_123",
+            range_name="A1:A10",
+        )
+    # both provided
+    with pytest.raises(UserInputError):
+        await _manage_data_validation_impl(
+            service=mock_service,
+            spreadsheet_id="ss_123",
+            range_name="A1:A10",
+            values=["X"],
+            source_range="Lists!A1:A5",
+        )
+
+
+@pytest.mark.asyncio
+async def test_invalid_action_rejected():
+    mock_service = create_mock_service()
+    with pytest.raises(UserInputError):
+        await _manage_data_validation_impl(
+            service=mock_service,
+            spreadsheet_id="ss_123",
+            range_name="A1:A10",
+            action="delete",
+        )

--- a/tests/gsheets/test_read_data_validation.py
+++ b/tests/gsheets/test_read_data_validation.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import Mock
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gsheets.sheets_tools import _read_data_validation_impl
+
+
+def _service_with(rowdata, start_row=1, start_col=2, title="Sheet1"):
+    mock_service = Mock()
+    mock_service.spreadsheets().get().execute = Mock(
+        return_value={
+            "sheets": [
+                {
+                    "properties": {"title": title},
+                    "data": [
+                        {
+                            "startRow": start_row,
+                            "startColumn": start_col,
+                            "rowData": rowdata,
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    return mock_service
+
+
+@pytest.mark.asyncio
+async def test_reads_list_and_range_rules_with_addresses():
+    rowdata = [
+        {
+            "values": [
+                {
+                    "dataValidation": {
+                        "condition": {
+                            "type": "ONE_OF_LIST",
+                            "values": [
+                                {"userEnteredValue": "Open"},
+                                {"userEnteredValue": "Won"},
+                            ],
+                        },
+                        "strict": True,
+                        "showCustomUi": True,
+                    }
+                }
+            ]
+        },
+        {"values": [{}]},  # no validation on this cell
+        {
+            "values": [
+                {
+                    "dataValidation": {
+                        "condition": {
+                            "type": "ONE_OF_RANGE",
+                            "values": [{"userEnteredValue": "=Lists!A1:A10"}],
+                        },
+                        "strict": False,
+                        "showCustomUi": True,
+                    }
+                }
+            ]
+        },
+    ]
+    service = _service_with(rowdata, start_row=1, start_col=2)  # origin C2
+    result = await _read_data_validation_impl(
+        service=service, spreadsheet_id="ss_1", range_name="Sheet1!C2:C4"
+    )
+
+    cells = result["cells_with_validation"]
+    assert result["cells_checked"] == 3
+    assert len(cells) == 2
+
+    first = cells[0]
+    assert first["address"] == "Sheet1!C2"
+    assert first["type"] == "ONE_OF_LIST"
+    assert first["values"] == ["Open", "Won"]
+    assert first["strict"] is True
+    assert first["show_dropdown"] is True
+
+    second = cells[1]
+    assert second["address"] == "Sheet1!C4"
+    assert second["type"] == "ONE_OF_RANGE"
+    assert second["values"] == ["=Lists!A1:A10"]
+    assert second["strict"] is False
+
+
+@pytest.mark.asyncio
+async def test_no_validation_returns_empty_list():
+    rowdata = [{"values": [{}]}, {"values": [{}]}]
+    service = _service_with(rowdata)
+    result = await _read_data_validation_impl(
+        service=service, spreadsheet_id="ss_1", range_name="Sheet1!C2:C3"
+    )
+    assert result["cells_with_validation"] == []
+    assert result["cells_checked"] == 2


### PR DESCRIPTION
## What
Adds two complementary Google Sheets data-validation (dropdown) tools:
- `manage_data_validation` — set or clear validation on a range
- `read_data_validation` — read back the validation rule on each cell (read-only)

## Why
The server can format cells (`format_sheet_range`) and manage conditional formatting (`manage_conditional_formatting`), but there was no way to add a data-validation dropdown, nor to read one back to verify it. These fill that gap and pair naturally: set a dropdown, then confirm it.

## Behavior
**`manage_data_validation`** (write)
- `action="set"` + `values=[...]` → fixed-list dropdown (`ONE_OF_LIST`)
- `action="set"` + `source_range="Lists!A1:A20"` → range-sourced dropdown (`ONE_OF_RANGE`; a leading `=` is added if omitted)
- `action="clear"` → removes validation on the range
- Options: `strict` (reject vs. warn), `show_dropdown` (the chip / `showCustomUi`), `input_message`

**`read_data_validation`** (read-only)
- Inspects a range and returns, for each cell that has a rule: A1 address, condition type, the list options or source range, `strict`, and whether the dropdown chip is shown.

## Implementation notes
- Mirrors existing patterns: split `_impl` + decorated tool, `_parse_a1_range` / `_format_a1_cell` helpers, `asyncio.to_thread(...)`.
- `read_data_validation` uses `spreadsheets.get` with `fields=…dataValidation…` (sheets **read** scope only); `manage_data_validation` uses the existing sheets **write** scope. No new OAuth scopes.
- Both registered under `sheets` → `complete` tier in `core/tool_tiers.yaml`.
- Adds `tests/gsheets/test_manage_data_validation.py` and `tests/gsheets/test_read_data_validation.py`.

## Testing
`uv run pytest tests/gsheets/test_manage_data_validation.py tests/gsheets/test_read_data_validation.py` → 7 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing Google Sheets dropdown/data-validation rules.
  * Added a way to inspect existing validation rules on cells, including type, allowed values, and settings.

* **Bug Fixes**
  * Improved handling of validation inputs so only valid combinations are accepted.
  * Clearer cell-level reporting when checking validation across a range.

* **Tests**
  * Added coverage for creating, clearing, and reading validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->