### PR TITLE
feat(gmail): add get_gmail_message_full for untruncated body export

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,10 +795,9 @@ cp .env.oauth21 .env
 | <sub>Tool</sub> | <sub>Tier</sub> | <sub>Description</sub> |
 |------|------|-------------|
 | <sub>`search_gmail_messages`</sub> | <sub>Core</sub> | <sub>Search with Gmail operators</sub> |
-| <sub>`get_gmail_message_content`</sub> | <sub>Core</sub> | <sub>Retrieve message content</sub> |
+| <sub>`get_gmail_message_content`</sub> | <sub>Core</sub> | <sub>Retrieve message content (`full=True` exports the untruncated message to a file/URL)</sub> |
 | <sub>`get_gmail_messages_content_batch`</sub> | <sub>Core</sub> | <sub>Batch retrieve message content</sub> |
 | <sub>`send_gmail_message`</sub> | <sub>Core</sub> | <sub>Send emails</sub> |
-| <sub>`get_gmail_message_full`</sub> | <sub>Extended</sub> | <sub>Export complete untruncated message to a file/URL</sub> |
 | <sub>`get_gmail_thread_content`</sub> | <sub>Extended</sub> | <sub>Get full thread content</sub> |
 | <sub>`modify_gmail_message_labels`</sub> | <sub>Extended</sub> | <sub>Modify message labels</sub> |
 | <sub>`list_gmail_labels`</sub> | <sub>Extended</sub> | <sub>List available labels</sub> |

--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ cp .env.oauth21 .env
 | <sub>Tool</sub> | <sub>Tier</sub> | <sub>Description</sub> |
 |------|------|-------------|
 | <sub>`search_gmail_messages`</sub> | <sub>Core</sub> | <sub>Search with Gmail operators</sub> |
-| <sub>`get_gmail_message_content`</sub> | <sub>Core</sub> | <sub>Retrieve message content (`full=True` exports the untruncated message to a file/URL)</sub> |
+| <sub>`get_gmail_message_content`</sub> | <sub>Core</sub> | <sub>Retrieve message content (`full=True` returns the untruncated message via file/URL, or inline when no file storage)</sub> |
 | <sub>`get_gmail_messages_content_batch`</sub> | <sub>Core</sub> | <sub>Batch retrieve message content</sub> |
 | <sub>`send_gmail_message`</sub> | <sub>Core</sub> | <sub>Send emails</sub> |
 | <sub>`get_gmail_thread_content`</sub> | <sub>Extended</sub> | <sub>Get full thread content</sub> |

--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ cp .env.oauth21 .env
 | <sub>`get_gmail_message_content`</sub> | <sub>Core</sub> | <sub>Retrieve message content</sub> |
 | <sub>`get_gmail_messages_content_batch`</sub> | <sub>Core</sub> | <sub>Batch retrieve message content</sub> |
 | <sub>`send_gmail_message`</sub> | <sub>Core</sub> | <sub>Send emails</sub> |
+| <sub>`get_gmail_message_full`</sub> | <sub>Extended</sub> | <sub>Export complete untruncated message to a file/URL</sub> |
 | <sub>`get_gmail_thread_content`</sub> | <sub>Extended</sub> | <sub>Get full thread content</sub> |
 | <sub>`modify_gmail_message_labels`</sub> | <sub>Extended</sub> | <sub>Modify message labels</sub> |
 | <sub>`list_gmail_labels`</sub> | <sub>Extended</sub> | <sub>List available labels</sub> |

--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -7,6 +7,7 @@ gmail:
 
   extended:
     - get_gmail_attachment_content
+    - get_gmail_message_full
     - get_gmail_thread_content
     - modify_gmail_message_labels
     - list_gmail_labels

--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -7,7 +7,6 @@ gmail:
 
   extended:
     - get_gmail_attachment_content
-    - get_gmail_message_full
     - get_gmail_thread_content
     - modify_gmail_message_labels
     - list_gmail_labels

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -334,12 +334,13 @@ async def _export_full_message(
     body_format: Literal["text", "html", "raw"],
 ) -> str:
     """
-    Save a message's complete, untruncated content to local storage and format the
-    response as a download URL (HTTP transport) or file path (stdio transport).
+    Return a message's complete, untruncated content: saved to local storage and
+    referenced by download URL (HTTP transport) or file path (stdio transport), or —
+    in stateless mode, where there is no storage — inlined in the response.
 
-    The body is never included in the returned string — that is the point of the
-    export: large messages are handed off out-of-band instead of through the model
-    context, and no truncation limit applies.
+    Whenever a file is written the body is kept out of the returned string, which is
+    the point of the export: large messages are handed off out-of-band instead of
+    through the model context. Either way no truncation limit applies.
 
     Args:
         service: Authenticated Gmail API service.
@@ -349,7 +350,8 @@ async def _export_full_message(
             "html" saves the raw HTML body, "text" saves the plaintext body.
 
     Returns:
-        str: Header summary plus the saved file's URL or path, or an "Error:" string.
+        str: Header summary plus the saved file's URL or path (or the inline body in
+            stateless mode), or an "Error:" string.
     """
     subject = headers.get("Subject", "message") or "message"
     notes: List[str] = []
@@ -415,6 +417,37 @@ async def _export_full_message(
             return "Error: message has no readable body content to export."
         content_bytes = content_str.encode("utf-8")
 
+    # Stateless deployments have no persistent storage to hand a file reference off
+    # from, but the guarantee callers actually want is "complete and untruncated".
+    # Inline delivery satisfies that; it only costs model context.
+    stateless = is_stateless_mode()
+
+    size_bytes = len(content_bytes)
+    size_kb = size_bytes / 1024
+    result_lines = _format_message_header_lines(headers)
+    result_lines.append(
+        "\n--- FULL MESSAGE ---" if stateless else "\n--- FULL MESSAGE EXPORT ---"
+    )
+    result_lines.append(f"Format: {extension.lstrip('.')}")
+    result_lines.append(f"Size: {size_kb:.1f} KB ({size_bytes} bytes)")
+
+    if stateless:
+        for note in notes:
+            result_lines.append(f"Note: {note}")
+        result_lines.append(
+            "\nStateless mode: no file storage available, so the complete message is "
+            "included inline below instead of as a download URL. It is NOT truncated."
+        )
+        result_lines.append(
+            "\n--- BODY (COMPLETE, NOT TRUNCATED) ---\n"
+            f"{content_bytes.decode('utf-8', errors='replace')}"
+        )
+        logger.info(
+            f"[get_gmail_message_content] Returned {size_kb:.1f} KB "
+            f"({extension.lstrip('.')}) inline (stateless mode)"
+        )
+        return "\n".join(result_lines)
+
     # Encode + write on a worker thread so a large export doesn't block the event loop.
     # Cap the sender-controlled subject so a pathologically long Subject can't overflow
     # the filesystem's filename limit, and surface a clean error if the write fails.
@@ -433,13 +466,6 @@ async def _export_full_message(
         logger.error(f"[get_gmail_message_content] Failed to save message: {exc}")
         return f"Error: failed to save message to storage: {exc}"
 
-    size_bytes = len(content_bytes)
-    size_kb = size_bytes / 1024
-
-    result_lines = _format_message_header_lines(headers)
-    result_lines.append("\n--- FULL MESSAGE EXPORT ---")
-    result_lines.append(f"Format: {extension.lstrip('.')}")
-    result_lines.append(f"Size: {size_kb:.1f} KB ({size_bytes} bytes)")
     result_lines.append(f"Saved filename: {Path(saved.path).name}")
     for note in notes:
         result_lines.append(f"Note: {note}")
@@ -1573,11 +1599,12 @@ async def get_gmail_message_content(
         bool,
         Field(
             description=(
-                "When True, save the COMPLETE untruncated message to local storage and "
-                "return a download URL/file path instead of the body text. Use for "
-                "messages large enough to hit the truncation limit, or when byte-exact "
-                "fidelity is needed (pair with body_format='raw' for a .eml export). "
-                "Requires persistent storage, so it is unavailable in stateless mode."
+                "When True, return the COMPLETE untruncated message: saved to local "
+                "storage and referenced by download URL/file path instead of the body "
+                "text, or inlined in the response when the server has no file storage "
+                "(stateless mode). Use for messages large enough to hit the truncation "
+                "limit, or when byte-exact fidelity is needed (pair with "
+                "body_format='raw' for a .eml export)."
             ),
         ),
     ] = False,
@@ -1586,9 +1613,11 @@ async def get_gmail_message_content(
     Retrieves the full content (subject, sender, recipients, body) of a specific Gmail message.
 
     Bodies are returned inline and truncated at 20,000 characters. Set full=True to
-    export the complete, untruncated message to disk instead: the response then carries
-    a short-lived download URL (HTTP transport) or file path (stdio transport) rather
-    than the body, so large messages never stream through the model context.
+    get the complete, untruncated message instead: it is exported to disk and the
+    response carries a short-lived download URL (HTTP transport) or file path (stdio
+    transport) rather than the body, so large messages never stream through the model
+    context. Stateless deployments have no file storage, so there full=True returns the
+    untruncated body inline.
 
     Args:
         message_id (str): The unique ID of the Gmail message to retrieve.
@@ -1602,27 +1631,19 @@ async def get_gmail_message_content(
             file type: "raw" saves the byte-exact RFC 5322 message as .eml, "html"
             saves the raw HTML body, "text" saves the plaintext body. The "html"/"text"
             exports decode as UTF-8 and drop undecodable bytes, so prefer "raw" when
-            byte-exact fidelity matters. Unavailable in stateless mode.
+            byte-exact fidelity matters. In stateless mode there is no storage to write
+            to, so the untruncated content is returned inline instead.
 
     Returns:
         str: The message details including subject, sender, date, Message-ID, recipients
             (To, Cc), and body content — or, when full=True, the saved file's download
-            URL or path in place of the body.
+            URL or path in place of the body (the untruncated body itself in stateless
+            mode).
     """
     logger.info(
         f"[get_gmail_message_content] Invoked. Message ID: '{message_id}', "
         f"Email: '{user_google_email}', body_format='{body_format}', full={full}"
     )
-
-    # A full export exists to write the message to disk; stateless deployments have no
-    # persistent storage (and the callback-served URL is per-process), so there is
-    # nothing sensible to return. Steer the caller back to the inline path.
-    if full and is_stateless_mode():
-        return (
-            "Error: full=True is unavailable in stateless mode (no persistent file "
-            "storage). Retry with full=False, which returns the body inline truncated "
-            f"at {HTML_BODY_TRUNCATE_LIMIT:,} characters."
-        )
 
     # Fetch message metadata first to get headers
     message_metadata = await asyncio.to_thread(

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -1520,6 +1520,164 @@ async def get_gmail_message_content(
 
 
 @server.tool(
+    title="Get Gmail Message Full",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("get_gmail_message_full", is_read_only=True, service_type="gmail")
+@require_google_service("gmail", "gmail_read")
+async def get_gmail_message_full(
+    service,
+    message_id: str,
+    user_google_email: str,
+    deliver_as: Annotated[
+        Literal["eml", "html", "txt"],
+        Field(
+            description=(
+                "Output format for the saved file. "
+                "'eml' (default) saves the complete raw RFC 5322 message (all headers, "
+                "parts, and inline attachments). "
+                "'html' saves the raw HTML body. "
+                "'txt' saves the plaintext body (HTML converted to text as fallback)."
+            ),
+        ),
+    ] = "eml",
+) -> str:
+    """
+    Retrieves the COMPLETE, untruncated content of a Gmail message and saves it to
+    local storage, returning a URL/path instead of the body text.
+
+    Unlike get_gmail_message_content (which caps body output at 20,000 chars and returns
+    it inline), this tool never truncates and never streams the body through the model
+    context. It writes the full message to disk and hands back a short-lived download URL
+    (HTTP transport) or file path (stdio transport), so large emails can be fetched and
+    processed out-of-band.
+
+    Args:
+        message_id (str): The unique ID of the Gmail message to retrieve.
+        user_google_email (str): The user's Google email address. Required.
+        deliver_as (Literal["eml", "html", "txt"]): Output format for the saved file.
+            "eml" (default) saves the complete raw RFC 5322 message.
+            "html" saves the raw HTML body. "txt" saves the plaintext body.
+
+    Returns:
+        str: A summary (subject, sender, recipients, size) plus the download URL or file
+            path for the saved file. The message body itself is NOT included in the response.
+    """
+    from core.attachment_storage import get_attachment_storage, get_attachment_url
+    from core.config import get_transport_mode
+
+    logger.info(
+        f"[get_gmail_message_full] Invoked. Message ID: '{message_id}', "
+        f"Email: '{user_google_email}', deliver_as='{deliver_as}'"
+    )
+
+    # Fetch headers first for the summary.
+    message_metadata = await asyncio.to_thread(
+        service.users()
+        .messages()
+        .get(
+            userId="me",
+            id=message_id,
+            format="metadata",
+            metadataHeaders=GMAIL_METADATA_HEADERS,
+        )
+        .execute
+    )
+    headers = _extract_headers(
+        message_metadata.get("payload", {}), GMAIL_METADATA_HEADERS
+    )
+    subject = headers.get("Subject", "message") or "message"
+
+    if deliver_as == "eml":
+        message_raw = await asyncio.to_thread(
+            service.users()
+            .messages()
+            .get(userId="me", id=message_id, format="raw")
+            .execute
+        )
+        raw_data = message_raw.get("raw", "")
+        if not raw_data:
+            return "Error: message has no raw content to export."
+        padded_raw = raw_data + "=" * (-len(raw_data) % 4)
+        try:
+            content_bytes = base64.urlsafe_b64decode(padded_raw)
+        except (binascii.Error, ValueError) as exc:
+            return f"Error: failed to decode raw MIME content: {exc}"
+        mime_type = "message/rfc822"
+        extension = ".eml"
+    else:
+        message_full = await asyncio.to_thread(
+            service.users()
+            .messages()
+            .get(userId="me", id=message_id, format="full")
+            .execute
+        )
+        bodies = _extract_message_bodies(message_full.get("payload", {}))
+        text_body = bodies.get("text", "")
+        html_body = bodies.get("html", "")
+
+        if deliver_as == "html":
+            content_str = html_body.strip() or text_body.strip()
+            mime_type = "text/html"
+            extension = ".html"
+        else:  # txt
+            text_stripped = text_body.strip()
+            html_stripped = html_body.strip()
+            if text_stripped:
+                content_str = text_stripped
+            elif html_stripped:
+                content_str = _html_to_text(html_stripped).strip()
+            else:
+                content_str = ""
+            mime_type = "text/plain"
+            extension = ".txt"
+
+        if not content_str:
+            return "Error: message has no readable body content to export."
+        content_bytes = content_str.encode("utf-8")
+
+    # Save via the shared attachment storage (which expects urlsafe base64).
+    storage = get_attachment_storage()
+    saved = storage.save_attachment(
+        base64_data=base64.urlsafe_b64encode(content_bytes).decode("ascii"),
+        filename=f"{subject}{extension}",
+        mime_type=mime_type,
+    )
+    size_bytes = len(content_bytes)
+    size_kb = size_bytes / 1024
+
+    result_lines = _format_message_header_lines(headers)
+    result_lines.append("\n--- FULL MESSAGE EXPORT ---")
+    result_lines.append(f"Format: {deliver_as}")
+    result_lines.append(f"Size: {size_kb:.1f} KB ({size_bytes} bytes)")
+    result_lines.append(f"Saved filename: {Path(saved.path).name}")
+
+    if get_transport_mode() == "stdio":
+        result_lines.append(f"\n📎 Saved to: {saved.path}")
+        result_lines.append(
+            "\nThe full message has been written to disk and can be read directly "
+            "from the file path (its content is NOT included above)."
+        )
+    else:
+        download_url = get_attachment_url(saved.file_id)
+        result_lines.append(f"\n📎 Download URL: {download_url}")
+        result_lines.append(
+            "\nFetch the full message from the URL above (content is NOT included "
+            "in this response). The file will expire after 1 hour."
+        )
+
+    logger.info(
+        f"[get_gmail_message_full] Saved {size_kb:.1f} KB ({deliver_as}) to {saved.path}"
+    )
+    return "\n".join(result_lines)
+
+
+@server.tool(
     title="Get Gmail Messages Content Batch",
     annotations=ToolAnnotations(
         readOnlyHint=True,

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -1522,9 +1522,9 @@ async def get_gmail_message_content(
 @server.tool(
     title="Get Gmail Message Full",
     annotations=ToolAnnotations(
-        readOnlyHint=True,
+        readOnlyHint=False,
         destructiveHint=False,
-        idempotentHint=True,
+        idempotentHint=False,
         openWorldHint=True,
     ),
 )
@@ -1557,6 +1557,12 @@ async def get_gmail_message_full(
     (HTTP transport) or file path (stdio transport), so large emails can be fetched and
     processed out-of-band.
 
+    For byte-exact fidelity prefer deliver_as="eml": it is the raw message as Gmail stores
+    it. The "html"/"txt" formats decode the body as UTF-8 and drop undecodable bytes, so
+    they may not be byte-identical for messages in other charsets.
+
+    This tool writes to disk and is therefore unavailable in stateless mode.
+
     Args:
         message_id (str): The unique ID of the Gmail message to retrieve.
         user_google_email (str): The user's Google email address. Required.
@@ -1568,6 +1574,7 @@ async def get_gmail_message_full(
         str: A summary (subject, sender, recipients, size) plus the download URL or file
             path for the saved file. The message body itself is NOT included in the response.
     """
+    from auth.oauth_config import is_stateless_mode
     from core.attachment_storage import get_attachment_storage, get_attachment_url
     from core.config import get_transport_mode
 
@@ -1575,6 +1582,16 @@ async def get_gmail_message_full(
         f"[get_gmail_message_full] Invoked. Message ID: '{message_id}', "
         f"Email: '{user_google_email}', deliver_as='{deliver_as}'"
     )
+
+    # This tool exists to write the full message to disk; stateless deployments
+    # have no persistent storage (and the callback-served URL is per-process), so
+    # there is nothing sensible to return. Steer callers to the inline tool.
+    if is_stateless_mode():
+        return (
+            "Error: get_gmail_message_full is unavailable in stateless mode "
+            "(no persistent file storage). Use get_gmail_message_content instead "
+            "(note it truncates bodies at 20,000 characters)."
+        )
 
     # Fetch headers first for the summary.
     message_metadata = await asyncio.to_thread(
@@ -1592,6 +1609,8 @@ async def get_gmail_message_full(
         message_metadata.get("payload", {}), GMAIL_METADATA_HEADERS
     )
     subject = headers.get("Subject", "message") or "message"
+
+    notes: List[str] = []
 
     if deliver_as == "eml":
         message_raw = await asyncio.to_thread(
@@ -1618,16 +1637,24 @@ async def get_gmail_message_full(
             .execute
         )
         bodies = _extract_message_bodies(message_full.get("payload", {}))
-        text_body = bodies.get("text", "")
-        html_body = bodies.get("html", "")
+        text_stripped = bodies.get("text", "").strip()
+        html_stripped = bodies.get("html", "").strip()
 
         if deliver_as == "html":
-            content_str = html_body.strip() or text_body.strip()
-            mime_type = "text/html"
-            extension = ".html"
+            if html_stripped:
+                content_str = html_stripped
+                mime_type = "text/html"
+                extension = ".html"
+            else:
+                # No HTML part; fall back to plaintext and label it honestly.
+                content_str = text_stripped
+                mime_type = "text/plain"
+                extension = ".txt"
+                if content_str:
+                    notes.append(
+                        "No HTML body present; exported the plaintext body instead."
+                    )
         else:  # txt
-            text_stripped = text_body.strip()
-            html_stripped = html_body.strip()
             if text_stripped:
                 content_str = text_stripped
             elif html_stripped:
@@ -1641,13 +1668,19 @@ async def get_gmail_message_full(
             return "Error: message has no readable body content to export."
         content_bytes = content_str.encode("utf-8")
 
-    # Save via the shared attachment storage (which expects urlsafe base64).
+    # Save via the shared attachment storage (which expects urlsafe base64). Cap the
+    # sender-controlled subject so a pathologically long Subject can't overflow the
+    # filesystem's filename limit, and surface a clean error if the write still fails.
     storage = get_attachment_storage()
-    saved = storage.save_attachment(
-        base64_data=base64.urlsafe_b64encode(content_bytes).decode("ascii"),
-        filename=f"{subject}{extension}",
-        mime_type=mime_type,
-    )
+    try:
+        saved = storage.save_attachment(
+            base64_data=base64.urlsafe_b64encode(content_bytes).decode("ascii"),
+            filename=f"{subject[:80]}{extension}",
+            mime_type=mime_type,
+        )
+    except OSError as exc:
+        logger.error(f"[get_gmail_message_full] Failed to save message: {exc}")
+        return f"Error: failed to save message to storage: {exc}"
     size_bytes = len(content_bytes)
     size_kb = size_bytes / 1024
 
@@ -1656,6 +1689,8 @@ async def get_gmail_message_full(
     result_lines.append(f"Format: {deliver_as}")
     result_lines.append(f"Size: {size_kb:.1f} KB ({size_bytes} bytes)")
     result_lines.append(f"Saved filename: {Path(saved.path).name}")
+    for note in notes:
+        result_lines.append(f"Note: {note}")
 
     if get_transport_mode() == "stdio":
         result_lines.append(f"\n📎 Saved to: {saved.path}")

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -1637,47 +1637,56 @@ async def get_gmail_message_full(
             .execute
         )
         bodies = _extract_message_bodies(message_full.get("payload", {}))
-        text_stripped = bodies.get("text", "").strip()
-        html_stripped = bodies.get("html", "").strip()
+        # Preserve the body exactly — the export must be complete — so use .strip()
+        # only to test for emptiness, never to trim the content that gets saved.
+        text_body = bodies.get("text", "")
+        html_body = bodies.get("html", "")
 
         if deliver_as == "html":
-            if html_stripped:
-                content_str = html_stripped
+            if html_body.strip():
+                content_str = html_body
                 mime_type = "text/html"
                 extension = ".html"
-            else:
+            elif text_body.strip():
                 # No HTML part; fall back to plaintext and label it honestly.
-                content_str = text_stripped
+                content_str = text_body
                 mime_type = "text/plain"
                 extension = ".txt"
-                if content_str:
-                    notes.append(
-                        "No HTML body present; exported the plaintext body instead."
-                    )
+                notes.append(
+                    "No HTML body present; exported the plaintext body instead."
+                )
+            else:
+                content_str = ""
+                mime_type = "text/html"
+                extension = ".html"
         else:  # txt
-            if text_stripped:
-                content_str = text_stripped
-            elif html_stripped:
-                content_str = _html_to_text(html_stripped).strip()
+            if text_body.strip():
+                content_str = text_body
+            elif html_body.strip():
+                content_str = _html_to_text(html_body)
             else:
                 content_str = ""
             mime_type = "text/plain"
             extension = ".txt"
 
-        if not content_str:
+        if not content_str.strip():
             return "Error: message has no readable body content to export."
         content_bytes = content_str.encode("utf-8")
 
-    # Save via the shared attachment storage (which expects urlsafe base64). Cap the
-    # sender-controlled subject so a pathologically long Subject can't overflow the
-    # filesystem's filename limit, and surface a clean error if the write still fails.
+    # Encode + write on a worker thread so a large export doesn't block the event loop.
+    # Cap the sender-controlled subject so a pathologically long Subject can't overflow
+    # the filesystem's filename limit, and surface a clean error if the write fails.
     storage = get_attachment_storage()
-    try:
-        saved = storage.save_attachment(
+
+    def _save_export():
+        return storage.save_attachment(
             base64_data=base64.urlsafe_b64encode(content_bytes).decode("ascii"),
             filename=f"{subject[:80]}{extension}",
             mime_type=mime_type,
         )
+
+    try:
+        saved = await asyncio.to_thread(_save_export)
     except OSError as exc:
         logger.error(f"[get_gmail_message_full] Failed to save message: {exc}")
         return f"Error: failed to save message to storage: {exc}"

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -27,9 +27,15 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 from googleapiclient.errors import HttpError
 
+from auth.oauth_config import is_stateless_mode
 from auth.service_decorator import require_google_service
-from core.attachment_storage import get_attachment_storage, STORAGE_DIR
+from core.attachment_storage import (
+    get_attachment_storage,
+    get_attachment_url,
+    STORAGE_DIR,
+)
 from core.config import (
+    get_transport_mode,
     WORKSPACE_EXTERNAL_URL,
     WORKSPACE_MCP_BASE_URI,
     WORKSPACE_MCP_PORT,
@@ -319,6 +325,143 @@ def _format_message_header_lines(
         content_lines.append(f"List-Id: {list_id}")
 
     return content_lines
+
+
+async def _export_full_message(
+    service,
+    message_id: str,
+    headers: Dict[str, str],
+    body_format: Literal["text", "html", "raw"],
+) -> str:
+    """
+    Save a message's complete, untruncated content to local storage and format the
+    response as a download URL (HTTP transport) or file path (stdio transport).
+
+    The body is never included in the returned string — that is the point of the
+    export: large messages are handed off out-of-band instead of through the model
+    context, and no truncation limit applies.
+
+    Args:
+        service: Authenticated Gmail API service.
+        message_id: The message to export.
+        headers: Already-fetched message headers, used for the summary and filename.
+        body_format: "raw" saves the byte-exact RFC 5322 message as .eml,
+            "html" saves the raw HTML body, "text" saves the plaintext body.
+
+    Returns:
+        str: Header summary plus the saved file's URL or path, or an "Error:" string.
+    """
+    subject = headers.get("Subject", "message") or "message"
+    notes: List[str] = []
+
+    if body_format == "raw":
+        message_raw = await asyncio.to_thread(
+            service.users()
+            .messages()
+            .get(userId="me", id=message_id, format="raw")
+            .execute
+        )
+        raw_data = message_raw.get("raw", "")
+        if not raw_data:
+            return "Error: message has no raw content to export."
+        padded_raw = raw_data + "=" * (-len(raw_data) % 4)
+        try:
+            content_bytes = base64.urlsafe_b64decode(padded_raw)
+        except (binascii.Error, ValueError) as exc:
+            return f"Error: failed to decode raw MIME content: {exc}"
+        mime_type = "message/rfc822"
+        extension = ".eml"
+    else:
+        message_full = await asyncio.to_thread(
+            service.users()
+            .messages()
+            .get(userId="me", id=message_id, format="full")
+            .execute
+        )
+        bodies = _extract_message_bodies(message_full.get("payload", {}))
+        # Preserve the body exactly — the export must be complete — so use .strip()
+        # only to test for emptiness, never to trim the content that gets saved.
+        text_body = bodies.get("text", "")
+        html_body = bodies.get("html", "")
+
+        if body_format == "html":
+            if html_body.strip():
+                content_str = html_body
+                mime_type = "text/html"
+                extension = ".html"
+            elif text_body.strip():
+                # No HTML part; fall back to plaintext and label it honestly.
+                content_str = text_body
+                mime_type = "text/plain"
+                extension = ".txt"
+                notes.append(
+                    "No HTML body present; exported the plaintext body instead."
+                )
+            else:
+                content_str = ""
+                mime_type = "text/html"
+                extension = ".html"
+        else:  # text
+            if text_body.strip():
+                content_str = text_body
+            elif html_body.strip():
+                content_str = _html_to_text(html_body)
+            else:
+                content_str = ""
+            mime_type = "text/plain"
+            extension = ".txt"
+
+        if not content_str.strip():
+            return "Error: message has no readable body content to export."
+        content_bytes = content_str.encode("utf-8")
+
+    # Encode + write on a worker thread so a large export doesn't block the event loop.
+    # Cap the sender-controlled subject so a pathologically long Subject can't overflow
+    # the filesystem's filename limit, and surface a clean error if the write fails.
+    storage = get_attachment_storage()
+
+    def _save_export():
+        return storage.save_attachment(
+            base64_data=base64.urlsafe_b64encode(content_bytes).decode("ascii"),
+            filename=f"{subject[:80]}{extension}",
+            mime_type=mime_type,
+        )
+
+    try:
+        saved = await asyncio.to_thread(_save_export)
+    except OSError as exc:
+        logger.error(f"[get_gmail_message_content] Failed to save message: {exc}")
+        return f"Error: failed to save message to storage: {exc}"
+
+    size_bytes = len(content_bytes)
+    size_kb = size_bytes / 1024
+
+    result_lines = _format_message_header_lines(headers)
+    result_lines.append("\n--- FULL MESSAGE EXPORT ---")
+    result_lines.append(f"Format: {extension.lstrip('.')}")
+    result_lines.append(f"Size: {size_kb:.1f} KB ({size_bytes} bytes)")
+    result_lines.append(f"Saved filename: {Path(saved.path).name}")
+    for note in notes:
+        result_lines.append(f"Note: {note}")
+
+    if get_transport_mode() == "stdio":
+        result_lines.append(f"\n📎 Saved to: {saved.path}")
+        result_lines.append(
+            "\nThe full message has been written to disk and can be read directly "
+            "from the file path (its content is NOT included above)."
+        )
+    else:
+        result_lines.append(f"\n📎 Download URL: {get_attachment_url(saved.file_id)}")
+        result_lines.append(
+            "\nFetch the full message from the URL above (content is NOT included "
+            "in this response). The file will expire after 1 hour."
+        )
+
+    logger.info(
+        f"[get_gmail_message_content] Exported {size_kb:.1f} KB "
+        f"({extension.lstrip('.')}) to {saved.path}"
+    )
+    return "\n".join(result_lines)
 
 
 def _build_message_get_request(
@@ -1426,9 +1569,26 @@ async def get_gmail_message_content(
             ),
         ),
     ] = "text",
+    full: Annotated[
+        bool,
+        Field(
+            description=(
+                "When True, save the COMPLETE untruncated message to local storage and "
+                "return a download URL/file path instead of the body text. Use for "
+                "messages large enough to hit the truncation limit, or when byte-exact "
+                "fidelity is needed (pair with body_format='raw' for a .eml export). "
+                "Requires persistent storage, so it is unavailable in stateless mode."
+            ),
+        ),
+    ] = False,
 ) -> str:
     """
     Retrieves the full content (subject, sender, recipients, body) of a specific Gmail message.
+
+    Bodies are returned inline and truncated at 20,000 characters. Set full=True to
+    export the complete, untruncated message to disk instead: the response then carries
+    a short-lived download URL (HTTP transport) or file path (stdio transport) rather
+    than the body, so large messages never stream through the model context.
 
     Args:
         message_id (str): The unique ID of the Gmail message to retrieve.
@@ -1437,15 +1597,32 @@ async def get_gmail_message_content(
             "text" (default) returns plaintext (HTML converted to text as fallback).
             "html" returns the raw HTML body as-is without conversion.
             "raw" fetches the full raw MIME message and returns the base64url-decoded content.
+        full (bool): When True, write the untruncated message to local storage and
+            return its URL/path instead of the body. body_format selects the exported
+            file type: "raw" saves the byte-exact RFC 5322 message as .eml, "html"
+            saves the raw HTML body, "text" saves the plaintext body. The "html"/"text"
+            exports decode as UTF-8 and drop undecodable bytes, so prefer "raw" when
+            byte-exact fidelity matters. Unavailable in stateless mode.
 
     Returns:
-        str: The message details including subject, sender, date, Message-ID, recipients (To, Cc), and body content.
+        str: The message details including subject, sender, date, Message-ID, recipients
+            (To, Cc), and body content — or, when full=True, the saved file's download
+            URL or path in place of the body.
     """
     logger.info(
-        f"[get_gmail_message_content] Invoked. Message ID: '{message_id}', Email: '{user_google_email}'"
+        f"[get_gmail_message_content] Invoked. Message ID: '{message_id}', "
+        f"Email: '{user_google_email}', body_format='{body_format}', full={full}"
     )
 
-    logger.info(f"[get_gmail_message_content] Using service for: {user_google_email}")
+    # A full export exists to write the message to disk; stateless deployments have no
+    # persistent storage (and the callback-served URL is per-process), so there is
+    # nothing sensible to return. Steer the caller back to the inline path.
+    if full and is_stateless_mode():
+        return (
+            "Error: full=True is unavailable in stateless mode (no persistent file "
+            "storage). Retry with full=False, which returns the body inline truncated "
+            f"at {HTML_BODY_TRUNCATE_LIMIT:,} characters."
+        )
 
     # Fetch message metadata first to get headers
     message_metadata = await asyncio.to_thread(
@@ -1463,6 +1640,10 @@ async def get_gmail_message_content(
     headers = _extract_headers(
         message_metadata.get("payload", {}), GMAIL_METADATA_HEADERS
     )
+
+    # Full export: hand back a file reference instead of the (truncated) body.
+    if full:
+        return await _export_full_message(service, message_id, headers, body_format)
 
     # Handle raw format separately - fetch with format="raw" and return decoded MIME
     if body_format == "raw":
@@ -1517,208 +1698,6 @@ async def get_gmail_message_content(
             )
 
     return "\n".join(content_lines)
-
-
-@server.tool(
-    title="Get Gmail Message Full",
-    annotations=ToolAnnotations(
-        readOnlyHint=False,
-        destructiveHint=False,
-        idempotentHint=False,
-        openWorldHint=True,
-    ),
-)
-@handle_http_errors("get_gmail_message_full", is_read_only=True, service_type="gmail")
-@require_google_service("gmail", "gmail_read")
-async def get_gmail_message_full(
-    service,
-    message_id: str,
-    user_google_email: str,
-    deliver_as: Annotated[
-        Literal["eml", "html", "txt"],
-        Field(
-            description=(
-                "Output format for the saved file. "
-                "'eml' (default) saves the complete raw RFC 5322 message (all headers, "
-                "parts, and inline attachments). "
-                "'html' saves the raw HTML body. "
-                "'txt' saves the plaintext body (HTML converted to text as fallback)."
-            ),
-        ),
-    ] = "eml",
-) -> str:
-    """
-    Retrieves the COMPLETE, untruncated content of a Gmail message and saves it to
-    local storage, returning a URL/path instead of the body text.
-
-    Unlike get_gmail_message_content (which caps body output at 20,000 chars and returns
-    it inline), this tool never truncates and never streams the body through the model
-    context. It writes the full message to disk and hands back a short-lived download URL
-    (HTTP transport) or file path (stdio transport), so large emails can be fetched and
-    processed out-of-band.
-
-    For byte-exact fidelity prefer deliver_as="eml": it is the raw message as Gmail stores
-    it. The "html"/"txt" formats decode the body as UTF-8 and drop undecodable bytes, so
-    they may not be byte-identical for messages in other charsets.
-
-    This tool writes to disk and is therefore unavailable in stateless mode.
-
-    Args:
-        message_id (str): The unique ID of the Gmail message to retrieve.
-        user_google_email (str): The user's Google email address. Required.
-        deliver_as (Literal["eml", "html", "txt"]): Output format for the saved file.
-            "eml" (default) saves the complete raw RFC 5322 message.
-            "html" saves the raw HTML body. "txt" saves the plaintext body.
-
-    Returns:
-        str: A summary (subject, sender, recipients, size) plus the download URL or file
-            path for the saved file. The message body itself is NOT included in the response.
-    """
-    from auth.oauth_config import is_stateless_mode
-    from core.attachment_storage import get_attachment_storage, get_attachment_url
-    from core.config import get_transport_mode
-
-    logger.info(
-        f"[get_gmail_message_full] Invoked. Message ID: '{message_id}', "
-        f"Email: '{user_google_email}', deliver_as='{deliver_as}'"
-    )
-
-    # This tool exists to write the full message to disk; stateless deployments
-    # have no persistent storage (and the callback-served URL is per-process), so
-    # there is nothing sensible to return. Steer callers to the inline tool.
-    if is_stateless_mode():
-        return (
-            "Error: get_gmail_message_full is unavailable in stateless mode "
-            "(no persistent file storage). Use get_gmail_message_content instead "
-            "(note it truncates bodies at 20,000 characters)."
-        )
-
-    # Fetch headers first for the summary.
-    message_metadata = await asyncio.to_thread(
-        service.users()
-        .messages()
-        .get(
-            userId="me",
-            id=message_id,
-            format="metadata",
-            metadataHeaders=GMAIL_METADATA_HEADERS,
-        )
-        .execute
-    )
-    headers = _extract_headers(
-        message_metadata.get("payload", {}), GMAIL_METADATA_HEADERS
-    )
-    subject = headers.get("Subject", "message") or "message"
-
-    notes: List[str] = []
-
-    if deliver_as == "eml":
-        message_raw = await asyncio.to_thread(
-            service.users()
-            .messages()
-            .get(userId="me", id=message_id, format="raw")
-            .execute
-        )
-        raw_data = message_raw.get("raw", "")
-        if not raw_data:
-            return "Error: message has no raw content to export."
-        padded_raw = raw_data + "=" * (-len(raw_data) % 4)
-        try:
-            content_bytes = base64.urlsafe_b64decode(padded_raw)
-        except (binascii.Error, ValueError) as exc:
-            return f"Error: failed to decode raw MIME content: {exc}"
-        mime_type = "message/rfc822"
-        extension = ".eml"
-    else:
-        message_full = await asyncio.to_thread(
-            service.users()
-            .messages()
-            .get(userId="me", id=message_id, format="full")
-            .execute
-        )
-        bodies = _extract_message_bodies(message_full.get("payload", {}))
-        # Preserve the body exactly — the export must be complete — so use .strip()
-        # only to test for emptiness, never to trim the content that gets saved.
-        text_body = bodies.get("text", "")
-        html_body = bodies.get("html", "")
-
-        if deliver_as == "html":
-            if html_body.strip():
-                content_str = html_body
-                mime_type = "text/html"
-                extension = ".html"
-            elif text_body.strip():
-                # No HTML part; fall back to plaintext and label it honestly.
-                content_str = text_body
-                mime_type = "text/plain"
-                extension = ".txt"
-                notes.append(
-                    "No HTML body present; exported the plaintext body instead."
-                )
-            else:
-                content_str = ""
-                mime_type = "text/html"
-                extension = ".html"
-        else:  # txt
-            if text_body.strip():
-                content_str = text_body
-            elif html_body.strip():
-                content_str = _html_to_text(html_body)
-            else:
-                content_str = ""
-            mime_type = "text/plain"
-            extension = ".txt"
-
-        if not content_str.strip():
-            return "Error: message has no readable body content to export."
-        content_bytes = content_str.encode("utf-8")
-
-    # Encode + write on a worker thread so a large export doesn't block the event loop.
-    # Cap the sender-controlled subject so a pathologically long Subject can't overflow
-    # the filesystem's filename limit, and surface a clean error if the write fails.
-    storage = get_attachment_storage()
-
-    def _save_export():
-        return storage.save_attachment(
-            base64_data=base64.urlsafe_b64encode(content_bytes).decode("ascii"),
-            filename=f"{subject[:80]}{extension}",
-            mime_type=mime_type,
-        )
-
-    try:
-        saved = await asyncio.to_thread(_save_export)
-    except OSError as exc:
-        logger.error(f"[get_gmail_message_full] Failed to save message: {exc}")
-        return f"Error: failed to save message to storage: {exc}"
-    size_bytes = len(content_bytes)
-    size_kb = size_bytes / 1024
-
-    result_lines = _format_message_header_lines(headers)
-    result_lines.append("\n--- FULL MESSAGE EXPORT ---")
-    result_lines.append(f"Format: {deliver_as}")
-    result_lines.append(f"Size: {size_kb:.1f} KB ({size_bytes} bytes)")
-    result_lines.append(f"Saved filename: {Path(saved.path).name}")
-    for note in notes:
-        result_lines.append(f"Note: {note}")
-
-    if get_transport_mode() == "stdio":
-        result_lines.append(f"\n📎 Saved to: {saved.path}")
-        result_lines.append(
-            "\nThe full message has been written to disk and can be read directly "
-            "from the file path (its content is NOT included above)."
-        )
-    else:
-        download_url = get_attachment_url(saved.file_id)
-        result_lines.append(f"\n📎 Download URL: {download_url}")
-        result_lines.append(
-            "\nFetch the full message from the URL above (content is NOT included "
-            "in this response). The file will expire after 1 hour."
-        )
-
-    logger.info(
-        f"[get_gmail_message_full] Saved {size_kb:.1f} KB ({deliver_as}) to {saved.path}"
-    )
-    return "\n".join(result_lines)
 
 
 @server.tool(

--- a/tests/gmail/test_body_format.py
+++ b/tests/gmail/test_body_format.py
@@ -609,6 +609,39 @@ async def test_get_gmail_message_full_html_saves_raw_html(stdio_storage):
 
 
 @pytest.mark.asyncio
+async def test_get_gmail_message_full_preserves_edge_whitespace(stdio_storage):
+    """A complete export must not strip leading/trailing body content."""
+    html_with_edges = "\n\n  <html><body>Body</body></html>  \n"
+    text_with_edges = "\n   Leading and trailing kept.   \n"
+    service = _build_service(
+        message_responses={
+            ("msg-ws", "metadata"): _metadata_response("msg-ws"),
+            ("msg-ws", "full"): _message_response(
+                "msg-ws", text=text_with_edges, html=html_with_edges
+            ),
+        }
+    )
+
+    html_result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-ws",
+        user_google_email="user@example.com",
+        deliver_as="html",
+    )
+    with open(_saved_path(html_result), "rb") as fh:
+        assert fh.read().decode() == html_with_edges
+
+    txt_result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-ws",
+        user_google_email="user@example.com",
+        deliver_as="txt",
+    )
+    with open(_saved_path(txt_result), "rb") as fh:
+        assert fh.read().decode() == text_with_edges
+
+
+@pytest.mark.asyncio
 async def test_get_gmail_message_full_does_not_truncate(stdio_storage):
     """The whole point: full-body export never applies the 20,000-char cap."""
     long_html = "<p>" + ("A" * 50000) + "</p>"

--- a/tests/gmail/test_body_format.py
+++ b/tests/gmail/test_body_format.py
@@ -13,7 +13,6 @@ from gmail.gmail_tools import (
     _format_body_content,
     _html_to_text,
     get_gmail_message_content,
-    get_gmail_message_full,
     get_gmail_messages_content_batch,
     get_gmail_thread_content,
     get_gmail_threads_content_batch,
@@ -515,13 +514,13 @@ def stdio_storage(monkeypatch, tmp_path):
 
     monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path)
     monkeypatch.setattr(attachment_storage, "_attachment_storage", None)
-    monkeypatch.setattr("core.config.get_transport_mode", lambda: "stdio")
-    monkeypatch.setattr("auth.oauth_config.is_stateless_mode", lambda: False)
+    monkeypatch.setattr(gmail_tools, "get_transport_mode", lambda: "stdio")
+    monkeypatch.setattr(gmail_tools, "is_stateless_mode", lambda: False)
     return tmp_path
 
 
 def _saved_path(result: str) -> str:
-    """Pull the on-disk path out of a stdio-mode get_gmail_message_full response."""
+    """Pull the on-disk path out of a stdio-mode full-export response."""
     marker = "📎 Saved to: "
     line = next(ln for ln in result.splitlines() if marker in ln)
     return line.split(marker, 1)[1].strip()
@@ -533,7 +532,7 @@ def _unpadded(text: str) -> str:
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_eml_saves_complete_raw(stdio_storage):
+async def test_full_export_raw_saves_complete_eml(stdio_storage):
     # Use unpadded base64url (as Gmail actually returns) to exercise padding repair.
     raw_mime = "From: sender@example.com\r\n\r\nComplete raw MIME body!"
     service = _build_service(
@@ -543,15 +542,17 @@ async def test_get_gmail_message_full_eml_saves_complete_raw(stdio_storage):
         }
     )
 
-    result = await _unwrap(get_gmail_message_full)(
+    result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-1",
         user_google_email="user@example.com",
-        deliver_as="eml",
+        body_format="raw",
+        full=True,
     )
 
     # Body content must NOT be inlined in the response.
     assert "Complete raw MIME body" not in result
+    assert "--- RAW MIME ---" not in result
     assert "--- FULL MESSAGE EXPORT ---" in result
     assert "Format: eml" in result
     assert "Subject: Example subject" in result
@@ -562,7 +563,7 @@ async def test_get_gmail_message_full_eml_saves_complete_raw(stdio_storage):
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_txt_uses_plaintext(stdio_storage):
+async def test_full_export_text_uses_plaintext(stdio_storage):
     service = _build_service(
         message_responses={
             ("msg-2", "metadata"): _metadata_response("msg-2"),
@@ -572,11 +573,11 @@ async def test_get_gmail_message_full_txt_uses_plaintext(stdio_storage):
         }
     )
 
-    result = await _unwrap(get_gmail_message_full)(
+    result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-2",
         user_google_email="user@example.com",
-        deliver_as="txt",
+        full=True,
     )
 
     assert "Plain body" not in result
@@ -586,7 +587,7 @@ async def test_get_gmail_message_full_txt_uses_plaintext(stdio_storage):
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_html_saves_raw_html(stdio_storage):
+async def test_full_export_html_saves_raw_html(stdio_storage):
     service = _build_service(
         message_responses={
             ("msg-3", "metadata"): _metadata_response("msg-3"),
@@ -596,11 +597,12 @@ async def test_get_gmail_message_full_html_saves_raw_html(stdio_storage):
         }
     )
 
-    result = await _unwrap(get_gmail_message_full)(
+    result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-3",
         user_google_email="user@example.com",
-        deliver_as="html",
+        body_format="html",
+        full=True,
     )
 
     assert "Rich HTML" not in result
@@ -609,7 +611,7 @@ async def test_get_gmail_message_full_html_saves_raw_html(stdio_storage):
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_preserves_edge_whitespace(stdio_storage):
+async def test_full_export_preserves_edge_whitespace(stdio_storage):
     """A complete export must not strip leading/trailing body content."""
     html_with_edges = "\n\n  <html><body>Body</body></html>  \n"
     text_with_edges = "\n   Leading and trailing kept.   \n"
@@ -622,28 +624,30 @@ async def test_get_gmail_message_full_preserves_edge_whitespace(stdio_storage):
         }
     )
 
-    html_result = await _unwrap(get_gmail_message_full)(
+    html_result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-ws",
         user_google_email="user@example.com",
-        deliver_as="html",
+        body_format="html",
+        full=True,
     )
     with open(_saved_path(html_result), "rb") as fh:
         assert fh.read().decode() == html_with_edges
 
-    txt_result = await _unwrap(get_gmail_message_full)(
+    text_result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-ws",
         user_google_email="user@example.com",
-        deliver_as="txt",
+        body_format="text",
+        full=True,
     )
-    with open(_saved_path(txt_result), "rb") as fh:
+    with open(_saved_path(text_result), "rb") as fh:
         assert fh.read().decode() == text_with_edges
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_does_not_truncate(stdio_storage):
-    """The whole point: full-body export never applies the 20,000-char cap."""
+async def test_full_export_does_not_truncate(stdio_storage):
+    """The whole point: full=True never applies the 20,000-char cap."""
     long_html = "<p>" + ("A" * 50000) + "</p>"
     service = _build_service(
         message_responses={
@@ -652,11 +656,12 @@ async def test_get_gmail_message_full_does_not_truncate(stdio_storage):
         }
     )
 
-    result = await _unwrap(get_gmail_message_full)(
+    result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-4",
         user_google_email="user@example.com",
-        deliver_as="html",
+        body_format="html",
+        full=True,
     )
 
     assert "[Content truncated...]" not in result
@@ -667,15 +672,15 @@ async def test_get_gmail_message_full_does_not_truncate(stdio_storage):
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_http_returns_url(monkeypatch, tmp_path):
+async def test_full_export_http_returns_url(monkeypatch, tmp_path):
     import core.attachment_storage as attachment_storage
 
     monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path)
     monkeypatch.setattr(attachment_storage, "_attachment_storage", None)
-    monkeypatch.setattr("core.config.get_transport_mode", lambda: "streamable-http")
-    monkeypatch.setattr("auth.oauth_config.is_stateless_mode", lambda: False)
+    monkeypatch.setattr(gmail_tools, "get_transport_mode", lambda: "streamable-http")
+    monkeypatch.setattr(gmail_tools, "is_stateless_mode", lambda: False)
     monkeypatch.setattr(
-        attachment_storage,
+        gmail_tools,
         "get_attachment_url",
         lambda file_id: f"https://example.test/attachments/{file_id}",
     )
@@ -687,11 +692,12 @@ async def test_get_gmail_message_full_http_returns_url(monkeypatch, tmp_path):
         }
     )
 
-    result = await _unwrap(get_gmail_message_full)(
+    result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-5",
         user_google_email="user@example.com",
-        deliver_as="eml",
+        body_format="raw",
+        full=True,
     )
 
     assert "https://example.test/attachments/" in result
@@ -699,25 +705,46 @@ async def test_get_gmail_message_full_http_returns_url(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_blocked_in_stateless_mode(monkeypatch):
-    monkeypatch.setattr("auth.oauth_config.is_stateless_mode", lambda: True)
-    service = _build_service(
-        message_responses={("msg-6", "metadata"): _metadata_response("msg-6")}
-    )
+async def test_full_export_blocked_in_stateless_mode(monkeypatch):
+    monkeypatch.setattr(gmail_tools, "is_stateless_mode", lambda: True)
+    service = _build_service(message_responses={})
 
-    result = await _unwrap(get_gmail_message_full)(
+    result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-6",
         user_google_email="user@example.com",
-        deliver_as="eml",
+        body_format="raw",
+        full=True,
     )
 
     assert "stateless mode" in result.lower()
-    assert "get_gmail_message_content" in result
+    assert "full=False" in result
+    # Bails out before spending an API call.
+    service.users.return_value.messages.return_value.get.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_empty_raw_errors(stdio_storage):
+async def test_inline_path_unaffected_by_stateless_mode(monkeypatch):
+    """full=False is pure-read and must keep working in stateless deployments."""
+    monkeypatch.setattr(gmail_tools, "is_stateless_mode", lambda: True)
+    service = _build_service(
+        message_responses={
+            ("msg-6b", "metadata"): _metadata_response("msg-6b"),
+            ("msg-6b", "full"): _message_response("msg-6b", text="Inline body"),
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_content)(
+        service=service,
+        message_id="msg-6b",
+        user_google_email="user@example.com",
+    )
+
+    assert "Inline body" in result
+
+
+@pytest.mark.asyncio
+async def test_full_export_empty_raw_errors(stdio_storage):
     service = _build_service(
         message_responses={
             ("msg-7", "metadata"): _metadata_response("msg-7"),
@@ -725,11 +752,12 @@ async def test_get_gmail_message_full_empty_raw_errors(stdio_storage):
         }
     )
 
-    result = await _unwrap(get_gmail_message_full)(
+    result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-7",
         user_google_email="user@example.com",
-        deliver_as="eml",
+        body_format="raw",
+        full=True,
     )
 
     assert result.startswith("Error:")
@@ -737,7 +765,7 @@ async def test_get_gmail_message_full_empty_raw_errors(stdio_storage):
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_no_body_errors(stdio_storage):
+async def test_full_export_no_body_errors(stdio_storage):
     service = _build_service(
         message_responses={
             ("msg-8", "metadata"): _metadata_response("msg-8"),
@@ -745,11 +773,11 @@ async def test_get_gmail_message_full_no_body_errors(stdio_storage):
         }
     )
 
-    result = await _unwrap(get_gmail_message_full)(
+    result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-8",
         user_google_email="user@example.com",
-        deliver_as="txt",
+        full=True,
     )
 
     assert result.startswith("Error:")
@@ -757,9 +785,7 @@ async def test_get_gmail_message_full_no_body_errors(stdio_storage):
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_txt_converts_html_when_no_plaintext(
-    stdio_storage,
-):
+async def test_full_export_text_converts_html_when_no_plaintext(stdio_storage):
     service = _build_service(
         message_responses={
             ("msg-9", "metadata"): _metadata_response("msg-9"),
@@ -769,11 +795,11 @@ async def test_get_gmail_message_full_txt_converts_html_when_no_plaintext(
         }
     )
 
-    result = await _unwrap(get_gmail_message_full)(
+    result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-9",
         user_google_email="user@example.com",
-        deliver_as="txt",
+        full=True,
     )
 
     with open(_saved_path(result), "rb") as fh:
@@ -781,9 +807,7 @@ async def test_get_gmail_message_full_txt_converts_html_when_no_plaintext(
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_html_falls_back_to_text_and_labels_it(
-    stdio_storage,
-):
+async def test_full_export_html_falls_back_to_text_and_labels_it(stdio_storage):
     service = _build_service(
         message_responses={
             ("msg-10", "metadata"): _metadata_response("msg-10"),
@@ -793,14 +817,16 @@ async def test_get_gmail_message_full_html_falls_back_to_text_and_labels_it(
         }
     )
 
-    result = await _unwrap(get_gmail_message_full)(
+    result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-10",
         user_google_email="user@example.com",
-        deliver_as="html",
+        body_format="html",
+        full=True,
     )
 
     assert "No HTML body present" in result
+    assert "Format: txt" in result
     saved_path = _saved_path(result)
     assert saved_path.endswith(".txt")
     with open(saved_path, "rb") as fh:
@@ -808,7 +834,7 @@ async def test_get_gmail_message_full_html_falls_back_to_text_and_labels_it(
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_sanitizes_subject_filename(stdio_storage):
+async def test_full_export_sanitizes_subject_filename(stdio_storage):
     headers = _headers(Subject="../../etc/passwd")
     service = _build_service(
         message_responses={
@@ -817,11 +843,12 @@ async def test_get_gmail_message_full_sanitizes_subject_filename(stdio_storage):
         }
     )
 
-    result = await _unwrap(get_gmail_message_full)(
+    result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-11",
         user_google_email="user@example.com",
-        deliver_as="eml",
+        body_format="raw",
+        full=True,
     )
 
     saved_path = _saved_path(result)
@@ -831,7 +858,7 @@ async def test_get_gmail_message_full_sanitizes_subject_filename(stdio_storage):
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_long_subject_does_not_crash(stdio_storage):
+async def test_full_export_long_subject_does_not_crash(stdio_storage):
     headers = _headers(Subject="X" * 900)
     service = _build_service(
         message_responses={
@@ -840,11 +867,12 @@ async def test_get_gmail_message_full_long_subject_does_not_crash(stdio_storage)
         }
     )
 
-    result = await _unwrap(get_gmail_message_full)(
+    result = await _unwrap(get_gmail_message_content)(
         service=service,
         message_id="msg-12",
         user_google_email="user@example.com",
-        deliver_as="eml",
+        body_format="raw",
+        full=True,
     )
 
     saved_path = _saved_path(result)

--- a/tests/gmail/test_body_format.py
+++ b/tests/gmail/test_body_format.py
@@ -1,6 +1,7 @@
 """Tests for Gmail body_format support across helper and public tool APIs."""
 
 import base64
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -515,6 +516,7 @@ def stdio_storage(monkeypatch, tmp_path):
     monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path)
     monkeypatch.setattr(attachment_storage, "_attachment_storage", None)
     monkeypatch.setattr("core.config.get_transport_mode", lambda: "stdio")
+    monkeypatch.setattr("auth.oauth_config.is_stateless_mode", lambda: False)
     return tmp_path
 
 
@@ -525,13 +527,19 @@ def _saved_path(result: str) -> str:
     return line.split(marker, 1)[1].strip()
 
 
+def _unpadded(text: str) -> str:
+    """base64url without padding, exactly as the Gmail API returns raw content."""
+    return base64.urlsafe_b64encode(text.encode()).decode().rstrip("=")
+
+
 @pytest.mark.asyncio
 async def test_get_gmail_message_full_eml_saves_complete_raw(stdio_storage):
-    raw_mime = "From: sender@example.com\r\n\r\nComplete raw MIME body"
+    # Use unpadded base64url (as Gmail actually returns) to exercise padding repair.
+    raw_mime = "From: sender@example.com\r\n\r\nComplete raw MIME body!"
     service = _build_service(
         message_responses={
             ("msg-1", "metadata"): _metadata_response("msg-1"),
-            ("msg-1", "raw"): {"raw": _encode(raw_mime)},
+            ("msg-1", "raw"): {"raw": _unpadded(raw_mime)},
         }
     )
 
@@ -632,6 +640,7 @@ async def test_get_gmail_message_full_http_returns_url(monkeypatch, tmp_path):
     monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path)
     monkeypatch.setattr(attachment_storage, "_attachment_storage", None)
     monkeypatch.setattr("core.config.get_transport_mode", lambda: "streamable-http")
+    monkeypatch.setattr("auth.oauth_config.is_stateless_mode", lambda: False)
     monkeypatch.setattr(
         attachment_storage,
         "get_attachment_url",
@@ -654,3 +663,155 @@ async def test_get_gmail_message_full_http_returns_url(monkeypatch, tmp_path):
 
     assert "https://example.test/attachments/" in result
     assert "raw body" not in result
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_message_full_blocked_in_stateless_mode(monkeypatch):
+    monkeypatch.setattr("auth.oauth_config.is_stateless_mode", lambda: True)
+    service = _build_service(
+        message_responses={("msg-6", "metadata"): _metadata_response("msg-6")}
+    )
+
+    result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-6",
+        user_google_email="user@example.com",
+        deliver_as="eml",
+    )
+
+    assert "stateless mode" in result.lower()
+    assert "get_gmail_message_content" in result
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_message_full_empty_raw_errors(stdio_storage):
+    service = _build_service(
+        message_responses={
+            ("msg-7", "metadata"): _metadata_response("msg-7"),
+            ("msg-7", "raw"): {"raw": ""},
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-7",
+        user_google_email="user@example.com",
+        deliver_as="eml",
+    )
+
+    assert result.startswith("Error:")
+    assert "no raw content" in result
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_message_full_no_body_errors(stdio_storage):
+    service = _build_service(
+        message_responses={
+            ("msg-8", "metadata"): _metadata_response("msg-8"),
+            ("msg-8", "full"): _message_response("msg-8", text="", html=""),
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-8",
+        user_google_email="user@example.com",
+        deliver_as="txt",
+    )
+
+    assert result.startswith("Error:")
+    assert "no readable body" in result
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_message_full_txt_converts_html_when_no_plaintext(stdio_storage):
+    service = _build_service(
+        message_responses={
+            ("msg-9", "metadata"): _metadata_response("msg-9"),
+            ("msg-9", "full"): _message_response(
+                "msg-9", text="", html="<p>Converted body</p>"
+            ),
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-9",
+        user_google_email="user@example.com",
+        deliver_as="txt",
+    )
+
+    with open(_saved_path(result), "rb") as fh:
+        assert fh.read().decode() == "Converted body"
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_message_full_html_falls_back_to_text_and_labels_it(
+    stdio_storage,
+):
+    service = _build_service(
+        message_responses={
+            ("msg-10", "metadata"): _metadata_response("msg-10"),
+            ("msg-10", "full"): _message_response(
+                "msg-10", text="Only plaintext here", html=""
+            ),
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-10",
+        user_google_email="user@example.com",
+        deliver_as="html",
+    )
+
+    assert "No HTML body present" in result
+    saved_path = _saved_path(result)
+    assert saved_path.endswith(".txt")
+    with open(saved_path, "rb") as fh:
+        assert fh.read().decode() == "Only plaintext here"
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_message_full_sanitizes_subject_filename(stdio_storage):
+    headers = _headers(Subject="../../etc/passwd")
+    service = _build_service(
+        message_responses={
+            ("msg-11", "metadata"): _metadata_response("msg-11", headers=headers),
+            ("msg-11", "raw"): {"raw": _encode("raw body")},
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-11",
+        user_google_email="user@example.com",
+        deliver_as="eml",
+    )
+
+    saved_path = _saved_path(result)
+    # No path traversal escapes the storage dir.
+    assert Path(saved_path).parent == Path(stdio_storage)
+    assert "/" not in Path(saved_path).name.replace(str(stdio_storage), "")
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_message_full_long_subject_does_not_crash(stdio_storage):
+    headers = _headers(Subject="X" * 900)
+    service = _build_service(
+        message_responses={
+            ("msg-12", "metadata"): _metadata_response("msg-12", headers=headers),
+            ("msg-12", "raw"): {"raw": _encode("raw body")},
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-12",
+        user_google_email="user@example.com",
+        deliver_as="eml",
+    )
+
+    saved_path = _saved_path(result)
+    assert Path(saved_path).exists()
+    assert len(Path(saved_path).name) < 255

--- a/tests/gmail/test_body_format.py
+++ b/tests/gmail/test_body_format.py
@@ -12,6 +12,7 @@ from gmail.gmail_tools import (
     _format_body_content,
     _html_to_text,
     get_gmail_message_content,
+    get_gmail_message_full,
     get_gmail_messages_content_batch,
     get_gmail_thread_content,
     get_gmail_threads_content_batch,
@@ -504,3 +505,152 @@ async def test_get_gmail_message_content_preserves_html_format():
     assert "To: recipient@example.com" in result
     assert "Cc: cc@example.com" in result
     assert "From:    " not in result
+
+
+@pytest.fixture
+def stdio_storage(monkeypatch, tmp_path):
+    """Route attachment storage to a temp dir and force stdio (file-path) delivery."""
+    import core.attachment_storage as attachment_storage
+
+    monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path)
+    monkeypatch.setattr(attachment_storage, "_attachment_storage", None)
+    monkeypatch.setattr("core.config.get_transport_mode", lambda: "stdio")
+    return tmp_path
+
+
+def _saved_path(result: str) -> str:
+    """Pull the on-disk path out of a stdio-mode get_gmail_message_full response."""
+    marker = "📎 Saved to: "
+    line = next(ln for ln in result.splitlines() if marker in ln)
+    return line.split(marker, 1)[1].strip()
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_message_full_eml_saves_complete_raw(stdio_storage):
+    raw_mime = "From: sender@example.com\r\n\r\nComplete raw MIME body"
+    service = _build_service(
+        message_responses={
+            ("msg-1", "metadata"): _metadata_response("msg-1"),
+            ("msg-1", "raw"): {"raw": _encode(raw_mime)},
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-1",
+        user_google_email="user@example.com",
+        deliver_as="eml",
+    )
+
+    # Body content must NOT be inlined in the response.
+    assert "Complete raw MIME body" not in result
+    assert "--- FULL MESSAGE EXPORT ---" in result
+    assert "Format: eml" in result
+    assert "Subject: Example subject" in result
+
+    # The saved file must hold the complete, decoded message.
+    with open(_saved_path(result), "rb") as fh:
+        assert fh.read().decode() == raw_mime
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_message_full_txt_uses_plaintext(stdio_storage):
+    service = _build_service(
+        message_responses={
+            ("msg-2", "metadata"): _metadata_response("msg-2"),
+            ("msg-2", "full"): _message_response(
+                "msg-2", text="Plain body", html="<b>Plain body</b>"
+            ),
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-2",
+        user_google_email="user@example.com",
+        deliver_as="txt",
+    )
+
+    assert "Plain body" not in result
+    assert "Format: txt" in result
+    with open(_saved_path(result), "rb") as fh:
+        assert fh.read().decode() == "Plain body"
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_message_full_html_saves_raw_html(stdio_storage):
+    service = _build_service(
+        message_responses={
+            ("msg-3", "metadata"): _metadata_response("msg-3"),
+            ("msg-3", "full"): _message_response(
+                "msg-3", text="fallback", html="<p><b>Rich HTML</b></p>"
+            ),
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-3",
+        user_google_email="user@example.com",
+        deliver_as="html",
+    )
+
+    assert "Rich HTML" not in result
+    with open(_saved_path(result), "rb") as fh:
+        assert fh.read().decode() == "<p><b>Rich HTML</b></p>"
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_message_full_does_not_truncate(stdio_storage):
+    """The whole point: full-body export never applies the 20,000-char cap."""
+    long_html = "<p>" + ("A" * 50000) + "</p>"
+    service = _build_service(
+        message_responses={
+            ("msg-4", "metadata"): _metadata_response("msg-4"),
+            ("msg-4", "full"): _message_response("msg-4", text="", html=long_html),
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-4",
+        user_google_email="user@example.com",
+        deliver_as="html",
+    )
+
+    assert "[Content truncated...]" not in result
+    with open(_saved_path(result), "rb") as fh:
+        saved = fh.read().decode()
+    assert saved == long_html
+    assert len(saved) > 20000
+
+
+@pytest.mark.asyncio
+async def test_get_gmail_message_full_http_returns_url(monkeypatch, tmp_path):
+    import core.attachment_storage as attachment_storage
+
+    monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path)
+    monkeypatch.setattr(attachment_storage, "_attachment_storage", None)
+    monkeypatch.setattr("core.config.get_transport_mode", lambda: "streamable-http")
+    monkeypatch.setattr(
+        attachment_storage,
+        "get_attachment_url",
+        lambda file_id: f"https://example.test/attachments/{file_id}",
+    )
+
+    service = _build_service(
+        message_responses={
+            ("msg-5", "metadata"): _metadata_response("msg-5"),
+            ("msg-5", "raw"): {"raw": _encode("raw body")},
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_full)(
+        service=service,
+        message_id="msg-5",
+        user_google_email="user@example.com",
+        deliver_as="eml",
+    )
+
+    assert "https://example.test/attachments/" in result
+    assert "raw body" not in result

--- a/tests/gmail/test_body_format.py
+++ b/tests/gmail/test_body_format.py
@@ -757,7 +757,9 @@ async def test_get_gmail_message_full_no_body_errors(stdio_storage):
 
 
 @pytest.mark.asyncio
-async def test_get_gmail_message_full_txt_converts_html_when_no_plaintext(stdio_storage):
+async def test_get_gmail_message_full_txt_converts_html_when_no_plaintext(
+    stdio_storage,
+):
     service = _build_service(
         message_responses={
             ("msg-9", "metadata"): _metadata_response("msg-9"),

--- a/tests/gmail/test_body_format.py
+++ b/tests/gmail/test_body_format.py
@@ -705,9 +705,16 @@ async def test_full_export_http_returns_url(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_full_export_blocked_in_stateless_mode(monkeypatch):
+async def test_full_export_inlines_content_in_stateless_mode(monkeypatch):
+    """Without file storage, full=True still delivers the complete message — inline."""
     monkeypatch.setattr(gmail_tools, "is_stateless_mode", lambda: True)
-    service = _build_service(message_responses={})
+    raw_mime = "From: sender@example.com\r\n\r\nComplete raw MIME body!"
+    service = _build_service(
+        message_responses={
+            ("msg-6", "metadata"): _metadata_response("msg-6"),
+            ("msg-6", "raw"): {"raw": _unpadded(raw_mime)},
+        }
+    )
 
     result = await _unwrap(get_gmail_message_content)(
         service=service,
@@ -717,10 +724,36 @@ async def test_full_export_blocked_in_stateless_mode(monkeypatch):
         full=True,
     )
 
-    assert "stateless mode" in result.lower()
-    assert "full=False" in result
-    # Bails out before spending an API call.
-    service.users.return_value.messages.return_value.get.assert_not_called()
+    assert "--- BODY (COMPLETE, NOT TRUNCATED) ---" in result
+    assert raw_mime in result
+    assert "Format: eml" in result
+    assert "Subject: Example subject" in result
+    # No file was written, so nothing to point at.
+    assert "Saved to:" not in result
+    assert "Download URL:" not in result
+
+
+@pytest.mark.asyncio
+async def test_full_inline_in_stateless_mode_does_not_truncate(monkeypatch):
+    monkeypatch.setattr(gmail_tools, "is_stateless_mode", lambda: True)
+    long_html = "<p>" + ("x" * 30000) + "</p>"
+    service = _build_service(
+        message_responses={
+            ("msg-6c", "metadata"): _metadata_response("msg-6c"),
+            ("msg-6c", "full"): _message_response("msg-6c", text="", html=long_html),
+        }
+    )
+
+    result = await _unwrap(get_gmail_message_content)(
+        service=service,
+        message_id="msg-6c",
+        user_google_email="user@example.com",
+        body_format="html",
+        full=True,
+    )
+
+    assert long_html in result
+    assert "[Content truncated...]" not in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`get_gmail_message_content` caps body output at **20,000 chars** (`HTML_BODY_TRUNCATE_LIMIT` / `RAW_BODY_TRUNCATE_LIMIT`) and returns the body **inline**. For large emails that means the content is both **silently truncated** (`[Content truncated...]`) and **expensive to pass through the model context**. Note `body_format="raw"` truncates too, so it doesn't serve archival use cases (cf. #389). This is the same token-consumption concern raised in #638 (partial reads) and #888 (large payloads over a URL rather than base64-through-the-model).

## What this adds

A new read-only tool **`get_gmail_message_full`** that fetches the **complete, untruncated** message and writes it to the existing attachment storage instead of returning the body inline. It returns only a summary (subject/from/to/size) plus a short-lived **download URL** (HTTP transport) or **file path** (stdio transport), so the full content can be fetched and processed out-of-band — no truncation, and nothing large flows through the context window.

- `deliver_as="eml"` (default) — complete raw RFC 5322 message (all headers, parts, inline attachments)
- `deliver_as="html"` — raw HTML body
- `deliver_as="txt"` — plaintext (HTML→text fallback)

It reuses the `save_attachment` / `get_attachment_url` machinery already used by `get_gmail_attachment_content`, mirroring its stdio (path) vs HTTP (URL) delivery, TTL, and storage location. No new scopes (`gmail.readonly` already grants `format=raw`/`full`) and no new dependencies.

## Tests

Added to `tests/gmail/test_body_format.py`, covering each format, the **no-truncation guarantee** for a >20k body, and both stdio and HTTP delivery paths. Full gmail suite passes (`uv run pytest tests/gmail/`), `ruff` clean.

## Notes / open questions for maintainer

- Tool name / param naming (`deliver_as`) — happy to align with your conventions.
- Could alternatively be folded into `get_gmail_message_content` as a delivery mode; kept it as a separate additive tool to avoid changing existing behavior. Open to either.
- Could also adopt the signed-URL mechanism from #888 if/when that lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to export complete, untruncated Gmail messages as downloadable files or local files.
  * Supports raw MIME, HTML, and plain-text exports, including readable fallback conversions.
  * Export responses include file format, size, filename, and access details.

* **Documentation**
  * Updated Gmail tool documentation to describe full-message export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->