### PR TITLE
fix(sheets): reject non-letter column values in `_column_to_index`

### DIFF
--- a/gsheets/sheets_helpers.py
+++ b/gsheets/sheets_helpers.py
@@ -29,7 +29,7 @@ def _column_to_index(column: str) -> Optional[int]:
     # check the arithmetic below still produces a plausible index -- "B2" gives
     # 37, i.e. column AL -- and the callers' `if col_idx is None` guards never
     # fire, so a delete_columns request silently targets a column nobody named.
-    if not column or not COLUMN_LETTERS_RE.match(column):
+    if not column or not COLUMN_LETTERS_RE.fullmatch(column):
         return None
     result = 0
     for char in column.upper():

--- a/gsheets/sheets_helpers.py
+++ b/gsheets/sheets_helpers.py
@@ -19,11 +19,17 @@ MAX_GRID_METADATA_CELLS = 5000
 
 A1_PART_REGEX = re.compile(r"^([A-Za-z]*)(\d*)$")
 SHEET_TITLE_SAFE_RE = re.compile(r"^[A-Za-z0-9_]+$")
+COLUMN_LETTERS_RE = re.compile(r"^[A-Za-z]+$")
 
 
 def _column_to_index(column: str) -> Optional[int]:
     """Convert column letters (A, B, AA) to zero-based index."""
-    if not column:
+    # Callers pass raw tool arguments straight through, so a cell reference or a
+    # range can arrive where a bare column letter was expected. Without a format
+    # check the arithmetic below still produces a plausible index -- "B2" gives
+    # 37, i.e. column AL -- and the callers' `if col_idx is None` guards never
+    # fire, so a delete_columns request silently targets a column nobody named.
+    if not column or not COLUMN_LETTERS_RE.match(column):
         return None
     result = 0
     for char in column.upper():

--- a/tests/gsheets/test_resize_sheet_dimensions.py
+++ b/tests/gsheets/test_resize_sheet_dimensions.py
@@ -583,7 +583,7 @@ async def test_delete_rows_non_integer_value_raises_user_input_error():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("column", ["B2", "A1", "C3", "5", "A:B", "Sheet1"])
+@pytest.mark.parametrize("column", ["B2", "A1", "C3", "5", "A:B", "Sheet1", "AA\n"])
 async def test_delete_columns_rejects_non_letter_values(column):
     """Test delete_columns rejects values that are not bare column letters."""
     mock_service = create_mock_service()

--- a/tests/gsheets/test_resize_sheet_dimensions.py
+++ b/tests/gsheets/test_resize_sheet_dimensions.py
@@ -6,6 +6,7 @@ Tests column/row resizing, auto-resize, freeze, and hide/unhide operations.
 
 import pytest
 from unittest.mock import Mock
+import re
 import sys
 import os
 
@@ -579,3 +580,63 @@ async def test_delete_rows_non_integer_value_raises_user_input_error():
             spreadsheet_id="test_123",
             delete_rows=["abc"],
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("column", ["B2", "A1", "C3", "5", "A:B", "Sheet1"])
+async def test_delete_columns_rejects_non_letter_values(column):
+    """Test delete_columns rejects values that are not bare column letters."""
+    mock_service = create_mock_service()
+    batch_update = mock_service.spreadsheets().batchUpdate
+    calls_before = batch_update.call_count
+
+    from core.utils import UserInputError
+
+    with pytest.raises(
+        UserInputError,
+        match=rf"Invalid column letter in delete_columns: '{re.escape(column)}'\.",
+    ):
+        await _resize_sheet_dimensions_impl(
+            service=mock_service,
+            spreadsheet_id="test_123",
+            delete_columns=[column],
+        )
+
+    # The whole point is that nothing is deleted: "B2" used to resolve to index
+    # 37 and delete column AL, so the request must never reach the API.
+    assert batch_update.call_count == calls_before
+
+
+@pytest.mark.asyncio
+async def test_insert_columns_at_rejects_cell_reference():
+    """Test insert_columns_at rejects a cell reference instead of a column letter."""
+    mock_service = create_mock_service()
+
+    from core.utils import UserInputError
+
+    with pytest.raises(
+        UserInputError, match=r"Invalid column letter for insert_columns_at: 'B2'\."
+    ):
+        await _resize_sheet_dimensions_impl(
+            service=mock_service,
+            spreadsheet_id="test_123",
+            insert_columns=1,
+            insert_columns_at="B2",
+        )
+
+
+@pytest.mark.asyncio
+async def test_multi_letter_column_still_resolves():
+    """Test that valid multi-letter columns are unaffected by the format check."""
+    mock_service = create_mock_service()
+
+    await _resize_sheet_dimensions_impl(
+        service=mock_service,
+        spreadsheet_id="test_123",
+        column_sizes={"AA": 150},
+    )
+
+    call_args = mock_service.spreadsheets().batchUpdate.call_args
+    req = call_args[1]["body"]["requests"][0]["updateDimensionProperties"]
+    assert req["range"]["startIndex"] == 26
+    assert req["range"]["endIndex"] == 27


### PR DESCRIPTION

## Description

Fixes #958.

`_column_to_index` (`gsheets/sheets_helpers.py`) returned `None` only for an empty string. Any other
input ran through the base-26 arithmetic and produced a plausible-looking index:

```python
if not column:
    return None
result = 0
for char in column.upper():
    result = result * 26 + (ord(char) - ord("A") + 1)
return result - 1
```

| input   | index | column targeted |
|---------|-------|-----------------|
| `"A1"`  | 10    | K               |
| `"B2"`  | 37    | **AL**          |
| `"C3"`  | 64    | BM              |
| `"A:B"` | 521   | TB              |
| `"5"`   | -12   | negative index  |

All five call sites in `gsheets/sheets_tools.py` (1571, 1762, 1831, 1996, 2114) guard with
`if col_idx is None: raise UserInputError(...)`, so every one of those guards was unreachable.
The practical consequence is that `resize_sheet_dimensions(delete_columns=["B2"])` issues a
`deleteDimension` for index 37 and **permanently deletes column AL**, then reports success.

## Fix

Validate the format in the helper, so the guards the call sites already have start firing:

```python
COLUMN_LETTERS_RE = re.compile(r"^[A-Za-z]+$")

if not column or not COLUMN_LETTERS_RE.match(column):
    return None
```

Deliberately scoped to the helper — no call-site changes, so all five paths are fixed at once and
the existing per-site error messages are preserved. `_parse_a1_part` is unaffected: it only ever
passes the `[A-Za-z]*` capture group from `A1_PART_REGEX`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually — *not against a live spreadsheet (no credentials); the
  defect and the fix are both verified against the shipped helper and through
  `_resize_sheet_dimensions_impl` with a mocked Sheets service, per the repo's
  "mock Google APIs, never hit live services" rule.*

Added to `tests/gsheets/test_resize_sheet_dimensions.py`:

- `test_delete_columns_rejects_non_letter_values` — parametrized over `B2`, `A1`, `C3`, `5`, `A:B`,
  `Sheet1`; asserts `UserInputError` **and** that no `batchUpdate` call is made, since the point is
  that nothing gets deleted.
- `test_insert_columns_at_rejects_cell_reference` — the other destructive/positional call site.
- `test_multi_letter_column_still_resolves` — pins `"AA"` → `startIndex` 26 so the new check can't
  over-reject.

Note the pre-existing `test_invalid_column_letter_raises_error` only covered `column_sizes={"": 200}`,
i.e. the one input the old code did reject — which is why this went unnoticed.

Verification:

```
# all 7 new tests fail on main without the source change
7 failed, 29 passed

# with the fix
1291 passed, 2 skipped, 3 warnings in 7.38s   (baseline on main: 1283 passed, 2 skipped)

uvx ruff check          -> All checks passed!
uvx ruff format --check -> 2 files already formatted
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

Scope kept deliberately narrow. Two adjacent things I did **not** touch, happy to follow up on
either if you'd like:

- `delete_rows` / `delete_columns` sort descending but never de-duplicate, so `delete_rows=[5, 5]`
  deletes two rows while reporting `"deleted rows: 5, 5"`.
- No upper bound on the resulting index (Sheets caps at column ZZZ). Out-of-range values fail loudly
  at the API rather than corrupting data, so I left it alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for spreadsheet column inputs to ensure only bare column letters (e.g., `A`, `AA`) are accepted.
  * Malformed values like cell references (`B2`), ranges, numeric strings, and other non-column fragments are now rejected instead of being misinterpreted.
  * Column operations now avoid sending spreadsheet update requests when validation fails, preventing unintended changes.

* **Tests**
  * Added coverage for invalid/valid column formats and confirmed no update requests are made on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->