### PR TITLE
fix(gappsscript): wrap deployment update body in deploymentConfig (#836)

### DIFF
--- a/gappsscript/apps_script_tools.py
+++ b/gappsscript/apps_script_tools.py
@@ -531,6 +531,7 @@ async def manage_deployment(
     deployment_id: Optional[str] = None,
     description: Optional[str] = None,
     version_description: Optional[str] = None,
+    version_number: Optional[int] = None,
 ) -> str:
     """
     Manages Apps Script deployments. Supports creating, updating, and deleting deployments.
@@ -543,6 +544,8 @@ async def manage_deployment(
         deployment_id: The deployment ID (required for update and delete)
         description: Deployment description (required for create and update)
         version_description: Optional version description (for create only)
+        version_number: Version number to point the deployment at (for update only).
+            Required to roll a deployment forward to a newly created script version.
 
     Returns:
         str: Formatted string with deployment details or confirmation
@@ -560,7 +563,12 @@ async def manage_deployment(
         if description is None or description.strip() == "":
             raise ValueError("description is required for update action")
         return await _update_deployment_impl(
-            service, user_google_email, script_id, deployment_id, description
+            service,
+            user_google_email,
+            script_id,
+            deployment_id,
+            description,
+            version_number,
         )
     elif action == "delete":
         if not deployment_id:
@@ -642,15 +650,27 @@ async def _update_deployment_impl(
     script_id: str,
     deployment_id: str,
     description: Optional[str] = None,
+    version_number: Optional[int] = None,
 ) -> str:
-    """Internal implementation for update_deployment."""
+    """Internal implementation for update_deployment.
+
+    The Apps Script ``projects.deployments.update`` endpoint expects every
+    field nested inside a ``deploymentConfig`` object; sending them at the top
+    level fails with ``400 Invalid JSON payload``. ``scriptId`` is always part
+    of the config, and ``versionNumber`` is required to repoint a deployment at
+    a newer script version.
+    """
     logger.info(
         f"[update_deployment] Email: {user_google_email}, Script: {script_id}, Deployment: {deployment_id}"
     )
 
-    request_body = {}
+    deployment_config: Dict[str, Any] = {"scriptId": script_id}
+    if version_number is not None:
+        deployment_config["versionNumber"] = version_number
     if description:
-        request_body["description"] = description
+        deployment_config["description"] = description
+
+    request_body = {"deploymentConfig": deployment_config}
 
     deployment = await asyncio.to_thread(
         service.projects()
@@ -659,10 +679,17 @@ async def _update_deployment_impl(
         .execute
     )
 
+    deployment_config_resp = deployment.get("deploymentConfig", {})
+    resolved_version = deployment_config_resp.get("versionNumber", version_number)
+    resolved_description = deployment_config_resp.get(
+        "description", deployment.get("description", "No description")
+    )
+
     output = [
         f"Updated deployment: {deployment_id}",
         f"Script: {script_id}",
-        f"Description: {deployment.get('description', 'No description')}",
+        f"Version: {resolved_version if resolved_version is not None else 'unchanged'}",
+        f"Description: {resolved_description}",
     ]
 
     logger.info(f"[update_deployment] Updated deployment {deployment_id}")

--- a/gappsscript/apps_script_tools.py
+++ b/gappsscript/apps_script_tools.py
@@ -542,7 +542,8 @@ async def manage_deployment(
         action: Action to perform - "create", "update", or "delete"
         script_id: The script project ID
         deployment_id: The deployment ID (required for update and delete)
-        description: Deployment description (required for create and update)
+        description: Deployment description (required for create; optional for update
+            when version_number is supplied)
         version_description: Optional version description (for create only)
         version_number: Version number to point the deployment at (for update only).
             Required to roll a deployment forward to a newly created script version.
@@ -560,8 +561,11 @@ async def manage_deployment(
     elif action == "update":
         if not deployment_id:
             raise ValueError("deployment_id is required for update action")
-        if description is None or description.strip() == "":
-            raise ValueError("description is required for update action")
+        has_description = description is not None and description.strip() != ""
+        if not has_description and version_number is None:
+            raise ValueError(
+                "description or version_number is required for update action"
+            )
         return await _update_deployment_impl(
             service,
             user_google_email,

--- a/tests/gappsscript/test_apps_script_tools.py
+++ b/tests/gappsscript/test_apps_script_tools.py
@@ -237,11 +237,14 @@ async def test_list_deployments():
 
 @pytest.mark.asyncio
 async def test_update_deployment():
-    """Test updating deployment"""
+    """Test updating deployment wraps fields in deploymentConfig (issue #836)."""
     mock_service = Mock()
     mock_response = {
         "deploymentId": "deploy123",
-        "description": "Updated description",
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "description": "Updated description",
+        },
     }
 
     mock_service.projects().deployments().update().execute.return_value = mock_response
@@ -254,7 +257,58 @@ async def test_update_deployment():
         description="Updated description",
     )
 
+    # The Apps Script API rejects a flat body; fields must live under
+    # ``deploymentConfig`` and the config must always carry ``scriptId``.
+    _, update_kwargs = mock_service.projects().deployments().update.call_args
+    assert update_kwargs["scriptId"] == "test123"
+    assert update_kwargs["deploymentId"] == "deploy123"
+    assert update_kwargs["body"] == {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "description": "Updated description",
+        }
+    }
+    assert "description" not in update_kwargs["body"]
+
     assert "Updated deployment: deploy123" in result
+    assert "Updated description" in result
+
+
+@pytest.mark.asyncio
+async def test_update_deployment_with_version_number():
+    """Updating with a version_number repoints the deployment (issue #836)."""
+    mock_service = Mock()
+    mock_response = {
+        "deploymentId": "deploy123",
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 2,
+            "description": "v2 - updated layout",
+        },
+    }
+
+    mock_service.projects().deployments().update().execute.return_value = mock_response
+
+    result = await _update_deployment_impl(
+        service=mock_service,
+        user_google_email="test@example.com",
+        script_id="test123",
+        deployment_id="deploy123",
+        description="v2 - updated layout",
+        version_number=2,
+    )
+
+    _, update_kwargs = mock_service.projects().deployments().update.call_args
+    assert update_kwargs["body"] == {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 2,
+            "description": "v2 - updated layout",
+        }
+    }
+
+    assert "Version: 2" in result
+    assert "v2 - updated layout" in result
 
 
 @pytest.mark.asyncio

--- a/tests/gappsscript/test_apps_script_tools.py
+++ b/tests/gappsscript/test_apps_script_tools.py
@@ -32,6 +32,7 @@ from gappsscript.apps_script_tools import (
     _get_version_impl,
     _get_script_metrics_impl,
     _generate_trigger_code_impl,
+    manage_deployment,
     run_script_function,
 )
 
@@ -309,6 +310,39 @@ async def test_update_deployment_with_version_number():
 
     assert "Version: 2" in result
     assert "v2 - updated layout" in result
+
+
+@pytest.mark.asyncio
+async def test_manage_deployment_update_allows_version_number_without_description():
+    """The public update branch allows roll-forward updates without a description."""
+    mock_service = Mock()
+    mock_response = {
+        "deploymentId": "deploy123",
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 2,
+        },
+    }
+    mock_service.projects().deployments().update().execute.return_value = mock_response
+
+    undecorated_manage_deployment = manage_deployment.__wrapped__.__wrapped__
+    result = await undecorated_manage_deployment(
+        service=mock_service,
+        user_google_email="test@example.com",
+        action="update",
+        script_id="test123",
+        deployment_id="deploy123",
+        version_number=2,
+    )
+
+    _, update_kwargs = mock_service.projects().deployments().update.call_args
+    assert update_kwargs["body"] == {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 2,
+        }
+    }
+    assert "Version: 2" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`_update_deployment_impl` sent fields at the top level of the request body, which the Apps Script `projects.deployments.update` endpoint rejects with `400 Invalid JSON payload received. Unknown name "description"`. All fields must be nested inside a `deploymentConfig` object, which must also carry `scriptId`.

Also adds an optional `version_number` so an update can repoint a deployment at a newly created script version (without it the update is a no-op even once the wrapper is fixed). `manage_deployment` now forwards `version_number` for the update action.

Updates the existing test to assert the wrapped body shape and adds a test covering the version-number path.

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Add any other context about the pull request here.

---

**⚠️ IMPORTANT:** This repository requires that you enable "Allow edits from maintainers" when creating your pull request. This allows maintainers to make small fixes and improvements directly to your branch, speeding up the review process.

To enable this setting:
1. When creating the PR, check the "Allow edits from maintainers" checkbox
2. If you've already created the PR, you can enable this in the PR sidebar under "Allow edits from maintainers"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment updates can now target a specific script version, using a version number (optionally without changing the description).
  * Deployment update results now include the resolved version number in the output.
* **Bug Fixes**
  * Deployment update requests and responses were aligned so description and version details are handled consistently after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->