### PR TITLE
feat(auth): trusted-upstream mode for multi-tenant gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,60 @@ cp .env.oauth21 .env
 
 </details>
 
+<details>
+<summary>🔐 <b>Trusted-Upstream Mode</b> <sub><sup>← Multi-tenant gateway deployments</sup></sub></summary>
+
+Alternative authentication path for deployments where an **upstream gateway** (e.g. a multi-tenant SaaS platform) has already authenticated the end-user with Google. Instead of the sidecar holding a single Google OAuth `client_id/client_secret` pair — which is a hard cap of one tenant per container — the gateway forwards a Google Bearer plus an HMAC-signed identity.
+
+**When to use:**
+
+- You run a platform (Abra, another AI orchestrator...) that serves multiple end-user organizations, each with their own Google Cloud OAuth app.
+- Your platform already validates the user's Google token server-side.
+- You want a single `google-workspace-mcp` sidecar to serve all tenants.
+
+**How it works:**
+
+1. The gateway extracts the user's Google email from the validated token.
+2. The gateway signs `f"{email}\n{timestamp_ms}"` with an HMAC-SHA256 shared secret.
+3. It forwards the request to the sidecar with three extra headers:
+   - `X-Abra-User-Email: user@example.com`
+   - `X-Abra-Timestamp: 1720441234567`  (Unix ms)
+   - `X-Abra-Signature: <hex-hmac-sha256>`
+4. The sidecar verifies the signature + timestamp window, sets the authenticated user, and skips its own Google userinfo lookup.
+5. The unmodified Bearer forwarded to `googleapis.com` remains the final source of truth for the data returned.
+
+**Config:**
+
+```bash
+export TRUSTED_UPSTREAM_MODE="true"
+export MCP_UPSTREAM_SECRET="$(openssl rand -hex 32)"   # 64 hex chars
+# Optional : replay window in seconds (default 60)
+export TRUSTED_UPSTREAM_WINDOW_SECS="60"
+```
+
+When enabled, you can **omit** `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` — the sidecar never calls `userinfo` on the incoming Bearer.
+
+**Signing (Python reference):**
+
+```python
+import hashlib, hmac, time
+email = "user@example.com"
+timestamp_ms = int(time.time() * 1000)
+message = f"{email}\n{timestamp_ms}".encode()
+signature = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+```
+
+**Security notes:**
+
+- HMAC signature binds `(email, timestamp)` — swapping either breaks verification.
+- Timestamp window (default ±60 s) protects against replay ; widen with `TRUSTED_UPSTREAM_WINDOW_SECS` if your clocks drift.
+- The shared secret leak lets an attacker forge any identity but they still need a valid Google Bearer to actually retrieve data — rotate the secret + restart both sides.
+- Enable `TRUSTED_UPSTREAM_MODE=true` without setting `MCP_UPSTREAM_SECRET` → `is_enabled()` returns False (with a critical log line) rather than accepting unsigned identity.
+
+See `auth/trusted_upstream.py` for the full implementation and `tests/auth/test_trusted_upstream.py` for the contract test suite.
+
+</details>
+
 ---
 
 ## 🧰 Available Tools

--- a/auth/auth_info_middleware.py
+++ b/auth/auth_info_middleware.py
@@ -12,6 +12,7 @@ from fastmcp.server.dependencies import get_http_headers
 from auth.external_oauth_provider import get_session_time
 from auth.oauth21_session_store import ensure_session_from_access_token
 from auth.oauth_types import WorkspaceAccessToken
+from auth import trusted_upstream
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -42,6 +43,56 @@ class AuthInfoMiddleware(Middleware):
 
         authenticated_user = None
         auth_via = None
+
+        # Trusted-Upstream Mode — a multi-tenant gateway (e.g. Abra)
+        # has already validated the end-user's Google token upstream
+        # and signed the resulting identity with a shared HMAC secret.
+        # Verify the signature and short-circuit the entire OAuth
+        # provider path so the sidecar can serve many tenants without
+        # holding any per-tenant client_id/client_secret at boot.
+        #
+        # See auth/trusted_upstream.py for the full rationale + threat
+        # model. ``is_enabled()`` is False when the env is off or the
+        # secret is missing — we silently fall through to the normal
+        # paths in both cases.
+        if trusted_upstream.is_enabled():
+            try:
+                upstream_headers = get_http_headers()
+                if upstream_headers:
+                    upstream_email = trusted_upstream.extract_and_verify(
+                        upstream_headers
+                    )
+                    if upstream_email:
+                        logger.info(
+                            "✓ Using trusted-upstream identity for user: %s",
+                            upstream_email,
+                        )
+                        await context.fastmcp_context.set_state(
+                            "authenticated_user_email", upstream_email
+                        )
+                        await context.fastmcp_context.set_state(
+                            "authenticated_via", "trusted_upstream"
+                        )
+                        await context.fastmcp_context.set_state(
+                            "user_email", upstream_email
+                        )
+                        await context.fastmcp_context.set_state(
+                            "username", upstream_email
+                        )
+                        # Nothing else to populate — the sidecar will
+                        # forward the incoming Bearer to googleapis
+                        # unchanged. No local access_token wrapping
+                        # needed because we never call verify_token().
+                        return
+            except Exception as e:
+                # Fail closed on unexpected errors : log + fall
+                # through to the normal path rather than pretending
+                # the request was authenticated.
+                logger.warning(
+                    "[trusted-upstream] middleware check failed, "
+                    "falling back to normal auth: %s",
+                    e,
+                )
 
         # First check if FastMCP has already validated an access token
         try:

--- a/auth/trusted_upstream.py
+++ b/auth/trusted_upstream.py
@@ -1,0 +1,208 @@
+"""
+Trusted-Upstream Mode
+=====================
+
+Alternative authentication path for deployments where an upstream
+service (e.g. a multi-tenant SaaS gateway) has already authenticated
+the end-user with Google and forwards the request to workspace-mcp.
+
+The default modes (``EXTERNAL_OAUTH21_PROVIDER=true`` or a fully local
+OAuth server) require workspace-mcp to hold its OWN Google Cloud
+``client_id`` / ``client_secret`` at startup. That's fine for a
+single-tenant install, but a gateway that serves multiple tenants —
+each with their own Google Cloud OAuth app — has no single pair of
+credentials to bake into the sidecar env vars.
+
+Trusted-Upstream Mode solves this by moving token verification back to
+the gateway itself. The gateway :
+
+1. Validates the user's Google access-token server-side (via userinfo
+   or its own cached refresh flow),
+2. Extracts the user's email,
+3. Signs a short, replay-resistant tuple ``(email, timestamp)`` with a
+   shared HMAC secret,
+4. Forwards the request to workspace-mcp with three extra headers.
+
+workspace-mcp then :
+
+- Verifies the HMAC signature against the shared secret,
+- Verifies the timestamp is within ±60 seconds (replay window),
+- Skips its own Google userinfo lookup entirely,
+- Uses the header-supplied email as the authenticated user.
+
+The Bearer forwarded on to ``googleapis.com`` is still the real user
+token — Google itself is the final authority on what data comes back.
+The HMAC only asserts "this identity is the one the gateway vouched
+for" to prevent an attacker on the same network from forging a user
+identity even if they somehow obtained a valid Bearer.
+
+Threat model (see design doc for detail) :
+
+- ``MCP_UPSTREAM_SECRET`` leak → attacker can forge any identity, but
+  still needs a valid Bearer to actually pull data (googleapis is the
+  final gate). Rotate the secret + restart both sides.
+- Replay within 60 s → possible ; most tools are read-only or require
+  fresh args to have side effects. Add a nonce store if a specific
+  audit demands it.
+- ``TRUSTED_UPSTREAM_MODE`` enabled without ``MCP_UPSTREAM_SECRET`` →
+  ``is_enabled()`` returns False + log critical (config bug protection).
+
+Env vars :
+
+- ``TRUSTED_UPSTREAM_MODE``  ``"true"`` to enable ; anything else is off.
+- ``MCP_UPSTREAM_SECRET``    HMAC secret. 32+ random bytes hex.
+- ``TRUSTED_UPSTREAM_WINDOW_SECS``  optional, default 60. Replay window.
+
+Headers :
+
+- ``X-Abra-User-Email``      user's Google email
+- ``X-Abra-Timestamp``       Unix ms as decimal string
+- ``X-Abra-Signature``       hex HMAC-SHA256 of ``f"{email}\\n{timestamp}"``
+"""
+
+import hashlib
+import hmac
+import logging
+import os
+import time
+from typing import Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+# Header names — deliberately not "X-Forwarded-*" (RFC-reserved) and
+# not upstream-agnostic like "X-User-Email" (would collide with random
+# proxies). The ``X-Abra-*`` prefix makes the origin clear in traces.
+HEADER_EMAIL = "x-abra-user-email"
+HEADER_TIMESTAMP = "x-abra-timestamp"
+HEADER_SIGNATURE = "x-abra-signature"
+
+_DEFAULT_WINDOW_SECS = 60
+
+
+def is_enabled() -> bool:
+    """
+    True iff the sidecar is running in trusted-upstream mode with a
+    usable secret. Also returns False (with a critical log line) if
+    the mode env is on but the secret is missing — refuse to run in
+    insecure config rather than default open.
+    """
+    if os.getenv("TRUSTED_UPSTREAM_MODE", "").strip().lower() != "true":
+        return False
+    if not _get_secret():
+        logger.critical(
+            "TRUSTED_UPSTREAM_MODE=true but MCP_UPSTREAM_SECRET is empty. "
+            "Refusing to enable trusted-upstream mode — every request will "
+            "fall through to the normal auth path. Set MCP_UPSTREAM_SECRET "
+            "to a 32+ byte hex string and restart the sidecar."
+        )
+        return False
+    return True
+
+
+def _get_secret() -> Optional[str]:
+    secret = os.getenv("MCP_UPSTREAM_SECRET", "")
+    return secret if secret.strip() else None
+
+
+def _get_window_secs() -> int:
+    try:
+        return int(os.getenv("TRUSTED_UPSTREAM_WINDOW_SECS", str(_DEFAULT_WINDOW_SECS)))
+    except (TypeError, ValueError):
+        return _DEFAULT_WINDOW_SECS
+
+
+def _canonical_message(email: str, timestamp: str) -> bytes:
+    """
+    The exact byte string that both sides sign. Kept in one function
+    so gateway and sidecar can never accidentally disagree on the
+    canonical form (delimiter, encoding, trailing newline, …).
+    """
+    return f"{email}\n{timestamp}".encode("utf-8")
+
+
+def sign(email: str, timestamp_ms: int, secret: str) -> str:
+    """
+    Compute the hex HMAC-SHA256 signature. Kept exported so the fork
+    tests + the Abra gateway can call the SAME function and never
+    drift. Not called by the middleware directly — the middleware
+    only verifies.
+    """
+    return hmac.new(
+        secret.encode("utf-8"),
+        _canonical_message(email, str(timestamp_ms)),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _normalize(headers: Mapping[str, str]) -> dict[str, str]:
+    """
+    HTTP headers are case-insensitive but Python dicts aren't. Lower
+    every key once so downstream lookups are trivial and consistent.
+    """
+    return {k.lower(): v for k, v in headers.items()}
+
+
+def extract_and_verify(headers: Mapping[str, str]) -> Optional[str]:
+    """
+    Central entry point. Given a request's HTTP headers, return the
+    authenticated user email if and only if all three headers are
+    present, the timestamp is inside the replay window, and the HMAC
+    matches. Any failure returns ``None`` and logs at ``warning``.
+
+    This function does NOT check ``is_enabled()`` — callers must
+    guard with ``is_enabled()`` first. Keeping this separation makes
+    the unit tests trivially reproducible without env manipulation.
+    """
+    secret = _get_secret()
+    if not secret:
+        return None
+
+    h = _normalize(headers)
+    email = h.get(HEADER_EMAIL, "").strip()
+    ts_raw = h.get(HEADER_TIMESTAMP, "").strip()
+    sig = h.get(HEADER_SIGNATURE, "").strip()
+
+    if not email or not ts_raw or not sig:
+        logger.warning(
+            "[trusted-upstream] missing headers "
+            "(email=%s, timestamp=%s, signature=%s)",
+            bool(email),
+            bool(ts_raw),
+            bool(sig),
+        )
+        return None
+
+    try:
+        ts_ms = int(ts_raw)
+    except ValueError:
+        logger.warning("[trusted-upstream] invalid timestamp value: %r", ts_raw)
+        return None
+
+    # Replay window : reject anything older or younger than ±window
+    # seconds. The bidirectional check catches an attacker replaying
+    # a captured request AND a misconfigured upstream sending future
+    # timestamps (clock drift). ±window also tolerates modest drift
+    # between gateway and sidecar clocks.
+    now_ms = int(time.time() * 1000)
+    delta = abs(now_ms - ts_ms)
+    max_delta = _get_window_secs() * 1000
+    if delta > max_delta:
+        logger.warning(
+            "[trusted-upstream] timestamp outside window "
+            "(delta_ms=%d, max_ms=%d)",
+            delta,
+            max_delta,
+        )
+        return None
+
+    expected = sign(email, ts_ms, secret)
+    # ``compare_digest`` — constant-time comparison. Not doing this
+    # opens a timing side-channel where an attacker measures how many
+    # bytes of the expected signature they matched.
+    if not hmac.compare_digest(expected, sig):
+        logger.warning(
+            "[trusted-upstream] HMAC mismatch for email=%s", email
+        )
+        return None
+
+    return email

--- a/tests/auth/test_trusted_upstream.py
+++ b/tests/auth/test_trusted_upstream.py
@@ -1,0 +1,278 @@
+"""
+Unit tests for auth.trusted_upstream — the HMAC-signed upstream
+identity path.
+
+Kept pure : no FastMCP fixtures, no HTTP mocking. Every test only
+manipulates env vars + a plain dict of headers, so they run in <10 ms
+each and are trivially reproducible.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+
+from auth import trusted_upstream
+
+
+SECRET = "0" * 64  # any hex-ish string of usable length
+EMAIL = "alice@example.com"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Default state : mode OFF + secret empty. Individual tests enable
+    what they need. ``autouse`` guarantees no test bleeds into the
+    next.
+    """
+    monkeypatch.delenv("TRUSTED_UPSTREAM_MODE", raising=False)
+    monkeypatch.delenv("MCP_UPSTREAM_SECRET", raising=False)
+    monkeypatch.delenv("TRUSTED_UPSTREAM_WINDOW_SECS", raising=False)
+    # Ensure the module reads fresh env — no module-level cache today
+    # but this guards against a future accidental cache.
+    importlib.reload(trusted_upstream)
+
+
+def _fresh_ts_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _headers(email: str, ts_ms: int, secret: str) -> dict[str, str]:
+    return {
+        "X-Abra-User-Email": email,
+        "X-Abra-Timestamp": str(ts_ms),
+        "X-Abra-Signature": trusted_upstream.sign(email, ts_ms, secret),
+    }
+
+
+# ── is_enabled ──────────────────────────────────────────────────────────
+
+
+def test_is_enabled_default_off() -> None:
+    assert trusted_upstream.is_enabled() is False
+
+
+def test_is_enabled_mode_only_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mode on without a secret is a config bug — refuse to enable."""
+    monkeypatch.setenv("TRUSTED_UPSTREAM_MODE", "true")
+    assert trusted_upstream.is_enabled() is False
+
+
+def test_is_enabled_when_mode_and_secret_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRUSTED_UPSTREAM_MODE", "true")
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    assert trusted_upstream.is_enabled() is True
+
+
+def test_is_enabled_case_insensitive_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRUSTED_UPSTREAM_MODE", "TRUE")
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    assert trusted_upstream.is_enabled() is True
+
+
+def test_is_enabled_rejects_non_true_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    for val in ("1", "yes", "on", "", " ", "false"):
+        monkeypatch.setenv("TRUSTED_UPSTREAM_MODE", val)
+        assert trusted_upstream.is_enabled() is False, (
+            f"unexpected enable for {val!r}"
+        )
+
+
+# ── extract_and_verify — happy path ─────────────────────────────────────
+
+
+def test_extract_and_verify_valid_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    ts = _fresh_ts_ms()
+    result = trusted_upstream.extract_and_verify(_headers(EMAIL, ts, SECRET))
+    assert result == EMAIL
+
+
+def test_extract_and_verify_headers_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HTTP headers are case-insensitive — the helper must accept
+    both ``X-Abra-*`` and ``x-abra-*``."""
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    ts = _fresh_ts_ms()
+    headers = {
+        "x-abra-user-email": EMAIL,
+        "X-ABRA-TIMESTAMP": str(ts),
+        "x-Abra-signature": trusted_upstream.sign(EMAIL, ts, SECRET),
+    }
+    assert trusted_upstream.extract_and_verify(headers) == EMAIL
+
+
+# ── extract_and_verify — replay window ──────────────────────────────────
+
+
+def test_extract_and_verify_rejects_stale_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    stale = _fresh_ts_ms() - (120 * 1000)  # 2 min ago, default window 60 s
+    assert (
+        trusted_upstream.extract_and_verify(_headers(EMAIL, stale, SECRET))
+        is None
+    )
+
+
+def test_extract_and_verify_rejects_future_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    future = _fresh_ts_ms() + (120 * 1000)
+    assert (
+        trusted_upstream.extract_and_verify(_headers(EMAIL, future, SECRET))
+        is None
+    )
+
+
+def test_extract_and_verify_custom_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Small drift OK when the operator widens the window."""
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    monkeypatch.setenv("TRUSTED_UPSTREAM_WINDOW_SECS", "600")  # 10 min
+    older = _fresh_ts_ms() - (300 * 1000)  # 5 min ago
+    assert (
+        trusted_upstream.extract_and_verify(_headers(EMAIL, older, SECRET))
+        == EMAIL
+    )
+
+
+# ── extract_and_verify — signature / tampering ──────────────────────────
+
+
+def test_extract_and_verify_rejects_bad_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    ts = _fresh_ts_ms()
+    headers = _headers(EMAIL, ts, SECRET)
+    headers["X-Abra-Signature"] = "f" * 64  # not the right hex
+    assert trusted_upstream.extract_and_verify(headers) is None
+
+
+def test_extract_and_verify_rejects_email_tamper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Signing alice + swapping the email header to eve must fail —
+    that's the core property of HMAC binding identity to timestamp."""
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    ts = _fresh_ts_ms()
+    headers = _headers(EMAIL, ts, SECRET)
+    headers["X-Abra-User-Email"] = "eve@example.com"
+    assert trusted_upstream.extract_and_verify(headers) is None
+
+
+def test_extract_and_verify_rejects_ts_tamper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    ts = _fresh_ts_ms()
+    headers = _headers(EMAIL, ts, SECRET)
+    # Change ts within window so window check passes, but signature
+    # no longer matches.
+    headers["X-Abra-Timestamp"] = str(ts + 1000)
+    assert trusted_upstream.extract_and_verify(headers) is None
+
+
+def test_extract_and_verify_rejects_wrong_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    ts = _fresh_ts_ms()
+    headers = _headers(EMAIL, ts, "different-secret")
+    assert trusted_upstream.extract_and_verify(headers) is None
+
+
+# ── extract_and_verify — malformed / missing ────────────────────────────
+
+
+def test_extract_and_verify_missing_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    ts = _fresh_ts_ms()
+    headers = _headers(EMAIL, ts, SECRET)
+    del headers["X-Abra-User-Email"]
+    assert trusted_upstream.extract_and_verify(headers) is None
+
+
+def test_extract_and_verify_missing_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    ts = _fresh_ts_ms()
+    headers = _headers(EMAIL, ts, SECRET)
+    del headers["X-Abra-Signature"]
+    assert trusted_upstream.extract_and_verify(headers) is None
+
+
+def test_extract_and_verify_invalid_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    ts = _fresh_ts_ms()
+    headers = _headers(EMAIL, ts, SECRET)
+    headers["X-Abra-Timestamp"] = "not-a-number"
+    assert trusted_upstream.extract_and_verify(headers) is None
+
+
+def test_extract_and_verify_no_secret_returns_none() -> None:
+    """Called without MCP_UPSTREAM_SECRET → None (caller should
+    guard with is_enabled but the helper stays safe on its own)."""
+    ts = _fresh_ts_ms()
+    headers = _headers(EMAIL, ts, SECRET)
+    assert trusted_upstream.extract_and_verify(headers) is None
+
+
+def test_extract_and_verify_empty_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_UPSTREAM_SECRET", SECRET)
+    assert trusted_upstream.extract_and_verify({}) is None
+
+
+# ── sign — round-trip determinism ───────────────────────────────────────
+
+
+def test_sign_deterministic() -> None:
+    """Same inputs → same output. Anything else means we accidentally
+    baked entropy into the signature and forgery becomes trivial."""
+    sig_a = trusted_upstream.sign(EMAIL, 1234567890, SECRET)
+    sig_b = trusted_upstream.sign(EMAIL, 1234567890, SECRET)
+    assert sig_a == sig_b
+
+
+def test_sign_changes_on_email() -> None:
+    sig_a = trusted_upstream.sign("a@x.com", 1234567890, SECRET)
+    sig_b = trusted_upstream.sign("b@x.com", 1234567890, SECRET)
+    assert sig_a != sig_b
+
+
+def test_sign_changes_on_timestamp() -> None:
+    sig_a = trusted_upstream.sign(EMAIL, 1000, SECRET)
+    sig_b = trusted_upstream.sign(EMAIL, 2000, SECRET)
+    assert sig_a != sig_b
+
+
+def test_sign_changes_on_secret() -> None:
+    sig_a = trusted_upstream.sign(EMAIL, 1234567890, "secret-a")
+    sig_b = trusted_upstream.sign(EMAIL, 1234567890, "secret-b")
+    assert sig_a != sig_b


### PR DESCRIPTION
Add TRUSTED_UPSTREAM_MODE that skips workspace-mcp's own token verification when an upstream gateway (e.g. a multi-tenant SaaS platform) has already validated the user's Google token and signed the resulting identity with a shared HMAC secret.

Uses three HTTP headers:
  X-Abra-User-Email, X-Abra-Timestamp, X-Abra-Signature

The Bearer forwarded to googleapis.com is unchanged - this only changes how the sidecar decides who the caller is, letting a single container serve tenants with different Google Cloud OAuth apps.

Config:
  TRUSTED_UPSTREAM_MODE=true
  MCP_UPSTREAM_SECRET=<hex>
  TRUSTED_UPSTREAM_WINDOW_SECS=60  (optional)

Falls through to the existing auth paths when mode is off or the secret is missing. Constant-time HMAC comparison, +/-60s replay window, refuses to enable in insecure config.

23 unit tests, no new deps (stdlib only).

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Add any other context about the pull request here.

---

**⚠️ IMPORTANT:** This repository requires that you enable "Allow edits from maintainers" when creating your pull request. This allows maintainers to make small fixes and improvements directly to your branch, speeding up the review process.

To enable this setting:
1. When creating the PR, check the "Allow edits from maintainers" checkbox
2. If you've already created the PR, you can enable this in the PR sidebar under "Allow edits from maintainers"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a trusted-upstream authentication mode for gateway deployments.
  * Documented how requests can carry a verified user identity through custom headers.

* **Bug Fixes**
  * Requests can now be authenticated using upstream-validated identity data, with replay-window and signature checks.
  * Invalid, missing, or tampered identity headers are safely rejected and fall back to normal authentication.

* **Tests**
  * Added coverage for enabling conditions, header validation, timestamp handling, signature checks, and tampering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->