### PR TITLE
feat(gmail): compose-then-send drafts — send_gmail_draft + draft-forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,13 +797,14 @@ cp .env.oauth21 .env
 | <sub>`get_gmail_message_content`</sub> | <sub>Core</sub> | <sub>Retrieve message content</sub> |
 | <sub>`get_gmail_messages_content_batch`</sub> | <sub>Core</sub> | <sub>Batch retrieve message content</sub> |
 | <sub>`send_gmail_message`</sub> | <sub>Core</sub> | <sub>Send emails</sub> |
+| <sub>`send_gmail_draft`</sub> | <sub>Core</sub> | <sub>Send an existing draft by draft ID or (edit-proof) thread ID</sub> |
 | <sub>`get_gmail_thread_content`</sub> | <sub>Extended</sub> | <sub>Get full thread content</sub> |
 | <sub>`modify_gmail_message_labels`</sub> | <sub>Extended</sub> | <sub>Modify message labels</sub> |
 | <sub>`list_gmail_labels`</sub> | <sub>Extended</sub> | <sub>List available labels</sub> |
 | <sub>`list_gmail_filters`</sub> | <sub>Extended</sub> | <sub>List Gmail filters</sub> |
 | <sub>`manage_gmail_label`</sub> | <sub>Extended</sub> | <sub>Create/update/delete labels</sub> |
 | <sub>`manage_gmail_filter`</sub> | <sub>Extended</sub> | <sub>Create or delete Gmail filters</sub> |
-| <sub>`draft_gmail_message`</sub> | <sub>Extended</sub> | <sub>Create drafts</sub> |
+| <sub>`draft_gmail_message`</sub> | <sub>Extended</sub> | <sub>Create drafts (compose, reply, or forward)</sub> |
 | <sub>`get_gmail_threads_content_batch`</sub> | <sub>Complete</sub> | <sub>Batch retrieve thread content</sub> |
 | <sub>`batch_modify_gmail_message_labels`</sub> | <sub>Complete</sub> | <sub>Batch modify labels</sub> |
 | <sub>`start_google_auth`</sub> | <sub>Complete</sub> | <sub>Legacy OAuth 2.0 auth (disabled when OAuth 2.1 is enabled)</sub> |

--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -4,6 +4,7 @@ gmail:
     - get_gmail_message_content
     - get_gmail_messages_content_batch
     - send_gmail_message
+    - send_gmail_draft
 
   extended:
     - get_gmail_attachment_content

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2391,6 +2391,24 @@ async def _forward_gmail_message_impl(
     return f"Email forwarded{attachment_info}! Message ID: {sent_message_id}"
 
 
+async def _draft_exists(service, draft_id: str) -> bool:
+    """True if draft_id still resolves to a live draft (else False on 404)."""
+    try:
+        await asyncio.to_thread(
+            service.users()
+            .drafts()
+            .get(userId="me", id=draft_id, format="minimal")
+            .execute
+        )
+        return True
+    except HttpError as e:
+        # 404 = draft gone; 400 = malformed/invalid id. Either way the draft_id is
+        # unusable, so report it missing and let the caller fall back to thread_id.
+        if e.resp.status in (400, 404):
+            return False
+        raise
+
+
 @server.tool(
     title="Send Gmail Draft",
     annotations=ToolAnnotations(
@@ -2409,10 +2427,11 @@ async def send_gmail_draft(
         Optional[str],
         Field(
             description=(
-                "The ID of an existing Gmail draft to send (as returned by "
-                "draft_gmail_message). NOTE: a draft_id goes stale if the draft is edited "
-                "in the Gmail UI afterward — prefer thread_id for a handle that survives "
-                "edits. Provide exactly one of draft_id or thread_id."
+                "Primary handle for the draft to send (as returned by draft_gmail_message). "
+                "In practice the most stable handle — it survives body edits on Gmail web and "
+                "mobile; only a rare discard-recreate rotates it. Pass this when you have it. "
+                "Provide draft_id, thread_id, or both (both = draft_id preferred, thread_id "
+                "used only as a fallback if draft_id no longer resolves)."
             ),
         ),
     ] = None,
@@ -2420,10 +2439,11 @@ async def send_gmail_draft(
         Optional[str],
         Field(
             description=(
-                "Send the unique draft in this Gmail thread. Unlike draft_id, a thread_id "
-                "is stable across edits made to the draft in the Gmail UI, so this is the "
-                "robust way to send a draft the user may have edited. Errors if the thread "
-                "has zero or more than one draft. Provide exactly one of draft_id or thread_id."
+                "Fallback handle: send the unique draft in this Gmail thread when draft_id is "
+                "absent or no longer resolves. CAVEAT: a draft's thread_id changes if the user "
+                "edits its SUBJECT (Gmail re-threads by subject), so a subject edit can move the "
+                "draft out of this thread and this lookup will miss it — draft_id is preferred. "
+                "Errors if the thread has more than one draft. Provide draft_id, thread_id, or both."
             ),
         ),
     ] = None,
@@ -2436,29 +2456,37 @@ async def send_gmail_draft(
     sent here. Sending requires the gmail.compose scope (drafts.send is not covered by
     gmail.send).
 
-    **Edit safety:** a draft's draft_id and message_id both change if the draft is edited
-    in the Gmail UI, but its thread_id does not. Pass thread_id to send whatever the
-    current draft in that thread is — the reliable choice when a human may have edited it.
+    **Edit safety (measured):** message_id rotates on *every* edit — never cache it.
+    draft_id is the most stable handle (unchanged across web/mobile body edits, subject
+    changes, and attachments in testing); only a rare discard-recreate rotates it.
+    thread_id is stable for body/attachment edits but MOVES if the subject is edited
+    (Gmail re-threads by subject). So prefer draft_id; thread_id is only a fallback and
+    can miss a draft whose subject changed.
 
     Args:
-        draft_id (Optional[str]): The draft to send. Stale if the draft was edited.
-        thread_id (Optional[str]): Send the unique draft in this thread (edit-proof).
+        draft_id (Optional[str]): Primary handle for the draft to send.
+        thread_id (Optional[str]): Fallback — send the unique draft in this thread.
         user_google_email (str): The user's Google email address. Required.
 
     Returns:
         str: Confirmation with the sent message's ID and thread ID.
     """
-    if bool(draft_id) == bool(thread_id):
-        raise UserInputError(
-            "Provide exactly one of 'draft_id' or 'thread_id'. Prefer 'thread_id' — it "
-            "survives edits made to the draft in the Gmail UI."
-        )
+    if not draft_id and not thread_id:
+        raise UserInputError("Provide 'draft_id', 'thread_id', or both.")
 
-    if thread_id:
-        # Re-resolve the live draft in the thread at send time. drafts.list returns each
-        # draft's message.threadId, so we can match without extra get() calls. Paginate so
-        # accounts with many drafts don't yield a false "no draft found"; stop early once
-        # the result is already ambiguous.
+    resolved_id = None
+
+    # Prefer draft_id — empirically the most stable handle across edits (web + mobile).
+    if draft_id and await _draft_exists(service, draft_id):
+        resolved_id = draft_id
+
+    # Fall back to a thread scan when draft_id is missing or no longer resolves. drafts.list
+    # returns each draft's message.threadId, so we can match without extra get() calls.
+    # NOTE: thread_id moves if the user edited the draft's SUBJECT, so this can legitimately
+    # find nothing even though the draft still exists — hence draft_id is preferred. Paginate
+    # so accounts with many drafts don't yield a false "no draft found"; stop early once
+    # the result is already ambiguous.
+    if resolved_id is None and thread_id:
         logger.info(
             f"[send_gmail_draft] Resolving draft in thread '{thread_id}' for '{user_google_email}'"
         )
@@ -2479,18 +2507,28 @@ async def send_gmail_draft(
             page_token = drafts_resp.get("nextPageToken")
             if len(matches) > 1 or not page_token:
                 break
-        if not matches:
-            raise UserInputError(
-                f"No draft found in thread '{thread_id}'. It may have already been sent "
-                "or discarded."
-            )
         if len(matches) > 1:
             ids = ", ".join(d.get("id", "?") for d in matches)
             raise UserInputError(
                 f"Thread '{thread_id}' has {len(matches)} drafts ({ids}); ambiguous. "
                 "Pass a specific draft_id."
             )
-        draft_id = matches[0].get("id")
+        if matches:
+            resolved_id = matches[0].get("id")
+
+    if resolved_id is None:
+        hint = (
+            " If the draft's subject was edited it may have moved to a different thread — "
+            "pass draft_id instead."
+            if thread_id and not draft_id
+            else ""
+        )
+        raise UserInputError(
+            f"No draft found for the given handle(s). It may have already been sent "
+            f"or discarded.{hint}"
+        )
+
+    draft_id = resolved_id
 
     logger.info(
         f"[send_gmail_draft] Invoked. Draft ID: '{draft_id}', Email: '{user_google_email}'"

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2046,6 +2046,7 @@ async def send_gmail_message(
         in_reply_to (Optional[str]): Optional RFC Message-ID of the message being replied to (e.g., '<message123@gmail.com>').
         references (Optional[str]): Optional chain of RFC Message-IDs for proper threading (e.g., '<msg1@gmail.com> <msg2@gmail.com>').
         include_signature (bool): Whether to append Gmail signature HTML from send-as settings.
+            Also honored when forwarding (the signature is appended after the quoted message).
             When include_signature is true and Gmail signature retrieval fails for benign reasons
             (e.g., missing gmail.settings.basic scope), the send proceeds without a signature.
             Non-benign failures such as quota/rate-limit or API errors raise ToolError and abort
@@ -2146,6 +2147,7 @@ async def send_gmail_message(
             forward_message=body,
             forward_message_format=body_format,
             include_attachments=include_forwarded_attachments,
+            include_signature=include_signature,
             cc=cc,
             bcc=bcc,
             from_name=from_name,
@@ -2315,6 +2317,7 @@ async def _forward_gmail_message_impl(
     forward_message: Optional[str] = None,
     forward_message_format: Literal["plain", "html"] = "plain",
     include_attachments: bool = True,
+    include_signature: bool = True,
     cc: Optional[str] = None,
     bcc: Optional[str] = None,
     from_name: Optional[str] = None,
@@ -2324,7 +2327,9 @@ async def _forward_gmail_message_impl(
     """Build and send a forward of an existing Gmail message.
 
     Shared by send_gmail_message's forward path. An explicit ``subject`` overrides
-    the auto-derived 'Fwd: <original subject>'.
+    the auto-derived 'Fwd: <original subject>'. When ``include_signature`` is true
+    the sender's Gmail signature is appended after the quoted message, matching
+    Gmail's default forward layout.
     """
     (
         forward_subject,
@@ -2342,6 +2347,13 @@ async def _forward_gmail_message_impl(
 
     # Prepare and send the message
     sender_email = from_email or user_google_email
+    if include_signature:
+        signature_html = await _get_send_as_signature_html_for_tool(
+            service, from_email=sender_email
+        )
+        forward_body = _append_signature_to_body(
+            forward_body, body_format, signature_html
+        )
     raw_message, _, attached_count, attachment_errors = _prepare_gmail_message(
         subject=forward_subject,
         body=forward_body,
@@ -2631,6 +2643,7 @@ async def draft_gmail_message(
               - 'filename' (required): Name of the file
               - 'mime_type' (optional): MIME type (defaults to 'application/octet-stream')
         include_signature (bool): Whether to append Gmail signature HTML from send-as settings.
+            Also honored when forwarding (the signature is appended after the quoted message).
             When include_signature is true and Gmail signature retrieval fails for benign reasons
             (e.g., missing gmail.settings.basic scope), the draft proceeds without a signature.
             Non-benign failures such as quota/rate-limit or API errors raise ToolError and abort
@@ -2711,8 +2724,9 @@ async def draft_gmail_message(
 
     if forward_message_id:
         # Forward draft: build the subject, quoted body, and carried-over attachments
-        # from the original ('body' becomes an optional prepended note). Reply/quote/
-        # signature composition does not apply to a forward.
+        # from the original ('body' becomes an optional prepended note). Reply/quote
+        # composition does not apply to a forward; the signature is appended after
+        # the quoted message, matching Gmail's default forward layout.
         (
             subject,
             draft_body,
@@ -2726,6 +2740,13 @@ async def draft_gmail_message(
             forward_message_format=body_format,
             include_attachments=include_forwarded_attachments,
         )
+        if include_signature:
+            signature_html = await _get_send_as_signature_html_for_tool(
+                service, from_email=sender_email
+            )
+            draft_body = _append_signature_to_body(
+                draft_body, body_format, signature_html
+            )
     else:
         subject = subject or ""
         draft_body = body or ""

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2227,34 +2227,28 @@ async def send_gmail_message(
     return f"Email sent! Message ID: {message_id}"
 
 
-# Internal implementation function for testing
-async def _forward_gmail_message_impl(
+async def _build_forward_message(
     service,
     message_id: str,
-    to: str,
+    *,
     subject: Optional[str] = None,
     forward_message: Optional[str] = None,
     forward_message_format: Literal["plain", "html"] = "plain",
     include_attachments: bool = True,
-    cc: Optional[str] = None,
-    bcc: Optional[str] = None,
-    from_name: Optional[str] = None,
-    from_email: Optional[str] = None,
-    user_google_email: str = "",
-) -> str:
-    """Build and send a forward of an existing Gmail message.
+) -> tuple[str, str, str, List[Dict[str, Any]]]:
+    """Fetch a message and build a forward of it.
 
-    Shared by send_gmail_message's forward path. An explicit ``subject`` overrides
-    the auto-derived 'Fwd: <original subject>'.
+    Returns ``(forward_subject, forward_body, body_format, attachments)`` where
+    ``attachments`` are standard-base64 ``content`` dicts ready for
+    ``_prepare_gmail_message``. Shared by both the send-forward and draft-forward
+    paths. An explicit ``subject`` overrides the auto-derived 'Fwd: <original>'.
     """
-    # Fetch the original message with full payload
     original_message = await asyncio.to_thread(
         service.users()
         .messages()
         .get(userId="me", id=message_id, format="full")
         .execute
     )
-
     payload = original_message.get("payload", {})
 
     forward_subject, forward_body, body_format = _build_forward_content(
@@ -2265,14 +2259,12 @@ async def _forward_gmail_message_impl(
         subject_override=subject,
     )
 
-    # Handle attachments
-    attachments_to_send = []
+    attachments_to_send: List[Dict[str, Any]] = []
     if include_attachments:
         attachment_metadata = _extract_attachments(payload)
         failed_attachments = []
         for att in attachment_metadata:
             try:
-                # Download attachment content
                 attachment_data = await asyncio.to_thread(
                     service.users()
                     .messages()
@@ -2304,13 +2296,49 @@ async def _forward_gmail_message_impl(
                 )
                 failed_attachments.append(att["filename"])
 
-        # Fail loudly rather than silently delivering an incomplete forward when
-        # the caller asked for the original attachments to be preserved.
+        # Fail loudly rather than silently building an incomplete forward when the
+        # caller asked for the original attachments to be preserved.
         if failed_attachments:
             raise Exception(
                 "Failed to include requested attachment(s): "
                 + ", ".join(failed_attachments)
             )
+
+    return forward_subject, forward_body, body_format, attachments_to_send
+
+
+async def _forward_gmail_message_impl(
+    service,
+    message_id: str,
+    to: str,
+    subject: Optional[str] = None,
+    forward_message: Optional[str] = None,
+    forward_message_format: Literal["plain", "html"] = "plain",
+    include_attachments: bool = True,
+    cc: Optional[str] = None,
+    bcc: Optional[str] = None,
+    from_name: Optional[str] = None,
+    from_email: Optional[str] = None,
+    user_google_email: str = "",
+) -> str:
+    """Build and send a forward of an existing Gmail message.
+
+    Shared by send_gmail_message's forward path. An explicit ``subject`` overrides
+    the auto-derived 'Fwd: <original subject>'.
+    """
+    (
+        forward_subject,
+        forward_body,
+        body_format,
+        attachments_to_send,
+    ) = await _build_forward_message(
+        service,
+        message_id,
+        subject=subject,
+        forward_message=forward_message,
+        forward_message_format=forward_message_format,
+        include_attachments=include_attachments,
+    )
 
     # Prepare and send the message
     sender_email = from_email or user_google_email
@@ -2352,6 +2380,124 @@ async def _forward_gmail_message_impl(
 
 
 @server.tool(
+    title="Send Gmail Draft",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("send_gmail_draft", service_type="gmail")
+@require_google_service("gmail", GMAIL_COMPOSE_SCOPE)
+async def send_gmail_draft(
+    service,
+    user_google_email: str,
+    draft_id: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "The ID of an existing Gmail draft to send (as returned by "
+                "draft_gmail_message). NOTE: a draft_id goes stale if the draft is edited "
+                "in the Gmail UI afterward — prefer thread_id for a handle that survives "
+                "edits. Provide exactly one of draft_id or thread_id."
+            ),
+        ),
+    ] = None,
+    thread_id: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Send the unique draft in this Gmail thread. Unlike draft_id, a thread_id "
+                "is stable across edits made to the draft in the Gmail UI, so this is the "
+                "robust way to send a draft the user may have edited. Errors if the thread "
+                "has zero or more than one draft. Provide exactly one of draft_id or thread_id."
+            ),
+        ),
+    ] = None,
+) -> str:
+    """
+    Sends an existing Gmail draft, by draft_id or (edit-proof) thread_id.
+
+    This is the "commit" half of a compose-then-send split: a draft is composed
+    separately (draft_gmail_message, which can reply or forward), reviewed, and then
+    sent here. Sending requires the gmail.compose scope (drafts.send is not covered by
+    gmail.send).
+
+    **Edit safety:** a draft's draft_id and message_id both change if the draft is edited
+    in the Gmail UI, but its thread_id does not. Pass thread_id to send whatever the
+    current draft in that thread is — the reliable choice when a human may have edited it.
+
+    Args:
+        draft_id (Optional[str]): The draft to send. Stale if the draft was edited.
+        thread_id (Optional[str]): Send the unique draft in this thread (edit-proof).
+        user_google_email (str): The user's Google email address. Required.
+
+    Returns:
+        str: Confirmation with the sent message's ID and thread ID.
+    """
+    if bool(draft_id) == bool(thread_id):
+        raise UserInputError(
+            "Provide exactly one of 'draft_id' or 'thread_id'. Prefer 'thread_id' — it "
+            "survives edits made to the draft in the Gmail UI."
+        )
+
+    if thread_id:
+        # Re-resolve the live draft in the thread at send time. drafts.list returns each
+        # draft's message.threadId, so we can match without extra get() calls. Paginate so
+        # accounts with many drafts don't yield a false "no draft found"; stop early once
+        # the result is already ambiguous.
+        logger.info(
+            f"[send_gmail_draft] Resolving draft in thread '{thread_id}' for '{user_google_email}'"
+        )
+        matches = []
+        page_token = None
+        while True:
+            drafts_resp = await asyncio.to_thread(
+                service.users()
+                .drafts()
+                .list(userId="me", maxResults=500, pageToken=page_token)
+                .execute
+            )
+            matches.extend(
+                d
+                for d in drafts_resp.get("drafts", [])
+                if d.get("message", {}).get("threadId") == thread_id
+            )
+            page_token = drafts_resp.get("nextPageToken")
+            if len(matches) > 1 or not page_token:
+                break
+        if not matches:
+            raise UserInputError(
+                f"No draft found in thread '{thread_id}'. It may have already been sent "
+                "or discarded."
+            )
+        if len(matches) > 1:
+            ids = ", ".join(d.get("id", "?") for d in matches)
+            raise UserInputError(
+                f"Thread '{thread_id}' has {len(matches)} drafts ({ids}); ambiguous. "
+                "Pass a specific draft_id."
+            )
+        draft_id = matches[0].get("id")
+
+    logger.info(
+        f"[send_gmail_draft] Invoked. Draft ID: '{draft_id}', Email: '{user_google_email}'"
+    )
+
+    sent = await asyncio.to_thread(
+        service.users().drafts().send(userId="me", body={"id": draft_id}).execute,
+        num_retries=GOOGLE_API_WRITE_RETRIES,
+    )
+    message_id = sent.get("id")
+    sent_thread_id = sent.get("threadId")
+    logger.info(f"[send_gmail_draft] Draft {draft_id} sent as message {message_id}.")
+    return (
+        f"Draft {draft_id} sent for {user_google_email}. "
+        f"Message ID: {message_id}, Thread ID: {sent_thread_id}."
+    )
+
+
+@server.tool(
     title="Draft Gmail Message",
     annotations=ToolAnnotations(
         readOnlyHint=False,
@@ -2365,8 +2511,18 @@ async def _forward_gmail_message_impl(
 async def draft_gmail_message(
     service,
     user_google_email: str,
-    subject: Annotated[str, Field(description="Email subject.")],
-    body: Annotated[str, Field(description="Email body (plain text).")],
+    subject: Annotated[
+        Optional[str],
+        Field(
+            description="Email subject. Optional when forwarding (defaults to 'Fwd: <original subject>').",
+        ),
+    ] = None,
+    body: Annotated[
+        Optional[str],
+        Field(
+            description="Email body (plain text or HTML). When forwarding, an optional note prepended above the quoted original.",
+        ),
+    ] = None,
     body_format: Annotated[
         Literal["plain", "html"],
         Field(
@@ -2433,15 +2589,27 @@ async def draft_gmail_message(
             description="Whether to include the original message as a quoted reply. Requires thread_id. Defaults to false.",
         ),
     ] = False,
+    forward_message_id: Annotated[
+        Optional[str],
+        Field(
+            description="Set to a Gmail message ID to draft a FORWARD of that message. The original subject, quoted body, and (optionally) attachments are carried over; 'body' becomes an optional note prepended above the forward. The result is a normal draft — nothing is sent until send_gmail_draft is called.",
+        ),
+    ] = None,
+    include_forwarded_attachments: Annotated[
+        bool,
+        Field(
+            description="When forwarding, whether to carry over the original message's attachments. Ignored unless forward_message_id is set.",
+        ),
+    ] = True,
 ) -> str:
     """
-    Creates a draft email in the user's Gmail account. Supports both new drafts and reply drafts with optional attachments.
+    Creates a draft email in the user's Gmail account. Supports new drafts, reply drafts, and forward drafts, with optional attachments.
     Supports Gmail's "Send As" feature to draft from configured alias addresses.
 
     Args:
         user_google_email (str): The user's Google email address. Required for authentication.
-        subject (str): Email subject.
-        body (str): Email body (plain text).
+        subject (Optional[str]): Email subject. Optional when forwarding (defaults to 'Fwd: <original subject>').
+        body (Optional[str]): Email body. When forwarding, an optional note prepended above the quoted original.
         body_format (Literal['plain', 'html']): Email body format. Defaults to 'plain'.
         to (Optional[str]): Optional recipient email address. Can be left empty for drafts.
         cc (Optional[str]): Optional CC email address.
@@ -2470,9 +2638,15 @@ async def draft_gmail_message(
         quote_original (bool): Whether to include the original message as a quoted reply.
             Requires thread_id to be provided. When enabled, fetches the original message
             and appends it below the signature. Defaults to False.
+        forward_message_id (Optional[str]): Gmail message ID to draft a FORWARD of. The
+            original subject, quoted body, and (optionally) attachments are carried over,
+            and 'body' becomes a note prepended above the forward.
+        include_forwarded_attachments (bool): When forwarding, whether to carry over the
+            original message's attachments. Ignored unless forward_message_id is set.
 
     Returns:
-        str: Confirmation message with the created draft's ID.
+        str: Confirmation with the created draft's ID, message ID, and thread ID (pass the
+            thread ID to send_gmail_draft — it survives edits made to the draft).
 
     Examples:
         # Create a new draft
@@ -2533,52 +2707,80 @@ async def draft_gmail_message(
     # Prepare the email message
     # Use from_email (Send As alias) if provided, otherwise default to authenticated user
     sender_email = from_email or user_google_email
-    draft_body = body
-    signature_html = ""
-    if include_signature:
-        signature_html = await _get_send_as_signature_html_for_tool(
-            service, from_email=sender_email
-        )
+    forwarded_attachments: List[Dict[str, Any]] = []
 
-    reply_context = None
-    if thread_id and (quote_original or not in_reply_to or not references or not to):
-        reply_context = await _fetch_thread_reply_context(
-            service,
-            thread_id,
-            in_reply_to=in_reply_to,
-            include_bodies=quote_original,
-        )
-
-    if thread_id and (not in_reply_to or not references):
-        thread_message_ids = (
-            reply_context.get("message_ids", []) if reply_context else []
-        )
-        in_reply_to, references = _derive_reply_headers(
-            thread_message_ids, in_reply_to, references
-        )
-
-    target_reply = reply_context.get("target") if reply_context else None
-    if thread_id and not to and target_reply:
-        to = target_reply.get("reply_to") or target_reply.get("from") or to
-    if thread_id and not subject.strip() and target_reply:
-        subject = target_reply.get("subject") or subject
-
-    if quote_original and target_reply:
-        draft_body = _build_quoted_reply_body(
+    if forward_message_id:
+        # Forward draft: build the subject, quoted body, and carried-over attachments
+        # from the original ('body' becomes an optional prepended note). Reply/quote/
+        # signature composition does not apply to a forward.
+        (
+            subject,
             draft_body,
             body_format,
-            signature_html,
-            {
-                "sender": target_reply.get("from") or "unknown",
-                "date": target_reply.get("date", ""),
-                "text_body": target_reply.get("text_body", ""),
-                "html_body": target_reply.get("html_body", ""),
-            },
+            forwarded_attachments,
+        ) = await _build_forward_message(
+            service,
+            forward_message_id,
+            subject=subject,
+            forward_message=body,
+            forward_message_format=body_format,
+            include_attachments=include_forwarded_attachments,
         )
     else:
-        draft_body = _append_signature_to_body(draft_body, body_format, signature_html)
+        subject = subject or ""
+        draft_body = body or ""
+        signature_html = ""
+        if include_signature:
+            signature_html = await _get_send_as_signature_html_for_tool(
+                service, from_email=sender_email
+            )
+
+        reply_context = None
+        if thread_id and (
+            quote_original or not in_reply_to or not references or not to
+        ):
+            reply_context = await _fetch_thread_reply_context(
+                service,
+                thread_id,
+                in_reply_to=in_reply_to,
+                include_bodies=quote_original,
+            )
+
+        if thread_id and (not in_reply_to or not references):
+            thread_message_ids = (
+                reply_context.get("message_ids", []) if reply_context else []
+            )
+            in_reply_to, references = _derive_reply_headers(
+                thread_message_ids, in_reply_to, references
+            )
+
+        target_reply = reply_context.get("target") if reply_context else None
+        if thread_id and not to and target_reply:
+            to = target_reply.get("reply_to") or target_reply.get("from") or to
+        if thread_id and not subject.strip() and target_reply:
+            subject = target_reply.get("subject") or subject
+
+        if quote_original and target_reply:
+            draft_body = _build_quoted_reply_body(
+                draft_body,
+                body_format,
+                signature_html,
+                {
+                    "sender": target_reply.get("from") or "unknown",
+                    "date": target_reply.get("date", ""),
+                    "text_body": target_reply.get("text_body", ""),
+                    "html_body": target_reply.get("html_body", ""),
+                },
+            )
+        else:
+            draft_body = _append_signature_to_body(
+                draft_body, body_format, signature_html
+            )
 
     resolved_attachments = await _resolve_url_attachments(attachments)
+    # Attachments carried over from a forwarded message lead the list.
+    if forwarded_attachments:
+        resolved_attachments = forwarded_attachments + (resolved_attachments or [])
     raw_message, _thread_id_final, attached_count, attachment_errors = (
         _prepare_gmail_message(
             subject=subject,
@@ -2596,7 +2798,8 @@ async def draft_gmail_message(
         )
     )
 
-    requested_attachment_count = len(attachments or [])
+    # Count both explicit attachments and any carried over from a forward.
+    requested_attachment_count = len(attachments or []) + len(forwarded_attachments)
     if requested_attachment_count > 0 and attached_count == 0:
         details = (
             f" Details: {'; '.join(attachment_errors)}" if attachment_errors else ""
@@ -2604,6 +2807,17 @@ async def draft_gmail_message(
         raise UserInputError(
             "No valid attachments were added. Verify each attachment path/content and retry."
             f"{details}"
+        )
+    # Forwarded attachments were already fetched, so a partial attach means one was
+    # dropped at MIME-build time — fail loudly rather than draft a partial forward
+    # (mirrors the send-forward path).
+    if forwarded_attachments and attached_count != requested_attachment_count:
+        details = (
+            f" Details: {'; '.join(attachment_errors)}" if attachment_errors else ""
+        )
+        raise UserInputError(
+            "Failed to include all requested attachment(s): "
+            f"{attached_count}/{requested_attachment_count} attached.{details}"
         )
 
     # Create a draft instead of sending. Gmail requires message.threadId plus
@@ -2620,10 +2834,26 @@ async def draft_gmail_message(
         num_retries=GOOGLE_API_WRITE_RETRIES,
     )
     draft_id = created_draft.get("id")
+    created_message = created_draft.get("message", {})
+    message_id = created_message.get("id")
+    result_thread_id = created_message.get("threadId")
     attachment_info = _format_attachment_result(
         attached_count, requested_attachment_count
     )
-    return f"Draft created{attachment_info}! Draft ID: {draft_id}"
+    # Return the thread_id too: it's the only handle that survives a later edit in the
+    # Gmail UI (the draft_id and message_id both rotate on edit), so send_gmail_draft can
+    # re-resolve the live draft by thread. See send_gmail_draft.
+    result = f"Draft created{attachment_info}! Draft ID: {draft_id}"
+    if message_id:
+        result += f", Message ID: {message_id}"
+    if result_thread_id:
+        result += (
+            f", Thread ID: {result_thread_id}. To send later, prefer "
+            f"send_gmail_draft(thread_id='{result_thread_id}') — it survives edits made to "
+            f"the draft in Gmail; send_gmail_draft(draft_id='{draft_id}') works only if the "
+            f"draft is not edited first."
+        )
+    return result
 
 
 def _format_thread_content(

--- a/tests/gmail/test_forward_gmail_message.py
+++ b/tests/gmail/test_forward_gmail_message.py
@@ -11,7 +11,23 @@ import os
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from gmail.gmail_tools import _forward_gmail_message_impl
+from gmail.gmail_tools import _forward_gmail_message_impl, draft_gmail_message
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def get_drafted_mime_message(mock_service):
+    """Decode the raw MIME message passed to drafts().create()."""
+    raw = (
+        mock_service.users().drafts().create.call_args.kwargs["body"]["message"]["raw"]
+    )
+    return message_from_bytes(base64.urlsafe_b64decode(raw))
 
 
 def get_sent_mime_message(mock_service):
@@ -171,6 +187,91 @@ async def test_forward_simple_text_email():
     assert "This is the body." in body
     assert "Forwarded message" in body
     assert "alice@example.com" in body
+
+
+@pytest.mark.asyncio
+async def test_draft_forward_carries_note_body_and_attachment():
+    """draft_gmail_message(forward_message_id=...) drafts a forward (not send)."""
+    message = create_mock_message(
+        subject="Quarterly",
+        from_addr="alice@example.com",
+        to_addr="me@example.com",
+        text_body="Original body.",
+        attachments=[
+            {
+                "filename": "report.pdf",
+                "mimeType": "application/pdf",
+                "attachmentId": "att1",
+                "size": 10,
+            }
+        ],
+    )
+    att_bytes = base64.urlsafe_b64encode(b"PDFDATA").decode()
+    mock = create_mock_service(message, attachments_data=[{"data": att_bytes}])
+    mock.users().drafts().create().execute.return_value = {"id": "draft-99"}
+
+    result = await _unwrap(draft_gmail_message)(
+        service=mock,
+        user_google_email="me@example.com",
+        to="recipient@example.com",
+        forward_message_id="msg123",
+        body="FYI",  # optional note prepended above the forward
+    )
+
+    # A draft was created, and the send path's execute() was never invoked.
+    assert "draft-99" in result
+    mock.users().drafts().create.assert_called()
+    mock.users().messages().send().execute.assert_not_called()
+
+    drafted = get_drafted_mime_message(mock)
+    assert drafted["Subject"] == "Fwd: Quarterly"
+    assert drafted["To"] == "recipient@example.com"
+    body_part, attachments = get_body_and_attachments(drafted)
+    body = get_body_text(drafted)
+    assert "FYI" in body  # the note
+    assert "Forwarded message" in body
+    assert "Original body." in body
+    assert len(attachments) == 1
+    assert attachments[0].get_filename() == "report.pdf"
+
+
+@pytest.mark.asyncio
+async def test_draft_forward_plus_explicit_attachment_counts_both():
+    """A forward that also has an explicit attachment must not misreport a partial."""
+    message = create_mock_message(
+        subject="Quarterly",
+        from_addr="alice@example.com",
+        to_addr="me@example.com",
+        text_body="Original body.",
+        attachments=[
+            {
+                "filename": "report.pdf",
+                "mimeType": "application/pdf",
+                "attachmentId": "att1",
+                "size": 10,
+            }
+        ],
+    )
+    att_bytes = base64.urlsafe_b64encode(b"PDFDATA").decode()
+    mock = create_mock_service(message, attachments_data=[{"data": att_bytes}])
+    mock.users().drafts().create().execute.return_value = {"id": "draft-1"}
+
+    # No UserInputError despite the explicit attachment + the forwarded one.
+    result = await _unwrap(draft_gmail_message)(
+        service=mock,
+        user_google_email="me@example.com",
+        to="recipient@example.com",
+        forward_message_id="msg123",
+        attachments=[
+            {"content": base64.b64encode(b"HI").decode(), "filename": "note.txt"}
+        ],
+    )
+
+    assert "draft-1" in result
+    drafted = get_drafted_mime_message(mock)
+    _, attachments = get_body_and_attachments(drafted)
+    names = sorted(a.get_filename() for a in attachments)
+    assert names == ["note.txt", "report.pdf"]  # both, no partial-failure error
 
 
 @pytest.mark.asyncio

--- a/tests/gmail/test_forward_gmail_message.py
+++ b/tests/gmail/test_forward_gmail_message.py
@@ -152,6 +152,10 @@ def create_mock_service(message, attachments_data=None, sent_message_id="sent123
     # Setup chain: service.users().messages().send()
     mock.users().messages().send().execute.return_value = {"id": sent_message_id}
 
+    # Setup chain: service.users().settings().sendAs().list() — no signature
+    # configured by default (include_signature defaults to True on the tools).
+    mock.users().settings().sendAs().list().execute.return_value = {"sendAs": []}
+
     return mock
 
 
@@ -233,6 +237,75 @@ async def test_draft_forward_carries_note_body_and_attachment():
     assert "Original body." in body
     assert len(attachments) == 1
     assert attachments[0].get_filename() == "report.pdf"
+
+
+@pytest.mark.asyncio
+async def test_forward_appends_signature_after_quoted_message():
+    """Send-forward honors include_signature: signature lands below the quote."""
+    message = create_mock_message(
+        subject="Hello",
+        from_addr="alice@example.com",
+        to_addr="bob@example.com",
+        text_body="Original body.",
+    )
+    mock_service = create_mock_service(message, sent_message_id="fwd-sig")
+    mock_service.users().settings().sendAs().list().execute.return_value = {
+        "sendAs": [
+            {
+                "sendAsEmail": "me@example.com",
+                "isPrimary": True,
+                "signature": "<div>Best,<br>Alice</div>",
+            }
+        ]
+    }
+
+    result = await _forward_gmail_message_impl(
+        service=mock_service,
+        message_id="msg123",
+        to="recipient@example.com",
+        user_google_email="me@example.com",
+    )
+
+    assert "fwd-sig" in result
+    body = get_body_text(get_sent_mime_message(mock_service))
+    assert "Best," in body
+    # Gmail's default forward layout: signature after the quoted message.
+    assert body.index("Original body.") < body.index("Best,")
+
+
+@pytest.mark.asyncio
+async def test_draft_forward_appends_signature_after_quoted_message():
+    """Draft-forward honors include_signature (was silently ignored)."""
+    message = create_mock_message(
+        subject="Hello",
+        from_addr="alice@example.com",
+        to_addr="bob@example.com",
+        text_body="Original body.",
+    )
+    mock = create_mock_service(message)
+    mock.users().drafts().create().execute.return_value = {"id": "draft-sig"}
+    mock.users().settings().sendAs().list().execute.return_value = {
+        "sendAs": [
+            {
+                "sendAsEmail": "me@example.com",
+                "isPrimary": True,
+                "signature": "<div>Best,<br>Alice</div>",
+            }
+        ]
+    }
+
+    result = await _unwrap(draft_gmail_message)(
+        service=mock,
+        user_google_email="me@example.com",
+        to="recipient@example.com",
+        forward_message_id="msg123",
+        body="FYI",
+    )
+
+    assert "draft-sig" in result
+    body = get_body_text(get_drafted_mime_message(mock))
+    assert "Best," in body
+    assert body.index("Original body.") < body.index("Best,")
 
 
 @pytest.mark.asyncio

--- a/tests/gmail/test_send_gmail_draft.py
+++ b/tests/gmail/test_send_gmail_draft.py
@@ -1,0 +1,122 @@
+"""Tests for send_gmail_draft (draft_id + edit-proof thread_id)."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from core.utils import UserInputError
+from gmail.gmail_tools import send_gmail_draft
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_draft_sends_by_id():
+    service = Mock()
+    send_request = Mock()
+    send_request.execute.return_value = {"id": "msg-123", "threadId": "thr-456"}
+    service.users().drafts().send.return_value = send_request
+
+    result = await _unwrap(send_gmail_draft)(
+        service=service, user_google_email="user@example.com", draft_id="draft-abc"
+    )
+
+    service.users().drafts().send.assert_called_with(
+        userId="me", body={"id": "draft-abc"}
+    )
+    assert "draft-abc" in result
+    assert "msg-123" in result
+    assert "thr-456" in result
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_draft_by_thread_resolves_unique_draft():
+    service = Mock()
+    service.users().drafts().list().execute.return_value = {
+        "drafts": [
+            {"id": "d1", "message": {"id": "m1", "threadId": "thrX"}},
+            {"id": "d2", "message": {"id": "m2", "threadId": "other"}},
+        ]
+    }
+    send_request = Mock()
+    send_request.execute.return_value = {"id": "sent1", "threadId": "thrX"}
+    service.users().drafts().send.return_value = send_request
+
+    result = await _unwrap(send_gmail_draft)(
+        service=service, user_google_email="user@example.com", thread_id="thrX"
+    )
+
+    service.users().drafts().send.assert_called_with(userId="me", body={"id": "d1"})
+    assert "sent1" in result
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_draft_thread_no_draft_errors():
+    service = Mock()
+    service.users().drafts().list().execute.return_value = {
+        "drafts": [{"id": "d1", "message": {"threadId": "other"}}]
+    }
+    with pytest.raises(UserInputError, match="No draft found"):
+        await _unwrap(send_gmail_draft)(
+            service=service, user_google_email="user@example.com", thread_id="thrX"
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_draft_thread_ambiguous_errors():
+    service = Mock()
+    service.users().drafts().list().execute.return_value = {
+        "drafts": [
+            {"id": "d1", "message": {"threadId": "thrX"}},
+            {"id": "d2", "message": {"threadId": "thrX"}},
+        ]
+    }
+    with pytest.raises(UserInputError, match="ambiguous"):
+        await _unwrap(send_gmail_draft)(
+            service=service, user_google_email="user@example.com", thread_id="thrX"
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_draft_requires_exactly_one_handle():
+    service = Mock()
+    with pytest.raises(UserInputError, match="exactly one"):
+        await _unwrap(send_gmail_draft)(
+            service=service, user_google_email="user@example.com"
+        )
+    with pytest.raises(UserInputError, match="exactly one"):
+        await _unwrap(send_gmail_draft)(
+            service=service,
+            user_google_email="user@example.com",
+            draft_id="d1",
+            thread_id="t1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_draft_thread_resolution_paginates():
+    """The target draft on a later page is still found (no false 'not found')."""
+    service = Mock()
+    service.users().drafts().list().execute.side_effect = [
+        {
+            "drafts": [{"id": "d1", "message": {"threadId": "other"}}],
+            "nextPageToken": "p2",
+        },
+        {"drafts": [{"id": "d2", "message": {"threadId": "thrX"}}]},
+    ]
+    send_request = Mock()
+    send_request.execute.return_value = {"id": "sent2", "threadId": "thrX"}
+    service.users().drafts().send.return_value = send_request
+
+    result = await _unwrap(send_gmail_draft)(
+        service=service, user_google_email="user@example.com", thread_id="thrX"
+    )
+
+    service.users().drafts().send.assert_called_with(userId="me", body={"id": "d2"})
+    assert "sent2" in result

--- a/tests/gmail/test_send_gmail_draft.py
+++ b/tests/gmail/test_send_gmail_draft.py
@@ -1,8 +1,9 @@
-"""Tests for send_gmail_draft (draft_id + edit-proof thread_id)."""
+"""Tests for send_gmail_draft (draft_id-first resolution, thread_id fallback)."""
 
 from unittest.mock import Mock
 
 import pytest
+from googleapiclient.errors import HttpError
 
 from core.utils import UserInputError
 from gmail.gmail_tools import send_gmail_draft
@@ -84,19 +85,60 @@ async def test_send_gmail_draft_thread_ambiguous_errors():
 
 
 @pytest.mark.asyncio
-async def test_send_gmail_draft_requires_exactly_one_handle():
+async def test_send_gmail_draft_requires_a_handle():
     service = Mock()
-    with pytest.raises(UserInputError, match="exactly one"):
+    with pytest.raises(UserInputError, match="draft_id.*thread_id.*both"):
         await _unwrap(send_gmail_draft)(
             service=service, user_google_email="user@example.com"
         )
-    with pytest.raises(UserInputError, match="exactly one"):
-        await _unwrap(send_gmail_draft)(
-            service=service,
-            user_google_email="user@example.com",
-            draft_id="d1",
-            thread_id="t1",
-        )
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_draft_prefers_draft_id_when_both_given():
+    """draft_id is the stable handle; when both are supplied it wins and thread_id is
+    never scanned."""
+    service = Mock()
+    send_request = Mock()
+    send_request.execute.return_value = {"id": "sent-x", "threadId": "t1"}
+    service.users().drafts().send.return_value = send_request
+
+    result = await _unwrap(send_gmail_draft)(
+        service=service,
+        user_google_email="user@example.com",
+        draft_id="d1",
+        thread_id="t1",
+    )
+
+    service.users().drafts().send.assert_called_with(userId="me", body={"id": "d1"})
+    service.users().drafts().list.assert_not_called()
+    assert "sent-x" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [404, 400])
+async def test_send_gmail_draft_falls_back_to_thread_when_draft_stale(status):
+    """A stale (404) or malformed (400) draft_id with a thread_id given recovers via
+    the thread scan."""
+    service = Mock()
+    resp = Mock()
+    resp.status = status
+    service.users().drafts().get().execute.side_effect = HttpError(resp, b"bad id")
+    service.users().drafts().list().execute.return_value = {
+        "drafts": [{"id": "d-live", "message": {"threadId": "thrX"}}]
+    }
+    send_request = Mock()
+    send_request.execute.return_value = {"id": "sent-fb", "threadId": "thrX"}
+    service.users().drafts().send.return_value = send_request
+
+    result = await _unwrap(send_gmail_draft)(
+        service=service,
+        user_google_email="user@example.com",
+        draft_id="stale",
+        thread_id="thrX",
+    )
+
+    service.users().drafts().send.assert_called_with(userId="me", body={"id": "d-live"})
+    assert "sent-fb" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Completes the Gmail **draft** workflow so a message can be composed/reviewed as a draft and **sent as a separate step** — useful for least-privilege setups (compose on a drafts-scoped profile, send on a send-scoped one) and for human-in-the-loop review before sending.

- **`send_gmail_draft`** — send an existing draft by `draft_id` (preferred) and/or `thread_id` (fallback). Gmail has `drafts.create` but no send-a-draft tool today.
- **`draft_gmail_message`** — now returns `draft_id` + `message_id` + `thread_id`, and gains `forward_message_id` / `include_forwarded_attachments` to draft a **forward** (symmetric with the existing send-forward).

## Resolving the right draft at send time

`send_gmail_draft` accepts `draft_id`, `thread_id`, or both. I tested how a draft's three IDs behave across edits (live Gmail API, one reply draft edited repeatedly on **web and iOS**):

| Handle | Across edits |
|---|---|
| `message_id` | **rotates on every edit** — never cache it |
| `draft_id` | **most stable** — unchanged across body edits, a subject change, and adding an attachment (only a rare discard-recreate rotates it) |
| `thread_id` | stable for body/attachment edits, but **moves when the subject is edited** (Gmail re-threads by subject) |

So the tool resolves **`draft_id` first** (the durable handle); if it's absent or no longer resolves (404 probe), it falls back to a `thread_id` scan of `drafts.list` (match `message.threadId`, send the unique draft, error on >1). That keeps the "create → user edits → send" flow robust without relying on the fragile assumption that `thread_id` never changes. `draft_gmail_message` returns all three IDs so callers hold `draft_id` as primary and `thread_id` as a fallback anchor.

## Scope note

`drafts.send` requires `gmail.compose` (it is **not** covered by `gmail.send`), so `send_gmail_draft` declares `gmail.compose`. No change to existing tools' scopes.

## Relationship to #920

Deliberately scoped to avoid overlap with #920 (list/update/delete draft tools). This PR does **not** add a list-drafts tool — that's #920's `list_gmail_drafts`. The two are complementary: #920 covers listing/updating/deleting; this covers **sending** (`draft_id`-first, `thread_id` fallback) and **draft-forward**. (Related suggestion left on #920: surfacing `thread_id` per draft still pairs nicely with `send_gmail_draft` as a fallback anchor.)

## Implementation

- Extracted a shared `_build_forward_message` helper from the existing `_forward_gmail_message_impl` so the send-forward and new draft-forward paths reuse the same build-and-carry-attachments logic (no behavior change to send-forward).
- `draft_gmail_message` `subject`/`body` are now optional (auto-derived when forwarding).
- Registered `send_gmail_draft` (core tier) in `tool_tiers.yaml` + the README Available Tools table.

## Tests

`tests/gmail/test_send_gmail_draft.py` (draft_id-preferred send, stale-draft_id → thread fallback, thread resolution, 0/ambiguous errors, requires-a-handle guard) and a draft-forward case in `tests/gmail/test_forward_gmail_message.py`. Full gmail suite passes; `ruff check` + `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **send_gmail_draft** to send an existing Gmail draft using **draft ID** or **thread ID** (with clear disambiguation rules).
  * Enhanced **draft_gmail_message** to support forward-based draft creation, including forwarded content, attachments, and optional note text.
* **Bug Fixes**
  * Improved forward handling to fail fast when forwarded attachments can’t be downloaded/converted, avoiding partial forwards.
  * Added stricter validation for carried-forward attachments to prevent mismatches.
  * Signature placement is now honored consistently for both sent forwards and forward-based drafts.
* **Documentation**
  * Updated Gmail tool documentation and core tool tiers for the new draft-sending capability.
* **Tests**
  * Added/expanded tests covering draft selection, error cases, signature placement, and attachment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
