### PR TITLE
fix: align external OAuth metadata with MCP path

### DIFF
--- a/auth/external_oauth_provider.py
+++ b/auth/external_oauth_provider.py
@@ -152,7 +152,7 @@ class ExternalOAuthProvider(GoogleProvider):
         # For JWT tokens, use parent class implementation
         return await super().verify_token(token)
 
-    def get_routes(self, mcp_path: Optional[str] = None) -> list[Route]:
+    def get_routes(self, mcp_path: str | None = None) -> list[Route]:
         """
         Get OAuth routes for external provider mode.
 

--- a/auth/external_oauth_provider.py
+++ b/auth/external_oauth_provider.py
@@ -80,6 +80,8 @@ class ExternalOAuthProvider(GoogleProvider):
     ):
         """Initialize and store client credentials for token validation."""
         self._resource_server_url = resource_server_url
+        if resource_server_url and "resource_base_url" not in kwargs:
+            kwargs["resource_base_url"] = resource_server_url
         super().__init__(client_id=client_id, client_secret=client_secret, **kwargs)
         # Store credentials as they're not exposed by parent class
         self._client_id = client_id
@@ -150,7 +152,7 @@ class ExternalOAuthProvider(GoogleProvider):
         # For JWT tokens, use parent class implementation
         return await super().verify_token(token)
 
-    def get_routes(self, **kwargs) -> list[Route]:
+    def get_routes(self, mcp_path: Optional[str] = None) -> list[Route]:
         """
         Get OAuth routes for external provider mode.
 
@@ -159,7 +161,7 @@ class ExternalOAuthProvider(GoogleProvider):
         (/authorize, /token, etc.) since tokens are issued by Google directly.
 
         Args:
-            **kwargs: Additional arguments passed by FastMCP (e.g., mcp_path)
+            mcp_path: Path where FastMCP mounts the protected MCP endpoint.
 
         Returns:
             List of routes - only protected resource metadata
@@ -172,10 +174,18 @@ class ExternalOAuthProvider(GoogleProvider):
             )
             return []
 
+        self.set_mcp_path(mcp_path)
+        resource_url = self._get_resource_url(mcp_path)
+        if not resource_url:
+            logger.warning(
+                "ExternalOAuthProvider: protected resource URL could not be resolved"
+            )
+            return []
+
         # Create protected resource routes that point to Google as the authorization server
         # Pass strings directly - Pydantic validates them during model construction
         protected_routes = create_protected_resource_routes(
-            resource_url=self.resource_server_url,
+            resource_url=resource_url,
             authorization_servers=[GOOGLE_ISSUER_URL],
             scopes_supported=self.required_scopes,
             resource_name="Google Workspace MCP",

--- a/tests/core/test_well_known_cache_control_middleware.py
+++ b/tests/core/test_well_known_cache_control_middleware.py
@@ -233,3 +233,53 @@ def test_configured_server_applies_no_cache_to_served_oauth_discovery_routes(
     # Ensure we did not create a shadow route at the wrong path.
     wrong_path = client.get("/.well-known/oauth-protected-resource")
     assert wrong_path.status_code == 404
+
+
+def test_external_oauth_metadata_matches_mcp_resource_and_challenge(monkeypatch):
+    monkeypatch.setenv("MCP_ENABLE_OAUTH21", "true")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "dummy-client")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "dummy-secret")
+    monkeypatch.setenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
+    monkeypatch.setenv("WORKSPACE_MCP_PORT", "8000")
+    monkeypatch.setenv("WORKSPACE_EXTERNAL_URL", "https://workspace.example.com")
+    monkeypatch.setenv("EXTERNAL_OAUTH21_PROVIDER", "true")
+    monkeypatch.setenv("WORKSPACE_MCP_STATELESS_MODE", "true")
+
+    import core.server as core_server
+    from auth.oauth_config import reload_oauth_config
+
+    reload_oauth_config()
+    core_server = importlib.reload(core_server)
+    core_server.set_transport_mode("streamable-http")
+    core_server.configure_server_for_http()
+
+    app = core_server.server.http_app(transport="streamable-http", path="/mcp")
+    client = TestClient(app)
+
+    protected_resource = client.get("/.well-known/oauth-protected-resource/mcp")
+    assert protected_resource.status_code == 200
+    assert protected_resource.json()["resource"] == "https://workspace.example.com/mcp"
+
+    wrong_path = client.get("/.well-known/oauth-protected-resource")
+    assert wrong_path.status_code == 404
+
+    challenge = client.post(
+        "/mcp",
+        headers={"Accept": "application/json, text/event-stream"},
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1"},
+            },
+        },
+    )
+    assert challenge.status_code == 401
+    assert (
+        'resource_metadata="https://workspace.example.com/'
+        '.well-known/oauth-protected-resource/mcp"'
+        in challenge.headers["www-authenticate"]
+    )


### PR DESCRIPTION
## Description

Fix external OAuth protected-resource metadata when FastMCP is mounted at a path such as `/mcp`.

`ExternalOAuthProvider.get_routes()` received `mcp_path` but ignored it, so it registered metadata for the root resource while unauthenticated MCP responses advertised `/.well-known/oauth-protected-resource/mcp`. The advertised endpoint consequently returned 404.

This change makes the path-specific MCP resource canonical and ensures the registered metadata resource matches the URL advertised in the 401 challenge.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Added a regression test proving the fix
- [x] New and existing tests pass locally
- [x] Manually tested the affected OAuth flow

Automated verification:

- `uv run --frozen pytest`: 1,351 passed, 2 skipped
- Changed files pass the repository-locked Ruff lint and format checks
- Changed files pass Ruff 0.16 formatting
- Ruff 0.16 reports no new finding from this change; the five remaining findings in `external_oauth_provider.py` are also present on current `main`

Manual protocol verification against a deployed image:

- `GET /.well-known/oauth-protected-resource/mcp` returns 200
- The metadata resource is exactly `https://google-mcp.awork.com/mcp`
- An unauthenticated `POST /mcp` returns 401 and advertises that same reachable metadata URL

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have enabled **Allow edits from maintainers** for this pull request

## CI note

The current workflow invokes unpinned `uvx ruff`. Ruff 0.16 reports repository-wide baseline findings on current `main` (tracked separately by #967); this PR adds none after the type-annotation cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external OAuth routing for MCP endpoints.
  * Ensured OAuth metadata and authentication challenges reference the correct external MCP resource URL.
  * Requests to unsupported well-known paths now return the appropriate not-found response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->