### PR TITLE
feat(gmail): save message/thread bodies to file and improve HTML-to-text conversion

### DIFF
--- a/core/attachment_storage.py
+++ b/core/attachment_storage.py
@@ -100,9 +100,12 @@ class AttachmentStorage:
         # Generate unique file ID for metadata tracking
         file_id = str(uuid.uuid4())
 
-        # Decode base64 data
+        # Decode base64 data. Google APIs serialize bytes fields as base64url
+        # frequently WITHOUT '=' padding (RFC 4648 §5), which the strict
+        # stdlib decoder rejects; re-pad first (no-op for padded input).
+        padded_data = base64_data + "=" * (-len(base64_data) % 4)
         try:
-            file_bytes = base64.urlsafe_b64decode(base64_data)
+            file_bytes = base64.urlsafe_b64decode(padded_data)
         except Exception as e:
             logger.error(f"Failed to decode base64 attachment data: {e}")
             raise ValueError(f"Invalid base64 data: {e}")

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -150,6 +150,17 @@ def _plain_is_low_value(plain_words: List[str], html_words: List[str]) -> bool:
     return False
 
 
+def _pad_urlsafe_b64(data: str) -> str:
+    """
+    Re-pad a base64url string to a multiple of 4 characters.
+
+    Google APIs serialize bytes fields as base64url frequently WITHOUT '='
+    padding (RFC 4648 §5), which the strict stdlib decoder rejects with
+    "Incorrect padding". Padding an already-padded value is a no-op.
+    """
+    return data + "=" * (-len(data) % 4)
+
+
 def _extract_message_body(payload):
     """
     Helper function to extract plain text body from a Gmail message payload.
@@ -187,9 +198,9 @@ def _extract_message_bodies(payload):
 
         if body_data:
             try:
-                decoded_data = base64.urlsafe_b64decode(body_data).decode(
-                    "utf-8", errors="ignore"
-                )
+                decoded_data = base64.urlsafe_b64decode(
+                    _pad_urlsafe_b64(body_data)
+                ).decode("utf-8", errors="ignore")
                 if mime_type == "text/plain" and not text_body:
                     text_body = decoded_data
                 elif mime_type == "text/html" and not html_body:
@@ -204,9 +215,9 @@ def _extract_message_bodies(payload):
     # Check the main payload if it has body data directly
     if payload.get("body", {}).get("data"):
         try:
-            decoded_data = base64.urlsafe_b64decode(payload["body"]["data"]).decode(
-                "utf-8", errors="ignore"
-            )
+            decoded_data = base64.urlsafe_b64decode(
+                _pad_urlsafe_b64(payload["body"]["data"])
+            ).decode("utf-8", errors="ignore")
             mime_type = payload.get("mimeType", "")
             if mime_type == "text/plain" and not text_body:
                 text_body = decoded_data
@@ -292,9 +303,8 @@ def _decode_raw_mime_content(raw_data: str) -> str:
     if not raw_data:
         return "[No raw content found]"
 
-    padded_raw = raw_data + "=" * (-len(raw_data) % 4)
     try:
-        decoded_raw = base64.urlsafe_b64decode(padded_raw).decode(
+        decoded_raw = base64.urlsafe_b64decode(_pad_urlsafe_b64(raw_data)).decode(
             "utf-8", errors="replace"
         )
     except (binascii.Error, ValueError) as exc:
@@ -657,7 +667,7 @@ def _format_base64_content_block(urlsafe_b64_data: str) -> List[str]:
         decode, returns a single warning line instead of raising.
     """
     try:
-        raw_bytes = base64.urlsafe_b64decode(urlsafe_b64_data)
+        raw_bytes = base64.urlsafe_b64decode(_pad_urlsafe_b64(urlsafe_b64_data))
         standard_b64 = base64.b64encode(raw_bytes).decode("ascii")
         return [
             f"\n📦 Base64 content ({len(standard_b64)} chars, standard base64):",
@@ -2531,9 +2541,8 @@ async def _forward_gmail_message_impl(
                 # tolerantly and re-encode as standard, padded base64 so the
                 # downstream base64.b64decode() in _prepare_gmail_message succeeds.
                 urlsafe_data = attachment_data.get("data", "")
-                padded = urlsafe_data + "=" * (-len(urlsafe_data) % 4)
                 standard_b64 = base64.b64encode(
-                    base64.urlsafe_b64decode(padded)
+                    base64.urlsafe_b64decode(_pad_urlsafe_b64(urlsafe_data))
                 ).decode()
                 attachments_to_send.append(
                     {

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -28,7 +28,11 @@ from pydantic import Field
 from googleapiclient.errors import HttpError
 
 from auth.service_decorator import require_google_service
-from core.attachment_storage import get_attachment_storage, STORAGE_DIR
+from core.attachment_storage import (
+    get_attachment_storage,
+    sanitize_attachment_filename,
+    STORAGE_DIR,
+)
 from core.config import (
     WORKSPACE_EXTERNAL_URL,
     WORKSPACE_MCP_BASE_URI,
@@ -190,6 +194,7 @@ def _format_body_content(
     text_body: str,
     html_body: str,
     body_format: Literal["text", "html"] = "text",
+    truncate: bool = True,
 ) -> str:
     """
     Helper function to format message body content with HTML fallback and truncation.
@@ -200,6 +205,8 @@ def _format_body_content(
         html_body: HTML body content
         body_format: Output format - "text" converts HTML to plaintext (default),
                      "html" returns raw HTML body as-is
+        truncate: When True (default), truncate long content for inline display.
+                  Set False to get the full untruncated body (e.g. for file export).
 
     Returns:
         Formatted body content string
@@ -207,7 +214,7 @@ def _format_body_content(
     if body_format == "html":
         html_stripped = html_body.strip()
         if html_stripped:
-            if len(html_stripped) > HTML_BODY_TRUNCATE_LIMIT:
+            if truncate and len(html_stripped) > HTML_BODY_TRUNCATE_LIMIT:
                 return (
                     html_stripped[:HTML_BODY_TRUNCATE_LIMIT]
                     + "\n\n[Content truncated...]"
@@ -242,7 +249,7 @@ def _format_body_content(
 
     if use_html:
         content = html_text
-        if len(content) > HTML_BODY_TRUNCATE_LIMIT:
+        if truncate and len(content) > HTML_BODY_TRUNCATE_LIMIT:
             content = content[:HTML_BODY_TRUNCATE_LIMIT] + "\n\n[Content truncated...]"
         return content
     elif text_stripped:
@@ -336,11 +343,16 @@ def _build_message_get_request(
 def _validate_message_batch_options(
     response_format: Literal["full", "metadata"],
     body_format: Literal["text", "html", "raw"],
+    save_body_to_file: bool = False,
 ) -> None:
     """Reject incompatible output combinations for batch message reads."""
     if response_format == "metadata" and body_format != "text":
         raise UserInputError(
             "body_format='html' and body_format='raw' require format='full'."
+        )
+    if response_format == "metadata" and save_body_to_file:
+        raise UserInputError(
+            "save_body_to_file=True requires format='full' (metadata has no body to save)."
         )
 
 
@@ -378,9 +390,17 @@ async def _fetch_message_with_retry(
 
 async def _fetch_raw_message_contents(
     service, message_ids: List[str], log_prefix: str
-) -> Dict[str, str]:
-    """Fetch decoded raw MIME content for a set of Gmail message IDs."""
-    raw_contents: Dict[str, str] = {}
+) -> Dict[str, Dict[str, str]]:
+    """
+    Fetch raw MIME content for a set of Gmail message IDs.
+
+    Returns:
+        Mapping of message ID to a dict with:
+          - "decoded": decoded (truncated) raw MIME text for inline display
+          - "raw_b64": the undecoded urlsafe-base64 raw value (empty on failure),
+            suitable for saving the full untruncated MIME to a file
+    """
+    raw_contents: Dict[str, Dict[str, str]] = {}
     for message_id in message_ids:
         _, raw_message, raw_error = await _fetch_message_with_retry(
             service,
@@ -388,11 +408,17 @@ async def _fetch_raw_message_contents(
             message_format="raw",
             log_prefix=log_prefix,
         )
-        raw_contents[message_id] = (
-            _decode_raw_mime_content(raw_message.get("raw", ""))
-            if raw_message
-            else f"[Failed to fetch raw MIME: {raw_error}]"
-        )
+        if raw_message:
+            raw_b64 = raw_message.get("raw", "")
+            raw_contents[message_id] = {
+                "decoded": _decode_raw_mime_content(raw_b64),
+                "raw_b64": raw_b64,
+            }
+        else:
+            raw_contents[message_id] = {
+                "decoded": f"[Failed to fetch raw MIME: {raw_error}]",
+                "raw_b64": "",
+            }
         await asyncio.sleep(GMAIL_REQUEST_DELAY)
 
     return raw_contents
@@ -621,6 +647,147 @@ def _format_base64_content_block(urlsafe_b64_data: str) -> List[str]:
             f"to standard base64: {e}"
         )
         return [f"\n⚠️ Could not include base64 content: {e}"]
+
+
+# File extension and MIME type for saved email bodies, keyed by body_format.
+_BODY_FILE_FORMAT_INFO = {
+    "text": (".txt", "text/plain"),
+    "html": (".html", "text/html"),
+    "raw": (".eml", "message/rfc822"),
+}
+_BODY_FILE_SUBJECT_STEM_MAX = 50
+
+
+def _save_body_file(
+    body_content_b64: str,
+    message_id: str,
+    subject: str,
+    body_format: Literal["text", "html", "raw"],
+) -> tuple[List[str], bool]:
+    """
+    Save an email body to the managed attachment storage.
+
+    Mirrors the ``get_gmail_attachment_content`` response pattern: local file
+    path in stdio mode, temporary download URL (1-hour expiry) in HTTP mode,
+    and an inline fallback in stateless mode.
+
+    Args:
+        body_content_b64: URL-safe base64 of the file content.
+        message_id: Gmail message ID (used in the filename).
+        subject: Message subject (used in the filename).
+        body_format: Determines file extension (.txt/.html/.eml) and MIME type.
+
+    Returns:
+        Tuple of (result_lines, saved). When ``saved`` is False the caller
+        should keep the body inline; ``result_lines`` then contain only a
+        warning explaining why no file was written.
+    """
+    from auth.oauth_config import is_stateless_mode
+
+    if is_stateless_mode():
+        return (
+            [
+                "⚠️ Stateless mode: File storage disabled. Returning body inline instead."
+            ],
+            False,
+        )
+
+    if not body_content_b64:
+        return (["⚠️ No body content available to save to file."], False)
+
+    extension, mime_type = _BODY_FILE_FORMAT_INFO[body_format]
+    subject_stem = Path(sanitize_attachment_filename(subject or "email")).stem
+    subject_stem = subject_stem[:_BODY_FILE_SUBJECT_STEM_MAX].strip(" ._") or "email"
+    filename = f"{subject_stem}_{message_id}{extension}"
+
+    try:
+        from core.attachment_storage import get_attachment_url
+        from core.config import get_transport_mode
+
+        storage = get_attachment_storage()
+        result = storage.save_attachment(
+            base64_data=body_content_b64, filename=filename, mime_type=mime_type
+        )
+        size_bytes = Path(result.path).stat().st_size
+        size_kb = size_bytes / 1024
+
+        result_lines = [
+            f"Body saved to file ({body_format} format).",
+            f"Filename: {Path(result.path).name}",
+            f"Size: {size_kb:.1f} KB ({size_bytes} bytes)",
+        ]
+
+        if get_transport_mode() == "stdio":
+            result_lines.append(f"📎 Saved to: {result.path}")
+            result_lines.append(
+                "The file has been saved to disk and can be accessed directly via the file path."
+            )
+        else:
+            download_url = get_attachment_url(result.file_id)
+            result_lines.append(f"📎 Download URL: {download_url}")
+            result_lines.append("The file will expire after 1 hour.")
+
+        logger.info(
+            f"[_save_body_file] Saved {size_kb:.1f} KB body for message {message_id} to {result.path}"
+        )
+        return (result_lines, True)
+    except Exception as e:
+        logger.error(
+            f"[_save_body_file] Failed to save body for message {message_id}: {e}",
+            exc_info=True,
+        )
+        return (
+            [f"⚠️ Failed to save body to file: {e}. Returning body inline instead."],
+            False,
+        )
+
+
+def _build_body_section(
+    *,
+    message_id: str,
+    subject: str,
+    body_format: Literal["text", "html", "raw"],
+    save_body_to_file: bool,
+    text_body: str = "",
+    html_body: str = "",
+    raw_b64: str = "",
+    decoded_raw: str = "",
+) -> tuple[str, str]:
+    """
+    Build the body section of a message/thread response.
+
+    Returns:
+        Tuple of (label, content). Label is "BODY SAVED TO FILE" when the body
+        was persisted via ``_save_body_file``; otherwise the inline body is
+        returned under "BODY" / "RAW MIME", prefixed with a warning when
+        saving was requested but not possible.
+    """
+    warning_lines: List[str] = []
+    if save_body_to_file:
+        if body_format == "raw":
+            file_b64 = raw_b64
+        else:
+            full_body = _format_body_content(
+                text_body, html_body, body_format=body_format, truncate=False
+            )
+            file_b64 = base64.urlsafe_b64encode(full_body.encode("utf-8")).decode(
+                "ascii"
+            )
+        file_lines, saved = _save_body_file(file_b64, message_id, subject, body_format)
+        if saved:
+            return ("BODY SAVED TO FILE", "\n".join(file_lines))
+        warning_lines = file_lines
+
+    if body_format == "raw":
+        label = "RAW MIME"
+        content = decoded_raw or _decode_raw_mime_content(raw_b64)
+    else:
+        label = "BODY"
+        content = _format_body_content(text_body, html_body, body_format=body_format)
+
+    if warning_lines:
+        content = "\n".join(warning_lines) + "\n\n" + content
+    return (label, content)
 
 
 def _extract_attachments(payload: dict) -> List[Dict[str, Any]]:
@@ -1426,6 +1593,19 @@ async def get_gmail_message_content(
             ),
         ),
     ] = "text",
+    save_body_to_file: Annotated[
+        bool,
+        Field(
+            description=(
+                "When True, saves the full untruncated body to a file instead of "
+                "returning it inline. The response contains a local file path "
+                "(stdio mode) or a temporary download URL valid for 1 hour "
+                "(HTTP mode). File type follows body_format: .txt (text), "
+                ".html (html), .eml (raw MIME). Not available in stateless mode "
+                "(body stays inline with a warning)."
+            ),
+        ),
+    ] = False,
 ) -> str:
     """
     Retrieves the full content (subject, sender, recipients, body) of a specific Gmail message.
@@ -1437,9 +1617,15 @@ async def get_gmail_message_content(
             "text" (default) returns plaintext (HTML converted to text as fallback).
             "html" returns the raw HTML body as-is without conversion.
             "raw" fetches the full raw MIME message and returns the base64url-decoded content.
+        save_body_to_file (bool): When True, saves the full untruncated body to a
+            file via the managed attachment storage instead of returning it inline.
+            Returns a local file path (stdio mode) or a temporary download URL
+            (HTTP mode, 1-hour expiry). Falls back to inline output in stateless
+            mode or when saving fails.
 
     Returns:
-        str: The message details including subject, sender, date, Message-ID, recipients (To, Cc), and body content.
+        str: The message details including subject, sender, date, Message-ID, recipients (To, Cc),
+        and body content (inline, or the saved file location when save_body_to_file=True).
     """
     logger.info(
         f"[get_gmail_message_content] Invoked. Message ID: '{message_id}', Email: '{user_google_email}'"
@@ -1472,10 +1658,16 @@ async def get_gmail_message_content(
             .get(userId="me", id=message_id, format="raw")
             .execute
         )
-        decoded_raw = _decode_raw_mime_content(message_raw.get("raw", ""))
+        body_label, body_data = _build_body_section(
+            message_id=message_id,
+            subject=headers.get("Subject", ""),
+            body_format="raw",
+            save_body_to_file=save_body_to_file,
+            raw_b64=message_raw.get("raw", ""),
+        )
 
         content_lines = _format_message_header_lines(headers)
-        content_lines.append(f"\n--- RAW MIME ---\n{decoded_raw}")
+        content_lines.append(f"\n--- {body_label} ---\n{body_data}")
         return "\n".join(content_lines)
 
     # Now fetch the full message to get the body parts
@@ -1496,14 +1688,23 @@ async def get_gmail_message_content(
     text_body = bodies.get("text", "")
     html_body = bodies.get("html", "")
 
-    # Format body content with HTML fallback
-    body_data = _format_body_content(text_body, html_body, body_format=body_format)
+    # Format body content with HTML fallback (or save it to a file)
+    body_label, body_data = _build_body_section(
+        message_id=message_id,
+        subject=headers.get("Subject", ""),
+        body_format=body_format,
+        save_body_to_file=save_body_to_file,
+        text_body=text_body,
+        html_body=html_body,
+    )
 
     # Extract attachment metadata
     attachments = _extract_attachments(payload)
 
     content_lines = _format_message_header_lines(headers)
-    content_lines.append(f"\n--- BODY ---\n{body_data or '[No text/plain body found]'}")
+    content_lines.append(
+        f"\n--- {body_label} ---\n{body_data or '[No text/plain body found]'}"
+    )
 
     # Add attachment information if present
     if attachments:
@@ -1548,6 +1749,20 @@ async def get_gmail_messages_content_batch(
             ),
         ),
     ] = "text",
+    save_body_to_file: Annotated[
+        bool,
+        Field(
+            description=(
+                "When True, saves each message's full untruncated body to its own "
+                "file instead of returning it inline (requires format='full'). "
+                "The response contains a local file path (stdio mode) or a "
+                "temporary download URL valid for 1 hour (HTTP mode) per message. "
+                "File type follows body_format: .txt (text), .html (html), "
+                ".eml (raw MIME). Not available in stateless mode (bodies stay "
+                "inline with a warning)."
+            ),
+        ),
+    ] = False,
 ) -> str:
     """
     Retrieves the content of multiple Gmail messages in a single batch request.
@@ -1561,6 +1776,11 @@ async def get_gmail_messages_content_batch(
             "text" (default) returns plaintext (HTML converted to text as fallback).
             "html" returns the raw HTML body as-is without conversion.
             "raw" fetches the full raw MIME message and returns the base64url-decoded content.
+        save_body_to_file (bool): When True, saves each message's full untruncated
+            body to its own file via the managed attachment storage instead of
+            returning it inline (requires format='full'). Returns a local file path
+            (stdio mode) or a temporary download URL (HTTP mode, 1-hour expiry) per
+            message. Falls back to inline output in stateless mode or when saving fails.
 
     Returns:
         str: A formatted list of message contents including subject, sender, date, Message-ID, recipients (To, Cc), and body (if full format).
@@ -1571,7 +1791,7 @@ async def get_gmail_messages_content_batch(
 
     if not message_ids:
         raise Exception("No message IDs provided")
-    _validate_message_batch_options(format, body_format)
+    _validate_message_batch_options(format, body_format, save_body_to_file)
 
     output_messages = []
 
@@ -1625,7 +1845,7 @@ async def get_gmail_messages_content_batch(
                 # Brief delay between requests to allow connection cleanup
                 await asyncio.sleep(GMAIL_REQUEST_DELAY)
 
-        raw_contents: Optional[Dict[str, str]] = None
+        raw_contents: Optional[Dict[str, Dict[str, str]]] = None
         if format != "metadata" and body_format == "raw":
             raw_message_ids = [
                 mid for mid in chunk_ids if not results.get(mid, {}).get("error")
@@ -1662,23 +1882,28 @@ async def get_gmail_messages_content_batch(
                 else:
                     headers = _extract_headers(payload, GMAIL_METADATA_HEADERS)
                     if body_format == "raw":
-                        body_data = (
-                            raw_contents.get(
-                                mid, "[Failed to fetch raw MIME: No result]"
-                            )
-                            if raw_contents
-                            else "[Failed to fetch raw MIME: No result]"
+                        raw_entry = (raw_contents or {}).get(mid) or {}
+                        body_label, body_data = _build_body_section(
+                            message_id=mid,
+                            subject=headers.get("Subject", ""),
+                            body_format="raw",
+                            save_body_to_file=save_body_to_file,
+                            raw_b64=raw_entry.get("raw_b64", ""),
+                            decoded_raw=raw_entry.get(
+                                "decoded", "[Failed to fetch raw MIME: No result]"
+                            ),
                         )
-                        body_label = "RAW MIME"
                     else:
                         # Full format - extract body too
                         bodies = _extract_message_bodies(payload)
-                        text_body = bodies.get("text", "")
-                        html_body = bodies.get("html", "")
-                        body_data = _format_body_content(
-                            text_body, html_body, body_format=body_format
+                        body_label, body_data = _build_body_section(
+                            message_id=mid,
+                            subject=headers.get("Subject", ""),
+                            body_format=body_format,
+                            save_body_to_file=save_body_to_file,
+                            text_body=bodies.get("text", ""),
+                            html_body=bodies.get("html", ""),
                         )
-                        body_label = "BODY"
 
                     attachments = _extract_attachments(payload)
 
@@ -2630,7 +2855,8 @@ def _format_thread_content(
     thread_data: dict,
     thread_id: str,
     body_format: Literal["text", "html", "raw"] = "text",
-    raw_contents: Optional[Dict[str, str]] = None,
+    raw_contents: Optional[Dict[str, Dict[str, str]]] = None,
+    save_body_to_file: bool = False,
 ) -> str:
     """
     Helper function to format thread content from Gmail API response.
@@ -2639,7 +2865,10 @@ def _format_thread_content(
         thread_data (dict): Thread data from Gmail API
         thread_id (str): Thread ID for display
         body_format: Output format - "text" (default), "html", or "raw"
-        raw_contents: Optional mapping of message IDs to decoded raw MIME content
+        raw_contents: Optional mapping of message IDs to raw MIME content dicts
+            (with "decoded" and "raw_b64" keys, see _fetch_raw_message_contents)
+        save_body_to_file: When True, each message's full untruncated body is
+            saved to its own file and the file location replaces the inline body
 
     Returns:
         str: Formatted thread content
@@ -2677,26 +2906,32 @@ def _format_thread_content(
         in_reply_to = headers.get("In-Reply-To", "")
         references = headers.get("References", "")
 
+        message_id = message.get("id", "")
+
         if body_format == "raw":
-            body_data = (raw_contents or {}).get(
-                message.get("id", ""), "[No raw content found]"
+            raw_entry = (raw_contents or {}).get(message_id) or {}
+            body_label, body_data = _build_body_section(
+                message_id=message_id,
+                subject=subject,
+                body_format="raw",
+                save_body_to_file=save_body_to_file,
+                raw_b64=raw_entry.get("raw_b64", ""),
+                decoded_raw=raw_entry.get("decoded", "[No raw content found]"),
             )
-            body_label = "RAW MIME"
         else:
             # Extract both text and HTML bodies
             bodies = _extract_message_bodies(payload)
-            text_body = bodies.get("text", "")
-            html_body = bodies.get("html", "")
-
-            # Format body content with HTML fallback
-            body_data = _format_body_content(
-                text_body, html_body, body_format=body_format
+            body_label, body_data = _build_body_section(
+                message_id=message_id,
+                subject=subject,
+                body_format=body_format,
+                save_body_to_file=save_body_to_file,
+                text_body=bodies.get("text", ""),
+                html_body=bodies.get("html", ""),
             )
-            body_label = "BODY"
 
         # Extract attachment metadata for this message
         attachments = _extract_attachments(payload)
-        message_id = message.get("id", "")
 
         # Add message to content
         content_lines.extend(
@@ -2718,7 +2953,11 @@ def _format_thread_content(
         if subject != thread_subject:
             content_lines.append(f"Subject: {subject}")
 
-        if body_format == "raw":
+        # Plain text/html bodies are shown without a section label (existing
+        # behavior); raw MIME and saved-file blocks get a labeled section.
+        if body_label == "BODY":
+            content_lines.extend(["", body_data, ""])
+        else:
             content_lines.extend(
                 [
                     "",
@@ -2727,8 +2966,6 @@ def _format_thread_content(
                     "",
                 ]
             )
-        else:
-            content_lines.extend(["", body_data, ""])
 
         if attachments:
             content_lines.append("--- ATTACHMENTS ---")
@@ -2770,6 +3007,19 @@ async def get_gmail_thread_content(
             ),
         ),
     ] = "text",
+    save_body_to_file: Annotated[
+        bool,
+        Field(
+            description=(
+                "When True, saves each message's full untruncated body to its own "
+                "file instead of returning it inline. The response contains a "
+                "local file path (stdio mode) or a temporary download URL valid "
+                "for 1 hour (HTTP mode) per message. File type follows "
+                "body_format: .txt (text), .html (html), .eml (raw MIME). "
+                "Not available in stateless mode (bodies stay inline with a warning)."
+            ),
+        ),
+    ] = False,
     include_analysis: Annotated[
         bool,
         Field(
@@ -2797,6 +3047,11 @@ async def get_gmail_thread_content(
             "text" (default) returns plaintext (HTML converted to text as fallback).
             "html" returns the raw HTML body as-is without conversion.
             "raw" fetches each message's full raw MIME content and returns the base64url-decoded body.
+        save_body_to_file (bool): When True, saves each message's full untruncated
+            body to its own file via the managed attachment storage instead of
+            returning it inline. Returns a local file path (stdio mode) or a
+            temporary download URL (HTTP mode, 1-hour expiry) per message. Falls
+            back to inline output in stateless mode or when saving fails.
         include_analysis (bool): When True, returns a dict containing both the
             formatted thread content and structured ownership analysis. When
             False (default), returns the formatted content string (existing
@@ -2836,6 +3091,7 @@ async def get_gmail_thread_content(
         thread_id,
         body_format=body_format,
         raw_contents=raw_contents,
+        save_body_to_file=save_body_to_file,
     )
 
     if not include_analysis:
@@ -2873,6 +3129,19 @@ async def get_gmail_threads_content_batch(
             ),
         ),
     ] = "text",
+    save_body_to_file: Annotated[
+        bool,
+        Field(
+            description=(
+                "When True, saves each message's full untruncated body to its own "
+                "file instead of returning it inline. The response contains a "
+                "local file path (stdio mode) or a temporary download URL valid "
+                "for 1 hour (HTTP mode) per message. File type follows "
+                "body_format: .txt (text), .html (html), .eml (raw MIME). "
+                "Not available in stateless mode (bodies stay inline with a warning)."
+            ),
+        ),
+    ] = False,
 ) -> str:
     """
     Retrieves the content of multiple Gmail threads in a single batch request.
@@ -2885,6 +3154,11 @@ async def get_gmail_threads_content_batch(
             "text" (default) returns plaintext (HTML converted to text as fallback).
             "html" returns the raw HTML body as-is without conversion.
             "raw" fetches each message's full raw MIME content and returns the base64url-decoded body.
+        save_body_to_file (bool): When True, saves each message's full untruncated
+            body to its own file via the managed attachment storage instead of
+            returning it inline. Returns a local file path (stdio mode) or a
+            temporary download URL (HTTP mode, 1-hour expiry) per message. Falls
+            back to inline output in stateless mode or when saving fails.
 
     Returns:
         str: A formatted list of thread contents with separators.
@@ -2989,6 +3263,7 @@ async def get_gmail_threads_content_batch(
                         tid,
                         body_format=body_format,
                         raw_contents=raw_contents,
+                        save_body_to_file=save_body_to_file,
                     )
                 )
 

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -12,7 +12,6 @@ import re
 import ssl
 import mimetypes
 import html
-from html.parser import HTMLParser
 from pathlib import Path
 from typing import Annotated, Optional, List, Dict, Literal, Any
 from urllib.parse import unquote, urlparse, urlunsplit
@@ -21,6 +20,7 @@ from email.message import EmailMessage
 from email.policy import SMTP
 from email.utils import formataddr
 
+import html2text
 import httpx
 from mcp.types import ToolAnnotations
 
@@ -69,6 +69,8 @@ logger = logging.getLogger(__name__)
 GMAIL_BATCH_SIZE = 25
 GMAIL_REQUEST_DELAY = 0.1
 HTML_BODY_TRUNCATE_LIMIT = 20000
+# Marker phrases are matched against word-normalized text (lowercase words
+# separated by single spaces, no punctuation), so they must be word-normalized too.
 LOW_VALUE_TEXT_PLACEHOLDERS = (
     "your client does not support html",
     "view this email in your browser",
@@ -76,50 +78,76 @@ LOW_VALUE_TEXT_PLACEHOLDERS = (
 )
 LOW_VALUE_TEXT_FOOTER_MARKERS = (
     "mailing list",
-    "mailman/listinfo",
+    "mailman listinfo",
     "unsubscribe",
-    "list-unsubscribe",
+    "list unsubscribe",
     "manage preferences",
 )
-LOW_VALUE_TEXT_HTML_DIFF_MIN = 80
+LOW_VALUE_WORD_DIFF_MIN = 15
 CONTENT_ID_SAFE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+\-@]*$")
-
-
-class _HTMLTextExtractor(HTMLParser):
-    """Extract readable text from HTML using stdlib."""
-
-    def __init__(self):
-        super().__init__()
-        self._text = []
-        self._skip = False
-
-    def handle_starttag(self, tag, attrs):
-        if tag in ("script", "style"):
-            self._skip = True
-            return
-        if tag == "br" and not self._skip:
-            self._text.append(" ")
-
-    def handle_endtag(self, tag):
-        if tag in ("script", "style"):
-            self._skip = False
-
-    def handle_data(self, data):
-        if not self._skip:
-            self._text.append(data)
-
-    def get_text(self) -> str:
-        return " ".join("".join(self._text).split())
+MD_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")  # [label](url) -> label
+URL_RE = re.compile(r"(?:https?://|www\.)\S+", re.IGNORECASE)
 
 
 def _html_to_text(html: str) -> str:
-    """Convert HTML to readable plain text."""
+    """Convert HTML to readable plain text (Markdown-flavored)."""
     try:
-        parser = _HTMLTextExtractor()
-        parser.feed(html)
-        return parser.get_text()
+        converter = html2text.HTML2Text()
+        converter.body_width = 0  # no hard line-wrapping
+        converter.ignore_images = True  # drop logos/tracking pixels
+        converter.ignore_emphasis = True
+        return converter.handle(html).strip()
     except Exception:
         return html
+
+
+def _normalize_words(text: str) -> List[str]:
+    """Reduce text to lowercase word tokens for comparing MIME alternatives.
+
+    Markdown links keep their label (the target URL is plumbing); any URL that
+    remains visible becomes the single sentinel word "url" so it counts as
+    content while representational differences between the text/plain and
+    text/html parts (raw URL vs. anchor text vs. tracking redirect) can't
+    break the comparison.
+    """
+    text = MD_LINK_RE.sub(r"\1", text)
+    text = URL_RE.sub(" url ", text)
+    return re.findall(r"[^\W_]+", text.lower())
+
+
+def _plain_is_low_value(plain_words: List[str], html_words: List[str]) -> bool:
+    """Decide whether the text/plain part is a useless stand-in for the HTML.
+
+    Operates on word-normalized token lists (see _normalize_words) so the
+    checks are immune to punctuation, whitespace, markup, and URL drift
+    between the two MIME parts.
+    """
+    if not plain_words:
+        return False
+
+    # Pad with spaces for whole-word phrase matching ("unsubscribed" must not
+    # match the "unsubscribe" marker).
+    padded = f" {' '.join(plain_words)} "
+    html_richer = len(html_words) >= len(plain_words) + LOW_VALUE_WORD_DIFF_MIN
+
+    # Known placeholder phrases mark the plain part as a stub outright.
+    if any(f" {marker} " in padded for marker in LOW_VALUE_TEXT_PLACEHOLDERS):
+        return True
+
+    # Footer-only plain part: known list/footer markers plus much richer HTML.
+    if html_richer and any(
+        f" {marker} " in padded for marker in LOW_VALUE_TEXT_FOOTER_MARKERS
+    ):
+        return True
+
+    # Appended-boilerplate detector (keyword-free): the plain part is exactly
+    # the tail of the HTML's words and the HTML says much more. Suffix rather
+    # than containment on purpose: appended footers land at the end, while a
+    # mid-body match usually means a legitimate plain-text rendition.
+    if html_richer and html_words[-len(plain_words) :] == plain_words:
+        return True
+
+    return False
 
 
 def _extract_message_body(payload):
@@ -228,23 +256,17 @@ def _format_body_content(
     html_stripped = html_body.strip()
     html_text = _html_to_text(html_stripped).strip() if html_stripped else ""
 
-    plain_lower = " ".join(text_stripped.split()).lower()
-    html_lower = " ".join(html_text.split()).lower()
-    plain_is_low_value = plain_lower and (
-        any(marker in plain_lower for marker in LOW_VALUE_TEXT_PLACEHOLDERS)
-        or (
-            any(marker in plain_lower for marker in LOW_VALUE_TEXT_FOOTER_MARKERS)
-            and len(html_lower) >= len(plain_lower) + LOW_VALUE_TEXT_HTML_DIFF_MIN
-        )
-        or (
-            len(html_lower) >= len(plain_lower) + LOW_VALUE_TEXT_HTML_DIFF_MIN
-            and html_lower.endswith(plain_lower)
-        )
-    )
+    # Word-normalized views are used for the decision only, never for output.
+    plain_words = _normalize_words(text_stripped)
+    html_words = _normalize_words(html_text)
 
-    # Prefer plain text, but fall back to HTML when plain text is empty or clearly low-value.
-    use_html = html_text and (
-        not text_stripped or "<!--" in text_stripped or plain_is_low_value
+    # Prefer plain text, but fall back to HTML when plain text is wordless or
+    # clearly low-value. Gating on html_words keeps image-only HTML (zero
+    # readable words) from ever displacing a real plain part.
+    use_html = bool(html_words) and (
+        not plain_words
+        or "<!--" in text_stripped
+        or _plain_is_low_value(plain_words, html_words)
     )
 
     if use_html:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
  "pypdf>=6.13.3",
  "pytz>=2026.1.post1",
  "markdown-it-py>=3.0.0",
+ "html2text>=2025.4.15",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/skills/managing-google-workspace/references/gmail.md
+++ b/skills/managing-google-workspace/references/gmail.md
@@ -30,6 +30,8 @@ Get full content of a single message (subject, sender, recipients, date, Message
 |-----------|------|----------|---------|-------|
 | message_id | string | yes | | |
 | user_google_email | string | yes | | |
+| body_format | string | no | "text" | "text" (plaintext, HTML converted as fallback), "html" (raw HTML), or "raw" (decoded raw MIME) |
+| save_body_to_file | boolean | no | false | Save the full untruncated body to a file instead of returning it inline (see Full Message Bodies below) |
 
 ### get_gmail_messages_content_batch
 Get content of multiple messages in one request. Max 25 per batch.
@@ -39,6 +41,8 @@ Get content of multiple messages in one request. Max 25 per batch.
 | message_ids | array of strings | yes | | Max 25 |
 | user_google_email | string | yes | | |
 | format | string | no | "full" | "full" (with body) or "metadata" (headers only) |
+| body_format | string | no | "text" | "text", "html", or "raw"; requires format="full" for "html"/"raw" |
+| save_body_to_file | boolean | no | false | Save each message's full body to its own file; requires format="full" |
 
 ### get_gmail_thread_content
 Get all messages in a conversation thread.
@@ -47,6 +51,9 @@ Get all messages in a conversation thread.
 |-----------|------|----------|---------|-------|
 | thread_id | string | yes | | |
 | user_google_email | string | yes | | |
+| body_format | string | no | "text" | "text", "html", or "raw" |
+| save_body_to_file | boolean | no | false | Save each message's full body to its own file (one file per message in the thread) |
+| include_analysis | boolean | no | false | Also return structured ownership analysis (last sender, ball-in-court verdict, participants) |
 
 ### get_gmail_threads_content_batch
 Get content of multiple threads in one request. Auto-batches in chunks of 25.
@@ -55,6 +62,8 @@ Get content of multiple threads in one request. Auto-batches in chunks of 25.
 |-----------|------|----------|---------|-------|
 | thread_ids | array of strings | yes | | |
 | user_google_email | string | yes | | |
+| body_format | string | no | "text" | "text", "html", or "raw" |
+| save_body_to_file | boolean | no | false | Save each message's full body to its own file (one file per message per thread) |
 
 ### get_gmail_attachment_content
 Download an attachment to local disk (stdio mode) or get a temporary URL (HTTP mode, 1-hour expiry).
@@ -222,3 +231,8 @@ Create or delete a filter.
 - To find attachments, read the message with `get_gmail_message_content` -- attachment IDs are listed in the response.
 - Download with `get_gmail_attachment_content` using both the message_id and attachment_id.
 - When sending/drafting, attachments can be specified as file paths (auto-encoded) or pre-encoded base64 content (standard base64, not urlsafe).
+
+### Full Message Bodies
+- Inline bodies are truncated at 20000 characters for html/raw output. To get the complete body, pass `save_body_to_file=true` to any of the four content tools (`get_gmail_message_content`, `get_gmail_messages_content_batch`, `get_gmail_thread_content`, `get_gmail_threads_content_batch`).
+- The full untruncated body is written to one file per message: `.txt` for body_format="text", `.html` for "html", `.eml` (original MIME) for "raw". The response contains a local file path (stdio mode) or a temporary download URL that expires after 1 hour (HTTP mode) instead of the inline body.
+- Not available in stateless mode -- the body is returned inline with a warning instead.

--- a/tests/gmail/test_attachment_fix.py
+++ b/tests/gmail/test_attachment_fix.py
@@ -112,6 +112,19 @@ def test_save_attachment_sanitizes_windows_reserved_filenames(
     assert saved_bytes == payload
 
 
+def test_save_attachment_accepts_unpadded_base64url(isolated_storage):
+    """Google APIs emit base64url without '=' padding; save must still decode it."""
+    # Length not a multiple of 3 so the encoded form requires padding.
+    payload = b"unpadded base64url data!"[:22]
+    b64_unpadded = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+    assert len(b64_unpadded) % 4 != 0, "fixture must actually be unpadded"
+
+    result = isolated_storage.save_attachment(b64_unpadded, filename="test.bin")
+
+    with open(result.path, "rb") as f:
+        assert f.read() == payload
+
+
 def test_save_attachment_metadata_filename_matches_saved_file(isolated_storage):
     """Attachment metadata should report the on-disk filename."""
     payload = b"metadata filename check"

--- a/tests/gmail/test_body_format.py
+++ b/tests/gmail/test_body_format.py
@@ -356,6 +356,19 @@ class TestExtractMessageBodies:
         assert bodies["text"] == ""
         assert bodies["html"] == ""
 
+    def test_decodes_unpadded_base64url_body_data(self):
+        """Gmail serializes body data as base64url without '=' padding."""
+        text = "Unpadded text."  # 14 bytes -> unpadded base64 length % 4 != 0
+        unpadded = _encode(text).rstrip("=")
+        assert len(unpadded) % 4 != 0, "fixture must actually be unpadded"
+
+        payload = {
+            "mimeType": "text/plain",
+            "body": {"data": unpadded},
+        }
+        bodies = _extract_message_bodies(payload)
+        assert bodies["text"] == text
+
     def test_handles_nested_multipart(self):
         payload = {
             "mimeType": "multipart/mixed",

--- a/tests/gmail/test_body_format.py
+++ b/tests/gmail/test_body_format.py
@@ -156,11 +156,111 @@ class TestFormatBodyContentTextMode:
         result = _format_body_content("", long_html)
         assert "[Content truncated...]" in result
 
-    def test_html_to_text_separates_br_text(self):
-        assert _html_to_text("<div>Best,<br>Alice</div>") == "Best, Alice"
+    def test_html_to_text_renders_br_as_line_break(self):
+        result = _html_to_text("<div>Best,<br>Alice</div>")
+        assert "Best," in result
+        assert "Alice" in result
+        assert result.splitlines()[-1].strip() == "Alice"
 
-    def test_html_to_text_ignores_br_inside_skipped_tags(self):
-        assert _html_to_text("<script>x<br>y</script><p>Visible</p>") == "Visible"
+    def test_html_to_text_skips_script_and_style_content(self):
+        result = _html_to_text(
+            "<script>var x = 1;</script>"
+            "<style>body { color: red; }</style>"
+            "<p>Visible</p>"
+        )
+        assert result == "Visible"
+
+    def test_detects_mailman_footer_with_differing_urls(self):
+        # Plain part is only the appended list footer with a direct URL; the
+        # HTML part has the real content plus the same footer behind a
+        # tracking redirect. The url sentinel lets the tail alignment fire.
+        plain = (
+            "dev mailing list\n"
+            "https://lists.example.org/mailman/listinfo/dev\n"
+            "To manage preferences visit https://lists.example.org/prefs"
+        )
+        html = (
+            "<p>Hello team, here is the quarterly update with plenty of "
+            "detail about the roadmap, staffing, budget and milestones "
+            "for the next planning period.</p>"
+            "<p>dev mailing list<br>"
+            '<a href="https://track.example.com/r/abc">'
+            "https://lists.example.org/mailman/listinfo/dev</a><br>"
+            "To manage preferences visit "
+            '<a href="https://track.example.com/r/def">'
+            "https://lists.example.org/prefs</a></p>"
+        )
+        result = _format_body_content(plain, html)
+        assert "quarterly update" in result
+
+    def test_appended_footer_tail_without_markers_flips_to_html(self):
+        # Keyword-free appended boilerplate: only the tail-alignment check can
+        # catch this. Plain shows raw URLs, HTML wraps the same visible URLs
+        # in tracking-redirect anchors; the sentinel keeps the tails aligned.
+        plain = (
+            "Sent by Acme Notifications https://acme.example/notify\n"
+            "Update your settings at https://acme.example/settings"
+        )
+        html = (
+            "<p>Hello team, here is the quarterly update with plenty of "
+            "detail about the roadmap, staffing, budget and milestones "
+            "for the next planning period.</p>"
+            "<p>Sent by Acme Notifications "
+            '<a href="https://track.example.com/r/abc">'
+            "https://acme.example/notify</a><br>"
+            "Update your settings at "
+            '<a href="https://track.example.com/r/def">'
+            "https://acme.example/settings</a></p>"
+        )
+        result = _format_body_content(plain, html)
+        assert "quarterly update" in result
+
+    def test_keeps_plain_list_of_links(self):
+        plain = (
+            "https://example.com/one\n"
+            "https://example.com/two\n"
+            "https://example.com/three"
+        )
+        html = "<p>Some completely different HTML content</p>"
+        result = _format_body_content(plain, html)
+        assert result == plain
+
+    def test_image_only_html_never_wins(self):
+        plain = "Short real answer."
+        html = '<img src="https://cdn.example.com/logo.png" alt="">'
+        result = _format_body_content(plain, html)
+        assert result == plain
+
+    def test_near_identical_short_mail_keeps_plain_byte_exact(self):
+        plain = "Hello world, see you tomorrow at the office."
+        html = "<p><b>Hello world</b>, see you tomorrow at the office.</p>"
+        result = _format_body_content(plain, html)
+        assert result == plain
+
+    def test_unsubscribed_word_does_not_trigger_footer_marker(self):
+        plain = "You have been unsubscribed successfully. No further action needed."
+        html = (
+            "<p>You have been unsubscribed successfully. No further action "
+            "needed. We are sorry to see you go and hope you will come back "
+            "to our community some day in the future soon.</p>"
+        )
+        result = _format_body_content(plain, html)
+        assert result == plain
+
+    def test_footer_marker_with_richer_html_flips_to_html(self):
+        plain = "Unsubscribe from this mailing list at any time."
+        html = (
+            "<p>Big announcement: we are launching a brand new product line "
+            "next month with several new features and improvements for all "
+            "our customers worldwide.</p>"
+            "<p>Unsubscribe from this mailing list at any time.</p>"
+        )
+        result = _format_body_content(plain, html)
+        assert "Big announcement" in result
+
+    def test_punctuation_only_plain_flips_to_html(self):
+        result = _format_body_content("---", "<p>Actual HTML content</p>")
+        assert "Actual HTML content" in result
 
 
 class TestFormatBodyContentHtmlMode:

--- a/tests/gmail/test_get_gmail_attachment_content.py
+++ b/tests/gmail/test_get_gmail_attachment_content.py
@@ -31,9 +31,12 @@ def _build_mock_service(
     *,
     filename: str = "attachment.bin",
     mime_type: str = "application/octet-stream",
+    unpadded: bool = False,
 ) -> Mock:
     """Build a Mock google-api service returning ``payload`` as an attachment."""
     urlsafe_b64 = base64.urlsafe_b64encode(payload).decode("ascii")
+    if unpadded:
+        urlsafe_b64 = urlsafe_b64.rstrip("=")
 
     mock_service = Mock()
 
@@ -106,6 +109,18 @@ def test_format_base64_content_block_converts_urlsafe_to_standard():
     assert base64.b64decode(standard_b64) == payload
 
 
+def test_format_base64_content_block_accepts_unpadded_base64url():
+    """Gmail-style unpadded base64url must round-trip to standard base64."""
+    payload = bytes(range(256))
+    urlsafe_unpadded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    assert len(urlsafe_unpadded) % 4 != 0, "fixture must actually be unpadded"
+
+    lines = _format_base64_content_block(urlsafe_unpadded)
+
+    assert len(lines) == 2
+    assert base64.b64decode(lines[1]) == payload
+
+
 def test_format_base64_content_block_handles_invalid_input_gracefully():
     """Invalid base64 shouldn't raise — it should return a warning line."""
     lines = _format_base64_content_block("not valid base64 !!!")
@@ -132,6 +147,28 @@ async def test_default_call_omits_base64_content(isolated_attachment_env):
     assert "Attachment downloaded successfully!" in result
     assert "📦 Base64 content" not in result
     assert "standard base64" not in result
+
+
+@pytest.mark.asyncio
+async def test_unpadded_base64url_attachment_still_saved(isolated_attachment_env):
+    """Gmail serves attachment data as base64url without '=' padding; save must not fail."""
+    # Length not a multiple of 3 so the encoded form requires padding.
+    payload = b"unpadded attachment payload."
+    mock_service = _build_mock_service(payload, filename="doc.bin", unpadded=True)
+
+    result = await _unwrap(get_gmail_attachment_content)(
+        service=mock_service,
+        message_id="msg-1",
+        attachment_id="att-123",
+        user_google_email="user@example.com",
+    )
+
+    assert "Attachment downloaded successfully!" in result
+    assert "Failed to save attachment" not in result
+
+    saved_files = list(isolated_attachment_env.iterdir())
+    assert len(saved_files) == 1
+    assert saved_files[0].read_bytes() == payload
 
 
 @pytest.mark.asyncio

--- a/tests/gmail/test_save_body_to_file.py
+++ b/tests/gmail/test_save_body_to_file.py
@@ -1,0 +1,580 @@
+"""
+Tests for the ``save_body_to_file`` option on the Gmail content tools:
+``get_gmail_message_content``, ``get_gmail_messages_content_batch``,
+``get_gmail_thread_content``, and ``get_gmail_threads_content_batch``.
+"""
+
+import base64
+from unittest.mock import Mock
+
+import pytest
+
+import gmail.gmail_tools as gmail_tools
+from core.server import server
+from core.tool_registry import get_tool_components
+from core.utils import UserInputError
+from gmail.gmail_tools import (
+    get_gmail_message_content,
+    get_gmail_messages_content_batch,
+    get_gmail_thread_content,
+    get_gmail_threads_content_batch,
+)
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _encode(text: str) -> str:
+    return base64.urlsafe_b64encode(text.encode()).decode()
+
+
+def _headers(**overrides):
+    header_map = {
+        "Subject": "Example subject",
+        "From": "sender@example.com",
+        "To": "recipient@example.com",
+        "Cc": "cc@example.com",
+        "Message-ID": "<message@example.com>",
+        "Date": "Fri, 28 Mar 2026 10:00:00 -0400",
+    }
+    header_map.update(overrides)
+    return [{"name": name, "value": value} for name, value in header_map.items()]
+
+
+def _payload(headers=None, text=None, html=None):
+    payload = {"headers": headers or _headers()}
+    parts = []
+    if text is not None:
+        parts.append({"mimeType": "text/plain", "body": {"data": _encode(text)}})
+    if html is not None:
+        parts.append({"mimeType": "text/html", "body": {"data": _encode(html)}})
+    if parts:
+        payload["mimeType"] = "multipart/alternative"
+        payload["parts"] = parts
+    return payload
+
+
+def _message_response(message_id: str, text="", html="", headers=None):
+    return {
+        "id": message_id,
+        "payload": _payload(headers=headers, text=text, html=html),
+    }
+
+
+def _metadata_response(message_id: str, headers=None):
+    return {
+        "id": message_id,
+        "payload": {"headers": headers or _headers()},
+    }
+
+
+def _thread_response(thread_id: str, messages):
+    return {"id": thread_id, "messages": messages}
+
+
+class _FakeBatch:
+    def __init__(self, callback):
+        self._callback = callback
+        self._requests = []
+
+    def add(self, request, request_id):
+        self._requests.append((request_id, request))
+
+    def execute(self):
+        for request_id, request in self._requests:
+            try:
+                response = request.execute()
+                self._callback(request_id, response, None)
+            except Exception as exc:
+                self._callback(request_id, None, exc)
+
+
+def _build_service(*, message_responses=None, thread_responses=None):
+    message_responses = message_responses or {}
+    thread_responses = thread_responses or {}
+
+    service = Mock()
+
+    def message_get(**kwargs):
+        request = Mock()
+        response = message_responses[(kwargs["id"], kwargs["format"])]
+        if isinstance(response, Exception):
+            request.execute.side_effect = response
+        else:
+            request.execute.return_value = response
+        return request
+
+    def thread_get(**kwargs):
+        request = Mock()
+        response = thread_responses[(kwargs["id"], kwargs["format"])]
+        if isinstance(response, Exception):
+            request.execute.side_effect = response
+        else:
+            request.execute.return_value = response
+        return request
+
+    service.users().messages().get.side_effect = message_get
+    service.users().threads().get.side_effect = thread_get
+    service.new_batch_http_request.side_effect = lambda callback: _FakeBatch(callback)
+    return service
+
+
+@pytest.fixture
+def isolated_storage_env(tmp_path, monkeypatch):
+    """Route attachment storage to a temp dir and force HTTP (not stateless) mode."""
+    import core.attachment_storage as storage_module
+    import auth.oauth_config as oauth_config_module
+    import core.config as core_config_module
+
+    monkeypatch.setattr(storage_module, "STORAGE_DIR", tmp_path)
+    monkeypatch.setattr(oauth_config_module, "is_stateless_mode", lambda: False)
+    monkeypatch.setattr(core_config_module, "get_transport_mode", lambda: "http")
+
+    # Reset the cached module-level storage singleton so our patched
+    # STORAGE_DIR actually takes effect.
+    monkeypatch.setattr(storage_module, "_attachment_storage", None, raising=False)
+
+    return tmp_path
+
+
+def _saved_files(storage_dir):
+    return sorted(p for p in storage_dir.iterdir() if p.is_file())
+
+
+def test_schema_includes_save_body_to_file():
+    """Published MCP schemas of all four content tools expose save_body_to_file."""
+    components = get_tool_components(server)
+    for tool in (
+        get_gmail_message_content,
+        get_gmail_messages_content_batch,
+        get_gmail_thread_content,
+        get_gmail_threads_content_batch,
+    ):
+        schema = components[tool.__name__].parameters["properties"]
+        assert "save_body_to_file" in schema, tool.__name__
+        assert schema["save_body_to_file"]["type"] == "boolean"
+        assert schema["save_body_to_file"]["default"] is False
+
+
+class TestSingleMessage:
+    @pytest.mark.asyncio
+    async def test_text_body_saved_to_txt_file(self, isolated_storage_env):
+        service = _build_service(
+            message_responses={
+                ("msg-1", "metadata"): _metadata_response("msg-1"),
+                ("msg-1", "full"): _message_response(
+                    "msg-1", text="Plain body", html="<p>Plain body</p>"
+                ),
+            }
+        )
+
+        result = await _unwrap(get_gmail_message_content)(
+            service=service,
+            message_id="msg-1",
+            user_google_email="user@example.com",
+            save_body_to_file=True,
+        )
+
+        assert "--- BODY SAVED TO FILE ---" in result
+        assert "Download URL" in result
+        assert "Plain body" not in result
+
+        files = _saved_files(isolated_storage_env)
+        assert len(files) == 1
+        assert files[0].suffix == ".txt"
+        assert "msg-1" in files[0].name
+        assert files[0].read_text() == "Plain body"
+
+    @pytest.mark.asyncio
+    async def test_html_body_saved_untruncated(self, isolated_storage_env):
+        long_html = "<div>" + "x" * 25000 + "</div>"
+        service = _build_service(
+            message_responses={
+                ("msg-1", "metadata"): _metadata_response("msg-1"),
+                ("msg-1", "full"): _message_response(
+                    "msg-1", text="fallback", html=long_html
+                ),
+            }
+        )
+
+        result = await _unwrap(get_gmail_message_content)(
+            service=service,
+            message_id="msg-1",
+            user_google_email="user@example.com",
+            body_format="html",
+            save_body_to_file=True,
+        )
+
+        assert "--- BODY SAVED TO FILE ---" in result
+        assert "[Content truncated...]" not in result
+
+        files = _saved_files(isolated_storage_env)
+        assert len(files) == 1
+        assert files[0].suffix == ".html"
+        # Full untruncated body (inline display would cap at 20000 chars).
+        assert files[0].read_text() == long_html
+
+    @pytest.mark.asyncio
+    async def test_raw_body_saved_as_original_mime_eml(self, isolated_storage_env):
+        mime_bytes = (
+            b"From: sender@example.com\r\nSubject: Example subject\r\n\r\nRaw body\r\n"
+        )
+        raw_b64 = base64.urlsafe_b64encode(mime_bytes).decode()
+        service = _build_service(
+            message_responses={
+                ("msg-1", "metadata"): _metadata_response("msg-1"),
+                ("msg-1", "raw"): {"id": "msg-1", "raw": raw_b64},
+            }
+        )
+
+        result = await _unwrap(get_gmail_message_content)(
+            service=service,
+            message_id="msg-1",
+            user_google_email="user@example.com",
+            body_format="raw",
+            save_body_to_file=True,
+        )
+
+        assert "--- BODY SAVED TO FILE ---" in result
+        assert "--- RAW MIME ---" not in result
+
+        files = _saved_files(isolated_storage_env)
+        assert len(files) == 1
+        assert files[0].suffix == ".eml"
+        assert files[0].read_bytes() == mime_bytes
+
+    @pytest.mark.asyncio
+    async def test_filename_derived_from_subject(self, isolated_storage_env):
+        service = _build_service(
+            message_responses={
+                ("msg-1", "metadata"): _metadata_response(
+                    "msg-1", headers=_headers(Subject="RE: Q3 / Report?")
+                ),
+                ("msg-1", "full"): _message_response(
+                    "msg-1",
+                    text="Body",
+                    headers=_headers(Subject="RE: Q3 / Report?"),
+                ),
+            }
+        )
+
+        await _unwrap(get_gmail_message_content)(
+            service=service,
+            message_id="msg-1",
+            user_google_email="user@example.com",
+            save_body_to_file=True,
+        )
+
+        files = _saved_files(isolated_storage_env)
+        assert len(files) == 1
+        # Windows-reserved characters sanitized, message ID included.
+        assert "/" not in files[0].name
+        assert "?" not in files[0].name
+        assert files[0].name.startswith("RE_ Q3 _ Report")
+        assert "msg-1" in files[0].name
+
+    @pytest.mark.asyncio
+    async def test_stdio_mode_returns_file_path(
+        self, isolated_storage_env, monkeypatch
+    ):
+        import core.config as core_config_module
+
+        monkeypatch.setattr(core_config_module, "get_transport_mode", lambda: "stdio")
+
+        service = _build_service(
+            message_responses={
+                ("msg-1", "metadata"): _metadata_response("msg-1"),
+                ("msg-1", "full"): _message_response("msg-1", text="Body"),
+            }
+        )
+
+        result = await _unwrap(get_gmail_message_content)(
+            service=service,
+            message_id="msg-1",
+            user_google_email="user@example.com",
+            save_body_to_file=True,
+        )
+
+        assert "Saved to:" in result
+        assert str(isolated_storage_env) in result
+        assert "Download URL" not in result
+
+    @pytest.mark.asyncio
+    async def test_default_keeps_body_inline(self, isolated_storage_env):
+        service = _build_service(
+            message_responses={
+                ("msg-1", "metadata"): _metadata_response("msg-1"),
+                ("msg-1", "full"): _message_response("msg-1", text="Inline body"),
+            }
+        )
+
+        result = await _unwrap(get_gmail_message_content)(
+            service=service,
+            message_id="msg-1",
+            user_google_email="user@example.com",
+        )
+
+        assert "--- BODY ---" in result
+        assert "Inline body" in result
+        assert _saved_files(isolated_storage_env) == []
+
+    @pytest.mark.asyncio
+    async def test_stateless_mode_falls_back_to_inline(
+        self, isolated_storage_env, monkeypatch
+    ):
+        import auth.oauth_config as oauth_config_module
+
+        monkeypatch.setattr(oauth_config_module, "is_stateless_mode", lambda: True)
+
+        service = _build_service(
+            message_responses={
+                ("msg-1", "metadata"): _metadata_response("msg-1"),
+                ("msg-1", "full"): _message_response("msg-1", text="Inline body"),
+            }
+        )
+
+        result = await _unwrap(get_gmail_message_content)(
+            service=service,
+            message_id="msg-1",
+            user_google_email="user@example.com",
+            save_body_to_file=True,
+        )
+
+        assert "Stateless mode" in result
+        assert "Inline body" in result
+        assert _saved_files(isolated_storage_env) == []
+
+    @pytest.mark.asyncio
+    async def test_save_failure_falls_back_to_inline(
+        self, isolated_storage_env, monkeypatch
+    ):
+        from core.attachment_storage import AttachmentStorage
+
+        def _boom(self, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(AttachmentStorage, "save_attachment", _boom)
+
+        service = _build_service(
+            message_responses={
+                ("msg-1", "metadata"): _metadata_response("msg-1"),
+                ("msg-1", "full"): _message_response("msg-1", text="Inline body"),
+            }
+        )
+
+        result = await _unwrap(get_gmail_message_content)(
+            service=service,
+            message_id="msg-1",
+            user_google_email="user@example.com",
+            save_body_to_file=True,
+        )
+
+        assert "Failed to save body to file" in result
+        assert "Inline body" in result
+        assert _saved_files(isolated_storage_env) == []
+
+
+class TestBatchMessages:
+    @pytest.mark.asyncio
+    async def test_one_file_per_message(self, isolated_storage_env):
+        service = _build_service(
+            message_responses={
+                ("msg-1", "full"): _message_response("msg-1", text="First body"),
+                ("msg-2", "full"): _message_response("msg-2", text="Second body"),
+            }
+        )
+
+        result = await _unwrap(get_gmail_messages_content_batch)(
+            service=service,
+            message_ids=["msg-1", "msg-2"],
+            user_google_email="user@example.com",
+            save_body_to_file=True,
+        )
+
+        assert result.count("--- BODY SAVED TO FILE ---") == 2
+        assert "First body" not in result
+        assert "Second body" not in result
+
+        files = _saved_files(isolated_storage_env)
+        assert len(files) == 2
+        contents = {f.read_text() for f in files}
+        assert contents == {"First body", "Second body"}
+
+    @pytest.mark.asyncio
+    async def test_raw_batch_saves_untruncated_eml(self, isolated_storage_env):
+        mime_bytes = b"Subject: Example subject\r\n\r\n" + b"y" * 30000
+        raw_b64 = base64.urlsafe_b64encode(mime_bytes).decode()
+        service = _build_service(
+            message_responses={
+                ("msg-1", "metadata"): _metadata_response("msg-1"),
+                ("msg-1", "raw"): {"id": "msg-1", "raw": raw_b64},
+            }
+        )
+
+        result = await _unwrap(get_gmail_messages_content_batch)(
+            service=service,
+            message_ids=["msg-1"],
+            user_google_email="user@example.com",
+            body_format="raw",
+            save_body_to_file=True,
+        )
+
+        assert "--- BODY SAVED TO FILE ---" in result
+
+        files = _saved_files(isolated_storage_env)
+        assert len(files) == 1
+        assert files[0].suffix == ".eml"
+        # Full MIME, beyond the inline raw truncation limit.
+        assert files[0].read_bytes() == mime_bytes
+
+    @pytest.mark.asyncio
+    async def test_metadata_format_with_save_rejected(self, isolated_storage_env):
+        service = _build_service()
+
+        with pytest.raises(UserInputError, match="save_body_to_file"):
+            await _unwrap(get_gmail_messages_content_batch)(
+                service=service,
+                message_ids=["msg-1"],
+                user_google_email="user@example.com",
+                format="metadata",
+                save_body_to_file=True,
+            )
+
+
+class TestThreads:
+    def _thread_service(self):
+        return _build_service(
+            thread_responses={
+                ("thread-1", "full"): _thread_response(
+                    "thread-1",
+                    [
+                        _message_response("msg-1", text="First message body"),
+                        _message_response(
+                            "msg-2",
+                            text="Second message body",
+                            headers=_headers(From="other@example.com"),
+                        ),
+                    ],
+                )
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_thread_saves_one_file_per_message(self, isolated_storage_env):
+        result = await _unwrap(get_gmail_thread_content)(
+            service=self._thread_service(),
+            thread_id="thread-1",
+            user_google_email="user@example.com",
+            save_body_to_file=True,
+        )
+
+        assert "Thread ID: thread-1" in result
+        assert result.count("--- BODY SAVED TO FILE ---") == 2
+        assert "First message body" not in result
+        assert "Second message body" not in result
+
+        files = _saved_files(isolated_storage_env)
+        assert len(files) == 2
+        contents = {f.read_text() for f in files}
+        assert contents == {"First message body", "Second message body"}
+        names = {f.name for f in files}
+        assert any("msg-1" in name for name in names)
+        assert any("msg-2" in name for name in names)
+
+    @pytest.mark.asyncio
+    async def test_thread_default_keeps_bodies_inline(self, isolated_storage_env):
+        result = await _unwrap(get_gmail_thread_content)(
+            service=self._thread_service(),
+            thread_id="thread-1",
+            user_google_email="user@example.com",
+        )
+
+        assert "First message body" in result
+        assert "Second message body" in result
+        assert _saved_files(isolated_storage_env) == []
+
+    @pytest.mark.asyncio
+    async def test_thread_include_analysis_still_returns_dict(
+        self, isolated_storage_env
+    ):
+        result = await _unwrap(get_gmail_thread_content)(
+            service=self._thread_service(),
+            thread_id="thread-1",
+            user_google_email="user@example.com",
+            save_body_to_file=True,
+            include_analysis=True,
+        )
+
+        assert isinstance(result, dict)
+        assert "analysis" in result
+        assert "--- BODY SAVED TO FILE ---" in result["content"]
+        assert len(_saved_files(isolated_storage_env)) == 2
+
+    @pytest.mark.asyncio
+    async def test_threads_batch_saves_files(self, isolated_storage_env):
+        service = _build_service(
+            thread_responses={
+                ("thread-1", "full"): _thread_response(
+                    "thread-1", [_message_response("msg-1", text="Body one")]
+                ),
+                ("thread-2", "full"): _thread_response(
+                    "thread-2", [_message_response("msg-2", text="Body two")]
+                ),
+            }
+        )
+
+        result = await _unwrap(get_gmail_threads_content_batch)(
+            service=service,
+            thread_ids=["thread-1", "thread-2"],
+            user_google_email="user@example.com",
+            save_body_to_file=True,
+        )
+
+        assert result.count("--- BODY SAVED TO FILE ---") == 2
+
+        files = _saved_files(isolated_storage_env)
+        assert len(files) == 2
+        contents = {f.read_text() for f in files}
+        assert contents == {"Body one", "Body two"}
+
+    @pytest.mark.asyncio
+    async def test_thread_raw_saves_eml_per_message(self, isolated_storage_env):
+        mime_bytes = b"Subject: Example subject\r\n\r\nThread raw body\r\n"
+        raw_b64 = base64.urlsafe_b64encode(mime_bytes).decode()
+        service = _build_service(
+            message_responses={
+                ("msg-1", "raw"): {"id": "msg-1", "raw": raw_b64},
+            },
+            thread_responses={
+                ("thread-1", "full"): _thread_response(
+                    "thread-1", [_message_response("msg-1", text="ignored")]
+                )
+            },
+        )
+
+        result = await _unwrap(get_gmail_thread_content)(
+            service=service,
+            thread_id="thread-1",
+            user_google_email="user@example.com",
+            body_format="raw",
+            save_body_to_file=True,
+        )
+
+        assert "--- BODY SAVED TO FILE ---" in result
+
+        files = _saved_files(isolated_storage_env)
+        assert len(files) == 1
+        assert files[0].suffix == ".eml"
+        assert files[0].read_bytes() == mime_bytes
+
+
+class TestSaveBodyFileHelper:
+    def test_unknown_empty_content_returns_warning(self, isolated_storage_env):
+        lines, saved = gmail_tools._save_body_file("", "msg-1", "Subject", "raw")
+        assert saved is False
+        assert any("No body content" in line for line in lines)

--- a/tests/gmail/test_save_body_to_file.py
+++ b/tests/gmail/test_save_body_to_file.py
@@ -249,6 +249,37 @@ class TestSingleMessage:
         assert files[0].read_bytes() == mime_bytes
 
     @pytest.mark.asyncio
+    async def test_raw_body_with_unpadded_base64url_saved(self, isolated_storage_env):
+        """Gmail's raw field is base64url without '=' padding; save must not fail."""
+        # Length not a multiple of 3 so the encoded form requires padding.
+        mime_bytes = b"Subject: Example subject\r\n\r\nUnpadded raw body\r\n.."
+        raw_b64_unpadded = base64.urlsafe_b64encode(mime_bytes).decode().rstrip("=")
+        assert len(raw_b64_unpadded) % 4 != 0, "fixture must actually be unpadded"
+
+        service = _build_service(
+            message_responses={
+                ("msg-1", "metadata"): _metadata_response("msg-1"),
+                ("msg-1", "raw"): {"id": "msg-1", "raw": raw_b64_unpadded},
+            }
+        )
+
+        result = await _unwrap(get_gmail_message_content)(
+            service=service,
+            message_id="msg-1",
+            user_google_email="user@example.com",
+            body_format="raw",
+            save_body_to_file=True,
+        )
+
+        assert "--- BODY SAVED TO FILE ---" in result
+        assert "Failed to save body to file" not in result
+
+        files = _saved_files(isolated_storage_env)
+        assert len(files) == 1
+        assert files[0].suffix == ".eml"
+        assert files[0].read_bytes() == mime_bytes
+
+    @pytest.mark.asyncio
     async def test_filename_derived_from_subject(self, isolated_storage_env):
         service = _build_service(
             message_responses={

--- a/uv.lock
+++ b/uv.lock
@@ -747,6 +747,15 @@ wheels = [
 ]
 
 [[package]]
+name = "html2text"
+version = "2025.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316, upload-time = "2025-04-15T04:02:30.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656, upload-time = "2025-04-15T04:02:28.44Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2234,6 +2243,7 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
+    { name = "html2text" },
     { name = "httpx" },
     { name = "markdown-it-py" },
     { name = "py-key-value-aio" },
@@ -2314,6 +2324,7 @@ requires-dist = [
     { name = "google-cloud-storage", marker = "extra == 'dev'", specifier = ">=2.18.0" },
     { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=2.18.0" },
     { name = "google-cloud-storage", marker = "extra == 'test'", specifier = ">=2.18.0" },
+    { name = "html2text", specifier = ">=2025.4.15" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "markdown-it-py", specifier = ">=3.0.0" },
     { name = "py-key-value-aio", specifier = ">=0.3.0" },


### PR DESCRIPTION
## Description
Two related improvements to the Gmail content tools:

1. **`save_body_to_file` option** for `get_gmail_message_content`, `get_gmail_messages_content_batch`, `get_gmail_thread_content`, and `get_gmail_threads_content_batch`. When enabled, the full untruncated body is written to a file via the managed attachment storage instead of being returned inline — `.txt`/`.html`/`.eml` depending on `body_format`. The response contains a local file path (stdio mode) or a temporary 1-hour download URL (HTTP mode). This keeps large emails from flooding the model's context while preserving access to the complete content. Falls back to inline output (with a warning) in stateless mode or if saving fails.

2. **Better HTML-to-text conversion and low-value plain-part detection.** HTML bodies are now converted with `html2text` (new dependency) instead of a minimal stdlib parser, producing readable Markdown-flavored text with preserved structure. The heuristic that detects useless `text/plain` parts (e.g. "view this email in your browser" stubs, footer-only content) now compares word-normalized tokens instead of raw strings, making it robust against punctuation, whitespace, and URL formatting differences between the MIME alternatives. Image-only HTML can no longer displace a real plain-text part.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
- New runtime dependency: `html2text>=2025.4.15` (added to `pyproject.toml` and `uv.lock`).
- `save_body_to_file` defaults to `False`, and inline output for text/html bodies is byte-for-byte unchanged, so existing callers are unaffected.
- New test suite `tests/gmail/test_save_body_to_file.py` covers the file-saving flow across all four tools, both transport modes, and the stateless/failure fallbacks; `tests/gmail/test_body_format.py` was extended for the word-based low-value detection.
- Full test suite: 1302 passed. `ruff check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `save_body_to_file` to Gmail content tools to persist full, untruncated message/thread bodies instead of returning inline truncated text.
  * Supports `body_format` for plaintext, HTML, and raw MIME, generating one file per message (including batch/thread variants).
  * When available, responses include file paths or temporary download links; otherwise, graceful fallback with warnings occurs (e.g., stateless mode).
* **Bug Fixes**
  * Improved decoding for Gmail base64url content that omits `=` padding, ensuring attachment saving works reliably.
* **Documentation**
  * Updated Gmail tool docs with `body_format` and `save_body_to_file` options, full-body/truncation rules, and stateless limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->