### PR TITLE
fix: streamable-http port probe SO_REUSEADDR + ERROR bind logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import io
 import argparse
+import errno
 import json
 import logging
 import os
@@ -226,11 +227,23 @@ def report_preflight_bind_failure(port: int, error: OSError) -> None:
 
     safe_print alone routes to DEBUG in non-TTY / container environments, so
     operators would otherwise see only a silent exit-1 crash-loop.
+
+    Only label the failure as port contention for errno.EADDRINUSE; other
+    OSError values (permission, address family, unavailable address) keep a
+    generic bind-failure message that includes the original error.
     """
     logger.error("Socket error during pre-flight bind: %s", error)
-    logger.error("Port %s is already in use. Cannot start HTTP server.", port)
     safe_print(f"Socket error: {error}")
-    safe_print(f"❌ Port {port} is already in use. Cannot start HTTP server.")
+    if error.errno == errno.EADDRINUSE:
+        logger.error("Port %s is already in use. Cannot start HTTP server.", port)
+        safe_print(f"❌ Port {port} is already in use. Cannot start HTTP server.")
+    else:
+        logger.error(
+            "Failed to bind HTTP server on port %s: %s",
+            port,
+            error,
+        )
+        safe_print(f"❌ Failed to bind HTTP server on port {port}: {error}")
 
 
 def configure_safe_logging():
@@ -908,11 +921,18 @@ def main():
                     try:
                         # Same SO_REUSEADDR probe as streamable-http above.
                         probe_tcp_bind(http_host, http_port)
-                    except OSError:
-                        logger.warning(
-                            "Port %d in use, workspace-cli HTTP endpoint unavailable",
-                            http_port,
-                        )
+                    except OSError as e:
+                        if e.errno == errno.EADDRINUSE:
+                            logger.warning(
+                                "Port %d in use, workspace-cli HTTP endpoint unavailable",
+                                http_port,
+                            )
+                        else:
+                            logger.warning(
+                                "Failed to bind workspace-cli HTTP endpoint on port %d: %s",
+                                http_port,
+                                e,
+                            )
                         http_available = False
 
                     http_srv = None

--- a/main.py
+++ b/main.py
@@ -208,6 +208,31 @@ def safe_print(text):
         print(text.encode("ascii", errors="replace").decode(), file=sys.stderr)
 
 
+def probe_tcp_bind(host: str, port: int) -> None:
+    """Pre-flight TCP bind probe matching uvicorn/asyncio reuse_address behavior.
+
+    Sets SO_REUSEADDR so a lingering TIME_WAIT socket in a shared network
+    namespace (common on fast in-place container restarts) does not produce a
+    false EADDRINUSE before the real uvicorn bind runs. Raises OSError if the
+    address cannot be bound.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind((host, port))
+
+
+def report_preflight_bind_failure(port: int, error: OSError) -> None:
+    """Log a failed pre-flight bind at ERROR (visible when stderr is not a TTY).
+
+    safe_print alone routes to DEBUG in non-TTY / container environments, so
+    operators would otherwise see only a silent exit-1 crash-loop.
+    """
+    logger.error("Socket error during pre-flight bind: %s", error)
+    logger.error("Port %s is already in use. Cannot start HTTP server.", port)
+    safe_print(f"Socket error: {error}")
+    safe_print(f"❌ Port {port} is already in use. Cannot start HTTP server.")
+
+
 def configure_safe_logging():
     """Replace console handlers with ASCII-safe formatters for Windows compatibility."""
 
@@ -848,15 +873,16 @@ def main():
             )
 
         if args.transport == "streamable-http":
-            # Check port availability before starting HTTP server
+            # Check port availability before starting HTTP server.
+            # SO_REUSEADDR matches asyncio/uvicorn so a quick restart is not
+            # blocked by lingering TIME_WAIT sockets. On failure log at ERROR:
+            # safe_print alone is DEBUG-only when stderr is not a TTY, and
+            # SystemExit from sys.exit is not caught by except Exception below,
+            # which previously produced a silent crash-loop in containers.
             try:
-                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                    s.bind((host, port))
+                probe_tcp_bind(host, port)
             except OSError as e:
-                safe_print(f"Socket error: {e}")
-                safe_print(
-                    f"❌ Port {port} is already in use. Cannot start HTTP server."
-                )
+                report_preflight_bind_failure(port, e)
                 sys.exit(1)
 
             server.run(
@@ -880,8 +906,8 @@ def main():
                     """Run stdio and HTTP transports concurrently."""
                     http_available = True
                     try:
-                        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                            s.bind((http_host, http_port))
+                        # Same SO_REUSEADDR probe as streamable-http above.
+                        probe_tcp_bind(http_host, http_port)
                     except OSError:
                         logger.warning(
                             "Port %d in use, workspace-cli HTTP endpoint unavailable",

--- a/tests/test_main_port_probe.py
+++ b/tests/test_main_port_probe.py
@@ -1,0 +1,116 @@
+"""Tests for streamable-http / dual-transport TCP bind pre-flight probes."""
+
+import logging
+import os
+import socket
+import sys
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+os.environ.setdefault("MCP_ENABLE_OAUTH21", "false")
+os.environ.setdefault("WORKSPACE_MCP_STATELESS_MODE", "false")
+
+import main
+
+
+@contextmanager
+def _hold_listening_port(host: str = "127.0.0.1"):
+    """Hold an exclusive listening socket so a SO_REUSEADDR probe still fails."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+        # Windows: prevent SO_REUSEADDR peers from sharing the bind.
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+    else:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
+    s.bind((host, 0))
+    s.listen(1)
+    port = s.getsockname()[1]
+    try:
+        yield host, port
+    finally:
+        s.close()
+
+
+def _free_port(host: str = "127.0.0.1") -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, 0))
+        return s.getsockname()[1]
+
+
+def test_probe_tcp_bind_succeeds_on_free_port():
+    host = "127.0.0.1"
+    port = _free_port(host)
+    main.probe_tcp_bind(host, port)
+
+
+def test_probe_tcp_bind_sets_so_reuseaddr():
+    """Probe must enable SO_REUSEADDR to match uvicorn/asyncio bind semantics."""
+    recorded: list[tuple[int, int, int]] = []
+    real_socket = socket.socket
+
+    class TrackingSocket:
+        def __init__(self, *args, **kwargs):
+            self._sock = real_socket(*args, **kwargs)
+
+        def setsockopt(self, level, optname, value, *args, **kwargs):
+            recorded.append((level, optname, value))
+            return self._sock.setsockopt(level, optname, value, *args, **kwargs)
+
+        def bind(self, address):
+            return self._sock.bind(address)
+
+        def close(self):
+            return self._sock.close()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self.close()
+            return False
+
+    host = "127.0.0.1"
+    port = _free_port(host)
+    with patch("main.socket.socket", TrackingSocket):
+        main.probe_tcp_bind(host, port)
+
+    assert (socket.SOL_SOCKET, socket.SO_REUSEADDR, 1) in recorded
+
+
+def test_probe_tcp_bind_raises_when_port_held():
+    with _hold_listening_port() as (host, port):
+        with pytest.raises(OSError):
+            main.probe_tcp_bind(host, port)
+
+
+def test_report_preflight_bind_failure_logs_at_error(caplog):
+    """Bind failure must be visible at ERROR when stderr is non-TTY (containers)."""
+    error = OSError(98, "Address already in use")
+    with caplog.at_level(logging.DEBUG, logger="main"):
+        main.report_preflight_bind_failure(8123, error)
+
+    error_messages = [
+        r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR
+    ]
+    assert any("Socket error during pre-flight bind" in m for m in error_messages)
+    assert any("8123" in m and "already in use" in m for m in error_messages)
+    # Must not be debug-only: at least one ERROR record for the failure.
+    assert any(r.levelno == logging.ERROR for r in caplog.records)
+
+
+def test_outer_except_exception_does_not_catch_systemexit():
+    """Regression for #946: SystemExit is BaseException, not Exception."""
+
+    def raises_system_exit():
+        try:
+            raise SystemExit(1)
+        except Exception:
+            return "swallowed"
+        except BaseException as e:
+            return type(e).__name__
+
+    assert raises_system_exit() == "SystemExit"

--- a/tests/test_main_port_probe.py
+++ b/tests/test_main_port_probe.py
@@ -1,5 +1,6 @@
 """Tests for streamable-http / dual-transport TCP bind pre-flight probes."""
 
+import errno
 import logging
 import os
 import socket
@@ -35,16 +36,10 @@ def _hold_listening_port(host: str = "127.0.0.1"):
         s.close()
 
 
-def _free_port(host: str = "127.0.0.1") -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind((host, 0))
-        return s.getsockname()[1]
-
-
 def test_probe_tcp_bind_succeeds_on_free_port():
+    # Port 0 lets the OS allocate an ephemeral port atomically during the probe.
     host = "127.0.0.1"
-    port = _free_port(host)
-    main.probe_tcp_bind(host, port)
+    main.probe_tcp_bind(host, 0)
 
 
 def test_probe_tcp_bind_sets_so_reuseaddr():
@@ -74,9 +69,8 @@ def test_probe_tcp_bind_sets_so_reuseaddr():
             return False
 
     host = "127.0.0.1"
-    port = _free_port(host)
     with patch("main.socket.socket", TrackingSocket):
-        main.probe_tcp_bind(host, port)
+        main.probe_tcp_bind(host, 0)
 
     assert (socket.SOL_SOCKET, socket.SO_REUSEADDR, 1) in recorded
 
@@ -89,7 +83,7 @@ def test_probe_tcp_bind_raises_when_port_held():
 
 def test_report_preflight_bind_failure_logs_at_error(caplog):
     """Bind failure must be visible at ERROR when stderr is non-TTY (containers)."""
-    error = OSError(98, "Address already in use")
+    error = OSError(errno.EADDRINUSE, "Address already in use")
     with caplog.at_level(logging.DEBUG, logger="main"):
         main.report_preflight_bind_failure(8123, error)
 
@@ -100,6 +94,20 @@ def test_report_preflight_bind_failure_logs_at_error(caplog):
     assert any("8123" in m and "already in use" in m for m in error_messages)
     # Must not be debug-only: at least one ERROR record for the failure.
     assert any(r.levelno == logging.ERROR for r in caplog.records)
+
+
+def test_report_preflight_bind_failure_non_eaddrinuse_is_generic(caplog):
+    """Non-EADDRINUSE bind errors must not claim the port is already in use."""
+    error = OSError(errno.EACCES, "Permission denied")
+    with caplog.at_level(logging.DEBUG, logger="main"):
+        main.report_preflight_bind_failure(8123, error)
+
+    error_messages = [
+        r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR
+    ]
+    assert any("Socket error during pre-flight bind" in m for m in error_messages)
+    assert any("Failed to bind HTTP server on port 8123" in m for m in error_messages)
+    assert not any("already in use" in m for m in error_messages)
 
 
 def test_outer_except_exception_does_not_catch_systemexit():

--- a/tests/test_main_port_probe.py
+++ b/tests/test_main_port_probe.py
@@ -81,6 +81,48 @@ def test_probe_tcp_bind_raises_when_port_held():
             main.probe_tcp_bind(host, port)
 
 
+def _leave_time_wait_on_port(host: str = "127.0.0.1") -> int:
+    """Return a port whose only occupant is a server-side TIME_WAIT socket.
+
+    The listener accepts one connection and closes it first, so the TIME_WAIT
+    state lands on the server side (local port = the listener's port). Peers
+    and listener are all closed before returning; only the lingering state is
+    left, which is exactly what a fast restart of the HTTP server sees.
+    """
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind((host, 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+    client = socket.create_connection((host, port))
+    server_side, _ = listener.accept()
+    server_side.close()  # active close on the server side -> TIME_WAIT there
+    assert client.recv(1) == b""  # client sees EOF, then closes its end
+    client.close()
+    listener.close()
+    return port
+
+
+def test_probe_tcp_bind_accepts_port_with_only_time_wait_sockets():
+    """Regression for #946: lingering TIME_WAIT must not read as a conflict.
+
+    A bare bind (the pre-fix probe) fails here with EADDRINUSE; uvicorn's
+    SO_REUSEADDR bind would succeed, so the probe must succeed too.
+    """
+    host = "127.0.0.1"
+    port = _leave_time_wait_on_port(host)
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as bare:
+        try:
+            bare.bind((host, port))
+        except OSError as exc:
+            assert exc.errno == errno.EADDRINUSE
+        else:
+            pytest.skip("platform does not block a bare bind on TIME_WAIT")
+
+    main.probe_tcp_bind(host, port)  # must not raise
+
+
 def test_report_preflight_bind_failure_logs_at_error(caplog):
     """Bind failure must be visible at ERROR when stderr is non-TTY (containers)."""
     error = OSError(errno.EADDRINUSE, "Address already in use")


### PR DESCRIPTION
## Description

Fixes the streamable-http pre-flight port bind that can false-fail on fast restart and crash-loop silently in Kubernetes / non-TTY environments (#946).

Two changes together:

1. **SO_REUSEADDR on both bind probes** (main streamable-http listener and the dual-transport workspace-cli sidecar), matching uvicorn/asyncio `reuse_address` so lingering TIME_WAIT sockets do not produce a false EADDRINUSE before the real server bind.
2. **Log bind failure at ERROR** via `report_preflight_bind_failure` (not only `safe_print`, which is DEBUG when stderr is not a TTY). That makes genuine bind failures visible in container logs. Confirmed at HEAD that the outer `except Exception` does not catch `SystemExit` (it subclasses `BaseException`); ERROR logging is what restores diagnostics.

Related narrower open PR: #744 (SO_REUSEADDR only, opened May). This PR is a completeness superset: same reuseaddr coverage on both probes, plus ERROR-level failure reporting and tests.

Fixes #946

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## AI assistance

This change was developed with AI assistance (Cursor / Grok), reviewed and verified on Windows 11 by Stan Shih (@stantheman0128).

## Evidence

**Unit tests** (`uv run pytest tests/test_main_port_probe.py -v`):

```
tests/test_main_port_probe.py::test_probe_tcp_bind_succeeds_on_free_port PASSED
tests/test_main_port_probe.py::test_probe_tcp_bind_sets_so_reuseaddr PASSED
tests/test_main_port_probe.py::test_probe_tcp_bind_raises_when_port_held PASSED
tests/test_main_port_probe.py::test_report_preflight_bind_failure_logs_at_error PASSED
tests/test_main_port_probe.py::test_outer_except_exception_does_not_catch_systemexit PASSED
============================== 5 passed in 5.35s ==============================
```

**Live non-TTY simulation** (stderr.isatty()=False, exclusive hold on a port, INFO root logger):

Before (safe_print only; invisible at INFO):
```
DEBUG:main:[MCP Server] Socket error: [WinError 10048] Only one usage of each socket address ...
DEBUG:main:[MCP Server] Port 57898 already in use
(no INFO/ERROR lines from safe_print above)
```

After (`report_preflight_bind_failure`):
```
ERROR:main:Socket error during pre-flight bind: [WinError 10013] An attempt was made to access a socket in a way forbidden by its access permissions
ERROR:main:Port 57898 is already in use. Cannot start HTTP server.
SO_REUSEADDR_SET=True
```

## What was not tested

- Full `workspace-mcp --transport streamable-http` boot against a real Kubernetes shared network namespace (no cluster in this environment). The probe and logging helpers used by that path are covered above.
- End-to-end uvicorn bind after the probe on macOS TIME_WAIT (issue/PR #744 manual scenario); SO_REUSEADDR is asserted in unit tests.

## Additional Notes

Allow edits from maintainers is enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup behavior when the main or HTTP port is already in use.
  * Standardized, more informative port-binding error messages, distinguishing occupied ports from other failures.
  * Improved handling of reusable TCP ports during server and HTTP sidecar startup.

* **Tests**
  * Added coverage for free, occupied, reusable, and temporary TCP ports.
  * Verified error logging distinguishes occupied ports from other binding failures.
  * Added regression coverage to ensure system-exit behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->