### PR TITLE
fix(gappsscript): keep existing deployment config when updating

### DIFF
--- a/gappsscript/apps_script_tools.py
+++ b/gappsscript/apps_script_tools.py
@@ -685,7 +685,7 @@ async def _update_deployment_impl(
     deployment_config.setdefault("manifestFileName", "appsscript")
     if version_number is not None:
         deployment_config["versionNumber"] = version_number
-    if description is not None:
+    if description is not None and description.strip() != "":
         deployment_config["description"] = description
 
     request_body = {"deploymentConfig": deployment_config}

--- a/gappsscript/apps_script_tools.py
+++ b/gappsscript/apps_script_tools.py
@@ -607,10 +607,16 @@ async def _list_deployments_impl(
 
     for i, deployment in enumerate(deployments, 1):
         deployment_id = deployment.get("deploymentId", "Unknown")
-        description = deployment.get("description", "No description")
+        deployment_config = deployment.get("deploymentConfig", {})
+        description = deployment_config.get(
+            "description", deployment.get("description", "No description")
+        )
         update_time = deployment.get("updateTime", "Unknown")
+        version_number = deployment_config.get("versionNumber")
 
         output.append(f"{i}. {description} ({deployment_id})")
+        if version_number is not None:
+            output.append(f"   Version: {version_number}")
         output.append(f"   Updated: {update_time}")
         output.append("")
 
@@ -668,10 +674,18 @@ async def _update_deployment_impl(
         f"[update_deployment] Email: {user_google_email}, Script: {script_id}, Deployment: {deployment_id}"
     )
 
-    deployment_config: Dict[str, Any] = {"scriptId": script_id}
+    current = await asyncio.to_thread(
+        service.projects()
+        .deployments()
+        .get(scriptId=script_id, deploymentId=deployment_id)
+        .execute
+    )
+    deployment_config: Dict[str, Any] = dict(current.get("deploymentConfig", {}) or {})
+    deployment_config["scriptId"] = script_id
+    deployment_config.setdefault("manifestFileName", "appsscript")
     if version_number is not None:
         deployment_config["versionNumber"] = version_number
-    if description:
+    if description is not None:
         deployment_config["description"] = description
 
     request_body = {"deploymentConfig": deployment_config}

--- a/gappsscript/apps_script_tools.py
+++ b/gappsscript/apps_script_tools.py
@@ -806,7 +806,7 @@ async def _update_deployment_impl(
     deployment_config.setdefault("manifestFileName", "appsscript")
     if version_number is not None:
         deployment_config["versionNumber"] = version_number
-    if description is not None:
+    if description is not None and description.strip() != "":
         deployment_config["description"] = description
 
     request_body = {"deploymentConfig": deployment_config}

--- a/gappsscript/apps_script_tools.py
+++ b/gappsscript/apps_script_tools.py
@@ -795,10 +795,18 @@ async def _update_deployment_impl(
         f"[update_deployment] Email: {user_google_email}, Script: {script_id}, Deployment: {deployment_id}"
     )
 
-    deployment_config: Dict[str, Any] = {"scriptId": script_id}
+    current = await asyncio.to_thread(
+        service.projects()
+        .deployments()
+        .get(scriptId=script_id, deploymentId=deployment_id)
+        .execute
+    )
+    deployment_config: Dict[str, Any] = dict(current.get("deploymentConfig", {}) or {})
+    deployment_config["scriptId"] = script_id
+    deployment_config.setdefault("manifestFileName", "appsscript")
     if version_number is not None:
         deployment_config["versionNumber"] = version_number
-    if description:
+    if description is not None:
         deployment_config["description"] = description
 
     request_body = {"deploymentConfig": deployment_config}

--- a/tests/gappsscript/test_apps_script_tools.py
+++ b/tests/gappsscript/test_apps_script_tools.py
@@ -220,8 +220,11 @@ async def test_list_deployments():
         "deployments": [
             {
                 "deploymentId": "deploy123",
-                "description": "Production",
                 "updateTime": "2026-01-12T15:30:00Z",
+                "deploymentConfig": {
+                    "versionNumber": 7,
+                    "description": "Production",
+                },
             }
         ]
     }
@@ -234,6 +237,47 @@ async def test_list_deployments():
 
     assert "Production" in result
     assert "deploy123" in result
+    assert "Version: 7" in result
+
+
+@pytest.mark.asyncio
+async def test_update_deployment_preserves_unspecified_config_fields():
+    mock_service = Mock()
+    mock_service.projects().deployments().get().execute.return_value = {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 6,
+            "manifestFileName": "appsscript",
+            "description": "Old description",
+        }
+    }
+    mock_service.projects().deployments().update().execute.return_value = {
+        "deploymentId": "deploy123",
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 6,
+            "manifestFileName": "appsscript",
+            "description": "New description",
+        },
+    }
+
+    await _update_deployment_impl(
+        service=mock_service,
+        user_google_email="test@example.com",
+        script_id="test123",
+        deployment_id="deploy123",
+        description="New description",
+    )
+
+    _, update_kwargs = mock_service.projects().deployments().update.call_args
+    assert update_kwargs["body"] == {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 6,
+            "manifestFileName": "appsscript",
+            "description": "New description",
+        }
+    }
 
 
 @pytest.mark.asyncio
@@ -248,6 +292,9 @@ async def test_update_deployment():
         },
     }
 
+    mock_service.projects().deployments().get().execute.return_value = {
+        "deploymentConfig": {"scriptId": "test123", "manifestFileName": "appsscript"}
+    }
     mock_service.projects().deployments().update().execute.return_value = mock_response
 
     result = await _update_deployment_impl(
@@ -266,6 +313,7 @@ async def test_update_deployment():
     assert update_kwargs["body"] == {
         "deploymentConfig": {
             "scriptId": "test123",
+            "manifestFileName": "appsscript",
             "description": "Updated description",
         }
     }
@@ -288,6 +336,13 @@ async def test_update_deployment_with_version_number():
         },
     }
 
+    mock_service.projects().deployments().get().execute.return_value = {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 1,
+            "manifestFileName": "appsscript",
+        }
+    }
     mock_service.projects().deployments().update().execute.return_value = mock_response
 
     result = await _update_deployment_impl(
@@ -304,6 +359,7 @@ async def test_update_deployment_with_version_number():
         "deploymentConfig": {
             "scriptId": "test123",
             "versionNumber": 2,
+            "manifestFileName": "appsscript",
             "description": "v2 - updated layout",
         }
     }
@@ -323,6 +379,13 @@ async def test_manage_deployment_update_allows_version_number_without_descriptio
             "versionNumber": 2,
         },
     }
+    mock_service.projects().deployments().get().execute.return_value = {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 1,
+            "manifestFileName": "appsscript",
+        }
+    }
     mock_service.projects().deployments().update().execute.return_value = mock_response
 
     undecorated_manage_deployment = manage_deployment.__wrapped__.__wrapped__
@@ -340,6 +403,7 @@ async def test_manage_deployment_update_allows_version_number_without_descriptio
         "deploymentConfig": {
             "scriptId": "test123",
             "versionNumber": 2,
+            "manifestFileName": "appsscript",
         }
     }
     assert "Version: 2" in result

--- a/tests/gappsscript/test_apps_script_tools.py
+++ b/tests/gappsscript/test_apps_script_tools.py
@@ -369,6 +369,41 @@ async def test_update_deployment_with_version_number():
 
 
 @pytest.mark.asyncio
+async def test_update_deployment_preserves_description_when_blank():
+    """Blank descriptions leave the existing deployment description intact."""
+    mock_service = Mock()
+    mock_service.projects().deployments().get().execute.return_value = {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 1,
+            "manifestFileName": "appsscript",
+            "description": "Production",
+        }
+    }
+    mock_service.projects().deployments().update().execute.return_value = {
+        "deploymentId": "deploy123",
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 2,
+            "manifestFileName": "appsscript",
+            "description": "Production",
+        },
+    }
+
+    await _update_deployment_impl(
+        service=mock_service,
+        user_google_email="test@example.com",
+        script_id="test123",
+        deployment_id="deploy123",
+        description="   ",
+        version_number=2,
+    )
+
+    _, update_kwargs = mock_service.projects().deployments().update.call_args
+    assert update_kwargs["body"]["deploymentConfig"]["description"] == "Production"
+
+
+@pytest.mark.asyncio
 async def test_manage_deployment_update_allows_version_number_without_description():
     """The public update branch allows roll-forward updates without a description."""
     mock_service = Mock()

--- a/tests/gappsscript/test_apps_script_tools.py
+++ b/tests/gappsscript/test_apps_script_tools.py
@@ -619,6 +619,41 @@ async def test_update_deployment_with_version_number():
 
 
 @pytest.mark.asyncio
+async def test_update_deployment_preserves_description_when_blank():
+    """Blank descriptions leave the existing deployment description intact."""
+    mock_service = Mock()
+    mock_service.projects().deployments().get().execute.return_value = {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 1,
+            "manifestFileName": "appsscript",
+            "description": "Production",
+        }
+    }
+    mock_service.projects().deployments().update().execute.return_value = {
+        "deploymentId": "deploy123",
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 2,
+            "manifestFileName": "appsscript",
+            "description": "Production",
+        },
+    }
+
+    await _update_deployment_impl(
+        service=mock_service,
+        user_google_email="test@example.com",
+        script_id="test123",
+        deployment_id="deploy123",
+        description="   ",
+        version_number=2,
+    )
+
+    _, update_kwargs = mock_service.projects().deployments().update.call_args
+    assert update_kwargs["body"]["deploymentConfig"]["description"] == "Production"
+
+
+@pytest.mark.asyncio
 async def test_manage_deployment_update_allows_version_number_without_description():
     """The public update branch allows roll-forward updates without a description."""
     mock_service = Mock()

--- a/tests/gappsscript/test_apps_script_tools.py
+++ b/tests/gappsscript/test_apps_script_tools.py
@@ -491,6 +491,46 @@ async def test_list_deployments_head_deployment_has_no_version():
 
 
 @pytest.mark.asyncio
+async def test_update_deployment_preserves_unspecified_config_fields():
+    mock_service = Mock()
+    mock_service.projects().deployments().get().execute.return_value = {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 6,
+            "manifestFileName": "appsscript",
+            "description": "Old description",
+        }
+    }
+    mock_service.projects().deployments().update().execute.return_value = {
+        "deploymentId": "deploy123",
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 6,
+            "manifestFileName": "appsscript",
+            "description": "New description",
+        },
+    }
+
+    await _update_deployment_impl(
+        service=mock_service,
+        user_google_email="test@example.com",
+        script_id="test123",
+        deployment_id="deploy123",
+        description="New description",
+    )
+
+    _, update_kwargs = mock_service.projects().deployments().update.call_args
+    assert update_kwargs["body"] == {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 6,
+            "manifestFileName": "appsscript",
+            "description": "New description",
+        }
+    }
+
+
+@pytest.mark.asyncio
 async def test_update_deployment():
     """Test updating deployment wraps fields in deploymentConfig (issue #836)."""
     mock_service = Mock()
@@ -502,6 +542,9 @@ async def test_update_deployment():
         },
     }
 
+    mock_service.projects().deployments().get().execute.return_value = {
+        "deploymentConfig": {"scriptId": "test123", "manifestFileName": "appsscript"}
+    }
     mock_service.projects().deployments().update().execute.return_value = mock_response
 
     result = await _update_deployment_impl(
@@ -520,6 +563,7 @@ async def test_update_deployment():
     assert update_kwargs["body"] == {
         "deploymentConfig": {
             "scriptId": "test123",
+            "manifestFileName": "appsscript",
             "description": "Updated description",
         }
     }
@@ -542,6 +586,13 @@ async def test_update_deployment_with_version_number():
         },
     }
 
+    mock_service.projects().deployments().get().execute.return_value = {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 1,
+            "manifestFileName": "appsscript",
+        }
+    }
     mock_service.projects().deployments().update().execute.return_value = mock_response
 
     result = await _update_deployment_impl(
@@ -558,6 +609,7 @@ async def test_update_deployment_with_version_number():
         "deploymentConfig": {
             "scriptId": "test123",
             "versionNumber": 2,
+            "manifestFileName": "appsscript",
             "description": "v2 - updated layout",
         }
     }
@@ -577,6 +629,13 @@ async def test_manage_deployment_update_allows_version_number_without_descriptio
             "versionNumber": 2,
         },
     }
+    mock_service.projects().deployments().get().execute.return_value = {
+        "deploymentConfig": {
+            "scriptId": "test123",
+            "versionNumber": 1,
+            "manifestFileName": "appsscript",
+        }
+    }
     mock_service.projects().deployments().update().execute.return_value = mock_response
 
     undecorated_manage_deployment = manage_deployment.__wrapped__.__wrapped__
@@ -594,6 +653,7 @@ async def test_manage_deployment_update_allows_version_number_without_descriptio
         "deploymentConfig": {
             "scriptId": "test123",
             "versionNumber": 2,
+            "manifestFileName": "appsscript",
         }
     }
     assert "Version: 2" in result


### PR DESCRIPTION
## Summary

Rebased onto main. #894 and #1063 already cover the `deploymentConfig` wrapper and showing versions in `list_deployments`, so I dropped those parts. What's left:

- `update` now fetches the deployment and merges into its existing `deploymentConfig`. On main, an update that only changes the description sends `{scriptId, description}`, which drops `versionNumber`, so a deployment pinned to a version gets repointed to HEAD.
- A blank or whitespace description keeps the existing one instead of clearing it.

## Validation

- `uv run --extra test pytest tests/gappsscript -q` (40 passed)
- `uvx ruff@0.15.22 check .` and `uvx ruff@0.15.22 format --check .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Script updates now merge with existing files by default, while supporting full replacement when requested.
  * Deployment listings now show each deployment’s version, including whether it uses the latest code.
  * Deployment updates preserve existing configuration details when only selected fields are changed.

* **Bug Fixes**
  * Blank deployment descriptions no longer overwrite existing descriptions.
  * Script update results now clearly identify the update mode and resulting files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->