### PR TITLE
Add file version-history (Drive revisions) and spreadsheet audit/diff tools

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -37,6 +37,8 @@ drive:
     - update_drive_file
     - manage_drive_access
     - set_drive_file_permissions
+    - list_file_revisions
+    - export_file_revision
   complete:
     - get_drive_file_permissions
     - check_drive_file_public_access
@@ -95,6 +97,8 @@ sheets:
     - list_spreadsheet_comments
     - manage_spreadsheet_comment
     - manage_conditional_formatting
+    - audit_spreadsheet_errors
+    - diff_spreadsheets
 
 chat:
   core:

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -2674,3 +2674,252 @@ async def set_drive_file_permissions(
     output_parts.extend(["", f"View link: {file_metadata.get('webViewLink', 'N/A')}"])
 
     return "\n".join(output_parts)
+
+
+@server.tool(
+    title="List File Revisions",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("list_file_revisions", is_read_only=True, service_type="drive")
+@require_google_service("drive", "drive_read")
+async def list_file_revisions(
+    service,
+    user_google_email: str,
+    file_id: str,
+    max_results: int = 50,
+) -> str:
+    """
+    Lists the version history (Drive revisions) of a file: revision id, modified
+    time and last editor. Works for any Drive file, including Google Sheets, Docs
+    and Slides.
+
+    Use the returned revision ids with export_file_revision to inspect how a file
+    looked at an earlier point in time (e.g. to recover how a spreadsheet's
+    formulas were built before an error was introduced).
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        file_id (str): The Drive file ID (a spreadsheet/doc ID works). Required.
+        max_results (int): Maximum number of most recent revisions to return. Defaults to 50.
+
+    Returns:
+        str: A chronologically ordered list of revisions (oldest to newest).
+    """
+    logger.info(
+        f"[list_file_revisions] Invoked. File ID: '{file_id}', Email: '{user_google_email}'"
+    )
+
+    resolved_file_id, file_metadata = await resolve_drive_item(
+        service, file_id, extra_fields="name"
+    )
+    file_id = resolved_file_id
+    file_name = file_metadata.get("name", "Unknown File")
+
+    revisions: List[Dict[str, Any]] = []
+    page_token = None
+    while True:
+        response = await asyncio.to_thread(
+            service.revisions()
+            .list(
+                fileId=file_id,
+                pageSize=200,
+                pageToken=page_token,
+                fields="nextPageToken,revisions(id,modifiedTime,lastModifyingUser(displayName,emailAddress),size)",
+            )
+            .execute
+        )
+        revisions.extend(response.get("revisions", []))
+        page_token = response.get("nextPageToken")
+        if not page_token:
+            break
+
+    if not revisions:
+        return f'No revisions available for "{file_name}" (ID: {file_id}).'
+
+    total = len(revisions)
+    shown = revisions[-max_results:] if max_results and max_results > 0 else revisions
+
+    lines = [
+        f'Version history for "{file_name}" (ID: {file_id}) — '
+        f"{total} revision(s), showing {len(shown)} (oldest to newest):"
+    ]
+    for rev in shown:
+        editor = rev.get("lastModifyingUser") or {}
+        who = editor.get("displayName") or editor.get("emailAddress") or "unknown"
+        lines.append(
+            f'- revision {rev.get("id")} | {rev.get("modifiedTime", "?")} | by {who}'
+        )
+    lines.append(
+        "\nTip: use export_file_revision(file_id, revision_id=...) to download a "
+        "specific revision (e.g. as xlsx) and inspect its contents/formulas."
+    )
+    return "\n".join(lines)
+
+
+@server.tool(
+    title="Export File Revision",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("export_file_revision", is_read_only=True, service_type="drive")
+@require_google_service("drive", "drive_read")
+async def export_file_revision(
+    service,
+    user_google_email: str,
+    file_id: str,
+    revision_id: str,
+    export_format: Optional[str] = None,
+) -> str:
+    """
+    Downloads a specific historical revision of a Drive file and saves it.
+
+    In stdio mode returns the local file path; in HTTP mode returns a temporary
+    download URL (valid for 1 hour). For Google native files (Sheets/Docs/Slides)
+    the revision is exported (Sheets -> xlsx by default, or 'csv'/'pdf'); for other
+    files the original bytes of that revision are returned. Useful for recovering
+    how a spreadsheet's formulas looked at an earlier revision — pair it with
+    list_file_revisions.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        file_id (str): The Drive file ID. Required.
+        revision_id (str): The revision id (from list_file_revisions). Required.
+        export_format (str): Optional export format for Google native files.
+            Sheets: 'xlsx' (default), 'csv', 'pdf'. Docs/Slides: 'pdf' (default), 'docx'/'pptx'.
+
+    Returns:
+        str: Metadata with a local file path (stdio) or a download URL (HTTP).
+    """
+    logger.info(
+        f"[export_file_revision] Invoked. File: '{file_id}', Revision: '{revision_id}'"
+    )
+
+    resolved_file_id, file_metadata = await resolve_drive_item(
+        service, file_id, extra_fields="name, mimeType"
+    )
+    file_id = resolved_file_id
+    mime_type = file_metadata.get("mimeType", "")
+    file_name = file_metadata.get("name", "Unknown File")
+
+    native_defaults = {
+        "application/vnd.google-apps.spreadsheet": (
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "xlsx",
+        ),
+        "application/vnd.google-apps.document": ("application/pdf", "pdf"),
+        "application/vnd.google-apps.presentation": ("application/pdf", "pdf"),
+    }
+    fmt_map = {
+        "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "csv": "text/csv",
+        "tsv": "text/tab-separated-values",
+        "pdf": "application/pdf",
+        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "ods": "application/x-vnd.oasis.opendocument.spreadsheet",
+    }
+
+    revision = await asyncio.to_thread(
+        service.revisions()
+        .get(
+            fileId=file_id,
+            revisionId=revision_id,
+            fields="id,modifiedTime,mimeType,exportLinks",
+        )
+        .execute
+    )
+    export_links = revision.get("exportLinks", {}) or {}
+
+    if mime_type in native_defaults:
+        default_mime, default_ext = native_defaults[mime_type]
+        if export_format and export_format in fmt_map:
+            target_mime, ext = fmt_map[export_format], export_format
+        else:
+            target_mime, ext = default_mime, default_ext
+        output_filename = f"{Path(file_name).stem}_rev{revision_id}.{ext}"
+
+        url = export_links.get(target_mime)
+        if not url:
+            return (
+                f'Revision {revision_id} of "{file_name}" cannot be exported as '
+                f"'{ext}'. Available formats: "
+                f"{', '.join(sorted(export_links.keys())) or 'none'}."
+            )
+        # Download the per-revision export link via the service's authorized transport
+        resp, content = await asyncio.to_thread(service._http.request, url)
+        status = int(getattr(resp, "status", 0))
+        if status != 200:
+            return (
+                f"Error: failed to download revision {revision_id} of "
+                f'"{file_name}" (HTTP {status}).'
+            )
+        file_content_bytes = content
+        output_mime_type = target_mime
+    else:
+        # Binary / uploaded file: download that revision's media directly
+        request_obj = service.revisions().get_media(
+            fileId=file_id, revisionId=revision_id
+        )
+        fh = io.BytesIO()
+        downloader = MediaIoBaseDownload(fh, request_obj)
+        loop = asyncio.get_event_loop()
+        done = False
+        while not done:
+            _, done = await loop.run_in_executor(None, downloader.next_chunk)
+        file_content_bytes = fh.getvalue()
+        output_mime_type = mime_type
+        stem, suffix = Path(file_name).stem, Path(file_name).suffix
+        output_filename = f"{stem}_rev{revision_id}{suffix}"
+
+    size_bytes = len(file_content_bytes)
+    size_kb = size_bytes / 1024 if size_bytes else 0
+
+    if is_stateless_mode():
+        return "\n".join(
+            [
+                "Revision exported successfully!",
+                f"File: {file_name} (revision {revision_id}, {revision.get('modifiedTime', '?')})",
+                f"Size: {size_kb:.1f} KB ({size_bytes} bytes)",
+                f"MIME Type: {output_mime_type}",
+                "\n⚠️ Stateless mode: file storage disabled.",
+            ]
+        )
+
+    try:
+        storage = get_attachment_storage()
+        base64_data = base64.urlsafe_b64encode(file_content_bytes).decode("utf-8")
+        result = storage.save_attachment(
+            base64_data=base64_data,
+            filename=output_filename,
+            mime_type=output_mime_type,
+        )
+        result_lines = [
+            "Revision exported successfully!",
+            f"File: {file_name}",
+            f"Revision: {revision_id} ({revision.get('modifiedTime', '?')})",
+            f"Size: {size_kb:.1f} KB ({size_bytes} bytes)",
+            f"MIME Type: {output_mime_type}",
+        ]
+        if get_transport_mode() == "stdio":
+            result_lines.append(f"\n📎 Saved to: {result.path}")
+        else:
+            result_lines.append(
+                f"\n📎 Download URL: {get_attachment_url(result.file_id)}"
+            )
+            result_lines.append("\nThe file will expire after 1 hour.")
+        return "\n".join(result_lines)
+    except Exception as e:
+        logger.error(f"[export_file_revision] Failed to save file: {e}")
+        return (
+            f"Error: revision {revision_id} was downloaded ({size_kb:.1f} KB) but "
+            f"could not be saved.\n\nError details: {str(e)}"
+        )

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -2432,6 +2432,204 @@ async def move_sheet_rows(
     return text_output
 
 
+@server.tool(
+    title="Audit Spreadsheet Errors",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("audit_spreadsheet_errors", is_read_only=True, service_type="sheets")
+@require_google_service("sheets", "sheets_read")
+async def audit_spreadsheet_errors(
+    service,
+    user_google_email: str,
+    spreadsheet_id: str,
+    sheet: Optional[str] = None,
+    max_details: int = 50,
+) -> str:
+    """
+    Scans a spreadsheet for formula error cells (#REF!, #DIV/0!, #N/A, #VALUE!,
+    #NAME?, #NUM!, #ERROR!, #NULL!) and reports per-sheet counts and sample cells.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        spreadsheet_id (str): The ID of the spreadsheet. Required.
+        sheet (str): Optional single sheet/tab name to scan. Defaults to all sheets.
+        max_details (int): Max number of example cell addresses to include. Defaults to 50.
+
+    Returns:
+        str: A summary of formula error cells found.
+    """
+    logger.info(
+        f"[audit_spreadsheet_errors] Invoked. Spreadsheet: {spreadsheet_id}, Email: '{user_google_email}'"
+    )
+
+    info = await asyncio.to_thread(
+        service.spreadsheets()
+        .get(spreadsheetId=spreadsheet_id, fields="sheets(properties(title))")
+        .execute
+    )
+    titles = [s["properties"]["title"] for s in info.get("sheets", [])]
+    if sheet:
+        titles = [t for t in titles if t == sheet]
+        if not titles:
+            return f"Sheet '{sheet}' not found in spreadsheet {spreadsheet_id}."
+
+    total = 0
+    per_sheet_lines: List[str] = []
+    sample_lines: List[str] = []
+    for title in titles:
+        quoted = "'" + title.replace("'", "''") + "'"
+        errors = await _fetch_detailed_sheet_errors(service, spreadsheet_id, quoted)
+        if not errors:
+            continue
+        total += len(errors)
+        per_sheet_lines.append(f"- {title}: {len(errors)} error cell(s)")
+        for item in errors:
+            if len(sample_lines) >= max_details:
+                break
+            cell = item.get("cell") or "?"
+            if "!" not in str(cell):
+                cell = f"{title}!{cell}"
+            etype = item.get("type") or "(error)"
+            sample_lines.append(f"    {cell}: {etype}")
+
+    if total == 0:
+        return (
+            f"No formula error cells found in spreadsheet {spreadsheet_id} "
+            f"({len(titles)} sheet(s) scanned)."
+        )
+
+    out = [f"Found {total} formula error cell(s) in spreadsheet {spreadsheet_id}:"]
+    out.extend(per_sheet_lines)
+    if sample_lines:
+        out.append("\nExamples:")
+        out.extend(sample_lines)
+        if total > len(sample_lines):
+            out.append(f"    ... and {total - len(sample_lines)} more")
+    logger.info(f"[audit_spreadsheet_errors] {total} error cells for {user_google_email}")
+    return "\n".join(out)
+
+
+@server.tool(
+    title="Diff Spreadsheets",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("diff_spreadsheets", is_read_only=True, service_type="sheets")
+@require_google_service("sheets", "sheets_read")
+async def diff_spreadsheets(
+    service,
+    user_google_email: str,
+    spreadsheet_id_a: str,
+    spreadsheet_id_b: str,
+    sheet: str,
+    range_name: Optional[str] = None,
+    max_examples: int = 6,
+) -> str:
+    """
+    Compares the same sheet between two spreadsheets on the formula level. Reports:
+    frozen (a formula in A became a static value in B), changed formulas, cells
+    cleared in B, and cells added in B. Useful to verify or reverse-engineer a
+    transformation between a master spreadsheet and a derived copy.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        spreadsheet_id_a (str): First spreadsheet ID (baseline, e.g. master). Required.
+        spreadsheet_id_b (str): Second spreadsheet ID (comparison, e.g. export). Required.
+        sheet (str): Sheet/tab name to compare (must exist in both). Required.
+        range_name (str): Optional A1 range to limit the comparison. Defaults to whole sheet.
+        max_examples (int): Max examples per category. Defaults to 6.
+
+    Returns:
+        str: A summary of the differences with examples.
+    """
+    logger.info(
+        f"[diff_spreadsheets] Invoked. A: {spreadsheet_id_a}, B: {spreadsheet_id_b}, Sheet: '{sheet}'"
+    )
+
+    quoted = "'" + sheet.replace("'", "''") + "'"
+    full_range = f"{quoted}!{range_name}" if range_name else quoted
+
+    async def grab(sid: str) -> List[List]:
+        result = await asyncio.to_thread(
+            service.spreadsheets()
+            .values()
+            .get(spreadsheetId=sid, range=full_range, valueRenderOption="FORMULA")
+            .execute
+        )
+        return result.get("values", [])
+
+    grid_a = await grab(spreadsheet_id_a)
+    grid_b = await grab(spreadsheet_id_b)
+
+    def a1(row_idx: int, col_idx: int) -> str:
+        letters = ""
+        n = col_idx + 1
+        while n > 0:
+            n, rem = divmod(n - 1, 26)
+            letters = chr(65 + rem) + letters
+        return f"{letters}{row_idx + 1}"
+
+    frozen = changed = cleared = added = same_formula = same_literal = 0
+    examples = {"frozen": [], "changed": [], "cleared": [], "added": []}
+    n_rows = max(len(grid_a), len(grid_b))
+    for i in range(n_rows):
+        row_a = grid_a[i] if i < len(grid_a) else []
+        row_b = grid_b[i] if i < len(grid_b) else []
+        n_cols = max(len(row_a), len(row_b))
+        for j in range(n_cols):
+            av = row_a[j] if j < len(row_a) else ""
+            bv = row_b[j] if j < len(row_b) else ""
+            a_has = av not in (None, "")
+            b_has = bv not in (None, "")
+            a_form = isinstance(av, str) and av.startswith("=")
+            b_form = isinstance(bv, str) and bv.startswith("=")
+            addr = a1(i, j)
+            if a_form and b_has and not b_form:
+                frozen += 1
+                if len(examples["frozen"]) < max_examples:
+                    examples["frozen"].append(f"    {addr}: {str(av)[:40]} -> {str(bv)[:30]}")
+            elif a_form and b_form:
+                if av == bv:
+                    same_formula += 1
+                else:
+                    changed += 1
+                    if len(examples["changed"]) < max_examples:
+                        examples["changed"].append(f"    {addr}: {str(av)[:34]} -> {str(bv)[:34]}")
+            elif a_has and not b_has:
+                cleared += 1
+                if len(examples["cleared"]) < max_examples:
+                    examples["cleared"].append(f"    {addr}: {str(av)[:40]}")
+            elif b_has and not a_has:
+                added += 1
+                if len(examples["added"]) < max_examples:
+                    examples["added"].append(f"    {addr}: {str(bv)[:40]}")
+            elif a_has and b_has:
+                same_literal += 1
+
+    out = [
+        f"Diff of sheet '{sheet}' ({'range ' + range_name if range_name else 'whole sheet'}):",
+        f"- frozen (formula -> value in B): {frozen}",
+        f"- changed formulas: {changed}",
+        f"- cleared in B: {cleared}",
+        f"- added in B: {added}",
+        f"- unchanged formulas: {same_formula} | unchanged literals: {same_literal}",
+    ]
+    for label in ("frozen", "changed", "cleared", "added"):
+        if examples[label]:
+            out.append(f"\n{label} examples:")
+            out.extend(examples[label])
+    return "\n".join(out)
+
+
 # Create comment management tools for sheets
 _comment_tools = create_comment_tools("spreadsheet", "spreadsheet_id")
 


### PR DESCRIPTION
## Summary

Adds **file version-history** tools (Drive revisions) and two **spreadsheet auditing** tools. All changes are additive; existing tools and behavior are unchanged.

Motivation: there was no way to inspect a file's revision history or recover how a spreadsheet looked at an earlier point in time (e.g. to find how a formula was built before a `#REF!` was introduced). These tools fill that gap, plus quick error/diff auditing for spreadsheets.

## New tools

**Drive** (`gdrive/drive_tools.py`) — work for any Drive file, incl. Sheets/Docs/Slides:

| Tool | Purpose |
|---|---|
| `list_file_revisions` | List a file's Drive revision history (revision id, modified time, last editor). |
| `export_file_revision` | Download a specific historical revision. Google-native files are exported (Sheets → `xlsx` default / `csv` / `pdf`); other files return the original revision bytes. Saved via the existing attachment storage (local path in stdio mode, download URL in HTTP mode). |

**Sheets** (`gsheets/sheets_tools.py`):

| Tool | Purpose |
|---|---|
| `audit_spreadsheet_errors` | Scan a spreadsheet (all sheets or one) for formula error cells (`#REF!`, `#DIV/0!`, `#N/A`, `#VALUE!`, `#NAME?`, `#NUM!`, `#ERROR!`, `#NULL!`); returns per-sheet counts and sample cells. Reuses the existing `_fetch_detailed_sheet_errors` grid helper. |
| `diff_spreadsheets` | Compare the same sheet across two spreadsheets on the formula level: frozen (formula→static value), changed formulas, cleared, and added cells. Useful to verify/reverse-engineer a transformation between a master and a derived copy. |

## Implementation notes

- Follows the existing conventions: `@server.tool` + `@handle_http_errors` + `@require_google_service`, `asyncio.to_thread` around the blocking Google client calls, human-readable string returns.
- `export_file_revision` mirrors `get_drive_file_download_url`'s storage/return handling (stateless / stdio path / HTTP URL). For Google-native files it downloads the per-revision `exportLinks` via the service's already-authorized transport; for binary files it uses `revisions().get_media`.
- Uses the read-only Drive scope group (`drive_read`) already resolved by the service decorator — sufficient for reading revisions of files the user can access.
- Registered in `core/tool_tiers.yaml`: revisions under `drive.extended`, audit/diff under `sheets.complete`.

## Testing

- `uv sync` + import of the modified modules succeeds (decorators register without error).
- `server.list_tools()` reports all four new tools among the registered set (35 total in the `complete` tier).
- The underlying Drive-revision / error-grid / formula-diff logic was validated against the live Google APIs in a standalone harness; end-to-end validation of these tools inside the server against a live account is in progress and I'm happy to attach output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools to view Google Drive file revision history, including revision IDs, timestamps, and editors.
  * Added support for exporting or downloading specific Drive file revisions in suitable formats.
  * Added spreadsheet error auditing with per-sheet counts and example error cells.
  * Added spreadsheet comparison tools to identify changed, added, cleared, or converted formulas across matching sheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->