### PR TITLE
perf: defer GoogleProvider/Flow/external-oauth-provider imports until actually used

### DIFF
--- a/auth/auth_info_middleware.py
+++ b/auth/auth_info_middleware.py
@@ -9,7 +9,6 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.server.dependencies import get_access_token
 from fastmcp.server.dependencies import get_http_headers
 
-from auth.external_oauth_provider import get_session_time
 from auth.oauth21_session_store import ensure_session_from_access_token
 from auth.oauth_types import WorkspaceAccessToken
 
@@ -126,7 +125,17 @@ class AuthInfoMiddleware(Middleware):
                                             access_token = verified_auth
                                         else:
                                             # Standard GoogleProvider returns a base AccessToken;
-                                            # wrap it in WorkspaceAccessToken for identical downstream handling
+                                            # wrap it in WorkspaceAccessToken for identical downstream handling.
+                                            # Imported here (not at module top) so importing this
+                                            # middleware doesn't drag in `auth.external_oauth_provider`
+                                            # (and transitively GoogleProvider's whole FastMCP
+                                            # OAuth-proxy stack) unless a token actually needs
+                                            # wrapping — mirrors the existing lazy
+                                            # `from core.server import get_auth_provider` import above.
+                                            from auth.external_oauth_provider import (
+                                                get_session_time,
+                                            )
+
                                             verified_expires = getattr(
                                                 verified_auth, "expires_at", None
                                             )

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -8,11 +8,10 @@ import logging
 import os
 import webbrowser
 
-from typing import List, Optional, Tuple, Dict, Any
+from typing import List, Optional, Tuple, Dict, Any, TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
 from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import Flow
 from google.auth.transport.requests import Request
 from google.auth.exceptions import RefreshError
 from googleapiclient.discovery import build
@@ -34,6 +33,18 @@ try:
     from fastmcp.server.dependencies import get_context as get_fastmcp_context
 except ImportError:
     get_fastmcp_context = None
+
+if TYPE_CHECKING:
+    from google_auth_oauthlib.flow import Flow
+else:
+    # Deferred at runtime (see the lazy import in create_oauth_flow below): this
+    # single import pulls in the whole google_auth_oauthlib package (including
+    # the `.interactive` submodule), which costs ~700ms of import time and is
+    # only needed when actually *starting* a new OAuth flow — never when
+    # serving tool calls off already-cached, refreshed credentials. Kept as a
+    # real (if `None`) module attribute so it stays a valid
+    # `monkeypatch`/`patch` target for anything that patches the whole name.
+    Flow = None
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -326,8 +337,17 @@ def create_oauth_flow(
     state: Optional[str] = None,
     code_verifier: Optional[str] = None,
     autogenerate_code_verifier: bool = True,
-) -> Flow:
+) -> "Flow":
     """Creates an OAuth flow using environment variables or client secrets file."""
+    # Imported lazily (module-global-cached) so importing this module — which
+    # every code path does, including a plain `--help` — doesn't pay the
+    # ~700ms google_auth_oauthlib import cost unless a NEW auth flow is
+    # actually being started. `global` + the NameError guard keep `Flow`
+    # patchable at the module level (existing tests do
+    # `patch("auth.google_auth.Flow.from_client_config", ...)`).
+    global Flow
+    if Flow is None:
+        from google_auth_oauthlib.flow import Flow
     flow_kwargs = {
         "scopes": scopes,
         "redirect_uri": redirect_uri,

--- a/core/server.py
+++ b/core/server.py
@@ -4,7 +4,7 @@ import asyncio
 import hashlib
 import logging
 import os
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 from importlib import metadata
 from urllib.parse import urlparse, ParseResult
 
@@ -35,7 +35,6 @@ from core.config import (
 )
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
 from fastmcp import FastMCP
-from fastmcp.server.auth.providers.google import GoogleProvider
 from mcp.types import ToolAnnotations, Icon
 from starlette.applications import Starlette
 from starlette.datastructures import MutableHeaders
@@ -43,10 +42,22 @@ from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.types import ASGIApp, Scope, Receive, Send
 
+if TYPE_CHECKING:
+    from fastmcp.server.auth.providers.google import GoogleProvider
+else:
+    # Deferred at runtime (see the lazy import in configure_server_for_http's
+    # "Standard OAuth 2.1 mode" branch below): this class pulls in FastMCP's
+    # OAuth-proxy stack, which costs ~650ms of import time and is only ever
+    # needed when protocol-level OAuth 2.1 auth is actually configured. Legacy
+    # OAuth 2.0 mode (the default) never touches it. Kept as a real (if `None`)
+    # module attribute — not omitted — so it stays a valid
+    # `monkeypatch.setattr(server_module, "GoogleProvider", Fake)` target.
+    GoogleProvider = None
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-_auth_provider: Optional[GoogleProvider] = None
+_auth_provider: Optional["GoogleProvider"] = None
 _legacy_callback_registered = False
 
 session_middleware = Middleware(MCPSessionMiddleware)
@@ -635,7 +646,18 @@ def configure_server_for_http():
                     "Protected resource metadata points to Google's authorization server"
                 )
             else:
-                # Standard OAuth 2.1 mode: use FastMCP's GoogleProvider
+                # Standard OAuth 2.1 mode: use FastMCP's GoogleProvider. Imported
+                # lazily (module-global-cached) so a `--transport stdio` process
+                # using legacy OAuth 2.0 (this branch never runs) doesn't pay the
+                # ~650ms FastMCP OAuth-proxy import cost on every cold start.
+                # `global` + the NameError guard keep `GoogleProvider` patchable
+                # at the module level (tests do
+                # `monkeypatch.setattr(server_module, "GoogleProvider", Fake)`).
+                global GoogleProvider
+                if GoogleProvider is None:
+                    from fastmcp.server.auth.providers.google import (
+                        GoogleProvider,
+                    )
                 allowed_client_redirect_uris = _parse_allowed_redirect_uris(
                     os.getenv("WORKSPACE_MCP_ALLOWED_CLIENT_REDIRECT_URIS")
                 )
@@ -694,7 +716,7 @@ def configure_server_for_http():
         _ensure_legacy_callback_route()
 
 
-def get_auth_provider() -> Optional[GoogleProvider]:
+def get_auth_provider() -> Optional["GoogleProvider"]:
     """Gets the global authentication provider instance."""
     return _auth_provider
 

--- a/core/server.py
+++ b/core/server.py
@@ -4,7 +4,7 @@ import asyncio
 import hashlib
 import logging
 import os
-from typing import List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional, Protocol, TYPE_CHECKING
 from importlib import metadata
 from urllib.parse import urlparse, ParseResult
 
@@ -54,10 +54,20 @@ else:
     # `monkeypatch.setattr(server_module, "GoogleProvider", Fake)` target.
     GoogleProvider = None
 
+
+class _AuthProvider(Protocol):
+    """Structural type for the cached provider — GoogleProvider and its
+    ExternalOAuthProvider subclass (see auth/external_oauth_provider.py) are
+    both stored in `_auth_provider`; this covers the shared interface
+    `AuthInfoMiddleware` actually calls without over-narrowing to one type."""
+
+    async def verify_token(self, token: str) -> Any: ...
+
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-_auth_provider: Optional["GoogleProvider"] = None
+_auth_provider: Optional[_AuthProvider] = None
 _legacy_callback_registered = False
 
 session_middleware = Middleware(MCPSessionMiddleware)
@@ -716,7 +726,7 @@ def configure_server_for_http():
         _ensure_legacy_callback_route()
 
 
-def get_auth_provider() -> Optional["GoogleProvider"]:
+def get_auth_provider() -> Optional[_AuthProvider]:
     """Gets the global authentication provider instance."""
     return _auth_provider
 

--- a/tests/auth/test_google_auth_pkce.py
+++ b/tests/auth/test_google_auth_pkce.py
@@ -29,7 +29,7 @@ def test_create_oauth_flow_autogenerates_verifier_when_missing():
             return_value=DUMMY_CLIENT_CONFIG,
         ),
         patch(
-            "auth.google_auth.Flow.from_client_config",
+            "google_auth_oauthlib.flow.Flow.from_client_config",
             return_value=expected_flow,
         ) as mock_from_client_config,
     ):
@@ -54,7 +54,7 @@ def test_create_oauth_flow_preserves_callback_verifier():
             return_value=DUMMY_CLIENT_CONFIG,
         ),
         patch(
-            "auth.google_auth.Flow.from_client_config",
+            "google_auth_oauthlib.flow.Flow.from_client_config",
             return_value=expected_flow,
         ) as mock_from_client_config,
     ):
@@ -78,7 +78,7 @@ def test_create_oauth_flow_file_config_still_enables_pkce():
         patch("auth.google_auth.load_client_secrets_from_env", return_value=None),
         patch("auth.google_auth.os.path.exists", return_value=True),
         patch(
-            "auth.google_auth.Flow.from_client_secrets_file",
+            "google_auth_oauthlib.flow.Flow.from_client_secrets_file",
             return_value=expected_flow,
         ) as mock_from_file,
     ):
@@ -102,7 +102,7 @@ def test_create_oauth_flow_allows_disabling_autogenerate_without_verifier():
             return_value=DUMMY_CLIENT_CONFIG,
         ),
         patch(
-            "auth.google_auth.Flow.from_client_config",
+            "google_auth_oauthlib.flow.Flow.from_client_config",
             return_value=expected_flow,
         ) as mock_from_client_config,
     ):


### PR DESCRIPTION
Closes #896

## Summary

Three unconditional top-level imports pull in the full FastMCP OAuth-proxy stack (`authlib`, `joserfc`, `key_value.aio`) and the full `google_auth_oauthlib` stack (`oauthlib`, `requests_oauthlib`) on **every** process spawn — even `--help`, even in the common legacy-OAuth-2.0/stdio configuration that never reaches any of the code paths that actually need them. This patch defers all three to lazy, module-global-cached imports, only paid if the owning branch is ever reached.

See #896 for the full profiling writeup and root-cause detail.

## What changed

- **`core/server.py`** — `GoogleProvider` is only ever instantiated inside `configure_server_for_http()`'s "Standard OAuth 2.1 mode" branch. Import deferred there.
- **`auth/google_auth.py`** — `Flow` is only used inside `create_oauth_flow()` (starting a *new* interactive auth flow — never when serving tool calls off cached, refreshed credentials). Import deferred there.
- **`auth/auth_info_middleware.py`** — importing `auth.external_oauth_provider` at all drags in `GoogleProvider` too (`ExternalOAuthProvider(GoogleProvider)` subclasses it at module scope) via a path independent of `core/server.py`'s own import — so fixing (1) alone doesn't help unless this one is fixed too. `get_session_time()` is only reached inside the non-`WorkspaceAccessToken` branch; import deferred right above its one call site (mirrors the existing local `from core.server import get_auth_provider` import already a few lines up in the same method).

Pattern used for all three: keep the name as a real module attribute initialized to `None` (`if TYPE_CHECKING: from ... import X else: X = None`), then at the point of use: `global X; if X is None: from ... import X`. This keeps every name a valid `monkeypatch.setattr(module, "Name", Fake)` target (matches the existing lazy-singleton-via-module-global convention already used elsewhere in this codebase — `auth/credential_store.py`, `auth/oauth_config.py`, `auth/scopes.py`, `core/tool_registry.py`, `auth/permissions.py`). `Flow`'s existing tests (`tests/auth/test_google_auth_pkce.py`) needed their `patch(...)` targets updated from `auth.google_auth.Flow.*` to `google_auth_oauthlib.flow.Flow.*` directly — patching a nested attribute (`Flow.from_client_config`) requires the class to already be resolvable at patch-setup time, which a `None` sentinel can't satisfy. `GoogleProvider`'s tests didn't need this since they patch the whole name, not a sub-attribute.

## Verification

- `sys.modules` check after `import main`: none of `fastmcp.server.auth.providers.google`, `fastmcp.server.auth.oauth_proxy`, `google_auth_oauthlib`, or `auth.external_oauth_provider` load in the default config.
- Full `python -X importtime` module-graph diff (patched vs. unpatched): **278 modules imported only in the unpatched build, zero imported only in the patched one.**
- `uv run --frozen pytest -q`: 1265 passed / 2 skipped, same single pre-existing failure (`tests/gforms/test_forms_tools.py::test_set_publish_settings_builds_publish_state_body`) present on unmodified `main` too — unrelated, not touched by this change.
- `ruff check .`: clean.

## Known trade-off

Because `GoogleProvider`/`Flow` are literally `None` until first real use, `typing.get_type_hints()` called on `create_oauth_flow`, `get_auth_provider`, or the containing modules *before* either lazy import has fired resolves the forward-ref annotation to `NoneType` silently. Currently inert — neither function is `@server.tool()`-decorated and the repo has no mypy/pyright/Sphinx step that would trip on it — but flagging it as an accepted trade-off of keeping these names monkeypatch-compatible, in case that changes later.

## Scope note

This is deliberately scoped to the import-time cost only. #832/#842 already fixed the *other* half of stdio cold-start (eager OAuth/attachment-callback HTTP server bind) — not revisited here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication startup behavior by deferring imports for Google OAuth components until an OAuth flow is actually created.
  * Preserved existing sign-in, token verification, and session timing behavior while making OAuth handling more reliable.

* **Tests**
  * Updated OAuth PKCE-related tests to patch the upstream OAuth flow constructor methods instead of the module-level flow symbol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->