### PR TITLE
feat(gmail): update an existing draft in place via draft_id on draft_gmail_message

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2433,10 +2433,18 @@ async def draft_gmail_message(
             description="Whether to include the original message as a quoted reply. Requires thread_id. Defaults to false.",
         ),
     ] = False,
+    draft_id: Annotated[
+        Optional[str],
+        Field(
+            description="Optional ID of an existing draft to update in place (drafts().update) instead of creating a new draft. The draft's message is fully replaced, so re-supply every field (subject, body, recipients, threading) as it should appear after the update. The draft ID remains stable across updates.",
+        ),
+    ] = None,
 ) -> str:
     """
     Creates a draft email in the user's Gmail account. Supports both new drafts and reply drafts with optional attachments.
     Supports Gmail's "Send As" feature to draft from configured alias addresses.
+    When draft_id is provided, updates that existing draft in place (full message replacement)
+    instead of creating a new one, so revising a draft does not leave stale duplicates behind.
 
     Args:
         user_google_email (str): The user's Google email address. Required for authentication.
@@ -2470,9 +2478,13 @@ async def draft_gmail_message(
         quote_original (bool): Whether to include the original message as a quoted reply.
             Requires thread_id to be provided. When enabled, fetches the original message
             and appends it below the signature. Defaults to False.
+        draft_id (Optional[str]): Optional ID of an existing draft to update in place
+            (drafts().update) instead of creating a new draft. Gmail replaces the draft's
+            message wholesale, so all fields must be re-supplied; the draft ID itself
+            remains stable across updates.
 
     Returns:
-        str: Confirmation message with the created draft's ID.
+        str: Confirmation message with the created (or updated) draft's ID.
 
     Examples:
         # Create a new draft
@@ -2524,6 +2536,14 @@ async def draft_gmail_message(
             thread_id="thread_123",
             in_reply_to="<message123@gmail.com>",
             references="<original@gmail.com> <message123@gmail.com>"
+        )
+
+        # Revise an existing draft in place (no duplicate drafts)
+        draft_gmail_message(
+            subject="Re: Meeting tomorrow",
+            body="Updated: see you at 10am instead.",
+            to="user@example.com",
+            draft_id="r1234567890"
         )
     """
     logger.info(
@@ -2614,16 +2634,31 @@ async def draft_gmail_message(
     if thread_id and in_reply_to and references:
         draft_body["message"]["threadId"] = thread_id
 
+    attachment_info = _format_attachment_result(
+        attached_count, requested_attachment_count
+    )
+
+    if draft_id:
+        # Update the existing draft in place. Gmail replaces the contained
+        # message wholesale (it cannot be edited field-by-field), while the
+        # draft ID remains stable across updates.
+        updated_draft = await asyncio.to_thread(
+            service.users()
+            .drafts()
+            .update(userId="me", id=draft_id, body=draft_body)
+            .execute,
+            num_retries=GOOGLE_API_WRITE_RETRIES,
+        )
+        updated_id = updated_draft.get("id", draft_id)
+        return f"Draft updated{attachment_info}! Draft ID: {updated_id}"
+
     # Create the draft
     created_draft = await asyncio.to_thread(
         service.users().drafts().create(userId="me", body=draft_body).execute,
         num_retries=GOOGLE_API_WRITE_RETRIES,
     )
-    draft_id = created_draft.get("id")
-    attachment_info = _format_attachment_result(
-        attached_count, requested_attachment_count
-    )
-    return f"Draft created{attachment_info}! Draft ID: {draft_id}"
+    created_id = created_draft.get("id")
+    return f"Draft created{attachment_info}! Draft ID: {created_id}"
 
 
 def _format_thread_content(

--- a/tests/gmail/test_draft_gmail_message.py
+++ b/tests/gmail/test_draft_gmail_message.py
@@ -690,6 +690,68 @@ async def test_draft_gmail_message_gracefully_degrades_when_thread_has_no_messag
     assert "threadId" not in create_kwargs["body"]["message"]
 
 
+@pytest.mark.asyncio
+async def test_draft_gmail_message_updates_existing_draft_when_draft_id_provided():
+    mock_service = Mock()
+    mock_service.users().drafts().update().execute.return_value = {"id": "draft123"}
+
+    result = await _unwrap(draft_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        to="recipient@example.com",
+        subject="Updated subject",
+        body="Updated body.",
+        draft_id="draft123",
+        include_signature=False,
+    )
+
+    assert "Draft updated! Draft ID: draft123" in result
+
+    update_kwargs = (
+        mock_service.users.return_value.drafts.return_value.update.call_args.kwargs
+    )
+    assert update_kwargs["userId"] == "me"
+    assert update_kwargs["id"] == "draft123"
+    raw_text = base64.urlsafe_b64decode(update_kwargs["body"]["message"]["raw"]).decode(
+        "utf-8", errors="ignore"
+    )
+    assert "Updated body." in raw_text
+    assert mock_service.users.return_value.drafts.return_value.create.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_draft_gmail_message_update_preserves_thread_context():
+    mock_service = Mock()
+    mock_service.users().drafts().update().execute.return_value = {"id": "draft_reply"}
+    mock_service.users().threads().get().execute.return_value = _thread_response(
+        "<msg1@example.com>",
+        "<msg2@example.com>",
+    )
+
+    result = await _unwrap(draft_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        to="recipient@example.com",
+        subject="Meeting tomorrow",
+        body="Revised reply.",
+        thread_id="thread123",
+        draft_id="draft_reply",
+        include_signature=False,
+    )
+
+    assert "Draft updated! Draft ID: draft_reply" in result
+
+    update_kwargs = (
+        mock_service.users.return_value.drafts.return_value.update.call_args.kwargs
+    )
+    assert update_kwargs["body"]["message"]["threadId"] == "thread123"
+    raw_text = base64.urlsafe_b64decode(update_kwargs["body"]["message"]["raw"]).decode(
+        "utf-8", errors="ignore"
+    )
+    assert "In-Reply-To: <msg2@example.com>" in raw_text
+    assert "References: <msg1@example.com> <msg2@example.com>" in raw_text
+
+
 # ---------------------------------------------------------------------------
 # URL-based attachment tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an optional `draft_id` parameter to the existing `draft_gmail_message` tool. When provided, the tool calls `drafts().update` instead of `drafts().create`: the draft's message is replaced wholesale while the draft ID stays stable, so revising a draft no longer leaves a stale duplicate behind for manual cleanup.

**No new tool is added** — this follows the maintainer's request in #812 to build draft management into existing tools rather than adding purpose-built ones (OpenAI payload max limit). It covers the "update" piece of #912; listing/deletion (#699, #781, #812) and send/forward (#943) are intentionally left to their own PRs.

## Behavior

- `draft_id` omitted → exact current behavior (create). Zero change for existing callers.
- `draft_id` provided → full-replacement update via `drafts().update`. All existing machinery flows through the same code path unchanged: reply-context derivation, `In-Reply-To`/`References` headers and `threadId` (a threaded reply draft stays in its conversation after the update), signatures, `quote_original`, attachments (path/base64/URL), and Send-As.
- The return string distinguishes `Draft updated` from `Draft created`.

## Why full replacement

The Gmail API cannot edit a draft's message field-by-field: `users.drafts.update` replaces the contained message, with the draft ID remaining stable while the underlying message ID rotates (this matches the behavior measured in the #920 discussion — `draft_id` is the stable handle). The parameter description and docstring spell this out so agents know to re-supply every field.

## Motivation

Real-world use case (same as #912): an agent prepares and revises reply drafts, a human stays responsible for sending. With create-only, every revision produces a second draft and the stale one has to be deleted by hand in the Gmail UI.

## Tests

- 2 new tests in `tests/gmail/test_draft_gmail_message.py`: update path (asserts `update(userId, id, body)` kwargs, raw message content, and that `create` is never called) and threaded update (asserts `threadId` + derived reply headers survive the update path).
- Full gmail suite: 145 passed. `ruff check` and `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating an existing Gmail draft in place using its draft ID.
  * Existing drafts can retain thread context, including reply headers and conversation association.
  * Updated status messages and usage documentation to distinguish between created and updated drafts.

* **Tests**
  * Added coverage for draft updates and preservation of thread context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->