### PR TITLE
feat(docs): render GFM tables natively in populate_from_markdown

### DIFF
--- a/gdocs/docs_markdown_writer.py
+++ b/gdocs/docs_markdown_writer.py
@@ -47,11 +47,22 @@ def markdown_to_docs_requests(
     return requests
 
 
+def _utf16_len(text: str) -> int:
+    """Length of text in UTF-16 code units - the unit Docs API indexes use.
+
+    Python len() counts code points, so any non-BMP character (emoji and
+    other supplementary-plane characters) would otherwise undercount by one
+    UTF-16 unit and shift every later insertion index and style range.
+    """
+    return len(text.encode("utf-16-le")) // 2
+
+
 def _emit_requests(tokens, requests, tab_id, start_index):
     """Walk markdown-it tokens and append Docs API requests.
 
     Maintains a running `cursor` that represents the current insertion point
-    in the document. Each insertText advances cursor by len(text).
+    in the document. Each insertText advances cursor by the UTF-16 length
+    of the inserted text (see _utf16_len), matching Docs API index units.
     """
     cursor = [start_index]  # mutable via list so helpers can advance it
 
@@ -68,7 +79,7 @@ def _emit_requests(tokens, requests, tab_id, start_index):
             text += "\n"
             range_start = cursor[0]
             requests.append(_build_insert_text(cursor[0], text, tab_id))
-            cursor[0] += len(text)
+            cursor[0] += _utf16_len(text)
             requests.append(_build_heading_style(range_start, cursor[0], level, tab_id))
             requests.extend(inline_styles)
             # Blank spacer paragraph between top-level blocks for visual spacing
@@ -110,7 +121,7 @@ def _emit_requests(tokens, requests, tab_id, start_index):
                         )
                         text += "\n"
                         requests.append(_build_insert_text(cursor[0], text, tab_id))
-                        cursor[0] += len(text)
+                        cursor[0] += _utf16_len(text)
                         requests.extend(inline_styles)
                 k += 1
             list_end = cursor[0]
@@ -141,7 +152,7 @@ def _emit_requests(tokens, requests, tab_id, start_index):
             # more blank line than other top-level blocks.
             text = content if content.endswith("\n") else content + "\n"
             requests.append(_build_insert_text(cursor[0], text, tab_id))
-            cursor[0] += len(text)
+            cursor[0] += _utf16_len(text)
             # Style the code characters but not the paragraph-ending newline.
             code_end = cursor[0] - 1
             _append_text_style(
@@ -185,7 +196,7 @@ def _emit_requests(tokens, requests, tab_id, start_index):
                     )
                     text += "\n"
                     requests.append(_build_insert_text(cursor[0], text, tab_id))
-                    cursor[0] += len(text)
+                    cursor[0] += _utf16_len(text)
                     requests.extend(inline_styles)
                     k += 3
                     continue
@@ -246,7 +257,7 @@ def _emit_requests(tokens, requests, tab_id, start_index):
             )
             text += "\n"
             requests.append(_build_insert_text(cursor[0], text, tab_id))
-            cursor[0] += len(text)
+            cursor[0] += _utf16_len(text)
             requests.extend(inline_styles)
             # Blank spacer paragraph between top-level blocks for visual spacing.
             # Only top-level paragraphs receive spacers - list-item paragraphs
@@ -336,7 +347,7 @@ def _emit_table(row_cells, requests, cursor, tab_id):
                 cell_texts.append(text)
             line = " | ".join(cell_texts) + "\n"
             requests.append(_build_insert_text(cursor[0], line, tab_id))
-            cursor[0] += len(line)
+            cursor[0] += _utf16_len(line)
         return
 
     table_location = cursor[0]
@@ -355,7 +366,7 @@ def _emit_table(row_cells, requests, cursor, tab_id):
             if not text:
                 continue
             fills.append((insertion_index, text, styles, r == 0))
-            total_text_len += len(text)
+            total_text_len += _utf16_len(text)
 
     for insertion_index, text, styles, is_header in reversed(fills):
         requests.append(_build_insert_text(insertion_index, text, tab_id))
@@ -364,7 +375,7 @@ def _emit_table(row_cells, requests, cursor, tab_id):
             _append_text_style(
                 requests,
                 insertion_index,
-                insertion_index + len(text),
+                insertion_index + _utf16_len(text),
                 {"bold": True},
                 "bold",
                 tab_id,
@@ -416,7 +427,7 @@ def _render_inline_with_styles(
     for tok in children:
         if tok.type == "text":
             text_parts.append(tok.content)
-            local_pos += len(tok.content)
+            local_pos += _utf16_len(tok.content)
         elif tok.type == "softbreak":
             text_parts.append(" ")
             local_pos += 1
@@ -427,7 +438,7 @@ def _render_inline_with_styles(
             # self-contained - emit style immediately
             start_local = local_pos
             text_parts.append(tok.content)
-            local_pos += len(tok.content)
+            local_pos += _utf16_len(tok.content)
             _append_text_style(
                 style_requests,
                 base_index + start_local,
@@ -478,7 +489,7 @@ def _render_inline_with_styles(
             if label:
                 start_local = local_pos
                 text_parts.append(label)
-                local_pos += len(label)
+                local_pos += _utf16_len(label)
                 if src:
                     _append_text_style(
                         style_requests,
@@ -490,7 +501,7 @@ def _render_inline_with_styles(
                     )
         elif tok.type in ("html_inline", "html_block"):
             text_parts.append(tok.content)
-            local_pos += len(tok.content)
+            local_pos += _utf16_len(tok.content)
 
     return "".join(text_parts), style_requests
 

--- a/gdocs/docs_markdown_writer.py
+++ b/gdocs/docs_markdown_writer.py
@@ -53,8 +53,10 @@ def _utf16_len(text: str) -> int:
     Python len() counts code points, so any non-BMP character (emoji and
     other supplementary-plane characters) would otherwise undercount by one
     UTF-16 unit and shift every later insertion index and style range.
+    surrogatepass keeps lone surrogates (possible in poorly scraped input)
+    counting as single code units instead of raising UnicodeEncodeError.
     """
-    return len(text.encode("utf-16-le")) // 2
+    return len(text.encode("utf-16-le", errors="surrogatepass")) // 2
 
 
 def _emit_requests(tokens, requests, tab_id, start_index):

--- a/gdocs/docs_markdown_writer.py
+++ b/gdocs/docs_markdown_writer.py
@@ -6,8 +6,9 @@ markdown into a document or a specific tab within a document.
 
 Supported constructs - headings H1-H6, paragraphs with inline bold/italic/
 code/links, ordered and unordered lists, fenced code blocks, blockquotes,
-horizontal rules, and image alt text linked to the image URL. GFM-only
-features (tables, strikethrough, task lists, autolinks) are not enabled;
+horizontal rules, image alt text linked to the image URL, and GFM pipe
+tables (rendered as native Docs tables with bold header rows). Other
+GFM-only features (strikethrough, task lists, autolinks) are not enabled;
 extend the parser config below if they become needed.
 
 Primary entry point - markdown_to_docs_requests(markdown_text, tab_id=None).
@@ -38,7 +39,7 @@ def markdown_to_docs_requests(
     if not markdown_text.strip():
         return []
 
-    md = MarkdownIt("commonmark")
+    md = MarkdownIt("commonmark").enable("table")
     tokens = md.parse(markdown_text)
 
     requests: list[dict] = []
@@ -218,6 +219,25 @@ def _emit_requests(tokens, requests, tab_id, start_index):
             i += 1
             continue
 
+        if tok.type == "table_open":
+            depth = 1
+            j = i + 1
+            while j < len(tokens) and depth > 0:
+                if tokens[j].type == "table_open":
+                    depth += 1
+                elif tokens[j].type == "table_close":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                j += 1
+            row_cells = _collect_table_cells(tokens, i + 1, j)
+            _emit_table(row_cells, requests, cursor, tab_id)
+            # Blank spacer paragraph between top-level blocks for visual spacing
+            requests.append(_build_insert_text(cursor[0], "\n", tab_id))
+            cursor[0] += 1
+            i = j + 1
+            continue
+
         if tok.type == "paragraph_open":
             # paragraph_open is followed by inline (children), then paragraph_close
             inline_tok = tokens[i + 1]
@@ -237,6 +257,137 @@ def _emit_requests(tokens, requests, tab_id, start_index):
             continue
 
         i += 1
+
+
+def _collect_table_cells(tokens, start, end):
+    """Collect table cell inline tokens between table_open and table_close.
+
+    Args:
+        tokens - the full markdown-it token list
+        start - index of the first token after table_open
+        end - index of the matching table_close
+
+    Returns:
+        List of rows; each row is a list of cells; each cell is the list of
+        inline child tokens for that cell (empty list for an empty cell).
+    """
+    rows: list[list] = []
+    current_row: Optional[list] = None
+    k = start
+    while k < end:
+        t = tokens[k]
+        if t.type == "tr_open":
+            current_row = []
+        elif t.type == "tr_close":
+            if current_row is not None:
+                rows.append(current_row)
+            current_row = None
+        elif t.type in ("th_open", "td_open") and current_row is not None:
+            if k + 1 < end and tokens[k + 1].type == "inline":
+                current_row.append(tokens[k + 1].children or [])
+                k += 1
+            else:
+                current_row.append([])
+        k += 1
+    return rows
+
+
+# Google Docs API hard limits on table dimensions.
+_DOCS_MAX_TABLE_ROWS = 1000
+_DOCS_MAX_TABLE_COLS = 20
+
+
+def _emit_table(row_cells, requests, cursor, tab_id):
+    """Emit insertTable plus cell-fill requests for one markdown table.
+
+    A freshly inserted empty table has a deterministic index layout, which
+    lets the whole table land in the same single batchUpdate as the rest of
+    the markdown - no document re-fetch between requests:
+
+    - insertTable at index L first inserts a newline at L; the table element
+      itself starts at L + 1 and occupies 2 + rows * (1 + 2 * cols) indexes
+      (1 leading and 1 trailing structural index, plus 1 per row plus, per
+      cell, 1 for the cell and 1 for its empty paragraph). Verified against
+      the live API - a 2x2 table inserted at index 1 yields table [2, 14)
+      with cell paragraphs at 5, 7, 10, 12 and the next paragraph at 14.
+    - Row r starts at L + 2 + r * (1 + 2 * cols); cell (r, c) starts 1 + 2c
+      after that, and its text insertion point is one past the cell start.
+
+    Cells are filled bottom-right to top-left so each insertion happens at
+    its precomputed empty-table index without shifting the ones still to
+    come. Text styles ride along with already-inserted text, so applying
+    them before earlier-position fills is safe. The header row is bolded to
+    match the create_table_with_data tool's default.
+
+    Advances cursor past the fully populated table.
+    """
+    rows = len(row_cells)
+    cols = max((len(r) for r in row_cells), default=0)
+    if rows == 0 or cols == 0:
+        return
+
+    if rows > _DOCS_MAX_TABLE_ROWS or cols > _DOCS_MAX_TABLE_COLS:
+        # Docs would reject the insertTable request and fail the whole
+        # batch; degrade to one plain-text paragraph per row instead.
+        for row in row_cells:
+            cell_texts = []
+            for children in row:
+                text, _ = _render_inline_with_styles(children, cursor[0], tab_id)
+                cell_texts.append(text)
+            line = " | ".join(cell_texts) + "\n"
+            requests.append(_build_insert_text(cursor[0], line, tab_id))
+            cursor[0] += len(line)
+        return
+
+    table_location = cursor[0]
+    requests.append(_build_insert_table(table_location, rows, cols, tab_id))
+
+    fills = []
+    total_text_len = 0
+    for r in range(rows):
+        row_start = table_location + 2 + r * (1 + 2 * cols)
+        for c in range(cols):
+            insertion_index = row_start + 2 + 2 * c
+            children = row_cells[r][c] if c < len(row_cells[r]) else []
+            text, styles = _render_inline_with_styles(
+                children, insertion_index, tab_id
+            )
+            if not text:
+                continue
+            fills.append((insertion_index, text, styles, r == 0))
+            total_text_len += len(text)
+
+    for insertion_index, text, styles, is_header in reversed(fills):
+        requests.append(_build_insert_text(insertion_index, text, tab_id))
+        requests.extend(styles)
+        if is_header:
+            _append_text_style(
+                requests,
+                insertion_index,
+                insertion_index + len(text),
+                {"bold": True},
+                "bold",
+                tab_id,
+            )
+
+    empty_table_end = table_location + 3 + rows * (1 + 2 * cols)
+    cursor[0] = empty_table_end + total_text_len
+
+
+def _build_insert_table(
+    index: int, rows: int, cols: int, tab_id: Optional[str]
+) -> dict:
+    """Build an insertTable request dict, threading tab_id if provided."""
+    location = {"index": index}
+    if tab_id:
+        location["tabId"] = tab_id
+    return {
+        "insertTable": {
+            "location": location,
+            "rows": rows,
+            "columns": cols,
+        }
+    }
 
 
 def _render_inline_with_styles(

--- a/tests/gdocs/test_docs_markdown_writer.py
+++ b/tests/gdocs/test_docs_markdown_writer.py
@@ -467,6 +467,59 @@ def test_multiple_tables_maintain_correct_offsets():
     assert tables[1]["location"]["index"] == 28
 
 
+def test_emoji_paragraph_advances_cursor_in_utf16_units():
+    """Docs indexes count UTF-16 code units - a non-BMP emoji is 2 units."""
+    requests = markdown_to_docs_requests("Hi \U0001f600\n\nAfter")
+    inserts = [r for r in requests if "insertText" in r]
+    texts = [r["insertText"]["text"] for r in inserts]
+    assert texts == ["Hi \U0001f600\n", "\n", "After\n", "\n"]
+    # "Hi <emoji>\n" is 6 UTF-16 units (H, i, space, 2 for the emoji, newline),
+    # so the spacer lands at 7 and "After" at 8.
+    assert inserts[1]["insertText"]["location"]["index"] == 7
+    assert inserts[2]["insertText"]["location"]["index"] == 8
+
+
+def test_emoji_before_bold_span_offsets_style_range_in_utf16_units():
+    requests = markdown_to_docs_requests("\U0001f600 **bold**")
+    styles = [
+        r
+        for r in requests
+        if "updateTextStyle" in r and r["updateTextStyle"]["textStyle"].get("bold")
+    ]
+    assert len(styles) == 1
+    rng = styles[0]["updateTextStyle"]["range"]
+    # "<emoji> " is 3 UTF-16 units, so bold spans [4, 8).
+    assert rng["startIndex"] == 4
+    assert rng["endIndex"] == 8
+
+
+def test_emoji_in_table_cell_keeps_following_content_aligned():
+    md = "| A | B |\n|---|---|\n| \U0001f600 | ok |\n\nAfter"
+    requests = markdown_to_docs_requests(md)
+    inserts = [r for r in requests if "insertText" in r]
+    after = [i for i in inserts if i["insertText"]["text"] == "After\n"]
+    assert len(after) == 1
+    # Empty 2x2 table at 1 puts the next paragraph at 14; cell text adds
+    # 1 (A) + 1 (B) + 2 (emoji) + 2 (ok) = 6 UTF-16 units; spacer adds 1 -
+    # so "After" starts at 21.
+    assert after[0]["insertText"]["location"]["index"] == 21
+
+
+def test_emoji_header_cell_bold_range_uses_utf16_units():
+    md = "| \U0001f600! | B |\n|---|---|\n| 1 | 2 |"
+    requests = markdown_to_docs_requests(md)
+    bold_ranges = [
+        (
+            r["updateTextStyle"]["range"]["startIndex"],
+            r["updateTextStyle"]["range"]["endIndex"],
+        )
+        for r in requests
+        if "updateTextStyle" in r and r["updateTextStyle"]["textStyle"].get("bold")
+    ]
+    # Header cell "<emoji>!" fills at 5 and spans 3 UTF-16 units - [5, 8).
+    assert (5, 8) in bold_ranges
+
+
 def test_wide_table_beyond_docs_limit_degrades_to_text():
     """Docs rejects tables wider than 20 columns - the converter degrades to
     plain text lines rather than failing the whole batch."""

--- a/tests/gdocs/test_docs_markdown_writer.py
+++ b/tests/gdocs/test_docs_markdown_writer.py
@@ -339,3 +339,142 @@ def test_paragraph_between_blocks_has_spacers_around_it():
     texts = [r["insertText"]["text"] for r in inserts]
     # Heading, spacer, paragraph, spacer
     assert texts == ["Title\n", "\n", "Body text\n", "\n"]
+
+
+SIMPLE_TABLE_MD = "| A | B |\n|---|---|\n| 1 | 2 |"
+
+
+def test_table_emits_insert_table_with_correct_dimensions():
+    requests = markdown_to_docs_requests(SIMPLE_TABLE_MD)
+    tables = [r for r in requests if "insertTable" in r]
+    assert len(tables) == 1
+    t = tables[0]["insertTable"]
+    assert t["rows"] == 2
+    assert t["columns"] == 2
+    assert t["location"]["index"] == 1
+
+
+def test_table_does_not_emit_pipe_text_paragraphs():
+    """The regression this feature fixes - table rows must never land as
+    literal pipe-delimited paragraph text."""
+    requests = markdown_to_docs_requests(SIMPLE_TABLE_MD)
+    for r in requests:
+        if "insertText" in r:
+            assert "|" not in r["insertText"]["text"]
+
+
+def test_table_cell_fill_indices_match_empty_table_layout():
+    """Cells fill bottom-right to top-left at the deterministic indexes of a
+    freshly inserted empty table - for a 2x2 table inserted at index 1 the
+    cell paragraphs start at 5, 7, 10, 12."""
+    requests = markdown_to_docs_requests(SIMPLE_TABLE_MD)
+    inserts = [
+        r["insertText"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["text"] != "\n"
+    ]
+    fills = [(i["location"]["index"], i["text"]) for i in inserts]
+    assert fills == [(12, "2"), (10, "1"), (7, "B"), (5, "A")]
+
+
+def test_table_header_row_is_bolded():
+    requests = markdown_to_docs_requests(SIMPLE_TABLE_MD)
+    bold_ranges = [
+        (
+            r["updateTextStyle"]["range"]["startIndex"],
+            r["updateTextStyle"]["range"]["endIndex"],
+        )
+        for r in requests
+        if "updateTextStyle" in r and r["updateTextStyle"]["textStyle"].get("bold")
+    ]
+    # Header cells "B" at [7, 8) and "A" at [5, 6); body cells stay unstyled.
+    assert sorted(bold_ranges) == [(5, 6), (7, 8)]
+
+
+def test_content_after_table_lands_past_the_populated_table():
+    """The cursor must account for the table's full footprint - structure
+    plus inserted cell text - so following blocks do not overlap it."""
+    requests = markdown_to_docs_requests(SIMPLE_TABLE_MD + "\n\nAfter")
+    inserts = [r for r in requests if "insertText" in r]
+    after = [i for i in inserts if i["insertText"]["text"] == "After\n"]
+    assert len(after) == 1
+    # An empty 2x2 table inserted at 1 spans [2, 14) with the next paragraph
+    # at 14; four 1-char cells add 4; the spacer paragraph adds 1 - so
+    # "After" starts at 19.
+    assert after[0]["insertText"]["location"]["index"] == 19
+
+
+def test_table_after_heading_parses_as_table():
+    """A table directly under a heading (no blank line) must still emit
+    insertTable - the acceptance-test layout that regressed in the field."""
+    requests = markdown_to_docs_requests("## Register\n" + SIMPLE_TABLE_MD)
+    tables = [r for r in requests if "insertTable" in r]
+    assert len(tables) == 1
+
+
+def test_table_with_inline_styles_and_special_chars_in_cells():
+    md = '| Item | Price |\n|---|---|\n| **Widget** "Pro" | $300 |'
+    requests = markdown_to_docs_requests(md)
+    tables = [r for r in requests if "insertTable" in r]
+    assert len(tables) == 1
+    texts = [
+        r["insertText"]["text"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["text"] != "\n"
+    ]
+    assert 'Widget "Pro"' in texts
+    assert "$300" in texts
+    # The bold span inside the body cell is preserved
+    bolds = [
+        r
+        for r in requests
+        if "updateTextStyle" in r and r["updateTextStyle"]["textStyle"].get("bold")
+    ]
+    # Two header cells plus the **Widget** span
+    assert len(bolds) == 3
+
+
+def test_table_empty_cells_emit_no_inserts():
+    md = "| A | B |\n|---|---|\n| 1 | |"
+    requests = markdown_to_docs_requests(md)
+    inserts = [
+        r["insertText"]
+        for r in requests
+        if "insertText" in r and r["insertText"]["text"] != "\n"
+    ]
+    assert [i["text"] for i in inserts] == ["1", "B", "A"]
+
+
+def test_table_threads_tab_id_through_all_requests():
+    requests = markdown_to_docs_requests(SIMPLE_TABLE_MD, tab_id="t.0.1")
+    tables = [r for r in requests if "insertTable" in r]
+    assert tables[0]["insertTable"]["location"].get("tabId") == "t.0.1"
+    for r in requests:
+        if "insertText" in r:
+            assert r["insertText"]["location"].get("tabId") == "t.0.1"
+        if "updateTextStyle" in r:
+            assert r["updateTextStyle"]["range"].get("tabId") == "t.0.1"
+
+
+def test_multiple_tables_maintain_correct_offsets():
+    md = SIMPLE_TABLE_MD + "\n\nBetween\n\n| X | Y |\n|---|---|\n| 9 | 8 |"
+    requests = markdown_to_docs_requests(md)
+    tables = [r["insertTable"] for r in requests if "insertTable" in r]
+    assert len(tables) == 2
+    # First table at 1; populated it ends at 18, spacer -> 19, "Between\n"
+    # ends at 27, spacer -> 28 - the second table inserts there.
+    assert tables[0]["location"]["index"] == 1
+    assert tables[1]["location"]["index"] == 28
+
+
+def test_wide_table_beyond_docs_limit_degrades_to_text():
+    """Docs rejects tables wider than 20 columns - the converter degrades to
+    plain text lines rather than failing the whole batch."""
+    cols = 21
+    header = "|" + "|".join(f" c{n} " for n in range(cols)) + "|"
+    sep = "|" + "---|" * cols
+    row = "|" + "|".join(f" v{n} " for n in range(cols)) + "|"
+    requests = markdown_to_docs_requests("\n".join([header, sep, row]))
+    assert not any("insertTable" in r for r in requests)
+    texts = [r["insertText"]["text"] for r in requests if "insertText" in r]
+    assert any(t.startswith("c0 | c1") for t in texts)


### PR DESCRIPTION
### What

`manage_doc_tab populate_from_markdown` (and anything else that goes through `markdown_to_docs_requests`) silently flattens GFM pipe tables into a single paragraph of literal pipe text. The parser is built with the `commonmark` preset, where tables are not enabled - each `| a | b |` line parses as paragraph text and the softbreaks between rows render as spaces. The tool still returns success, so the failure is invisible until someone opens the Doc.

This PR enables the table rule and teaches the emitter to render tables natively:

- `MarkdownIt("commonmark").enable("table")`
- A `table_open` branch walks the row/cell tokens and emits one `insertTable` plus per-cell `insertText`/`updateTextStyle` requests.
- Everything stays in the existing single-batchUpdate design. A freshly inserted empty R x C table has a deterministic index layout (verified against the live API - a 2x2 table inserted at index 1 yields table [2, 14) with cell paragraphs at 5, 7, 10, 12 and the next paragraph at 14). Cells are filled bottom-right to top-left so every insertion lands at its precomputed empty-table index, and the running cursor advances by the table footprint plus inserted text.
- Header row cells are bolded, matching `create_table_with_data`'s default.
- Inline markdown inside cells (bold, italic, code, links) is preserved via the existing inline renderer.
- Tables exceeding the Docs API limits (1000 rows / 20 columns) degrade to plain text lines rather than failing the whole batch.

### Testing

- 11 new unit tests in `tests/gdocs/test_docs_markdown_writer.py` covering dimensions, exact fill indexes, header bolding, cursor continuation after tables, multiple tables, tab_id threading, empty cells, special characters, and the oversized-table fallback. Full suite green (1287 passed).
- Live acceptance on a real document - a markdown file with three tables (one directly under a heading, one 23 x 4, one with quotes and dollar signs in cells) populated into a tab, verified structurally (3 native tables, zero pipe-text paragraphs) and visually via PDF export. Re-populate over the existing content (replace_existing=True deleting a body that already contains tables) and populate into a freshly created second tab both verified.

### Notes

- The spacer-paragraph convention between top-level blocks is preserved; `insertTable`'s built-in leading newline gives tables the same one-blank-line rhythm as other blocks.
- Alignment markers (`:---:`) are accepted by the parser but not yet mapped to cell paragraph alignment - happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GFM tables, rendering them as native Google Docs tables with a bold header row.
  * Preserves inline formatting and special characters inside table cells.
  * When tables exceed Docs limits, they automatically degrade to plain-text row output.

* **Bug Fixes**
  * Corrected cursor/index advancement to match Google Docs’ UTF-16 indexing, including emoji and inline style ranges.
  * Improved table emission and placement so content after tables lands at the correct position.

* **Tests**
  * Expanded table conversion, placement, deterministic cell fill behavior, and UTF-16/emoji regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->