### PR TITLE
feat(gmail): add draft management tools — list, update (with thread attach), delete

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -12,12 +12,15 @@ gmail:
     - list_gmail_labels
     - manage_gmail_label
     - draft_gmail_message
+    - list_gmail_drafts
+    - update_gmail_draft
     - list_gmail_filters
     - manage_gmail_filter
 
   complete:
     - get_gmail_threads_content_batch
     - batch_modify_gmail_message_labels
+    - delete_gmail_draft
     - start_google_auth
 
 drive:

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2626,6 +2626,452 @@ async def draft_gmail_message(
     return f"Draft created{attachment_info}! Draft ID: {draft_id}"
 
 
+@server.tool(
+    title="List Gmail Drafts",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("list_gmail_drafts", is_read_only=True, service_type="gmail")
+@require_google_service("gmail", GMAIL_COMPOSE_SCOPE)
+async def list_gmail_drafts(
+    service,
+    user_google_email: str,
+    page_size: Annotated[
+        int,
+        Field(
+            description="Maximum number of drafts to return per page (capped at 50). Defaults to 20.",
+        ),
+    ] = 20,
+    page_token: Annotated[
+        Optional[str],
+        Field(
+            description="Token for retrieving the next page of results. Use the next page token from a previous response.",
+        ),
+    ] = None,
+    query: Annotated[
+        Optional[str],
+        Field(
+            description="Optional Gmail search query to filter drafts (same syntax as Gmail search, e.g. 'subject:invoice' or 'to:someone@example.com').",
+        ),
+    ] = None,
+) -> str:
+    """
+    Lists draft emails in the user's Gmail account, showing each draft's subject
+    and snippet for quick identification. Supports pagination and Gmail search
+    query filtering.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        page_size (int): Maximum number of drafts to return per page (capped at 50). Defaults to 20.
+        page_token (Optional[str]): Token for retrieving the next page of results. Use the
+            next page token from a previous response.
+        query (Optional[str]): Optional Gmail search query to filter drafts.
+
+    Returns:
+        str: The total number of drafts found, followed by one line per draft with
+        the Draft ID, Message ID, Thread ID, Subject, and a short snippet. Includes
+        a pagination token if more results are available.
+
+    Examples:
+        # List the 20 most recent drafts
+        list_gmail_drafts()
+
+        # List drafts matching a search query
+        list_gmail_drafts(query="subject:invoice")
+
+        # Get the next page of results
+        list_gmail_drafts(page_token="EAAY...")
+    """
+    logger.info(
+        f"[list_gmail_drafts] Email: '{user_google_email}', Query: '{query}'"
+    )
+
+    request_params: Dict[str, Any] = {"userId": "me", "maxResults": min(page_size, 50)}
+    if page_token:
+        request_params["pageToken"] = page_token
+    if query:
+        request_params["q"] = query
+
+    response = await asyncio.to_thread(
+        service.users().drafts().list(**request_params).execute
+    )
+
+    drafts = response.get("drafts") or []
+    if not drafts:
+        if query:
+            return f"No drafts found for query: '{query}'."
+        return "No drafts found."
+
+    lines = [f"Found {len(drafts)} draft(s):", ""]
+    for draft in drafts:
+        draft_id = draft.get("id", "unknown")
+        message = draft.get("message") or {}
+        message_id = message.get("id")
+        thread_id = message.get("threadId", "unknown")
+
+        subject = "(no subject)"
+        snippet = ""
+        if message_id:
+            message_metadata = await asyncio.to_thread(
+                service.users()
+                .messages()
+                .get(
+                    userId="me",
+                    id=message_id,
+                    format="metadata",
+                    metadataHeaders=["Subject"],
+                )
+                .execute
+            )
+            headers = _extract_headers(
+                message_metadata.get("payload", {}), ["Subject"]
+            )
+            subject = headers.get("Subject") or subject
+            snippet = message_metadata.get("snippet", "") or ""
+
+        lines.append(
+            f"{draft_id} | {message_id or 'unknown'} | {thread_id} | {subject} | {snippet}"
+        )
+
+    next_page_token = response.get("nextPageToken")
+    if next_page_token:
+        lines.append("")
+        lines.append(f"Next page token: {next_page_token}")
+
+    return "\n".join(lines)
+
+
+@server.tool(
+    title="Update Gmail Draft",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("update_gmail_draft", service_type="gmail")
+@require_google_service("gmail", GMAIL_COMPOSE_SCOPE)
+async def update_gmail_draft(
+    service,
+    user_google_email: str,
+    draft_id: Annotated[
+        str, Field(description="The ID of the draft to update. Use list_gmail_drafts to find draft IDs.")
+    ],
+    subject: Annotated[str, Field(description="Email subject.")],
+    body: Annotated[str, Field(description="Email body (plain text).")],
+    body_format: Annotated[
+        Literal["plain", "html"],
+        Field(
+            description="Email body format. Use 'plain' for plaintext or 'html' for HTML content.",
+        ),
+    ] = "plain",
+    to: Annotated[
+        Optional[str],
+        Field(
+            description="Optional recipient email address.",
+        ),
+    ] = None,
+    cc: Annotated[
+        Optional[str], Field(description="Optional CC email address.")
+    ] = None,
+    bcc: Annotated[
+        Optional[str], Field(description="Optional BCC email address.")
+    ] = None,
+    from_name: Annotated[
+        Optional[str],
+        Field(
+            description="Optional sender display name (e.g., 'Peter Hartree'). If provided, the From header will be formatted as 'Name <email>'.",
+        ),
+    ] = None,
+    from_email: Annotated[
+        Optional[str],
+        Field(
+            description="Optional 'Send As' alias email address. Must be configured in Gmail settings (Settings > Accounts > Send mail as). If not provided, uses the authenticated user's email.",
+        ),
+    ] = None,
+    thread_id: Annotated[
+        Optional[str],
+        Field(
+            description="Optional Gmail thread ID to reply within.",
+        ),
+    ] = None,
+    in_reply_to: Annotated[
+        Optional[str],
+        Field(
+            description="Optional RFC Message-ID of the message being replied to (e.g., '<message123@gmail.com>').",
+        ),
+    ] = None,
+    references: Annotated[
+        Optional[str],
+        Field(
+            description="Optional chain of Message-IDs for proper threading.",
+        ),
+    ] = None,
+    attachments: Annotated[
+        Optional[DictList],
+        Field(
+            description="Optional list of attachments. Each can have: 'url' (fetch from URL — works with MCP attachment URLs from get_drive_file_download_url / get_gmail_attachment_content), OR 'path' (file path, auto-encodes), OR 'content' (standard base64, not urlsafe) + 'filename'. Optional 'mime_type'. Optional 'content_id' (string) makes the attachment inline-rendered: it lands in a multipart/related part with `Content-ID: <content_id>` and `Content-Disposition: inline`, and the HTML body can reference it via `<img src=\"cid:<content_id>\">` (RFC 2392). Without `content_id` the attachment is a regular multipart/mixed attachment.",
+        ),
+    ] = None,
+    include_signature: Annotated[
+        bool,
+        Field(
+            description="Whether to append the Gmail signature from Settings > Signature when available. Defaults to true.",
+        ),
+    ] = True,
+    quote_original: Annotated[
+        bool,
+        Field(
+            description="Whether to include the original message as a quoted reply. Requires thread_id. Defaults to false.",
+        ),
+    ] = False,
+    attach_to_thread: Annotated[
+        bool,
+        Field(
+            description="Whether the updated draft's message should carry the Gmail threadId, making it appear inside the conversation in the Gmail UI. Requires thread_id. Defaults to false.",
+        ),
+    ] = False,
+) -> str:
+    """
+    Updates an existing draft in the user's Gmail account.
+
+    IMPORTANT: drafts().update REPLACES the draft's entire message -- this is not
+    a partial/merge update. Any field not passed to this call (e.g. an existing
+    attachment, or a previous body) is not preserved; re-send everything the
+    draft should contain, exactly like draft_gmail_message.
+
+    Threading note: when creating a draft, Gmail intentionally avoids setting
+    threadId unless full reply headers (In-Reply-To/References) were derived,
+    so ad-hoc drafts don't get silently attached to the wrong conversation and
+    become hidden from the Gmail UI ("UI-hidden drafts"). On update, that safety
+    net does not apply the same way: set attach_to_thread=True to make Gmail
+    display the updated draft inside the thread_id conversation in the Gmail UI.
+    This is a deliberate opt-in (behavior validated empirically against the live
+    Gmail API on 2026-07-11) -- attach_to_thread=False (the default) never sets
+    threadId on the update, even if thread_id/in_reply_to/references were used
+    to derive the reply body/headers.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required for authentication.
+        draft_id (str): The ID of the draft to update. Use list_gmail_drafts to find draft IDs.
+        subject (str): Email subject.
+        body (str): Email body (plain text).
+        body_format (Literal['plain', 'html']): Email body format. Defaults to 'plain'.
+        to (Optional[str]): Optional recipient email address. Can be left empty for drafts.
+        cc (Optional[str]): Optional CC email address.
+        bcc (Optional[str]): Optional BCC email address.
+        from_name (Optional[str]): Optional sender display name. If provided, the From header will be formatted as 'Name <email>'.
+        from_email (Optional[str]): Optional 'Send As' alias email address. The alias must be
+            configured in Gmail settings (Settings > Accounts > Send mail as). If not provided,
+            the draft will be from the authenticated user's primary email address.
+        thread_id (Optional[str]): Optional Gmail thread ID to reply within. When provided, updates the draft as a reply.
+        in_reply_to (Optional[str]): Optional RFC Message-ID of the message being replied to (e.g., '<message123@gmail.com>').
+        references (Optional[str]): Optional chain of RFC Message-IDs for proper threading (e.g., '<msg1@gmail.com> <msg2@gmail.com>').
+        attachments (List[Dict[str, str]]): Optional list of attachments. Each dict can contain:
+            Option 1 - File path (auto-encodes):
+              - 'path' (required): File path to attach
+              - 'filename' (optional): Override filename
+              - 'mime_type' (optional): Override MIME type (auto-detected if not provided)
+            Option 2 - Base64 content:
+              - 'content' (required): Standard base64-encoded file content (not urlsafe)
+              - 'filename' (required): Name of the file
+              - 'mime_type' (optional): MIME type (defaults to 'application/octet-stream')
+        include_signature (bool): Whether to append Gmail signature HTML from send-as settings.
+            When include_signature is true and Gmail signature retrieval fails for benign reasons
+            (e.g., missing gmail.settings.basic scope), the draft proceeds without a signature.
+            Non-benign failures such as quota/rate-limit or API errors raise ToolError and abort
+            the update.
+        quote_original (bool): Whether to include the original message as a quoted reply.
+            Requires thread_id to be provided. When enabled, fetches the original message
+            and appends it below the signature. Defaults to False.
+        attach_to_thread (bool): Whether to set threadId on the updated draft's message so it
+            appears inside the thread_id conversation in the Gmail UI. Requires thread_id.
+            Defaults to False.
+
+    Returns:
+        str: Confirmation message with the updated draft's ID and message ID. Note that Gmail
+        may assign a new draft ID and always assigns a new message ID on update -- prefer
+        locating drafts via list_gmail_drafts rather than caching IDs across updates.
+
+    Examples:
+        # Replace a draft's subject and body
+        update_gmail_draft(draft_id="r-123", subject="Updated subject", body="New content")
+
+        # Replace a draft and attach it to its thread's conversation view
+        update_gmail_draft(
+            draft_id="r-123",
+            subject="Re: Meeting tomorrow",
+            body="Thanks for the update!",
+            thread_id="thread_123",
+            attach_to_thread=True,
+        )
+    """
+    logger.info(
+        f"[update_gmail_draft] Invoked. Email: '{user_google_email}', Draft ID: '{draft_id}'"
+    )
+
+    if attach_to_thread and not thread_id:
+        raise UserInputError("attach_to_thread=True requires thread_id.")
+
+    # Prepare the email message
+    # Use from_email (Send As alias) if provided, otherwise default to authenticated user
+    sender_email = from_email or user_google_email
+    draft_body = body
+    signature_html = ""
+    if include_signature:
+        signature_html = await _get_send_as_signature_html_for_tool(
+            service, from_email=sender_email
+        )
+
+    reply_context = None
+    if thread_id and (quote_original or not in_reply_to or not references or not to):
+        reply_context = await _fetch_thread_reply_context(
+            service,
+            thread_id,
+            in_reply_to=in_reply_to,
+            include_bodies=quote_original,
+        )
+
+    if thread_id and (not in_reply_to or not references):
+        thread_message_ids = (
+            reply_context.get("message_ids", []) if reply_context else []
+        )
+        in_reply_to, references = _derive_reply_headers(
+            thread_message_ids, in_reply_to, references
+        )
+
+    target_reply = reply_context.get("target") if reply_context else None
+    if thread_id and not to and target_reply:
+        to = target_reply.get("reply_to") or target_reply.get("from") or to
+    if thread_id and not subject.strip() and target_reply:
+        subject = target_reply.get("subject") or subject
+
+    if quote_original and target_reply:
+        draft_body = _build_quoted_reply_body(
+            draft_body,
+            body_format,
+            signature_html,
+            {
+                "sender": target_reply.get("from") or "unknown",
+                "date": target_reply.get("date", ""),
+                "text_body": target_reply.get("text_body", ""),
+                "html_body": target_reply.get("html_body", ""),
+            },
+        )
+    else:
+        draft_body = _append_signature_to_body(draft_body, body_format, signature_html)
+
+    resolved_attachments = await _resolve_url_attachments(attachments)
+    raw_message, _thread_id_final, attached_count, attachment_errors = (
+        _prepare_gmail_message(
+            subject=subject,
+            body=draft_body,
+            body_format=body_format,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            thread_id=thread_id,
+            in_reply_to=in_reply_to,
+            references=references,
+            from_email=sender_email,
+            from_name=from_name,
+            attachments=resolved_attachments,
+        )
+    )
+
+    requested_attachment_count = len(attachments or [])
+    if requested_attachment_count > 0 and attached_count == 0:
+        details = (
+            f" Details: {'; '.join(attachment_errors)}" if attachment_errors else ""
+        )
+        raise UserInputError(
+            "No valid attachments were added. Verify each attachment path/content and retry."
+            f"{details}"
+        )
+
+    # drafts().update() replaces the draft's message wholesale. Only set threadId
+    # when the caller explicitly opts in via attach_to_thread -- see the docstring
+    # for why this differs from draft_gmail_message's create-time heuristic.
+    update_request_body = {"message": {"raw": raw_message}}
+    if attach_to_thread:
+        update_request_body["message"]["threadId"] = thread_id
+
+    updated_draft = await asyncio.to_thread(
+        service.users()
+        .drafts()
+        .update(userId="me", id=draft_id, body=update_request_body)
+        .execute,
+        num_retries=GOOGLE_API_WRITE_RETRIES,
+    )
+    new_draft_id = updated_draft.get("id", draft_id)
+    new_message_id = updated_draft.get("message", {}).get("id")
+    attachment_info = _format_attachment_result(
+        attached_count, requested_attachment_count
+    )
+    return (
+        f"Draft updated{attachment_info}! Draft ID: {new_draft_id}, "
+        f"Message ID: {new_message_id}. Note: draft/message IDs may change after "
+        "update; prefer locating drafts via list_gmail_drafts."
+    )
+
+
+@server.tool(
+    title="Delete Gmail Draft",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("delete_gmail_draft", service_type="gmail")
+@require_google_service("gmail", GMAIL_COMPOSE_SCOPE)
+async def delete_gmail_draft(
+    service,
+    user_google_email: str,
+    draft_id: Annotated[
+        str,
+        Field(
+            description="The ID of the draft to permanently delete. Use list_gmail_drafts to find draft IDs.",
+        ),
+    ],
+) -> str:
+    """
+    Permanently deletes a draft from the user's Gmail account.
+
+    WARNING: This is permanent. Unlike deleting a regular email message, deleting
+    a draft does NOT move it to Trash -- it is removed immediately and cannot be
+    recovered.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required for authentication.
+        draft_id (str): The ID of the draft to permanently delete. Use list_gmail_drafts to
+            find draft IDs.
+
+    Returns:
+        str: Confirmation message of the permanent deletion.
+
+    Examples:
+        # Permanently delete a draft
+        delete_gmail_draft(draft_id="r-1234567890")
+    """
+    logger.info(
+        f"[delete_gmail_draft] Invoked. Email: '{user_google_email}', Draft ID: '{draft_id}'"
+    )
+
+    await asyncio.to_thread(
+        service.users().drafts().delete(userId="me", id=draft_id).execute,
+        num_retries=GOOGLE_API_WRITE_RETRIES,
+    )
+
+    return f"Draft permanently deleted! Draft ID: {draft_id}"
+
+
 def _format_thread_content(
     thread_data: dict,
     thread_id: str,

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2716,22 +2716,29 @@ async def list_gmail_drafts(
         subject = "(no subject)"
         snippet = ""
         if message_id:
-            message_metadata = await asyncio.to_thread(
-                service.users()
-                .messages()
-                .get(
-                    userId="me",
-                    id=message_id,
-                    format="metadata",
-                    metadataHeaders=["Subject"],
+            try:
+                message_metadata = await asyncio.to_thread(
+                    service.users()
+                    .messages()
+                    .get(
+                        userId="me",
+                        id=message_id,
+                        format="metadata",
+                        metadataHeaders=["Subject"],
+                    )
+                    .execute
                 )
-                .execute
-            )
-            headers = _extract_headers(
-                message_metadata.get("payload", {}), ["Subject"]
-            )
-            subject = headers.get("Subject") or subject
-            snippet = message_metadata.get("snippet", "") or ""
+                headers = _extract_headers(
+                    message_metadata.get("payload", {}), ["Subject"]
+                )
+                subject = headers.get("Subject") or subject
+                snippet = message_metadata.get("snippet", "") or ""
+            except Exception:
+                logger.warning(
+                    f"Failed to fetch metadata for draft message {message_id}"
+                )
+                subject = "(unavailable)"
+                snippet = "(metadata fetch failed)"
 
         lines.append(
             f"{draft_id} | {message_id or 'unknown'} | {thread_id} | {subject} | {snippet}"
@@ -2917,6 +2924,9 @@ async def update_gmail_draft(
 
     if attach_to_thread and not thread_id:
         raise UserInputError("attach_to_thread=True requires thread_id.")
+
+    if quote_original and not thread_id:
+        raise UserInputError("quote_original=True requires thread_id.")
 
     # Prepare the email message
     # Use from_email (Send As alias) if provided, otherwise default to authenticated user

--- a/tests/gmail/test_delete_gmail_draft.py
+++ b/tests/gmail/test_delete_gmail_draft.py
@@ -1,0 +1,61 @@
+"""Tests for the delete_gmail_draft tool (draft rascunho family, F1-owned implementation).
+
+NOTE: gmail.gmail_tools.delete_gmail_draft does not exist yet in this worktree --
+family F1 is implementing it in parallel on gmail/gmail_tools.py. These tests are
+written against the agreed contract and will fail to import/collect until that
+implementation lands and this worktree is merged with it. That failure mode is
+expected at authoring time.
+"""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gmail.gmail_tools import delete_gmail_draft
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+@pytest.mark.asyncio
+async def test_delete_gmail_draft_calls_drafts_delete_with_correct_id():
+    mock_service = Mock()
+    mock_service.users().drafts().delete().execute.return_value = {}
+
+    await _unwrap(delete_gmail_draft)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        draft_id="draft123",
+    )
+
+    delete_kwargs = (
+        mock_service.users.return_value.drafts.return_value.delete.call_args.kwargs
+    )
+    assert delete_kwargs["userId"] == "me"
+    assert delete_kwargs["id"] == "draft123"
+    assert mock_service.users.return_value.drafts.return_value.delete.return_value.execute.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_gmail_draft_mentions_draft_id_and_deletion_in_confirmation():
+    mock_service = Mock()
+    mock_service.users().drafts().delete().execute.return_value = {}
+
+    result = await _unwrap(delete_gmail_draft)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        draft_id="draft123",
+    )
+
+    assert isinstance(result, str)
+    assert "draft123" in result
+    assert "delet" in result.lower()

--- a/tests/gmail/test_list_gmail_drafts.py
+++ b/tests/gmail/test_list_gmail_drafts.py
@@ -1,0 +1,183 @@
+"""Tests for the list_gmail_drafts tool (draft rascunho family, F1-owned implementation).
+
+NOTE: gmail.gmail_tools.list_gmail_drafts does not exist yet in this worktree --
+family F1 is implementing it in parallel on gmail/gmail_tools.py. These tests are
+written against the agreed contract and will fail to import/collect until that
+implementation lands and this worktree is merged with it. That failure mode is
+expected at authoring time.
+"""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gmail.gmail_tools import list_gmail_drafts
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _draft_entry(draft_id: str, message_id: str, thread_id: str) -> dict:
+    return {"id": draft_id, "message": {"id": message_id, "threadId": thread_id}}
+
+
+def _metadata_message(message_id: str, thread_id: str, subject: str, snippet: str) -> dict:
+    return {
+        "id": message_id,
+        "threadId": thread_id,
+        "snippet": snippet,
+        "payload": {"headers": [{"name": "Subject", "value": subject}]},
+    }
+
+
+def _message_get_side_effect(responses_by_message_id: dict):
+    """Return a side_effect callable keyed by the `id` kwarg, mirroring the
+    keyed-Mock idiom used in tests/gmail/test_body_format.py."""
+
+    def message_get(**kwargs):
+        request = Mock()
+        request.execute.return_value = responses_by_message_id[kwargs["id"]]
+        return request
+
+    return message_get
+
+
+@pytest.mark.asyncio
+async def test_list_gmail_drafts_returns_two_drafts_with_details():
+    mock_service = Mock()
+    mock_service.users().drafts().list().execute.return_value = {
+        "drafts": [
+            _draft_entry("draft1", "msg1", "thread1"),
+            _draft_entry("draft2", "msg2", "thread2"),
+        ]
+    }
+    mock_service.users().messages().get.side_effect = _message_get_side_effect(
+        {
+            "msg1": _metadata_message(
+                "msg1", "thread1", "Quarterly report", "Please find attached the report..."
+            ),
+            "msg2": _metadata_message(
+                "msg2", "thread2", "Lunch tomorrow?", "Are you free at noon..."
+            ),
+        }
+    )
+
+    result = await _unwrap(list_gmail_drafts)(
+        service=mock_service,
+        user_google_email="user@example.com",
+    )
+
+    assert isinstance(result, str)
+    assert "draft1" in result
+    assert "msg1" in result
+    assert "thread1" in result
+    assert "Quarterly report" in result
+    assert "Please find attached the report" in result
+    assert "draft2" in result
+    assert "msg2" in result
+    assert "thread2" in result
+    assert "Lunch tomorrow?" in result
+    assert "Are you free at noon" in result
+
+    # Each draft's subject/snippet must come from a per-draft metadata fetch.
+    get_calls = mock_service.users.return_value.messages.return_value.get.call_args_list
+    assert len(get_calls) == 2
+    for call in get_calls:
+        assert call.kwargs["format"] == "metadata"
+        assert call.kwargs["metadataHeaders"] == ["Subject"]
+
+
+@pytest.mark.asyncio
+async def test_list_gmail_drafts_returns_empty_page_message():
+    mock_service = Mock()
+    mock_service.users().drafts().list().execute.return_value = {"drafts": []}
+
+    result = await _unwrap(list_gmail_drafts)(
+        service=mock_service,
+        user_google_email="user@example.com",
+    )
+
+    assert isinstance(result, str)
+    assert result.strip() != ""
+    # No drafts means no per-draft subject/snippet lookups should happen.
+    assert mock_service.users.return_value.messages.return_value.get.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_list_gmail_drafts_uses_default_page_size_without_optional_params():
+    mock_service = Mock()
+    mock_service.users().drafts().list().execute.return_value = {"drafts": []}
+
+    await _unwrap(list_gmail_drafts)(
+        service=mock_service,
+        user_google_email="user@example.com",
+    )
+
+    list_kwargs = mock_service.users.return_value.drafts.return_value.list.call_args.kwargs
+    assert list_kwargs["userId"] == "me"
+    assert list_kwargs["maxResults"] == 20
+    assert "pageToken" not in list_kwargs
+    assert "q" not in list_kwargs
+
+
+@pytest.mark.asyncio
+async def test_list_gmail_drafts_passes_page_token_and_query_to_list_request():
+    mock_service = Mock()
+    mock_service.users().drafts().list().execute.return_value = {"drafts": []}
+
+    await _unwrap(list_gmail_drafts)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        page_size=5,
+        page_token="tok123",
+        query="is:draft has:attachment",
+    )
+
+    list_kwargs = mock_service.users.return_value.drafts.return_value.list.call_args.kwargs
+    assert list_kwargs["userId"] == "me"
+    assert list_kwargs["maxResults"] == 5
+    assert list_kwargs["pageToken"] == "tok123"
+    assert list_kwargs["q"] == "is:draft has:attachment"
+
+
+@pytest.mark.asyncio
+async def test_list_gmail_drafts_caps_page_size_at_fifty():
+    mock_service = Mock()
+    mock_service.users().drafts().list().execute.return_value = {"drafts": []}
+
+    await _unwrap(list_gmail_drafts)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        page_size=100,
+    )
+
+    list_kwargs = mock_service.users.return_value.drafts.return_value.list.call_args.kwargs
+    assert list_kwargs["maxResults"] == 50
+
+
+@pytest.mark.asyncio
+async def test_list_gmail_drafts_surfaces_next_page_token():
+    mock_service = Mock()
+    mock_service.users().drafts().list().execute.return_value = {
+        "drafts": [_draft_entry("draft1", "msg1", "thread1")],
+        "nextPageToken": "next-token-abc",
+    }
+    mock_service.users().messages().get.side_effect = _message_get_side_effect(
+        {"msg1": _metadata_message("msg1", "thread1", "Hello", "snippet text")}
+    )
+
+    result = await _unwrap(list_gmail_drafts)(
+        service=mock_service,
+        user_google_email="user@example.com",
+    )
+
+    assert "next-token-abc" in result

--- a/tests/gmail/test_update_gmail_draft.py
+++ b/tests/gmail/test_update_gmail_draft.py
@@ -1,0 +1,226 @@
+"""Tests for the update_gmail_draft tool (draft rascunho family, F1-owned implementation).
+
+NOTE: gmail.gmail_tools.update_gmail_draft does not exist yet in this worktree --
+family F1 is implementing it in parallel on gmail/gmail_tools.py. These tests are
+written against the agreed contract and will fail to import/collect until that
+implementation lands and this worktree is merged with it. That failure mode is
+expected at authoring time.
+
+Assumptions made about behavior not pinned down by the contract (flagged so the
+orchestrator/reviewer can confirm against the real implementation after merge):
+  * `attach_to_thread` defaults to False, and when False the update body's
+    "message" dict does NOT get a "threadId" key even if thread_id is passed
+    (only attach_to_thread=True adds it, per the contract).
+  * in_reply_to/references are asserted as direct passthrough into the raw MIME
+    headers (mirroring the explicit-header assertions in
+    test_draft_gmail_message_uses_explicit_in_reply_to_when_filling_references);
+    we do NOT assert anything about automatic derivation from a thread fetch
+    (e.g. a threads().get() call), since the contract does not specify that
+    update_gmail_draft performs one.
+"""
+
+import base64
+import os
+import sys
+from email import policy
+from email.parser import BytesParser
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from core.utils import UserInputError
+from gmail.gmail_tools import update_gmail_draft
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _parse_raw_message(raw_message: str):
+    return BytesParser(policy=policy.default).parsebytes(
+        base64.urlsafe_b64decode(raw_message)
+    )
+
+
+def _mock_update_response(draft_id: str, message_id: str) -> dict:
+    return {"id": draft_id, "message": {"id": message_id}}
+
+
+@pytest.mark.asyncio
+async def test_update_gmail_draft_builds_raw_message_with_new_subject_and_body():
+    mock_service = Mock()
+    mock_service.users().drafts().update().execute.return_value = _mock_update_response(
+        "draft1", "newmsg1"
+    )
+
+    await _unwrap(update_gmail_draft)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        draft_id="draft1",
+        subject="New subject",
+        body="New body content",
+        to="recipient@example.com",
+        include_signature=False,
+    )
+
+    update_kwargs = (
+        mock_service.users.return_value.drafts.return_value.update.call_args.kwargs
+    )
+    assert update_kwargs["userId"] == "me"
+    assert update_kwargs["id"] == "draft1"
+
+    raw_message = update_kwargs["body"]["message"]["raw"]
+    parsed = _parse_raw_message(raw_message)
+
+    assert parsed["Subject"] == "New subject"
+    assert parsed["To"] == "recipient@example.com"
+    assert "New body content" in parsed.get_body(preferencelist=("plain",)).get_content()
+
+
+@pytest.mark.asyncio
+async def test_update_gmail_draft_reports_draft_and_message_id_in_result():
+    mock_service = Mock()
+    mock_service.users().drafts().update().execute.return_value = _mock_update_response(
+        "draft42", "newmsg42"
+    )
+
+    result = await _unwrap(update_gmail_draft)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        draft_id="draft42",
+        subject="Subject",
+        body="Body",
+        include_signature=False,
+    )
+
+    assert isinstance(result, str)
+    assert "draft42" in result
+    assert "newmsg42" in result
+
+
+@pytest.mark.asyncio
+async def test_update_gmail_draft_supports_html_body_format():
+    mock_service = Mock()
+    mock_service.users().drafts().update().execute.return_value = _mock_update_response(
+        "draft1", "newmsg1"
+    )
+
+    await _unwrap(update_gmail_draft)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        draft_id="draft1",
+        subject="HTML update",
+        body="<p>Updated content</p>",
+        body_format="html",
+        to="recipient@example.com",
+        include_signature=False,
+    )
+
+    update_kwargs = (
+        mock_service.users.return_value.drafts.return_value.update.call_args.kwargs
+    )
+    raw_message = update_kwargs["body"]["message"]["raw"]
+    raw_text = base64.urlsafe_b64decode(raw_message).decode("utf-8", errors="ignore")
+
+    assert "<p>Updated content</p>" in raw_text
+
+
+@pytest.mark.asyncio
+async def test_update_gmail_draft_attach_to_thread_includes_thread_id_in_body():
+    mock_service = Mock()
+    mock_service.users().drafts().update().execute.return_value = _mock_update_response(
+        "draft1", "newmsg1"
+    )
+
+    await _unwrap(update_gmail_draft)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        draft_id="draft1",
+        subject="Reply",
+        body="Reply body",
+        thread_id="thread123",
+        attach_to_thread=True,
+        include_signature=False,
+    )
+
+    update_kwargs = (
+        mock_service.users.return_value.drafts.return_value.update.call_args.kwargs
+    )
+    assert update_kwargs["body"]["message"]["threadId"] == "thread123"
+
+
+@pytest.mark.asyncio
+async def test_update_gmail_draft_attach_to_thread_without_thread_id_raises_user_input_error():
+    mock_service = Mock()
+
+    with pytest.raises(UserInputError):
+        await _unwrap(update_gmail_draft)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            draft_id="draft1",
+            subject="Reply",
+            body="Reply body",
+            attach_to_thread=True,
+            include_signature=False,
+        )
+
+    assert mock_service.users.return_value.drafts.return_value.update.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_update_gmail_draft_without_attach_to_thread_omits_thread_id():
+    mock_service = Mock()
+    mock_service.users().drafts().update().execute.return_value = _mock_update_response(
+        "draft1", "newmsg1"
+    )
+
+    await _unwrap(update_gmail_draft)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        draft_id="draft1",
+        subject="Reply",
+        body="Reply body",
+        thread_id="thread123",
+        include_signature=False,
+    )
+
+    update_kwargs = (
+        mock_service.users.return_value.drafts.return_value.update.call_args.kwargs
+    )
+    assert "threadId" not in update_kwargs["body"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_update_gmail_draft_includes_explicit_in_reply_to_and_references_headers():
+    mock_service = Mock()
+    mock_service.users().drafts().update().execute.return_value = _mock_update_response(
+        "draft1", "newmsg1"
+    )
+
+    await _unwrap(update_gmail_draft)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        draft_id="draft1",
+        subject="Re: Meeting tomorrow",
+        body="Replying to an earlier message.",
+        to="recipient@example.com",
+        thread_id="thread123",
+        in_reply_to="<msg2@example.com>",
+        references="<msg1@example.com> <msg2@example.com>",
+        include_signature=False,
+    )
+
+    update_kwargs = (
+        mock_service.users.return_value.drafts.return_value.update.call_args.kwargs
+    )
+    raw_message = update_kwargs["body"]["message"]["raw"]
+    raw_text = base64.urlsafe_b64decode(raw_message).decode("utf-8", errors="ignore")
+
+    assert "In-Reply-To: <msg2@example.com>" in raw_text
+    assert "References: <msg1@example.com> <msg2@example.com>" in raw_text

--- a/tests/gmail/test_update_gmail_draft.py
+++ b/tests/gmail/test_update_gmail_draft.py
@@ -1,22 +1,15 @@
-"""Tests for the update_gmail_draft tool (draft rascunho family, F1-owned implementation).
+"""Tests for the update_gmail_draft tool.
 
-NOTE: gmail.gmail_tools.update_gmail_draft does not exist yet in this worktree --
-family F1 is implementing it in parallel on gmail/gmail_tools.py. These tests are
-written against the agreed contract and will fail to import/collect until that
-implementation lands and this worktree is merged with it. That failure mode is
-expected at authoring time.
-
-Assumptions made about behavior not pinned down by the contract (flagged so the
-orchestrator/reviewer can confirm against the real implementation after merge):
+Behavior notes (confirmed against the implementation in gmail/gmail_tools.py):
   * `attach_to_thread` defaults to False, and when False the update body's
     "message" dict does NOT get a "threadId" key even if thread_id is passed
-    (only attach_to_thread=True adds it, per the contract).
-  * in_reply_to/references are asserted as direct passthrough into the raw MIME
-    headers (mirroring the explicit-header assertions in
-    test_draft_gmail_message_uses_explicit_in_reply_to_when_filling_references);
-    we do NOT assert anything about automatic derivation from a thread fetch
-    (e.g. a threads().get() call), since the contract does not specify that
-    update_gmail_draft performs one.
+    (only attach_to_thread=True adds it).
+  * When thread_id is given and in_reply_to/references/to are not all explicit,
+    update_gmail_draft fetches the thread via threads().get() to derive reply
+    headers/recipient (same reply-context logic as draft_gmail_message), so
+    those tests must mock a realistic thread response.
+  * When to, in_reply_to and references are all explicit, no thread fetch
+    happens and the headers pass straight through into the raw MIME message.
 """
 
 import base64
@@ -50,6 +43,24 @@ def _parse_raw_message(raw_message: str):
 
 def _mock_update_response(draft_id: str, message_id: str) -> dict:
     return {"id": draft_id, "message": {"id": message_id}}
+
+
+def _thread_response(*message_ids):
+    """Realistic threads().get() payload, mirroring test_draft_gmail_message.py."""
+    return {
+        "messages": [
+            {
+                "payload": {
+                    "headers": [
+                        {"name": "Message-ID", "value": message_id},
+                        {"name": "From", "value": "sender@example.com"},
+                        {"name": "Subject", "value": "Meeting tomorrow"},
+                    ],
+                }
+            }
+            for message_id in message_ids
+        ]
+    }
 
 
 @pytest.mark.asyncio
@@ -137,6 +148,12 @@ async def test_update_gmail_draft_attach_to_thread_includes_thread_id_in_body():
     mock_service.users().drafts().update().execute.return_value = _mock_update_response(
         "draft1", "newmsg1"
     )
+    # thread_id without explicit in_reply_to/references/to triggers a thread
+    # fetch to derive the reply headers, so the mock must return real messages.
+    mock_service.users().threads().get().execute.return_value = _thread_response(
+        "<msg1@example.com>",
+        "<msg2@example.com>",
+    )
 
     await _unwrap(update_gmail_draft)(
         service=mock_service,
@@ -153,6 +170,12 @@ async def test_update_gmail_draft_attach_to_thread_includes_thread_id_in_body():
         mock_service.users.return_value.drafts.return_value.update.call_args.kwargs
     )
     assert update_kwargs["body"]["message"]["threadId"] == "thread123"
+
+    # Reply headers derived from the fetched thread should land in the raw MIME.
+    raw_message = update_kwargs["body"]["message"]["raw"]
+    raw_text = base64.urlsafe_b64decode(raw_message).decode("utf-8", errors="ignore")
+    assert "In-Reply-To: <msg2@example.com>" in raw_text
+    assert "References: <msg1@example.com> <msg2@example.com>" in raw_text
 
 
 @pytest.mark.asyncio
@@ -178,6 +201,11 @@ async def test_update_gmail_draft_without_attach_to_thread_omits_thread_id():
     mock_service = Mock()
     mock_service.users().drafts().update().execute.return_value = _mock_update_response(
         "draft1", "newmsg1"
+    )
+    # thread_id without explicit in_reply_to/references/to triggers a thread
+    # fetch to derive the reply headers, so the mock must return real messages.
+    mock_service.users().threads().get().execute.return_value = _thread_response(
+        "<msg1@example.com>",
     )
 
     await _unwrap(update_gmail_draft)(


### PR DESCRIPTION
## Summary

Adds three Gmail draft-management tools that round out the existing `draft_gmail_message`:

- **`list_gmail_drafts`** — paginated draft listing (`drafts().list`) with per-draft Subject + snippet (via `messages().get(format="metadata")`), Gmail search-query filtering, and `nextPageToken` surfacing. Read-only (`readOnlyHint=True`, `is_read_only=True`).
- **`update_gmail_draft`** — full replacement update of an existing draft (`drafts().update`), mirroring `draft_gmail_message`'s signature/reply-context/quote/attachment flow (same private helpers). Adds an opt-in **`attach_to_thread`** flag (requires `thread_id`, else `UserInputError`) that sets `message.threadId` on the update so the draft appears **inside the conversation** in the Gmail UI.
- **`delete_gmail_draft`** — permanent draft deletion (`drafts().delete`), `destructiveHint=True`, docstring warns it does not go to Trash.

All three are registered in `core/tool_tiers.yaml` (`list`/`update` → `extended`, `delete` → `complete`).

## Motivation

Agent workflows that prepare reply drafts for a human to finish (attach files from a phone, review, send) currently have no way to: find which draft is which, fix a draft without creating duplicates, remove superseded drafts, or make a reply draft show up inside its Gmail conversation. We hit all four gaps in production use against a Zendesk-backed support thread and had to fall back to raw API scripts.

## Design notes

- **Why `attach_to_thread` is opt-in:** `draft_gmail_message` deliberately keeps `threadId` off the created draft unless full reply headers were derived (avoids UI-hidden drafts). On *update* we found (validated against the live Gmail API, 2026-07-11) that setting `threadId` makes the draft render inside the conversation view as users expect. The flag keeps the safe default (`False` never sets `threadId`) and makes the UI-attach behavior an explicit choice.
- **ID churn documented:** Gmail may assign a new draft ID and always assigns a new message ID after `drafts().update`. The return string surfaces both new IDs and the docstrings steer callers to `list_gmail_drafts` instead of caching IDs.
- `update_gmail_draft` replicates (rather than refactors) `draft_gmail_message`'s flow to leave the existing, tested tool untouched. Happy to extract a shared helper if maintainers prefer.

## Tests

- 16 new tests in `tests/gmail/test_list_gmail_drafts.py` / `test_update_gmail_draft.py` / `test_delete_gmail_draft.py`, following the existing mock patterns (decorator unwrap, raw-MIME parsing, keyed `side_effect` per message ID).
- `uv run pytest tests/gmail/ -q` → **158 passed** (143 pre-existing + 15 collected new cases), no regressions.
- `uv run ruff check gmail/ core/ tests/gmail/` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8f3k8TDS7PBU59mgk794b


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gmail draft management tools: list drafts (with pagination and optional search), update drafts (plain or HTML, signatures, quoted replies, attachments), and permanently delete drafts.
  * Updating can optionally attach drafts to a conversation thread and derive reply headers for proper threading.
* **Enhancements**
  * Expanded tool access tiers to include draft-related actions for the appropriate Gmail tool tiers.
* **Tests**
  * Added contract tests covering list, update, and delete draft tool behaviors and expected Gmail API calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->