### PR TITLE
fix: persist refreshed secondary-account credentials on rebind

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -1141,19 +1141,27 @@ def get_credentials(
 
                 if persist_succeeded or is_stateless_mode():
                     # Also update OAuth21SessionStore
-                    store = get_oauth21_session_store()
-                    store.store_session(
-                        user_email=user_google_email,
-                        access_token=credentials.token,
-                        refresh_token=credentials.refresh_token,
-                        token_uri=credentials.token_uri,
-                        client_id=credentials.client_id,
-                        client_secret=credentials.client_secret,
-                        scopes=credentials.scopes,
-                        expiry=credentials.expiry,
-                        mcp_session_id=session_id,
-                        issuer="https://accounts.google.com",  # Add issuer for Google tokens
-                    )
+                    try:
+                        store = get_oauth21_session_store()
+                        store.store_session(
+                            user_email=user_google_email,
+                            access_token=credentials.token,
+                            refresh_token=credentials.refresh_token,
+                            token_uri=credentials.token_uri,
+                            client_id=credentials.client_id,
+                            client_secret=credentials.client_secret,
+                            scopes=credentials.scopes,
+                            expiry=credentials.expiry,
+                            mcp_session_id=session_id,
+                            issuer="https://accounts.google.com",  # Add issuer for Google tokens
+                        )
+                    except Exception as session_store_error:
+                        logger.warning(
+                            "[get_credentials] Failed to update OAuth 2.1 session store "
+                            "for refreshed credentials for user %s: %s",
+                            user_google_email,
+                            session_store_error,
+                        )
 
             if session_id and (persist_succeeded or is_stateless_mode()):
                 # Update session cache if it was the source or is active

--- a/auth/oauth21_session_store.py
+++ b/auth/oauth21_session_store.py
@@ -607,6 +607,15 @@ class OAuth21SessionStore:
         with self._lock:
             normalized_expiry = _normalize_expiry_to_naive_utc(expiry)
 
+            if mcp_session_id:
+                bound_user = self._session_auth_binding.get(mcp_session_id)
+                if bound_user and bound_user != user_email:
+                    logger.info(
+                        f"MCP session {mcp_session_id} is already bound to {bound_user}; "
+                        f"storing credentials for {user_email} without changing the session binding"
+                    )
+                    mcp_session_id = None
+
             # Clean up previous session mappings for this user before storing new one
             old_session = self._sessions.get(user_email)
             if old_session:
@@ -654,14 +663,6 @@ class OAuth21SessionStore:
                     self._session_auth_binding[mcp_session_id] = user_email
                     logger.info(
                         f"Created immutable session binding: {mcp_session_id} -> {user_email}"
-                    )
-                elif self._session_auth_binding[mcp_session_id] != user_email:
-                    # Security: Attempt to bind session to different user
-                    logger.error(
-                        f"SECURITY: Attempt to rebind session {mcp_session_id} from {self._session_auth_binding[mcp_session_id]} to {user_email}"
-                    )
-                    raise ValueError(
-                        f"Session {mcp_session_id} is already bound to a different user"
                     )
 
                 self._mcp_session_mapping[mcp_session_id] = user_email

--- a/tests/auth/test_google_auth_refresh_persistence.py
+++ b/tests/auth/test_google_auth_refresh_persistence.py
@@ -1,4 +1,5 @@
 from auth.google_auth import get_credentials
+from auth.oauth21_session_store import OAuth21SessionStore
 
 
 class _RefreshableCredentials:
@@ -20,9 +21,15 @@ class _RefreshableCredentials:
 
 
 class _OAuthSessionStore:
-    def __init__(self, session_credentials=None, session_user="user@example.com"):
+    def __init__(
+        self,
+        session_credentials=None,
+        session_user="user@example.com",
+        store_error=None,
+    ):
         self._session_credentials = session_credentials
         self._session_user = session_user
+        self._store_error = store_error
         self.store_calls = []
 
     def get_user_by_mcp_session(self, session_id):  # noqa: ARG002
@@ -33,6 +40,8 @@ class _OAuthSessionStore:
 
     def store_session(self, **kwargs):
         self.store_calls.append(kwargs)
+        if self._store_error:
+            raise self._store_error
 
 
 class _CredentialStore:
@@ -117,6 +126,134 @@ def test_get_credentials_skips_session_update_when_refresh_persist_fails(monkeyp
     assert oauth_store.store_calls == []
     assert len(session_cache_writes) == 1
     assert session_cache_writes[0][0] == "session-1"
+
+
+def test_get_credentials_returns_refreshed_secondary_credentials_when_session_bound_to_primary(
+    tmp_path,
+    monkeypatch,
+):
+    oauth_store = OAuth21SessionStore(
+        oauth_state_file=str(tmp_path / "oauth_states.json")
+    )
+    oauth_store.store_session(
+        user_email="primary@example.com",
+        access_token="primary-token",
+        mcp_session_id="session-1",
+    )
+    file_creds = _RefreshableCredentials()
+    credential_store = _CredentialStore(existing_credentials=file_creds)
+    session_cache_writes = []
+
+    monkeypatch.delenv("MCP_SINGLE_USER_MODE", raising=False)
+    monkeypatch.setattr(
+        "auth.google_auth.get_oauth21_session_store", lambda: oauth_store
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_credential_store", lambda: credential_store
+    )
+    monkeypatch.setattr("auth.google_auth.is_stateless_mode", lambda: False)
+    monkeypatch.setattr(
+        "auth.google_auth.has_required_scopes", lambda scopes, required: True
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.save_credentials_to_session",
+        lambda *args: session_cache_writes.append(args),
+    )
+
+    result = get_credentials(
+        user_google_email="secondary@example.com",
+        required_scopes=["scope.a"],
+        session_id="session-1",
+    )
+
+    assert result is file_creds
+    assert result.token == "fresh-token"
+    assert credential_store.store_calls == [("secondary@example.com", "fresh-token")]
+    assert oauth_store.get_user_by_mcp_session("session-1") == "primary@example.com"
+    assert oauth_store.get_credentials("secondary@example.com").token == "fresh-token"
+    assert session_cache_writes == [("session-1", file_creds)]
+
+
+def test_store_session_drops_cross_account_mcp_binding_but_persists_credentials(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.delenv("MCP_SINGLE_USER_MODE", raising=False)
+    store = OAuth21SessionStore(oauth_state_file=str(tmp_path / "oauth_states.json"))
+    store.store_session(
+        user_email="primary@example.com",
+        access_token="primary-token",
+        mcp_session_id="session-1",
+    )
+
+    store.store_session(
+        user_email="secondary@example.com",
+        access_token="secondary-token",
+        mcp_session_id="session-1",
+    )
+
+    assert store.get_user_by_mcp_session("session-1") == "primary@example.com"
+    assert store.get_credentials("secondary@example.com").token == "secondary-token"
+    assert store._sessions["secondary@example.com"]["mcp_session_id"] is None
+
+
+def test_store_session_keeps_same_user_mcp_binding(tmp_path, monkeypatch):
+    monkeypatch.delenv("MCP_SINGLE_USER_MODE", raising=False)
+    store = OAuth21SessionStore(oauth_state_file=str(tmp_path / "oauth_states.json"))
+    store.store_session(
+        user_email="primary@example.com",
+        access_token="stale-token",
+        mcp_session_id="session-1",
+    )
+
+    store.store_session(
+        user_email="primary@example.com",
+        access_token="fresh-token",
+        mcp_session_id="session-1",
+    )
+
+    assert store.get_user_by_mcp_session("session-1") == "primary@example.com"
+    assert store.get_credentials("primary@example.com").token == "fresh-token"
+    assert store._sessions["primary@example.com"]["mcp_session_id"] == "session-1"
+
+
+def test_get_credentials_returns_refreshed_credentials_when_session_store_fails(
+    caplog,
+    monkeypatch,
+):
+    file_creds = _RefreshableCredentials()
+    oauth_store = _OAuthSessionStore(
+        session_credentials=None,
+        store_error=RuntimeError("session store unavailable"),
+    )
+    credential_store = _CredentialStore(existing_credentials=file_creds)
+
+    monkeypatch.delenv("MCP_SINGLE_USER_MODE", raising=False)
+    monkeypatch.setattr(
+        "auth.google_auth.get_oauth21_session_store", lambda: oauth_store
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_credential_store", lambda: credential_store
+    )
+    monkeypatch.setattr("auth.google_auth.is_stateless_mode", lambda: False)
+    monkeypatch.setattr(
+        "auth.google_auth.has_required_scopes", lambda scopes, required: True
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.save_credentials_to_session", lambda *args: None
+    )
+
+    result = get_credentials(
+        user_google_email="user@example.com",
+        required_scopes=["scope.a"],
+        session_id="session-1",
+    )
+
+    assert result is file_creds
+    assert result.token == "fresh-token"
+    assert credential_store.store_calls == [("user@example.com", "fresh-token")]
+    assert len(oauth_store.store_calls) == 1
+    assert "Failed to update OAuth 2.1 session store" in caplog.text
 
 
 def test_get_credentials_single_user_returns_none_for_missing_requested_user(

--- a/tests/auth/test_oauth21_session_store.py
+++ b/tests/auth/test_oauth21_session_store.py
@@ -1,4 +1,3 @@
-import pytest
 
 from auth.oauth21_session_store import OAuth21SessionStore
 
@@ -135,7 +134,7 @@ def test_deserialize_oauth_state_entry_normalizes_invalid_and_naive_timestamps(
     assert deserialized["expires_at"] is None
 
 
-def test_store_session_rejects_mcp_session_rebind_by_default(tmp_path):
+def test_store_session_keeps_original_binding_on_cross_user_rebind(tmp_path):
     state_file = tmp_path / "oauth_states.json"
     store = OAuth21SessionStore(oauth_state_file=str(state_file))
 
@@ -145,12 +144,19 @@ def test_store_session_rejects_mcp_session_rebind_by_default(tmp_path):
         mcp_session_id="session-123",
     )
 
-    with pytest.raises(ValueError, match="already bound to a different user"):
-        store.store_session(
-            user_email="account-b@example.com",
-            access_token="token-b",
-            mcp_session_id="session-123",
-        )
+    # A second account reusing a session already bound to another user must not
+    # hijack the binding, but it also must not discard the second account's
+    # credentials. The session stays bound to the original user and the second
+    # account is persisted without an mcp_session_id (mirrors the read path and
+    # single-user mode), rather than raising and losing a valid refresh.
+    store.store_session(
+        user_email="account-b@example.com",
+        access_token="token-b",
+        mcp_session_id="session-123",
+    )
+
+    assert store.get_user_by_mcp_session("session-123") == "account-a@example.com"
+    assert store.get_credentials("account-b@example.com").token == "token-b"
 
 
 def test_store_session_skips_mcp_binding_in_single_user_mode(tmp_path, monkeypatch):


### PR DESCRIPTION
## Description
In the default multi-user / multi-account stdio setup, a tool call for a secondary Google account whose access token has expired triggers a full re-auth even though the refresh token is valid and the rotated token is already persisted to disk.

The cause is in the post-refresh write path. After a successful `credentials.refresh()` and `store_credential()`, `get_credentials()` calls `store.store_session(..., mcp_session_id=session_id)`. That session is already bound to the primary account, so `store_session()` raised the immutable-rebind `ValueError`, and the surrounding generic `except Exception` turned that into `return None`, discarding the already-successful refresh. The #716 fix only dropped `mcp_session_id` under `MCP_SINGLE_USER_MODE`, so the default multi-user path still reproduced.

This changes `store_session()` so that when a non-null `mcp_session_id` is already bound to a different user, it drops the session binding (sets it to `None`) instead of raising, mirroring what the read path and single-user mode already do. The original session stays bound to its first user (no hijack), and the second account's refreshed credentials are persisted by email. As defense-in-depth, the post-refresh `store_session(...)` call in the file-credential branch of `get_credentials()` is wrapped so any session-cache write failure is logged and the already-persisted credentials are still returned.

Note on the security contract: the previous behavior rejected a cross-user rebind by raising. That still protected the binding, but at the cost of discarding a valid refresh for the second account. The new behavior keeps the same protection (the session is never rebound to a different user) without the data loss. I updated the existing `test_store_session_rejects_mcp_session_rebind_by_default` accordingly (now `test_store_session_keeps_original_binding_on_cross_user_rebind`) to assert the binding is preserved and the second account's credentials are kept. Happy to revisit if you would rather keep the hard raise and address the discard another way.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

`uv run pytest tests/auth/test_google_auth_refresh_persistence.py tests/auth/test_oauth21_session_store.py` — 15 passed. `ruff check` is clean on the changed files.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
The new regression coverage exercises the happy path (a secondary account with an expired token over a session bound to the primary returns refreshed credentials), the cross-account rebind (binding preserved, second account persisted), and the store-failure path (a non-rebind `store_session` failure no longer discards a successful refresh).

Closes #926


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Credential refreshes now complete successfully even if session-store persistence encounters an error.
  * Prevented cross-account session binding conflicts from blocking credential storage.
  * Preserved existing session ownership while saving credentials for another account.

* **Tests**
  * Added coverage for credential refresh failures, cross-account sessions, and binding preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->