### PR TITLE
fix: add socket timeout so a hung OAuth token refresh can't stall the server

### DIFF
--- a/main.py
+++ b/main.py
@@ -295,6 +295,15 @@ def main():
     """
     _restore_stdout()
 
+    # Bound blocking client sockets so a stalled OAuth token refresh can't hang
+    # the server. googleapiclient's _auth.refresh_credentials() builds a bare
+    # httplib2.Http() with no timeout; with no process-wide default, that refresh
+    # POST runs on an unbounded socket and can block indefinitely on a stalled
+    # connection (surfaces as intermittent "Session terminated"). A raw socket
+    # inherits socket.getdefaulttimeout() at creation, so this gives the refresh
+    # path a ceiling; asyncio/uvicorn sockets are non-blocking and unaffected.
+    socket.setdefaulttimeout(30)
+
     # Configure safe logging for Windows Unicode handling
     configure_safe_logging()
 


### PR DESCRIPTION
## Problem

Running in service-account / domain-wide-delegation mode, we hit **intermittent `Session terminated`** errors reaching clients. Server logs showed the Google API call succeeding, immediately followed by:

```
[INFO] Attempting refresh to obtain initial access_token
```

…which then **hung with no completion**, tearing down the transport before results returned. It was intermittent, cleared on restart, and recurred.

## Root cause

The hang is in the OAuth token-refresh path, not the network. `googleapiclient`'s `_auth.refresh_credentials()` builds a **bare `httplib2.Http()` with no timeout**, and `main()` sets no process-wide default socket timeout. httplib2 with `timeout=None` never calls `settimeout()`, so the refresh POST runs on a **fully unbounded socket**. Normally it's sub-second, but when a socket stalls (stale keep-alive reuse / transient TLS–TCP hiccup) it blocks **forever** instead of erroring.

The server already sets `httplib2.Http(timeout=30)` in `_build_authorized_http()`, but that doesn't cover the library's *internal* refresh path — hence the gap.

## Fix

Set a process-wide default socket timeout at the top of `main()`:

```python
socket.setdefaulttimeout(30)
```

A raw socket inherits `socket.getdefaulttimeout()` at creation, so the timeout-less refresh `httplib2.Http()` now gets a ceiling and fails fast (and retries) instead of hanging. `asyncio`/`uvicorn` sockets are set non-blocking and ignore the default, so the streamable-HTTP transport is unaffected. The value (30s) matches the existing `_build_authorized_http()` convention.

`socket` is already imported in `main.py`, so this is a one-line change plus a comment.

## Verification

After applying, ran 7 back-to-back Gmail calls (searches + a content-batch fetch) with **no drops and no refresh hang**; the previously-hanging `Attempting refresh…` now completes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by setting a default timeout for new blocking network connections.
  * Reduced the chance of the app hanging indefinitely on stalled HTTP or socket requests, especially during sign-in and refresh flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->