### PR TITLE
feat(calendar): opt-in reminders in get_events + defaultReminders in list_calendars

### DIFF
--- a/gcalendar/calendar_helpers.py
+++ b/gcalendar/calendar_helpers.py
@@ -100,6 +100,51 @@ def _format_attachment_details(
     return f"\n{indent}".join(attachment_details_list)
 
 
+def _format_reminder_overrides(overrides: List[Dict[str, Any]]) -> str:
+    """Format a list of reminder override objects (method + minutes) for display.
+
+    Each override looks like ``{"method": "popup", "minutes": 10}``. Returns a
+    comma-separated summary such as ``"popup 10 min before, email 1440 min before"``,
+    or ``"None"`` if there are no overrides.
+    """
+    if not overrides:
+        return "None"
+
+    parts = []
+    for override in overrides:
+        method = override.get("method", "unknown")
+        minutes = override.get("minutes")
+        if minutes is None:
+            parts.append(method)
+        else:
+            parts.append(f"{method} {minutes} min before")
+    return ", ".join(parts)
+
+
+def _format_reminders(reminders: Optional[Dict[str, Any]]) -> str:
+    """Format an event's ``reminders`` object (useDefault + overrides) for display.
+
+    The Google Calendar API returns reminders as
+    ``{"useDefault": true}`` or ``{"useDefault": false, "overrides": [...]}``.
+    When ``useDefault`` is true the calendar's default reminders apply and any
+    overrides are ignored; when it is false the overrides (if any) are the
+    event's reminders.
+
+    Returns a human-readable summary, or ``"None"`` if no reminders data is present.
+    """
+    if not reminders:
+        return "None"
+
+    use_default = reminders.get("useDefault", False)
+    overrides = reminders.get("overrides", [])
+
+    if use_default:
+        return "Using calendar default reminders"
+    if overrides:
+        return _format_reminder_overrides(overrides)
+    return "No reminders"
+
+
 def _format_person(person: Optional[Dict[str, Any]]) -> Optional[str]:
     """Format a Google Calendar person dict (creator or organizer) for display."""
     if not person:

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -22,6 +22,8 @@ from gcalendar.calendar_helpers import (
     _format_attachment_details,
     _format_attendee_details,
     _format_person,
+    _format_reminder_overrides,
+    _format_reminders,
     _get_meeting_link,
 )
 
@@ -329,17 +331,25 @@ def _strip_utc_offset(datetime_str: str) -> str:
 )
 @handle_http_errors("list_calendars", is_read_only=True, service_type="calendar")
 @require_google_service("calendar", "calendar_read")
-async def list_calendars(service, user_google_email: str) -> str:
+async def list_calendars(
+    service, user_google_email: str, include_reminders: bool = False
+) -> str:
     """
     Retrieves a list of calendars accessible to the authenticated user.
 
     Args:
         user_google_email (str): The user's Google email address. Required.
+        include_reminders (bool): Whether to include each calendar's default reminders
+            (the notification settings applied to events that use calendar defaults) in
+            the output. Defaults to False to keep the listing concise.
 
     Returns:
-        str: A formatted list of the user's calendars (summary, ID, primary status).
+        str: A formatted list of the user's calendars (summary, ID, primary status,
+            and default reminders when include_reminders=True).
     """
-    logger.info(f"[list_calendars] Invoked. Email: '{user_google_email}'")
+    logger.info(
+        f"[list_calendars] Invoked. Email: '{user_google_email}', include_reminders: {include_reminders}"
+    )
 
     calendar_list_response = await asyncio.to_thread(
         lambda: service.calendarList().list().execute()
@@ -348,10 +358,18 @@ async def list_calendars(service, user_google_email: str) -> str:
     if not items:
         return f"No calendars found for {user_google_email}."
 
-    calendars_summary_list = [
-        f'- "{cal.get("summary", "No Summary")}"{" (Primary)" if cal.get("primary") else ""} (ID: {cal["id"]})'
-        for cal in items
-    ]
+    calendars_summary_list = []
+    for cal in items:
+        primary_marker = " (Primary)" if cal.get("primary") else ""
+        line = (
+            f'- "{cal.get("summary", "No Summary")}"{primary_marker} (ID: {cal["id"]})'
+        )
+        if include_reminders:
+            default_reminders = _format_reminder_overrides(
+                cal.get("defaultReminders", [])
+            )
+            line += f"\n  Default Reminders: {default_reminders}"
+        calendars_summary_list.append(line)
     text_output = (
         f"Successfully listed {len(items)} calendars for {user_google_email}:\n"
         + "\n".join(calendars_summary_list)
@@ -382,6 +400,7 @@ async def get_events(
     query: Optional[str] = None,
     detailed: bool = False,
     include_attachments: bool = False,
+    include_reminders: bool = False,
 ) -> str:
     """
     Retrieves events from a specified Google Calendar. Can retrieve a single event by ID or multiple events within a time range.
@@ -397,12 +416,13 @@ async def get_events(
         query (Optional[str]): A keyword to search for within event fields (summary, description, location). Ignored if event_id is provided.
         detailed (bool): Whether to return detailed event information including description, location, attendees, and attendee details (response status, organizer, optional flags). Defaults to False.
         include_attachments (bool): Whether to include attachment information in detailed event output. When True, shows attachment details (fileId, fileUrl, mimeType, title) for events that have attachments. Only applies when detailed=True. Set this to True when you need to view or access files that have been attached to calendar events, such as meeting documents, presentations, or other shared files. Defaults to False.
+        include_reminders (bool): Whether to include each event's reminder/notification settings in detailed event output. When True, shows whether the event uses the calendar's default reminders or has custom overrides (method + minutes before). Only applies when detailed=True. Defaults to False.
 
     Returns:
         str: A formatted list of events (summary, start and end times, link) within the specified range, or detailed information for a single event if event_id is provided.
     """
     logger.info(
-        f"[get_events] Raw parameters - event_id: '{event_id}', time_min: '{time_min}', time_max: '{time_max}', query: '{query}', detailed: {detailed}, include_attachments: {include_attachments}"
+        f"[get_events] Raw parameters - event_id: '{event_id}', time_min: '{time_min}', time_max: '{time_max}', query: '{query}', detailed: {detailed}, include_attachments: {include_attachments}, include_reminders: {include_reminders}"
     )
 
     # Handle single event retrieval
@@ -513,6 +533,10 @@ async def get_events(
             )
             event_details += f"- Attachments: {attachment_details_str}\n"
 
+        if include_reminders:
+            reminders_str = _format_reminders(item.get("reminders"))
+            event_details += f"- Reminders: {reminders_str}\n"
+
         event_details += f"- Event ID: {event_id}\n- Link: {link}"
         logger.info(
             f"[get_events] Successfully retrieved detailed event {event_id} for {user_google_email}."
@@ -567,6 +591,10 @@ async def get_events(
                     attachments, indent="    "
                 )
                 event_detail_parts += f"  Attachments: {attachment_details_str}\n"
+
+            if include_reminders:
+                reminders_str = _format_reminders(item.get("reminders"))
+                event_detail_parts += f"  Reminders: {reminders_str}\n"
 
             event_detail_parts += f"  ID: {item_event_id} | Link: {link}"
             event_details_list.append(event_detail_parts)

--- a/tests/gcalendar/test_format_reminders.py
+++ b/tests/gcalendar/test_format_reminders.py
@@ -1,0 +1,85 @@
+"""Unit tests for the reminder-formatting helpers used by get_events and
+list_calendars detailed output."""
+
+from gcalendar.calendar_helpers import (
+    _format_reminder_overrides,
+    _format_reminders,
+)
+
+
+# ---------------------------------------------------------------------------
+# _format_reminder_overrides (used for event overrides and calendar defaults)
+# ---------------------------------------------------------------------------
+
+
+def test_format_reminder_overrides_single():
+    assert (
+        _format_reminder_overrides([{"method": "popup", "minutes": 10}])
+        == "popup 10 min before"
+    )
+
+
+def test_format_reminder_overrides_multiple():
+    assert (
+        _format_reminder_overrides(
+            [
+                {"method": "popup", "minutes": 10},
+                {"method": "email", "minutes": 1440},
+            ]
+        )
+        == "popup 10 min before, email 1440 min before"
+    )
+
+
+def test_format_reminder_overrides_empty_returns_none():
+    assert _format_reminder_overrides([]) == "None"
+
+
+def test_format_reminder_overrides_missing_minutes():
+    # Defensive: an override without minutes should still render its method.
+    assert _format_reminder_overrides([{"method": "popup"}]) == "popup"
+
+
+def test_format_reminder_overrides_missing_method():
+    assert _format_reminder_overrides([{"minutes": 30}]) == "unknown 30 min before"
+
+
+# ---------------------------------------------------------------------------
+# _format_reminders (an event's reminders object: useDefault + overrides)
+# ---------------------------------------------------------------------------
+
+
+def test_format_reminders_use_default():
+    assert _format_reminders({"useDefault": True}) == "Using calendar default reminders"
+
+
+def test_format_reminders_use_default_ignores_overrides():
+    # Per the Calendar API, overrides are ignored when useDefault is true.
+    assert (
+        _format_reminders(
+            {"useDefault": True, "overrides": [{"method": "popup", "minutes": 5}]}
+        )
+        == "Using calendar default reminders"
+    )
+
+
+def test_format_reminders_custom_overrides():
+    assert (
+        _format_reminders(
+            {"useDefault": False, "overrides": [{"method": "email", "minutes": 60}]}
+        )
+        == "email 60 min before"
+    )
+
+
+def test_format_reminders_no_default_no_overrides():
+    assert _format_reminders({"useDefault": False}) == "No reminders"
+
+
+def test_format_reminders_none_input():
+    # Absent reminders data (e.g. field not returned) renders as "None".
+    assert _format_reminders(None) == "None"
+
+
+def test_format_reminders_empty_dict():
+    assert _format_reminders({}) == "None"

--- a/tests/gcalendar/test_get_events_reminders.py
+++ b/tests/gcalendar/test_get_events_reminders.py
@@ -1,0 +1,173 @@
+"""Integration-level tests for the include_reminders opt-in on get_events and
+list_calendars. These exercise the real tool functions (unwrapped past their
+auth/error decorators) against a mock Calendar service to verify the reminder
+data is surfaced only when requested and placed in the output correctly.
+"""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gcalendar.calendar_tools import get_events, list_calendars
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+_EVENT_WITH_CUSTOM_REMINDERS = {
+    "id": "evt123",
+    "summary": "Standup",
+    "start": {"dateTime": "2026-04-06T09:00:00Z"},
+    "end": {"dateTime": "2026-04-06T09:15:00Z"},
+    "htmlLink": "https://calendar.google.com/event?eid=evt123",
+    "reminders": {
+        "useDefault": False,
+        "overrides": [{"method": "popup", "minutes": 10}],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# get_events — single event by ID
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_events_single_includes_reminders_when_requested():
+    service = Mock()
+    service.events().get().execute = Mock(return_value=_EVENT_WITH_CUSTOM_REMINDERS)
+
+    result = await _unwrap(get_events)(
+        service=service,
+        user_google_email="user@example.com",
+        event_id="evt123",
+        detailed=True,
+        include_reminders=True,
+    )
+
+    assert "Reminders: popup 10 min before" in result
+
+
+@pytest.mark.asyncio
+async def test_get_events_single_omits_reminders_by_default():
+    service = Mock()
+    service.events().get().execute = Mock(return_value=_EVENT_WITH_CUSTOM_REMINDERS)
+
+    result = await _unwrap(get_events)(
+        service=service,
+        user_google_email="user@example.com",
+        event_id="evt123",
+        detailed=True,
+    )
+
+    assert "Reminders:" not in result
+
+
+# ---------------------------------------------------------------------------
+# get_events — multiple events (list path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_events_list_includes_reminders_when_requested():
+    default_event = {
+        "id": "evt456",
+        "summary": "1:1",
+        "start": {"dateTime": "2026-04-07T09:00:00Z"},
+        "end": {"dateTime": "2026-04-07T09:30:00Z"},
+        "htmlLink": "https://calendar.google.com/event?eid=evt456",
+        "reminders": {"useDefault": True},
+    }
+    service = Mock()
+    service.events().list().execute = Mock(
+        return_value={"items": [_EVENT_WITH_CUSTOM_REMINDERS, default_event]}
+    )
+
+    result = await _unwrap(get_events)(
+        service=service,
+        user_google_email="user@example.com",
+        detailed=True,
+        include_reminders=True,
+    )
+
+    assert "Reminders: popup 10 min before" in result
+    assert "Reminders: Using calendar default reminders" in result
+
+
+@pytest.mark.asyncio
+async def test_get_events_list_omits_reminders_by_default():
+    service = Mock()
+    service.events().list().execute = Mock(
+        return_value={"items": [_EVENT_WITH_CUSTOM_REMINDERS]}
+    )
+
+    result = await _unwrap(get_events)(
+        service=service,
+        user_google_email="user@example.com",
+        detailed=True,
+    )
+
+    assert "Reminders:" not in result
+
+
+# ---------------------------------------------------------------------------
+# list_calendars — default reminders
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_calendars_includes_default_reminders_when_requested():
+    service = Mock()
+    service.calendarList().list().execute = Mock(
+        return_value={
+            "items": [
+                {
+                    "id": "primary",
+                    "summary": "Personal",
+                    "primary": True,
+                    "defaultReminders": [{"method": "popup", "minutes": 30}],
+                }
+            ]
+        }
+    )
+
+    result = await _unwrap(list_calendars)(
+        service=service,
+        user_google_email="user@example.com",
+        include_reminders=True,
+    )
+
+    assert "Default Reminders: popup 30 min before" in result
+
+
+@pytest.mark.asyncio
+async def test_list_calendars_omits_default_reminders_by_default():
+    service = Mock()
+    service.calendarList().list().execute = Mock(
+        return_value={
+            "items": [
+                {
+                    "id": "primary",
+                    "summary": "Personal",
+                    "primary": True,
+                    "defaultReminders": [{"method": "popup", "minutes": 30}],
+                }
+            ]
+        }
+    )
+
+    result = await _unwrap(list_calendars)(
+        service=service,
+        user_google_email="user@example.com",
+    )
+
+    assert "Default Reminders:" not in result


### PR DESCRIPTION
## Summary

The Google Calendar API already returns each event's `reminders` (`useDefault` + `overrides[]`) and each calendar's `defaultReminders`, but the tool output dropped both — even `get_events(detailed=true)` omitted an event's reminders, and `list_calendars` never surfaced a calendar's default notification settings.

This adds an **opt-in** `include_reminders` flag (default `False`) to both tools, so the context-trimming default is preserved while full notification detail is available on request. This mirrors the existing `include_attachments` pattern on `get_events`.

## Changes

- **`get_events(include_reminders=True)`** — surfaces each event's reminder settings in detailed output, on both the single-event and multi-event paths. Only applies when `detailed=True` (same gating as `include_attachments`).
- **`list_calendars(include_reminders=True)`** — surfaces each calendar's default reminders.
- New formatting helpers `_format_reminders` / `_format_reminder_overrides` in `calendar_helpers.py`.

## Behavior

Defaults are unchanged — no output differs unless a caller passes `include_reminders=True`.

Example detailed output with the flag on:
```
- Reminders: popup 10 min before, email 1440 min before
```
```
- Reminders: Using calendar default reminders
```

## Testing

- Unit tests for the `_format_reminders` / `_format_reminder_overrides` helpers (custom overrides, `useDefault`, no-reminders, and malformed-input cases).
- Integration-level tests that drive the real `get_events` / `list_calendars` functions (unwrapped past their auth/error decorators) against a mock service, confirming reminders are surfaced only when `include_reminders=True` and omitted by default.
- Verified end-to-end against the live Google Calendar API: confirmed `events.list` returns reminder `overrides` (not just `events.get`), and that `events.list`, `events.get`, and `calendarList.list` all render correctly for custom-override, `useDefault`, and no-reminder events.

## Notes

This is read-side only and complements the write-side reminder support from #149 (create/modify event reminders); there is no overlap.
