### PR TITLE
slides: surface sheetsChart / image / video / wordArt in get_page

### DIFF
--- a/gforms/forms_tools.py
+++ b/gforms/forms_tools.py
@@ -286,7 +286,7 @@ async def set_publish_settings(
                 "isAcceptingResponses": is_accepting_responses,
             }
         },
-        "updateMask": "publishState",
+        "updateMask": "publishState.isPublished,publishState.isAcceptingResponses",
     }
 
     await asyncio.to_thread(

--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -74,7 +74,8 @@ def _describe_elements(
     Non-shape elements surface the identifying metadata a caller needs to act on
     them in a follow-up batch_update: a linked ``sheetsChart`` exposes its source
     ``spreadsheetId``/``chartId`` (so the source data can be edited and the chart
-    refreshed via ``refreshSheetsChart``), and images/videos expose their source.
+    refreshed via ``refreshSheetsChart``), and images/videos expose their source
+    or rendered content URL when available.
     """
     info: List[str] = []
     for element in elements or []:
@@ -114,8 +115,17 @@ def _describe_elements(
             )
         elif "image" in element:
             image = element["image"]
-            source = image.get("sourceUrl") or image.get("contentUrl") or "Unknown"
-            info.append(f"{indent}Image: ID {element_id}, Source: {source}")
+            source = image.get("sourceUrl")
+            if source:
+                info.append(f"{indent}Image: ID {element_id}, Source: {source}")
+            else:
+                content_url = image.get("contentUrl")
+                if content_url:
+                    info.append(
+                        f"{indent}Image: ID {element_id}, ContentURL: {content_url}"
+                    )
+                else:
+                    info.append(f"{indent}Image: ID {element_id}, Source: Unknown")
         elif "video" in element:
             video = element["video"]
             info.append(

--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -70,6 +70,11 @@ def _describe_elements(
     Recurses into elementGroup.children with deeper indentation so grouped shapes
     and their text are visible. Multi-line shape text is rendered as indented
     blockquote-style lines preserving paragraph structure.
+
+    Non-shape elements surface the identifying metadata a caller needs to act on
+    them in a follow-up batch_update: a linked ``sheetsChart`` exposes its source
+    ``spreadsheetId``/``chartId`` (so the source data can be edited and the chart
+    refreshed via ``refreshSheetsChart``), and images/videos expose their source.
     """
     info: List[str] = []
     for element in elements or []:
@@ -100,6 +105,29 @@ def _describe_elements(
         elif "line" in element:
             line_type = element["line"].get("lineType", "Unknown")
             info.append(f"{indent}Line: ID {element_id}, Type: {line_type}")
+        elif "sheetsChart" in element:
+            chart = element["sheetsChart"]
+            info.append(
+                f"{indent}SheetsChart: ID {element_id}, "
+                f"SpreadsheetID {chart.get('spreadsheetId', 'Unknown')}, "
+                f"ChartID {chart.get('chartId', 'Unknown')}"
+            )
+        elif "image" in element:
+            image = element["image"]
+            source = image.get("sourceUrl") or image.get("contentUrl") or "Unknown"
+            info.append(f"{indent}Image: ID {element_id}, Source: {source}")
+        elif "video" in element:
+            video = element["video"]
+            info.append(
+                f"{indent}Video: ID {element_id}, "
+                f"Source: {video.get('source', 'Unknown')}, VideoID: {video.get('id', 'Unknown')}"
+            )
+        elif "wordArt" in element:
+            rendered = element["wordArt"].get("renderedText", "")
+            if rendered:
+                info.append(f'{indent}WordArt: ID {element_id}, Text: "{rendered}"')
+            else:
+                info.append(f"{indent}WordArt: ID {element_id}")
         elif "elementGroup" in element:
             children = element["elementGroup"].get("children", [])
             info.append(f"{indent}Group: ID {element_id}, Children: {len(children)}")

--- a/tests/test_slides_tools.py
+++ b/tests/test_slides_tools.py
@@ -409,14 +409,16 @@ def test_describe_elements_surfaces_sheets_chart_with_missing_fields():
 def test_describe_elements_labels_image_video_and_wordart():
     elements = [
         {"objectId": "i1", "image": {"sourceUrl": "https://example.com/img.png"}},
-        {"objectId": "i2", "image": {}},
+        {"objectId": "i2", "image": {"contentUrl": "https://example.com/rendered.png"}},
+        {"objectId": "i3", "image": {}},
         {"objectId": "v1", "video": {"source": "YOUTUBE", "id": "abc123"}},
         {"objectId": "w1", "wordArt": {"renderedText": "Hello"}},
         {"objectId": "w2", "wordArt": {}},
     ]
     assert _describe_elements(elements) == [
         "  Image: ID i1, Source: https://example.com/img.png",
-        "  Image: ID i2, Source: Unknown",
+        "  Image: ID i2, ContentURL: https://example.com/rendered.png",
+        "  Image: ID i3, Source: Unknown",
         "  Video: ID v1, Source: YOUTUBE, VideoID: abc123",
         '  WordArt: ID w1, Text: "Hello"',
         "  WordArt: ID w2",

--- a/tests/test_slides_tools.py
+++ b/tests/test_slides_tools.py
@@ -371,12 +371,55 @@ def test_describe_elements_labels_non_text_element_types():
     elements = [
         {"objectId": "t1", "table": {"rows": 3, "columns": 2}},
         {"objectId": "l1", "line": {"lineType": "STRAIGHT"}},
-        {"objectId": "x1", "image": {}},
+        {"objectId": "x1", "speakerSpotlight": {}},
     ]
     assert _describe_elements(elements) == [
         "  Table: ID t1, Size: 3x2",
         "  Line: ID l1, Type: STRAIGHT",
         "  Element: ID x1, Type: Unknown",
+    ]
+
+
+def test_describe_elements_surfaces_sheets_chart_source():
+    """A linked Sheets chart must expose its source spreadsheetId/chartId so a
+    caller can edit the source data and refresh the chart with refreshSheetsChart.
+    """
+    elements = [
+        {
+            "objectId": "c1",
+            "sheetsChart": {
+                "spreadsheetId": "sheet-123",
+                "chartId": 456,
+                "contentUrl": "https://example.com/chart.png",
+            },
+        }
+    ]
+    assert _describe_elements(elements) == [
+        "  SheetsChart: ID c1, SpreadsheetID sheet-123, ChartID 456"
+    ]
+
+
+def test_describe_elements_surfaces_sheets_chart_with_missing_fields():
+    elements = [{"objectId": "c1", "sheetsChart": {}}]
+    assert _describe_elements(elements) == [
+        "  SheetsChart: ID c1, SpreadsheetID Unknown, ChartID Unknown"
+    ]
+
+
+def test_describe_elements_labels_image_video_and_wordart():
+    elements = [
+        {"objectId": "i1", "image": {"sourceUrl": "https://example.com/img.png"}},
+        {"objectId": "i2", "image": {}},
+        {"objectId": "v1", "video": {"source": "YOUTUBE", "id": "abc123"}},
+        {"objectId": "w1", "wordArt": {"renderedText": "Hello"}},
+        {"objectId": "w2", "wordArt": {}},
+    ]
+    assert _describe_elements(elements) == [
+        "  Image: ID i1, Source: https://example.com/img.png",
+        "  Image: ID i2, Source: Unknown",
+        "  Video: ID v1, Source: YOUTUBE, VideoID: abc123",
+        '  WordArt: ID w1, Text: "Hello"',
+        "  WordArt: ID w2",
     ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2216,7 +2216,7 @@ wheels = [
 
 [[package]]
 name = "workspace-mcp"
-version = "1.21.3"
+version = "1.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description

`get_page` (`_describe_elements`) only handled `shape`, `table`, `line`, and `elementGroup` page elements. Every other `PageElement` type — including a **linked Google Sheets chart** (`sheetsChart`), plus `image`, `video`, and `wordArt` — fell through to `Element: ID <id>, Type: Unknown`, discarding its identifying metadata.

This is a problem specifically for linked charts. `presentations.pages.get` returns `sheetsChart.spreadsheetId` and `sheetsChart.chartId`, and `batch_update_presentation` **already** whitelists `refreshSheetsChart`, `createSheetsChart`, and `replaceAllShapesWithSheetsChart`. So the full "update a linked chart" workflow is already supported by this server:

1. read the chart's source `spreadsheetId`/`chartId`,
2. edit the source cells (Sheets tools),
3. `refreshSheetsChart` via `batch_update_presentation`.

…except step 1 was impossible — `get_page` never surfaced the source IDs, so a caller couldn't even tell an element was a chart, let alone locate its backing spreadsheet. This PR closes that read-side gap; no API scopes, tools, or request types are added.

`_describe_elements` now reports:

- `SheetsChart: ID <id>, SpreadsheetID <id>, ChartID <id>`
- `Image: ID <id>, Source: <sourceUrl|contentUrl>`
- `Video: ID <id>, Source: <source>, VideoID: <id>`
- `WordArt: ID <id>, Text: "<renderedText>"`

Genuinely unhandled element types still fall back to `Type: Unknown`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

- `tests/test_slides_tools.py`: added coverage for `sheetsChart` (including missing-field defaults) and for `image`/`video`/`wordArt`; updated the existing "non-text element types" test to use `speakerSpotlight` so it still exercises the `Unknown` fallback (it previously used `image`, which is now handled). `24 passed` locally via `pytest tests/test_slides_tools.py`.
- The read-side gap was confirmed against a live deployment: `get_page` on a slide containing a linked Sheets chart reported the chart only as `Type: Unknown`, with no way to discover its source spreadsheet.
- Related: #785 also touches `_describe_elements` / its tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced slide element descriptions with richer labeling for charts, images, videos, and word art.
  * Chart descriptions now include spreadsheet and chart IDs when available.
  * Images and videos surface available source information; word art displays rendered text when present.

* **Bug Fixes**
  * Adjusted Google Forms publishing updates to target only the intended publish-setting fields.

* **Tests**
  * Expanded coverage for the updated slide element labeling, including fallback behavior for missing details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->