### PR TITLE
enh: to/cc headers in get_gmail_thread_content

### DIFF
--- a/gmail/gmail_helpers.py
+++ b/gmail/gmail_helpers.py
@@ -156,9 +156,10 @@ def _analyze_thread_ownership_impl(
 
     # Thread subject: first message's Subject header
     first_headers = {
-        h["name"]: h["value"] for h in messages[0].get("payload", {}).get("headers", [])
+        h["name"].lower(): h["value"]
+        for h in messages[0].get("payload", {}).get("headers", [])
     }
-    thread_subject = first_headers.get("Subject") or None
+    thread_subject = first_headers.get("subject") or None
 
     sender_counter: Counter[str] = Counter()
     participants: set[str] = set()
@@ -171,17 +172,21 @@ def _analyze_thread_ownership_impl(
         label_ids = message.get("labelIds", []) or []
         is_draft = "DRAFT" in label_ids
 
-        headers = {
-            h["name"]: h["value"] for h in message.get("payload", {}).get("headers", [])
-        }
+        raw_headers = message.get("payload", {}).get("headers", [])
+        headers = {h["name"].lower(): h["value"] for h in raw_headers}
 
-        from_addr = headers.get("From", "")
+        from_addr = headers.get("from", "")
         _name, from_email = parseaddr(from_addr)
         from_norm = _normalize_email(from_email) if from_email else ""
 
         # Collect participants from From/To/Cc using getaddresses (RFC-correct
-        # parsing of quoted display names with embedded commas).
-        header_values = [headers.get(hdr, "") for hdr in ("From", "To", "Cc")]
+        # parsing of quoted display names with embedded commas). Read the raw
+        # list so repeated fields are combined rather than silently overwritten.
+        header_values = [
+            h["value"]
+            for h in raw_headers
+            if h["name"].lower() in {"from", "to", "cc"} and h["value"]
+        ]
         message_participants = set()
         for _n, addr in getaddresses([v for v in header_values if v]):
             norm = _normalize_email(addr) if addr else ""
@@ -199,7 +204,7 @@ def _analyze_thread_ownership_impl(
             sender_counter[from_norm] += 1
 
         _iso, dt = _parse_date_header(
-            headers.get("Date", ""), message.get("internalDate")
+            headers.get("date", ""), message.get("internalDate")
         )
         if dt is not None:
             if last_non_draft is None or dt >= last_non_draft[0]:
@@ -220,7 +225,7 @@ def _analyze_thread_ownership_impl(
         }
 
     last_dt, _last_message, last_headers = last_non_draft
-    last_sender_raw = last_headers.get("From", "")
+    last_sender_raw = last_headers.get("from", "")
     _n, last_sender_email = parseaddr(last_sender_raw)
     last_sender_norm = _normalize_email(last_sender_email) if last_sender_email else ""
 

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2861,10 +2861,7 @@ def _format_thread_content(
 
     # Extract thread subject from the first message
     first_message = messages[0]
-    first_headers = {
-        h["name"]: h["value"]
-        for h in first_message.get("payload", {}).get("headers", [])
-    }
+    first_headers = _extract_headers(first_message.get("payload", {}), ["Subject"])
     thread_subject = first_headers.get("Subject", "(no subject)")
 
     # Build the thread content

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -313,10 +313,12 @@ def _format_message_header_lines(
         content_lines.append(f"In-Reply-To: {in_reply_to}")
     if references:
         content_lines.append(f"References: {references}")
-    if to:
-        content_lines.append(f"To: {to}")
-    if cc:
-        content_lines.append(f"Cc: {cc}")
+    content_lines.append(
+        f"To: {to}" if "To" in headers else "To: [not present in Gmail response]"
+    )
+    content_lines.append(
+        f"Cc: {cc}" if "Cc" in headers else "Cc: [not present in Gmail response]"
+    )
     if list_unsub:
         content_lines.append(f"List-Unsubscribe: {list_unsub}")
     if precedence:
@@ -844,7 +846,14 @@ def _extract_headers(payload: dict, header_names: List[str]) -> Dict[str, str]:
         header_name_lower = header["name"].lower()
         if header_name_lower in target_headers:
             # Store using the original requested casing
-            headers[target_headers[header_name_lower]] = header["value"]
+            target_name = target_headers[header_name_lower]
+            value = header["value"]
+            if header_name_lower in {"to", "cc"} and target_name in headers:
+                headers[target_name] = ", ".join(
+                    part for part in (headers[target_name], value) if part
+                )
+            else:
+                headers[target_name] = value
     return headers
 
 
@@ -2870,11 +2879,13 @@ def _format_thread_content(
     for i, message in enumerate(messages, 1):
         payload = message.get("payload", {})
         # Extract headers
-        headers = {h["name"]: h["value"] for h in payload.get("headers", [])}
+        headers = _extract_headers(payload, GMAIL_METADATA_HEADERS)
 
         sender = headers.get("From", "(unknown sender)")
         date = headers.get("Date", "(unknown date)")
         subject = headers.get("Subject", "(no subject)")
+        to = headers.get("To", "")
+        cc = headers.get("Cc", "")
         rfc822_message_id = headers.get("Message-ID", "")
         in_reply_to = headers.get("In-Reply-To", "")
         references = headers.get("References", "")
@@ -2907,6 +2918,12 @@ def _format_thread_content(
                 f"From: {sender}",
                 f"Date: {date}",
             ]
+        )
+        content_lines.append(
+            f"To: {to}" if "To" in headers else "To: [not present in Gmail response]"
+        )
+        content_lines.append(
+            f"Cc: {cc}" if "Cc" in headers else "Cc: [not present in Gmail response]"
         )
 
         if rfc822_message_id:

--- a/tests/gmail/test_get_gmail_thread_content_analysis.py
+++ b/tests/gmail/test_get_gmail_thread_content_analysis.py
@@ -93,6 +93,8 @@ async def test_default_returns_string_unchanged_behavior():
     assert isinstance(result, str)
     assert "Thread ID: t1" in result
     assert "alex@alexreynolds.com" in result or "Alex" in result
+    assert "To: vendor@example.com" in result
+    assert "Cc: [not present in Gmail response]" in result
 
 
 @pytest.mark.asyncio
@@ -111,6 +113,31 @@ async def test_include_analysis_true_returns_dict_with_both_keys():
     assert set(result.keys()) == {"content", "analysis"}
     assert isinstance(result["content"], str)
     assert isinstance(result["analysis"], dict)
+
+
+@pytest.mark.asyncio
+async def test_recipient_headers_are_complete_in_content_and_analysis():
+    thread = _fake_thread_response()
+    thread["messages"][0]["payload"]["headers"].extend(
+        [
+            {"name": "to", "value": "stakeholder@example.com"},
+            {"name": "CC", "value": "copied@example.com"},
+        ]
+    )
+    service = _build_mock_service(thread)
+
+    result = await _unwrap(get_gmail_thread_content)(
+        service=service,
+        thread_id="t1",
+        user_google_email="alex@alexreynolds.com",
+        include_analysis=True,
+    )
+
+    assert "To: vendor@example.com, stakeholder@example.com" in result["content"]
+    assert "Cc: copied@example.com" in result["content"]
+    assert {"stakeholder@example.com", "copied@example.com"} <= set(
+        result["analysis"]["participants"]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gmail/test_get_gmail_thread_content_analysis.py
+++ b/tests/gmail/test_get_gmail_thread_content_analysis.py
@@ -140,6 +140,26 @@ async def test_recipient_headers_are_complete_in_content_and_analysis():
     )
 
 
+@pytest.mark.parametrize("header_name", ["subject", "sUbJeCt"])
+@pytest.mark.asyncio
+async def test_thread_subject_header_is_case_insensitive(header_name):
+    thread = _fake_thread_response()
+    thread["messages"][0]["payload"]["headers"][-1]["name"] = header_name
+    service = _build_mock_service(thread)
+
+    result = await _unwrap(get_gmail_thread_content)(
+        service=service,
+        thread_id="t1",
+        user_google_email="alex@alexreynolds.com",
+    )
+
+    assert result.splitlines()[:3] == [
+        "Thread ID: t1",
+        "Subject: Test thread",
+        "Messages: 2",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_analysis_keys_match_helper_contract():
     """The analysis dict matches _analyze_thread_ownership_impl's documented shape."""

--- a/tests/gmail/test_thread_ownership_helpers.py
+++ b/tests/gmail/test_thread_ownership_helpers.py
@@ -303,6 +303,31 @@ class TestParticipantsAndCounts:
             "vendor@example.com",
         }
 
+    def test_recipient_headers_are_case_insensitive_and_not_collapsed(self):
+        message = _msg(
+            "m-case",
+            "Alex <alex@alexreynolds.com>",
+            "Mon, 14 Apr 2026 09:00:00 -0400",
+        )
+        message["payload"]["headers"].extend(
+            [
+                {"name": "TO", "value": "first@example.com"},
+                {"name": "to", "value": "second@example.com"},
+                {"name": "CC", "value": "copied@example.com"},
+            ]
+        )
+
+        result = _analyze_thread_ownership_impl(
+            _thread("t-case", [message]), "alex@alexreynolds.com"
+        )
+
+        assert set(result["participants"]) == {
+            "alex@alexreynolds.com",
+            "first@example.com",
+            "second@example.com",
+            "copied@example.com",
+        }
+
     def test_user_forwards_to_self_returns_none(self):
         """User → User (forward-to-self or archive-to-self): there's no
         external party to owe anything, so ball_in_court_of is None rather


### PR DESCRIPTION
Closes #693 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gmail thread analysis to handle header capitalization consistently.
  * Preserved all recipients when multiple `To`/`Cc` headers appear (now merged instead of overwritten).
  * Updated thread content rendering to always show `To` and `Cc`, using explicit placeholders when missing.
  * Enhanced participant detection to accurately reflect recipients from case-insensitive `To`/`Cc` headers.

* **Tests**
  * Added coverage for case-insensitive and non-collapsed recipient header parsing for both content and ownership analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->