### PR TITLE
feat(sheets): add update_cell_note tool to set/clear cell notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,6 +884,7 @@ Saved files expire after 1 hour and are cleaned up automatically.
 | <sub>`list_spreadsheets`</sub> | <sub>Extended</sub> | <sub>List accessible spreadsheets</sub> |
 | <sub>`get_spreadsheet_info`</sub> | <sub>Extended</sub> | <sub>Get spreadsheet metadata</sub> |
 | <sub>`format_sheet_range`</sub> | <sub>Extended</sub> | <sub>Apply colors, number formats, text wrapping, alignment, bold/italic, font size</sub> |
+| <sub>`update_cell_note`</sub> | <sub>Extended</sub> | <sub>Set or clear cell notes (hover annotations) without touching cell values</sub> |
 | <sub>`list_sheet_tables`</sub> | <sub>Extended</sub> | <sub>List structured tables with IDs, names, ranges, and columns</sub> |
 | <sub>`create_sheet`</sub> | <sub>Complete</sub> | <sub>Add sheets to existing files</sub> |
 | <sub>`move_sheet_rows`</sub> | <sub>Complete</sub> | <sub>Move rows between sheets within a spreadsheet</sub> |

--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -87,6 +87,7 @@ sheets:
     - get_spreadsheet_info
     - format_sheet_range
     - list_sheet_tables
+    - update_cell_note
   complete:
     - create_sheet
     - append_table_rows

--- a/gsheets/__init__.py
+++ b/gsheets/__init__.py
@@ -14,6 +14,7 @@ from .sheets_tools import (
     list_sheet_tables,
     append_table_rows,
     move_sheet_rows,
+    update_cell_note,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "list_sheet_tables",
     "append_table_rows",
     "move_sheet_rows",
+    "update_cell_note",
 ]

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -774,6 +774,140 @@ async def format_sheet_range(
     )
 
 
+# Internal implementation function for testing
+async def _update_cell_note_impl(
+    service,
+    spreadsheet_id: str,
+    range_name: str,
+    note: Optional[str] = None,
+    clear_note: bool = False,
+) -> dict:
+    """Internal implementation for update_cell_note.
+
+    Sets (or clears) the note attached to every cell in a range using a single
+    repeatCell batchUpdate with fields="note". Notes are the hover annotations
+    that live alongside a cell (Insert > Note); they are stored separately from
+    the cell's value and formatting, so this never overwrites cell contents.
+
+    Args:
+        service: Google Sheets API service client.
+        spreadsheet_id: The ID of the spreadsheet.
+        range_name: A1-style range (optionally with sheet name).
+        note: Note text to apply to every cell in the range.
+        clear_note: If True, removes the note from every cell in the range.
+
+    Returns:
+        Dictionary with keys: range_name, spreadsheet_id, summary.
+    """
+    if clear_note:
+        note_value = ""
+    else:
+        if not note:
+            raise UserInputError(
+                "Provide 'note' text to set, or pass clear_note=True to remove the note."
+            )
+        note_value = note
+
+    # Resolve the A1 range to a GridRange
+    metadata = await asyncio.to_thread(
+        service.spreadsheets()
+        .get(
+            spreadsheetId=spreadsheet_id,
+            fields="sheets(properties(sheetId,title))",
+        )
+        .execute
+    )
+    sheets = metadata.get("sheets", [])
+    grid_range = _parse_a1_range(range_name, sheets)
+
+    request_body = {
+        "requests": [
+            {
+                "repeatCell": {
+                    "range": grid_range,
+                    "cell": {"note": note_value},
+                    "fields": "note",
+                }
+            }
+        ]
+    }
+
+    await asyncio.to_thread(
+        service.spreadsheets()
+        .batchUpdate(spreadsheetId=spreadsheet_id, body=request_body)
+        .execute
+    )
+
+    summary = "cleared note" if clear_note else f"set note ({len(note_value)} chars)"
+
+    # Return structured data for the wrapper to format
+    return {
+        "range_name": range_name,
+        "spreadsheet_id": spreadsheet_id,
+        "summary": summary,
+    }
+
+
+@server.tool(
+    title="Update Cell Note",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("update_cell_note", service_type="sheets")
+@require_google_service("sheets", "sheets_write")
+async def update_cell_note(
+    service,
+    user_google_email: str,
+    spreadsheet_id: str,
+    range_name: str,
+    note: Optional[str] = None,
+    clear_note: bool = False,
+) -> str:
+    """
+    Sets or clears the note attached to cells in a range.
+
+    A note is the small annotation shown on hover (Insert > Note); it is stored
+    separately from the cell's value and formatting, so this never overwrites
+    cell contents. The same note is applied to every cell in the range. To set
+    distinct notes on different cells, call this once per cell (e.g. "Plan!B3").
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        spreadsheet_id (str): The ID of the spreadsheet. Required.
+        range_name (str): A1-style range (optionally with sheet name), e.g.
+            "Plan!M3". If no sheet name is provided, the first sheet is used.
+        note (Optional[str]): Note text to apply. Required unless clear_note=True.
+        clear_note (bool): If True, removes the note from every cell in the range.
+
+    Returns:
+        str: Confirmation of the note update.
+    """
+    logger.info(
+        "[update_cell_note] Invoked. Email: '%s', Spreadsheet: %s, Range: %s, Clear: %s",
+        user_google_email,
+        spreadsheet_id,
+        range_name,
+        clear_note,
+    )
+
+    result = await _update_cell_note_impl(
+        service=service,
+        spreadsheet_id=spreadsheet_id,
+        range_name=range_name,
+        note=note,
+        clear_note=clear_note,
+    )
+
+    return (
+        f"Updated note on range '{result['range_name']}' in spreadsheet "
+        f"{result['spreadsheet_id']} for {user_google_email}: {result['summary']}."
+    )
+
+
 @server.tool(
     title="Manage Conditional Formatting",
     annotations=ToolAnnotations(

--- a/tests/gsheets/test_update_cell_note.py
+++ b/tests/gsheets/test_update_cell_note.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for the Google Sheets update_cell_note tool.
+
+Covers setting a note, clearing a note, and input validation. The note is
+applied via a single repeatCell batchUpdate with fields="note", so it never
+touches the cell's value.
+"""
+
+import pytest
+from unittest.mock import Mock
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gsheets.sheets_tools import _update_cell_note_impl
+from core.utils import UserInputError
+
+
+def create_mock_service():
+    """Create a properly configured mock Google Sheets service."""
+    mock_service = Mock()
+
+    mock_metadata = {"sheets": [{"properties": {"sheetId": 0, "title": "Sheet1"}}]}
+    mock_service.spreadsheets().get().execute = Mock(return_value=mock_metadata)
+    mock_service.spreadsheets().batchUpdate().execute = Mock(return_value={})
+
+    return mock_service
+
+
+@pytest.mark.asyncio
+async def test_set_note_builds_repeat_cell_request():
+    """Setting a note issues a repeatCell request with the note and fields=note."""
+    mock_service = create_mock_service()
+
+    result = await _update_cell_note_impl(
+        service=mock_service,
+        spreadsheet_id="test_spreadsheet_123",
+        range_name="Sheet1!B3",
+        note="see PR #2470",
+    )
+
+    assert result["spreadsheet_id"] == "test_spreadsheet_123"
+    assert result["range_name"] == "Sheet1!B3"
+
+    call_args = mock_service.spreadsheets().batchUpdate.call_args
+    request = call_args[1]["body"]["requests"][0]["repeatCell"]
+    assert request["cell"]["note"] == "see PR #2470"
+    assert request["fields"] == "note"
+
+
+@pytest.mark.asyncio
+async def test_clear_note_sets_empty_note():
+    """clear_note=True writes an empty note so the annotation is removed."""
+    mock_service = create_mock_service()
+
+    result = await _update_cell_note_impl(
+        service=mock_service,
+        spreadsheet_id="test_spreadsheet_123",
+        range_name="A1",
+        clear_note=True,
+    )
+
+    assert result["summary"] == "cleared note"
+    call_args = mock_service.spreadsheets().batchUpdate.call_args
+    request = call_args[1]["body"]["requests"][0]["repeatCell"]
+    assert request["cell"]["note"] == ""
+    assert request["fields"] == "note"
+
+
+@pytest.mark.asyncio
+async def test_missing_note_raises():
+    """Neither a note nor clear_note is a user input error, no API call made."""
+    mock_service = create_mock_service()
+
+    with pytest.raises(UserInputError):
+        await _update_cell_note_impl(
+            service=mock_service,
+            spreadsheet_id="test_spreadsheet_123",
+            range_name="A1",
+        )
+
+    mock_service.spreadsheets().batchUpdate().execute.assert_not_called()


### PR DESCRIPTION
## Description
Adds a Google Sheets tool, `update_cell_note`, that sets or clears a cell **note** — the hover annotation from *Insert → Note* — without touching the cell's value or formatting. Notes are written via a single `repeatCell` `batchUpdate` with `fields="note"`. The same note is applied to every cell in the range; call once per cell (e.g. `Plan!B3`) for distinct notes. `clear_note=true` removes the note.

Motivation: there was no way to annotate cells programmatically — `modify_sheet_values` overwrites the value, and Drive comments can't be anchored to a specific cell via the API. Notes fill that gap (e.g. attaching a reference link or review remark to a cell).

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] I have added tests that prove my feature works (set / clear / input validation)
- [x] New and existing unit tests pass locally with my changes (`pytest tests/gsheets` — 24 passed)
- [x] I have tested this change manually (the tool registers on the MCP server; the `repeatCell` request body is verified)

## Checklist
- [x] My code follows the style guidelines of this project (mirrors `format_sheet_range`: thin `@server.tool` wrapper + tested `_impl`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Registered in the `sheets` Extended tier, exported from `gsheets`, documented in the README

## Additional Notes
Scope used is `sheets_write`, same as the other write tools. Implementation intentionally mirrors `format_sheet_range` for consistency.
