### PR TITLE
feat(telemetry): opt-in user.email span attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,15 @@ batching, and resource attributes are honored. `OTEL_EXPORTER_OTLP_TRACES_ENDPOI
 and `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` override their general counterparts. When
 neither endpoint variable is set, tracing is fully disabled.
 
+Spans already carry the opaque `enduser.id` FastMCP derives from the OAuth token.
+To also record the authenticated user's email as the OpenTelemetry `user.email`
+attribute — so traces can be attributed to a person — opt in explicitly. This is
+PII and is off by default:
+
+```bash
+export WORKSPACE_MCP_OTEL_USER_EMAIL="true"   # default: unset (disabled)
+```
+
 </details>
 
 ### Google Custom Search Setup

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -27,6 +27,7 @@ from auth.oauth_config import (
     is_service_account_enabled,
 )
 from core.context import set_fastmcp_session_id
+from core.telemetry import record_authenticated_user
 from auth.scopes import (
     GMAIL_READONLY_SCOPE,
     GMAIL_SEND_SCOPE,
@@ -98,6 +99,10 @@ async def _get_auth_context(
         authenticated_user = await ctx.get_state("authenticated_user_email")
         auth_method = await ctx.get_state("authenticated_via")
         mcp_session_id = ctx.session_id if hasattr(ctx, "session_id") else None
+
+        # Opt-in: enrich the active tool-call span with the human-readable user
+        # email (no-op unless WORKSPACE_MCP_OTEL_USER_EMAIL is set).
+        record_authenticated_user(authenticated_user)
 
         if mcp_session_id:
             set_fastmcp_session_id(mcp_session_id)

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -13,13 +13,46 @@ it by installing the ``otel`` extra and setting ``OTEL_EXPORTER_OTLP_ENDPOINT``.
 
 import logging
 import os
-from typing import Any
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_SERVICE_NAME = "google-workspace-mcp"
 _OTLP_PROTOCOL_GRPC = "grpc"
 _OTLP_PROTOCOL_HTTP = "http/protobuf"
+
+# Recording the authenticated user's email on spans is personally identifying,
+# so it is strictly opt-in and off by default. FastMCP's own spans already
+# carry the opaque ``enduser.id`` derived from the OAuth token; this adds a
+# human-readable ``user.email`` only when the operator sets this env var.
+USER_EMAIL_ATTRIBUTE_ENV = "WORKSPACE_MCP_OTEL_USER_EMAIL"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _user_email_attribute_enabled() -> bool:
+    """True if the operator opted in to recording the user email on spans."""
+    return os.getenv(USER_EMAIL_ATTRIBUTE_ENV, "").strip().lower() in _TRUTHY
+
+
+def record_authenticated_user(email: Optional[str]) -> None:
+    """Attach the authenticated Google user's email to the active span.
+
+    Sets the OpenTelemetry ``user.email`` attribute so tool-call traces can be
+    attributed to a person rather than only the opaque ``enduser.id`` FastMCP
+    derives from the OAuth token. This is PII, so it is a no-op unless the
+    operator opts in via ``WORKSPACE_MCP_OTEL_USER_EMAIL``. Safe to call
+    unconditionally: it no-ops when disabled, when there is no email, when the
+    OpenTelemetry API is not installed, or when no span is recording.
+    """
+    if not email or not _user_email_attribute_enabled():
+        return
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        return
+    span = trace.get_current_span()
+    if span is not None and span.is_recording():
+        span.set_attribute("user.email", email)
 
 
 def _otlp_endpoint_configured() -> bool:

--- a/tests/core/test_telemetry.py
+++ b/tests/core/test_telemetry.py
@@ -229,3 +229,112 @@ def test_exporter_configuration_error_never_prevents_startup(
         assert telemetry.configure_telemetry() is False
 
     assert "certificate file is unreadable" in caplog.text
+
+
+class _FakeSpan:
+    def __init__(self, recording: bool = True) -> None:
+        self._recording = recording
+        self.attributes: dict[str, object] = {}
+
+    def is_recording(self) -> bool:
+        return self._recording
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+
+def _patch_current_span(monkeypatch: pytest.MonkeyPatch, span: _FakeSpan) -> None:
+    from opentelemetry import trace
+
+    monkeypatch.setattr(trace, "get_current_span", lambda: span)
+
+
+def test_record_authenticated_user_sets_email_when_opted_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(telemetry.USER_EMAIL_ATTRIBUTE_ENV, "true")
+    span = _FakeSpan()
+    _patch_current_span(monkeypatch, span)
+
+    telemetry.record_authenticated_user("alice@example.com")
+
+    assert span.attributes == {"user.email": "alice@example.com"}
+
+
+@pytest.mark.parametrize("value", ("1", "yes", "on", "TRUE"))
+def test_record_authenticated_user_accepts_truthy_values(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(telemetry.USER_EMAIL_ATTRIBUTE_ENV, value)
+    span = _FakeSpan()
+    _patch_current_span(monkeypatch, span)
+
+    telemetry.record_authenticated_user("bob@example.com")
+
+    assert span.attributes == {"user.email": "bob@example.com"}
+
+
+def test_record_authenticated_user_is_noop_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(telemetry.USER_EMAIL_ATTRIBUTE_ENV, raising=False)
+    span = _FakeSpan()
+    _patch_current_span(monkeypatch, span)
+
+    telemetry.record_authenticated_user("alice@example.com")
+
+    assert span.attributes == {}
+
+
+@pytest.mark.parametrize("value", ("", "false", "0", "no"))
+def test_record_authenticated_user_ignores_falsy_values(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(telemetry.USER_EMAIL_ATTRIBUTE_ENV, value)
+    span = _FakeSpan()
+    _patch_current_span(monkeypatch, span)
+
+    telemetry.record_authenticated_user("alice@example.com")
+
+    assert span.attributes == {}
+
+
+@pytest.mark.parametrize("email", (None, ""))
+def test_record_authenticated_user_skips_empty_email(
+    monkeypatch: pytest.MonkeyPatch, email: object
+) -> None:
+    monkeypatch.setenv(telemetry.USER_EMAIL_ATTRIBUTE_ENV, "true")
+    span = _FakeSpan()
+    _patch_current_span(monkeypatch, span)
+
+    telemetry.record_authenticated_user(email)  # type: ignore[arg-type]
+
+    assert span.attributes == {}
+
+
+def test_record_authenticated_user_skips_non_recording_span(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(telemetry.USER_EMAIL_ATTRIBUTE_ENV, "true")
+    span = _FakeSpan(recording=False)
+    _patch_current_span(monkeypatch, span)
+
+    telemetry.record_authenticated_user("alice@example.com")
+
+    assert span.attributes == {}
+
+
+def test_record_authenticated_user_never_raises_without_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(telemetry.USER_EMAIL_ATTRIBUTE_ENV, "true")
+    real_import = builtins.__import__
+
+    def import_without_otel(name, *args, **kwargs):
+        if name == "opentelemetry" or name.startswith("opentelemetry."):
+            raise ImportError("simulated missing optional dependency")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_otel)
+
+    telemetry.record_authenticated_user("alice@example.com")  # must not raise


### PR DESCRIPTION
## Description
FastMCP tool-call spans only carry the opaque `enduser.id` FastMCP derives from the OAuth token, so traces can't be attributed to a person. This adds an **opt-in** OpenTelemetry `user.email` attribute (per the OTel user semantic conventions) set from the already-resolved authenticated Google user in `_get_auth_context`.

Because an email is PII, it is **off by default** and only recorded when `WORKSPACE_MCP_OTEL_USER_EMAIL` is set. The helper is a safe no-op when disabled, when there is no authenticated email, when the OpenTelemetry API isn't installed, or when no span is recording — so it never affects startup or the non-tracing path.

Complements #938 (the OTLP bootstrap).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

`uv run --extra otel --extra test pytest tests/core` → 138 passed (14 new cases in `tests/core/test_telemetry.py` cover the opt-in gate, truthy/falsy env values, empty email, non-recording span, and the missing-SDK path).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Attribute name follows the OTel `user.email` semantic convention. Default-off keeps PII out of traces unless an operator explicitly opts in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in OpenTelemetry tracing support to record the authenticated user’s email as `user.email`.
  * Email attribution is disabled by default and can be enabled with `WORKSPACE_MCP_OTEL_USER_EMAIL`.

* **Documentation**
  * Updated tracing documentation with privacy details and an example configuration.

* **Tests**
  * Added coverage for opt-in behavior, invalid settings, missing emails, inactive spans, and unavailable tracing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->