### PR TITLE
Load out-of-tree tool plugins via a workspace_mcp.tools entry-point group

### DIFF
--- a/fastmcp_server.py
+++ b/fastmcp_server.py
@@ -159,6 +159,21 @@ import gsearch.search_tools
 # Configure tool registration
 wrap_server_tool_method(server)
 
+# Load out-of-tree tool plugins (workspace_mcp.tools entry-point group), same
+# seam as main.py — importing each registers its @server.tool() tools.
+try:
+    from importlib.metadata import entry_points as _entry_points
+
+    for _ep in _entry_points(group="workspace_mcp.tools"):
+        try:
+            _ep.load()
+        except Exception:  # noqa: BLE001
+            logging.getLogger(__name__).error(
+                "Failed to load tool plugin '%s'", _ep.name, exc_info=True
+            )
+except Exception:  # pragma: no cover
+    pass
+
 # Enable all tools and services by default
 all_services = [
     "gmail",

--- a/main.py
+++ b/main.py
@@ -669,6 +669,28 @@ def main():
         safe_print(f"🔒 Permissions: {perm_summary}")
     safe_print("")
 
+    # Load out-of-tree tool plugins advertised via the "workspace_mcp.tools"
+    # entry-point group. Importing each entry point's module runs its
+    # @server.tool() decorators against the shared `server` singleton, exactly
+    # like the in-tree tool modules above — so external pip packages can
+    # contribute tools without editing this file.
+    try:
+        from importlib.metadata import entry_points as _entry_points
+
+        _eps = _entry_points(group="workspace_mcp.tools")
+    except Exception as _eps_exc:  # pragma: no cover - importlib API drift
+        _eps = ()
+        logger.debug("entry_points lookup failed: %s", _eps_exc)
+    for _ep in _eps:
+        try:
+            _ep.load()  # importing the module registers its tools as a side effect
+            safe_print(f"   🔌 Plugin loaded: {_ep.name}")
+        except Exception as _plugin_exc:  # noqa: BLE001 - one bad plugin must not abort startup
+            logger.error(
+                "Failed to load tool plugin '%s': %s", _ep.name, _plugin_exc, exc_info=True
+            )
+            safe_print(f"   ⚠️ Failed to load plugin '{_ep.name}' ({_plugin_exc}).")
+
     # Filter tools based on tier configuration (if tier-based loading is enabled)
     filter_server_tools(server)
 


### PR DESCRIPTION
## What

Adds a small extension seam so **external pip packages can contribute MCP tools without editing core**. At startup, `main.py` (and `fastmcp_server.py`) scan the `workspace_mcp.tools` entry-point group and import each module, which registers its `@server.tool()` decorators against the shared `server` singleton — exactly like the in-tree tool modules.

A plugin package declares:
```toml
[project.entry-points."workspace_mcp.tools"]
my_tools = "my_pkg.my_tools"   # module doing `from core.server import server; @server.tool()`
```

## Why

Today the only way to add tools is editing the hardcoded `tool_imports` dict in `main.py`, which forces a fork for any private/edge tool set and makes rebasing painful. This ~15-line opt-in seam lets those live as separate installable packages.

## Safety

- Runs **after** `wrap_server_tool_method(server)` and **before** `filter_server_tools(server)`, so name tracking and tier/`--read-only` filtering apply to plugin tools too.
- A failing plugin is logged and **never aborts startup**.
- No behavior change when no such entry points are installed. `py_compile` clean.

Happy to rename the group or gate it behind a flag if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading externally developed tool plugins at startup.
  * Available plugins can now extend Google Workspace tooling without modifying the core application.

* **Bug Fixes**
  * Improved startup resilience so plugin discovery or individual plugin failures do not prevent the server from launching.
  * Added clearer error reporting when a plugin cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->