### PR TITLE
Honor SSL_CERT_FILE/REQUESTS_CA_BUNDLE for httplib2 CA trust (fixes corporate TLS-proxy CERTIFICATE_VERIFY_FAILED)

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -86,6 +86,49 @@ def get_default_credentials_dir():
 DEFAULT_CREDENTIALS_DIR = get_default_credentials_dir()
 
 
+def _bridge_ca_bundle_env() -> None:
+    """Make httplib2 honor the standard SSL_CERT_FILE / REQUESTS_CA_BUNDLE env vars.
+
+    Google API clients here are backed by ``httplib2`` (directly via
+    ``_build_authorized_http`` and internally when ``build(..., credentials=...)``
+    is used). ``httplib2`` resolves its trust store from its own
+    ``HTTPLIB2_CA_CERTS`` env var, falling back to ``certifi`` — it does NOT read
+    ``SSL_CERT_FILE`` / ``REQUESTS_CA_BUNDLE`` like ``requests``/``urllib`` do.
+
+    In environments with a TLS-inspecting proxy (Zscaler, Netskope, corporate
+    MITM), the proxy presents a certificate signed by a private root that is not
+    in ``certifi``. Users conventionally point ``SSL_CERT_FILE`` /
+    ``REQUESTS_CA_BUNDLE`` at a bundle that includes that root — but httplib2
+    ignores them, so every Google API call fails with
+    ``CERTIFICATE_VERIFY_FAILED``.
+
+    This bridges those standard vars to ``HTTPLIB2_CA_CERTS`` when the latter is
+    not already set, so a single, conventional configuration works. Explicit
+    ``HTTPLIB2_CA_CERTS`` always wins; non-existent paths are ignored.
+    """
+    if os.environ.get("HTTPLIB2_CA_CERTS"):
+        return
+    for var in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"):
+        path = os.environ.get(var)
+        if path and os.path.isfile(path):
+            os.environ["HTTPLIB2_CA_CERTS"] = path
+            logger.info(
+                "Bridging %s -> HTTPLIB2_CA_CERTS=%s so httplib2 trusts the "
+                "configured CA bundle.",
+                var,
+                path,
+            )
+            return
+
+
+# Apply as early as possible so httplib2 freezes the right CA path. httplib2
+# caches ``CA_CERTS = certs.where()`` at import time, so the bridge is also
+# invoked from main.py before Google/httplib2 imports; calling it here as well
+# is a harmless, idempotent safety net for entry points that import this module
+# directly.
+_bridge_ca_bundle_env()
+
+
 def _build_authorized_http(
     credentials: Credentials, timeout: int = 30
 ) -> google_auth_httplib2.AuthorizedHttp:

--- a/main.py
+++ b/main.py
@@ -18,6 +18,34 @@ if sys.platform == "darwin":
     sys.stdout = io.StringIO()
 
 
+def _bridge_ca_bundle_env():
+    """Make httplib2 honor the standard SSL_CERT_FILE / REQUESTS_CA_BUNDLE vars.
+
+    httplib2 (which backs every Google API client here) reads its trust store
+    from its own ``HTTPLIB2_CA_CERTS`` env var, falling back to ``certifi`` — it
+    does NOT consult ``SSL_CERT_FILE`` / ``REQUESTS_CA_BUNDLE`` the way
+    ``requests``/``urllib`` do, and it freezes the value at import time. Behind a
+    TLS-inspecting proxy (Zscaler/Netskope/corporate MITM) whose root is not in
+    ``certifi``, this makes every call fail ``CERTIFICATE_VERIFY_FAILED`` even
+    when the user has set the conventional vars.
+
+    Bridge them to ``HTTPLIB2_CA_CERTS`` (when not already set) BEFORE httplib2 is
+    imported, so a single conventional configuration works. Explicit
+    ``HTTPLIB2_CA_CERTS`` always wins; non-existent paths are ignored. Idempotent.
+    """
+    if os.environ.get("HTTPLIB2_CA_CERTS"):
+        return
+    for var in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"):
+        path = os.environ.get(var)
+        if path and os.path.isfile(path):
+            os.environ["HTTPLIB2_CA_CERTS"] = path
+            return
+
+
+# Bridge process-supplied CA env vars before any Google/httplib2 import below.
+_bridge_ca_bundle_env()
+
+
 def _load_startup_dependencies():
     from auth.credential_store import get_credential_store, get_selected_backend
     from auth.oauth_config import (
@@ -83,6 +111,10 @@ def _load_startup_dependencies():
 
 dotenv_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
 load_dotenv(dotenv_path=dotenv_path)
+
+# Re-bridge in case the CA bundle path was supplied via the .env file rather
+# than the process environment.
+_bridge_ca_bundle_env()
 
 # Suppress googleapiclient discovery cache warning
 logging.getLogger("googleapiclient.discovery_cache").setLevel(logging.ERROR)


### PR DESCRIPTION
## Problem

Google API clients in this project are backed by **httplib2** (directly via `auth/google_auth.py::_build_authorized_http`, and internally when `googleapiclient.discovery.build(..., credentials=...)` is used in `auth/service_decorator.py`).

httplib2 resolves its trust store from its **own** `HTTPLIB2_CA_CERTS` env var, falling back to `certifi` — and it freezes that value into `httplib2.CA_CERTS` at import time. It does **not** consult `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` the way `requests`/`urllib`-based clients do.

Behind a TLS-inspecting proxy (Zscaler, Netskope, or any corporate MITM), the proxy presents a certificate signed by a private root that isn't in `certifi`. The conventional user fix is to point `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` at a bundle that includes that root — but httplib2 ignores those, so **every** Google API call fails:

```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
    certificate verify failed: unable to get local issuer certificate
```

The `@handle_http_errors` retry decorator then re-raises this as a generic `TransientNetworkError` ("A transient SSL error occurred ... please try again shortly"), which is misleading — it is neither transient nor network-related, and no amount of retrying helps.

## Fix

Add a tiny, dependency-free bridge that, **before any httplib2 import**, copies `SSL_CERT_FILE` (then `REQUESTS_CA_BUNDLE`) into `HTTPLIB2_CA_CERTS` when the latter isn't already set. This lets the single, conventional CA configuration that users already set for `requests`-based tooling work for httplib2 too.

- Runs at the very top of `main.py` (before the Google/httplib2 imports pulled in by `_load_startup_dependencies()`), and again right after `load_dotenv()` so a bundle path supplied via `.env` is also honored.
- A harmless, idempotent safety-net call is also added in `auth/google_auth.py` for entry points that import that module directly.
- **Explicit `HTTPLIB2_CA_CERTS` always wins.** Non-existent paths are ignored. No behavior change for users who don't set any of these vars (falls back to certifi exactly as before).

Ordering matters because `httplib2` caches `CA_CERTS = certs.where()` at import time — the bridge must run first, which is why it lives at the top of `main.py`.

## Testing

With a pristine `certifi` (no corporate root) and only `SSL_CERT_FILE` pointing at a bundle that includes the proxy root:

- **Before:** `httplib2.Http().request("https://www.googleapis.com/...")` → `CERTIFICATE_VERIFY_FAILED`.
- **After:** bridge sets `HTTPLIB2_CA_CERTS`, `httplib2.CA_CERTS` freezes to the correct bundle, and the request returns `200`.

Verified end-to-end replicating `main.py`'s boot/import order against a real `googleapis.com` endpoint through a Zscaler-inspected connection.

## Notes

No new dependencies. No changes to auth/credential handling or scopes. Purely additive env bridging at startup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure Google service connections by honoring standard certificate bundle environment settings.
  * Added support for certificate settings loaded from environment configuration files.
  * Prevented existing certificate configuration from being overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->