### PR TITLE
docs(create_doc): note content is plain text; point to import_to_google_doc for Markdown

### DIFF
--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -395,6 +395,11 @@ async def create_doc(
     """
     Creates a new Google Doc and optionally inserts initial content.
 
+    Note: `content` is inserted verbatim as plain text. Markdown is NOT rendered
+    (characters such as `#`, `**` and `-` appear literally). To create a document
+    from Markdown (or HTML/DOCX/etc.) with automatic conversion, use
+    `import_to_google_doc` with `source_format="markdown"` instead.
+
     After creation, the document body starts at index 1. A new empty doc
     has total length 2 (one section break at index 0, one newline at index 1).
 
@@ -406,7 +411,8 @@ async def create_doc(
     Args:
         user_google_email: User's Google email address
         title: Title of the new document
-        content: Optional initial plain text content to insert
+        content: Optional initial plain text content to insert. Inserted verbatim;
+            Markdown is not rendered. Use import_to_google_doc for Markdown/HTML/DOCX.
 
     Returns:
         str: Confirmation message with document ID, link, and initial document state.

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -397,8 +397,9 @@ async def create_doc(
 
     Note: `content` is inserted verbatim as plain text. Markdown is NOT rendered
     (characters such as `#`, `**` and `-` appear literally). To create a document
-    from Markdown (or HTML/DOCX/etc.) with automatic conversion, use
-    `import_to_google_doc` with `source_format="markdown"` instead.
+    from Markdown with automatic conversion, use `import_to_google_doc` with
+    `source_format="markdown"`. For HTML, use `source_format="html"`; for DOCX,
+    provide a `file_path` or `file_url` and use `source_format="docx"`.
 
     After creation, the document body starts at index 1. A new empty doc
     has total length 2 (one section break at index 0, one newline at index 1).


### PR DESCRIPTION
## What
`create_doc` inserts its `content` argument **verbatim as plain text** (a single `insertText` request), so Markdown passed to it lands as literal characters (`#`, `**`, `-`) instead of rendered formatting. The current docstring only describes `content` as *"plain text content to insert"* and doesn't mention that Markdown isn't rendered, nor point to the alternative.

Because a tool's docstring is the description an LLM reads when choosing tools, this omission leads models to pick `create_doc` for Markdown content and produce documents full of literal `#`/`**` characters.

## Change
Docstring-only, **no behavior change**: adds a short note that `content` is inserted verbatim and Markdown is not rendered, and points to `import_to_google_doc` with `source_format="markdown"` for automatic Markdown/HTML/DOCX conversion (that tool already documents importing Markdown `content` directly).

This is a small nudge that should improve tool selection for anyone building on the server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that document content is inserted as plain text, without Markdown rendering.
  * Added guidance to use the import tool for converting Markdown, HTML, or DOCX into Google Docs format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->