### PR TITLE
Fix inspect_doc_structure for tabbed Docs without tab_id

### DIFF
--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -1462,6 +1462,8 @@ async def inspect_doc_structure(
 
         first_tab_doc = first_document_tab(doc.get("tabs", []))
         if first_tab_doc:
+            analysis_doc["body"] = first_tab_doc.get("body", {})
+            analysis_doc["namedRanges"] = first_tab_doc.get("namedRanges", {})
             analysis_doc["headers"] = first_tab_doc.get("headers", {})
             analysis_doc["footers"] = first_tab_doc.get("footers", {})
             analysis_doc["documentStyle"] = first_tab_doc.get("documentStyle", {})

--- a/tests/gdocs/test_header_footer_guardrails.py
+++ b/tests/gdocs/test_header_footer_guardrails.py
@@ -338,7 +338,23 @@ class TestHeaderFooterGuardrails:
                 {
                     "tabProperties": {"tabId": "t.0"},
                     "documentTab": {
-                        "body": {"content": []},
+                        "body": {
+                            "content": [
+                                {
+                                    "startIndex": 1,
+                                    "endIndex": 19,
+                                    "paragraph": {
+                                        "elements": [
+                                            {
+                                                "textRun": {
+                                                    "content": "Tabbed body text"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        },
                         "headers": {
                             "hdr-tab-1": {
                                 "content": [
@@ -386,6 +402,10 @@ class TestHeaderFooterGuardrails:
         payload = result.split("\n\n", 1)[1].rsplit("\n\nLink:", 1)[0]
         parsed = json.loads(payload)
 
+        assert parsed["total_length"] == 19
+        assert parsed["statistics"]["elements"] == 1
+        assert parsed["statistics"]["paragraphs"] == 1
+        assert parsed["elements"][0]["text_preview"] == "Tabbed body text"
         assert parsed["headers"][0]["segment_id"] == "hdr-tab-1"
         assert parsed["headers"][0]["content_preview"] == "Hello"
         assert parsed["footers"][0]["segment_id"] == "ftr-tab-1"


### PR DESCRIPTION
## Description

Fixes `inspect_doc_structure` for tabbed Google Docs when callers do not provide `tab_id`.

When `documents.get(..., includeTabsContent=True)` returns tabbed document content under `tabs[].documentTab.body`, the current no-`tab_id` path copies the first tab's headers/footers/style for analysis but leaves `analysis_doc["body"]` set to the top-level document body. For tabbed Docs, that top-level body can be empty, so the tool can report `total_length: 0` and zero elements even when the first tab has body content.

This PR makes the existing first-document-tab fallback also use the first tab's body and named ranges before parsing structure.

Fixes #975.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

Commands run:

```bash
uv run pytest tests/gdocs/test_header_footer_guardrails.py -q
uv run ruff check gdocs/docs_tools.py tests/gdocs/test_header_footer_guardrails.py
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**
.
