### PR TITLE
fix(auth): resolve credentials case-insensitively by email

### DIFF
--- a/auth/credential_store.py
+++ b/auth/credential_store.py
@@ -140,10 +140,17 @@ class LocalDirectoryCredentialStore(CredentialStore):
     def _get_credential_path(self, user_email: str) -> str:
         """Get the file path for a user's credentials.
 
+        The address is lower-cased first, so that callers passing a differently
+        capitalized spelling of the same account (Google treats the local part
+        as case-insensitive) resolve to a single credential file rather than
+        missing it on a case-sensitive filesystem and reporting a spurious
+        "authentication needed".
+
         URL-encodes user_email to prevent path traversal while preserving a
         collision-free mapping from email address to filename. For backward
         compatibility, pre-existing legacy filenames from the older regex-based
-        sanitization scheme are still discovered if the URL-encoded file does
+        sanitization scheme, and pre-existing mixed-case filenames written
+        before normalization, are still discovered if the normalized file does
         not exist yet. The resolved path is validated to remain under base_dir.
         """
         if not user_email or not user_email.strip():
@@ -153,24 +160,54 @@ class LocalDirectoryCredentialStore(CredentialStore):
             os.makedirs(self.base_dir, mode=0o700, exist_ok=True)
             logger.info(f"Created credentials directory: {self.base_dir}")
 
-        safe_email = quote(user_email, safe="@._-")
+        normalized_email = user_email.strip().lower()
+
+        safe_email = quote(normalized_email, safe="@._-")
         creds_path = self._resolve_credential_path(f"{safe_email}{self.FILE_EXTENSION}")
 
         if os.path.exists(creds_path):
             return creds_path
 
-        legacy_safe_email = self._legacy_safe_email(user_email)
-        if legacy_safe_email != safe_email:
-            legacy_path = self._resolve_credential_path(
-                f"{legacy_safe_email}{self.FILE_EXTENSION}"
+        # Candidate fallbacks for credentials written by earlier versions:
+        # the legacy regex-sanitized form, and the caller's original casing.
+        fallback_names = [self._legacy_safe_email(normalized_email)]
+        if user_email.strip() != normalized_email:
+            fallback_names.append(quote(user_email.strip(), safe="@._-"))
+            fallback_names.append(self._legacy_safe_email(user_email.strip()))
+
+        for fallback_name in fallback_names:
+            if fallback_name == safe_email:
+                continue
+            fallback_path = self._resolve_credential_path(
+                f"{fallback_name}{self.FILE_EXTENSION}"
             )
-            if os.path.exists(legacy_path):
+            if os.path.exists(fallback_path):
                 logger.info(
                     "Using legacy credential filename for %s at %s",
                     user_email,
-                    legacy_path,
+                    fallback_path,
                 )
-                return legacy_path
+                return fallback_path
+
+        # Final fallback: a credential written before normalization may be
+        # stored under any casing. Match case-insensitively so those remain
+        # readable instead of appearing unauthenticated.
+        target_filename = f"{safe_email}{self.FILE_EXTENSION}".lower()
+        try:
+            existing_filenames = os.listdir(self.base_dir)
+        except OSError:
+            existing_filenames = []
+        for filename in sorted(existing_filenames):
+            if filename.lower() != target_filename:
+                continue
+            legacy_case_path = self._resolve_credential_path(filename)
+            if os.path.exists(legacy_case_path):
+                logger.info(
+                    "Using legacy mixed-case credential filename for %s at %s",
+                    user_email,
+                    legacy_case_path,
+                )
+                return legacy_case_path
 
         return creds_path
 

--- a/tests/auth/test_credential_security.py
+++ b/tests/auth/test_credential_security.py
@@ -173,6 +173,48 @@ class TestPathTraversal:
 
         assert resolved == legacy_path
 
+    def test_get_credential_path_normalizes_case(self, cred_store):
+        """Differently capitalized spellings map to one lower-cased filename."""
+        expected = f"user@example.com{CredentialStore.FILE_EXTENSION}"
+
+        for spelling in (
+            "user@example.com",
+            "User@example.com",
+            "USER@EXAMPLE.COM",
+            "  User@Example.com  ",
+        ):
+            assert os.path.basename(cred_store._get_credential_path(spelling)) == expected
+
+    def test_get_credential_path_finds_existing_mixed_case_file(self, cred_store):
+        """Credentials stored before normalization stay readable."""
+        mixed_case_path = os.path.join(
+            cred_store.base_dir,
+            f"User@Example.com{CredentialStore.FILE_EXTENSION}",
+        )
+        os.makedirs(cred_store.base_dir, exist_ok=True)
+        with open(mixed_case_path, "w") as f:
+            json.dump({}, f)
+
+        assert cred_store._get_credential_path("user@example.com") == mixed_case_path
+        assert cred_store._get_credential_path("USER@EXAMPLE.COM") == mixed_case_path
+
+    def test_get_credential_path_prefers_normalized_over_mixed_case(self, cred_store):
+        """A normalized file wins when both spellings exist on disk."""
+        os.makedirs(cred_store.base_dir, exist_ok=True)
+        normalized_path = os.path.join(
+            cred_store.base_dir, f"user@example.com{CredentialStore.FILE_EXTENSION}"
+        )
+        for path in (
+            normalized_path,
+            os.path.join(
+                cred_store.base_dir, f"User@Example.com{CredentialStore.FILE_EXTENSION}"
+            ),
+        ):
+            with open(path, "w") as f:
+                json.dump({}, f)
+
+        assert cred_store._get_credential_path("User@Example.com") == normalized_path
+
     def test_list_users_includes_legacy_filename_variants(self, cred_store):
         """Legacy sanitized filenames remain discoverable during migration."""
         os.makedirs(cred_store.base_dir, exist_ok=True)


### PR DESCRIPTION
Google treats the local part of an address as case-insensitive — `Info@example.com` and `info@example.com` are the same account, with the same tokens.

`LocalDirectoryCredentialStore._get_credential_path` builds the credential filename from the caller-supplied spelling verbatim (`quote(user_email, safe="@._-")`). On a case-sensitive filesystem, a client that passes a differently capitalized spelling therefore misses the stored credential file, and the server reports **"authentication needed" for an account that is already authenticated**. Re-authenticating writes a second file under the new casing, so the two spellings then drift apart with separate refresh tokens.

This bit us in practice: a caller passing `Info@` instead of `info@` produced a spurious auth prompt, and the local workaround was a symlink between the two filenames — which only covers the one account that happened to get hit.

## Change

Lower-case the address before building the filename, so every spelling of an account maps to one file.

Since `_get_credential_path` backs `get_credential`, `store_credential` and `delete_credential`, reads and writes normalize consistently.

## Backward compatibility

Credentials already written under a mixed-case filename stay readable: after the normalized and legacy-sanitized lookups miss, a case-insensitive scan of the credentials directory finds the existing file and returns it. No re-auth and no file migration is required, and an exactly-matching normalized file always wins over a mixed-case one.

## Tests

Three tests added to `tests/auth/test_credential_security.py`:

- `test_get_credential_path_normalizes_case` — mixed, upper and whitespace-padded spellings all resolve to one lower-cased filename
- `test_get_credential_path_finds_existing_mixed_case_file` — a pre-existing mixed-case credential remains readable
- `test_get_credential_path_prefers_normalized_over_mixed_case` — the normalized file wins when both exist

`tests/auth/` passes (137). On the full suite this adds 3 passing tests and no new failures; 3 failures in `tests/core/test_user_google_email_defaults.py` and `tests/gforms/test_forms_tools.py` reproduce identically on an unmodified checkout and are unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential file lookup by consistently handling email capitalization and surrounding whitespace.
  * Preserved access to credentials stored under older or mixed-case filenames.
  * Ensured normalized credential files are preferred when multiple matching files exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->