### PR TITLE
feat(sheets): add manage_sheet_table for native Sheets tables

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -95,6 +95,7 @@ sheets:
     - list_spreadsheet_comments
     - manage_spreadsheet_comment
     - manage_conditional_formatting
+    - manage_sheet_table
 
 chat:
   core:

--- a/gsheets/sheets_helpers.py
+++ b/gsheets/sheets_helpers.py
@@ -1127,3 +1127,148 @@ async def _fetch_grid_metadata(
         )
 
     return hyperlink_section, notes_section
+
+
+# ---------------------------------------------------------------------------
+# Native Sheets tables (addTable / updateTable / deleteTable)
+# ---------------------------------------------------------------------------
+
+# Column types accepted by TableColumnProperties.columnType. Mirrors the
+# Sheets v4 ColumnType enum; COLUMN_TYPE_UNSPECIFIED is deliberately omitted
+# because it is the "do not use" default.
+TABLE_COLUMN_TYPES = {
+    "DOUBLE",
+    "CURRENCY",
+    "PERCENT",
+    "DATE",
+    "TIME",
+    "DATE_TIME",
+    "TEXT",
+    "BOOLEAN",
+    "DROPDOWN",
+    "FILES_CHIP",
+    "PEOPLE_CHIP",
+    "FINANCE_CHIP",
+    "PLACE_CHIP",
+    "RATINGS_CHIP",
+}
+
+TABLE_ROW_COLOR_FIELDS = {
+    "header_color": "headerColorStyle",
+    "footer_color": "footerColorStyle",
+    "first_band_color": "firstBandColorStyle",
+    "second_band_color": "secondBandColorStyle",
+}
+
+
+def _parse_table_column_properties(
+    column_properties: Optional[Union[str, List[dict]]],
+) -> Optional[List[dict]]:
+    """
+    Normalize table column definitions into Sheets TableColumnProperties.
+
+    Accepts a list of dicts or a JSON-encoded list. Each entry supports:
+      - columnName (str): the column header label.
+      - columnType (str): one of TABLE_COLUMN_TYPES.
+      - columnIndex (int, optional): table-relative index; defaults to position.
+      - values (list, optional): dropdown choices. Only valid for DROPDOWN,
+        where the API accepts a validation rule whose condition is ONE_OF_LIST.
+    """
+    if column_properties is None:
+        return None
+
+    parsed = column_properties
+    if isinstance(parsed, str):
+        try:
+            parsed = json.loads(parsed)
+        except json.JSONDecodeError as exc:
+            raise UserInputError(
+                "column_properties must be a list or a JSON-encoded list "
+                '(e.g., \'[{"columnName":"Status","columnType":"DROPDOWN",'
+                '"values":["Open","Closed"]}]\').'
+            ) from exc
+
+    if not isinstance(parsed, list):
+        raise UserInputError("column_properties must be a list of column objects.")
+
+    normalized: List[dict] = []
+    for idx, column in enumerate(parsed):
+        if not isinstance(column, dict):
+            raise UserInputError(
+                f"column_properties[{idx}] must be an object with columnName/columnType."
+            )
+
+        raw_index = column.get("columnIndex")
+        if raw_index is None:
+            column_index = idx
+        else:
+            try:
+                column_index = int(raw_index)
+            except (TypeError, ValueError) as exc:
+                raise UserInputError(
+                    f"column_properties[{idx}].columnIndex must be an integer, "
+                    f"got {raw_index!r}."
+                ) from exc
+            if column_index < 0:
+                raise UserInputError(
+                    f"column_properties[{idx}].columnIndex must be zero or greater."
+                )
+
+        entry: dict = {"columnIndex": column_index}
+
+        name = column.get("columnName")
+        if name is not None:
+            entry["columnName"] = str(name)
+
+        raw_type = column.get("columnType")
+        column_type = str(raw_type).upper() if raw_type is not None else None
+        if column_type is not None:
+            if column_type not in TABLE_COLUMN_TYPES:
+                raise UserInputError(
+                    f"column_properties[{idx}].columnType must be one of "
+                    f"{sorted(TABLE_COLUMN_TYPES)}."
+                )
+            entry["columnType"] = column_type
+
+        values = column.get("values")
+        if values is not None and column_type != "DROPDOWN":
+            raise UserInputError(
+                f"column_properties[{idx}].values is only supported on DROPDOWN "
+                "columns; the Sheets API rejects column validation elsewhere."
+            )
+        if column_type == "DROPDOWN":
+            if not values:
+                raise UserInputError(
+                    f"column_properties[{idx}] is a DROPDOWN column and needs a "
+                    "non-empty 'values' list of choices."
+                )
+            if not isinstance(values, list):
+                raise UserInputError(
+                    f"column_properties[{idx}].values must be a list of choices."
+                )
+            entry["dataValidationRule"] = {
+                "condition": {
+                    "type": "ONE_OF_LIST",
+                    "values": [{"userEnteredValue": str(v)} for v in values],
+                }
+            }
+
+        normalized.append(entry)
+
+    return normalized
+
+
+def _build_table_rows_properties(**colors: Optional[str]) -> Optional[dict]:
+    """
+    Build TableRowsProperties from hex colors.
+
+    Accepts the keyword names in TABLE_ROW_COLOR_FIELDS. Returns None when no
+    color was supplied so the caller can omit rowsProperties entirely.
+    """
+    rows_properties: dict = {}
+    for key, api_field in TABLE_ROW_COLOR_FIELDS.items():
+        parsed = _parse_hex_color(colors.get(key))
+        if parsed:
+            rows_properties[api_field] = {"rgbColor": parsed}
+
+    return rows_properties or None

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -1638,6 +1638,11 @@ async def _manage_sheet_table_impl(
 
     if action_normalized == "create":
         table: dict = {"name": table_name, "range": grid_range}
+        # Truthiness is intentional here, and differs from the `is not None`
+        # check in the update branch below. On create there is no existing
+        # state, so None and [] both mean "no typed columns" and an empty
+        # columnProperties array would be sent for nothing. On update the two
+        # are distinct: None leaves columns untouched, [] clears them.
         if parsed_columns:
             table["columnProperties"] = parsed_columns
         if rows_properties:
@@ -1652,12 +1657,11 @@ async def _manage_sheet_table_impl(
             .execute
         )
 
-        created_id = (
-            response.get("replies", [{}])[0]
-            .get("addTable", {})
-            .get("table", {})
-            .get("tableId")
-        )
+        # A dict default only applies when the key is absent, so an explicitly
+        # empty "replies" list would still make [0] raise. Read the first reply
+        # defensively and report a missing id rather than failing the call.
+        replies = response.get("replies") or [{}]
+        created_id = replies[0].get("addTable", {}).get("table", {}).get("tableId")
         return {
             "spreadsheet_id": spreadsheet_id,
             "action": action_normalized,

--- a/gsheets/sheets_tools.py
+++ b/gsheets/sheets_tools.py
@@ -22,6 +22,8 @@ from gsheets.sheets_helpers import (
     _column_to_index,
     _build_boolean_rule,
     _build_gradient_rule,
+    _build_table_rows_properties,
+    _parse_table_column_properties,
     _fetch_cell_formulas,
     _fetch_detailed_sheet_errors,
     _fetch_grid_metadata,
@@ -1558,6 +1560,248 @@ async def append_table_rows(
     )
 
     logger.info(f"[append_table_rows] Appended {num_rows} rows for {user_google_email}")
+    return text_output
+
+
+TABLE_ACTIONS = ("create", "update", "delete")
+
+
+async def _manage_sheet_table_impl(
+    service,
+    spreadsheet_id: str,
+    action: str,
+    table_id: Optional[str] = None,
+    table_name: Optional[str] = None,
+    range_name: Optional[str] = None,
+    column_properties: Optional[Union[str, List[dict]]] = None,
+    header_color: Optional[str] = None,
+    footer_color: Optional[str] = None,
+    first_band_color: Optional[str] = None,
+    second_band_color: Optional[str] = None,
+) -> dict:
+    """
+    Core implementation for manage_sheet_table, decoupled from the MCP
+    decorators so it can be unit tested with a mock service.
+    """
+    action_normalized = (action or "").strip().lower()
+    if action_normalized not in TABLE_ACTIONS:
+        raise UserInputError(f"action must be one of {list(TABLE_ACTIONS)}.")
+
+    if action_normalized in ("update", "delete") and not table_id:
+        raise UserInputError(
+            f"table_id is required for the '{action_normalized}' action. "
+            "Use list_sheet_tables to find it."
+        )
+
+    if action_normalized == "delete":
+        requests = [{"deleteTable": {"tableId": table_id}}]
+        await asyncio.to_thread(
+            service.spreadsheets()
+            .batchUpdate(spreadsheetId=spreadsheet_id, body={"requests": requests})
+            .execute
+        )
+        return {
+            "spreadsheet_id": spreadsheet_id,
+            "action": action_normalized,
+            "table_id": table_id,
+            "summary": f"deleted table '{table_id}'",
+        }
+
+    if action_normalized == "create":
+        if not table_name:
+            raise UserInputError("table_name is required for the 'create' action.")
+        if not range_name:
+            raise UserInputError(
+                "range_name is required for the 'create' action, and must include "
+                "the header row (e.g., 'Sheet1!A1:D50')."
+            )
+
+    # create/update share range, column and color handling.
+    parsed_columns = _parse_table_column_properties(column_properties)
+    rows_properties = _build_table_rows_properties(
+        header_color=header_color,
+        footer_color=footer_color,
+        first_band_color=first_band_color,
+        second_band_color=second_band_color,
+    )
+
+    grid_range = None
+    if range_name:
+        spreadsheet = await asyncio.to_thread(
+            service.spreadsheets()
+            .get(
+                spreadsheetId=spreadsheet_id, fields="sheets(properties(sheetId,title))"
+            )
+            .execute
+        )
+        grid_range = _parse_a1_range(range_name, spreadsheet.get("sheets", []))
+
+    if action_normalized == "create":
+        table: dict = {"name": table_name, "range": grid_range}
+        if parsed_columns:
+            table["columnProperties"] = parsed_columns
+        if rows_properties:
+            table["rowsProperties"] = rows_properties
+
+        response = await asyncio.to_thread(
+            service.spreadsheets()
+            .batchUpdate(
+                spreadsheetId=spreadsheet_id,
+                body={"requests": [{"addTable": {"table": table}}]},
+            )
+            .execute
+        )
+
+        created_id = (
+            response.get("replies", [{}])[0]
+            .get("addTable", {})
+            .get("table", {})
+            .get("tableId")
+        )
+        return {
+            "spreadsheet_id": spreadsheet_id,
+            "action": action_normalized,
+            "table_id": created_id,
+            "table_name": table_name,
+            "summary": (
+                f"created table '{table_name}' over {range_name}"
+                + (
+                    f" with {len(parsed_columns)} typed column(s)"
+                    if parsed_columns
+                    else ""
+                )
+            ),
+        }
+
+    # update
+    table = {"tableId": table_id}
+    fields: List[str] = []
+
+    if table_name:
+        table["name"] = table_name
+        fields.append("name")
+    if grid_range is not None:
+        table["range"] = grid_range
+        fields.append("range")
+    if parsed_columns is not None:
+        table["columnProperties"] = parsed_columns
+        fields.append("columnProperties")
+    if rows_properties is not None:
+        table["rowsProperties"] = rows_properties
+        fields.append("rowsProperties")
+
+    if not fields:
+        raise UserInputError(
+            "Provide at least one of table_name, range_name, column_properties or a "
+            "color argument to update."
+        )
+
+    await asyncio.to_thread(
+        service.spreadsheets()
+        .batchUpdate(
+            spreadsheetId=spreadsheet_id,
+            body={
+                "requests": [
+                    {"updateTable": {"table": table, "fields": ",".join(fields)}}
+                ]
+            },
+        )
+        .execute
+    )
+
+    return {
+        "spreadsheet_id": spreadsheet_id,
+        "action": action_normalized,
+        "table_id": table_id,
+        "summary": f"updated table '{table_id}' ({', '.join(fields)})",
+    }
+
+
+@server.tool(
+    title="Manage Sheet Table",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("manage_sheet_table", service_type="sheets")
+@require_google_service("sheets", "sheets_write")
+async def manage_sheet_table(
+    service,
+    user_google_email: str,
+    spreadsheet_id: str,
+    action: str,
+    table_id: Optional[str] = None,
+    table_name: Optional[str] = None,
+    range_name: Optional[str] = None,
+    column_properties: Optional[Union[str, List[dict]]] = None,
+    header_color: Optional[str] = None,
+    footer_color: Optional[str] = None,
+    first_band_color: Optional[str] = None,
+    second_band_color: Optional[str] = None,
+) -> str:
+    """
+    Creates, updates, or deletes a native structured table in a Google Sheet.
+
+    Native tables give a range a name, typed columns, banded formatting and
+    per-column dropdowns. Use list_sheet_tables to discover existing table IDs
+    and append_table_rows to add data once a table exists.
+
+    Args:
+        user_google_email (str): The user's Google email address. Required.
+        spreadsheet_id (str): The ID of the spreadsheet. Required.
+        action (str): One of "create", "update", or "delete". Required.
+        table_id (Optional[str]): The table to change. Required for "update"
+            and "delete"; ignored for "create" (Sheets assigns the ID).
+        table_name (Optional[str]): Table name, unique within the spreadsheet.
+            Required for "create". Optional for "update" to rename.
+        range_name (Optional[str]): A1-style range the table covers, including
+            the header row (e.g., "Sheet1!A1:D50"). Required for "create".
+            Optional for "update" to resize. A range without a sheet prefix
+            resolves against the first sheet.
+        column_properties (Optional[Union[str, List[dict]]]): List (or JSON
+            list) of column definitions. Each entry accepts "columnName",
+            "columnType", an optional table-relative "columnIndex" (defaults to
+            position), and for DROPDOWN columns a "values" list of choices.
+            Valid columnType values: DOUBLE, CURRENCY, PERCENT, DATE, TIME,
+            DATE_TIME, TEXT, BOOLEAN, DROPDOWN, FILES_CHIP, PEOPLE_CHIP,
+            FINANCE_CHIP, PLACE_CHIP, RATINGS_CHIP.
+        header_color (Optional[str]): Hex color for the header row.
+        footer_color (Optional[str]): Hex color for the footer row.
+        first_band_color (Optional[str]): Hex color for odd banded rows.
+        second_band_color (Optional[str]): Hex color for even banded rows.
+
+    Returns:
+        str: Confirmation describing the table that was created or changed.
+    """
+    logger.info(
+        f"[manage_sheet_table] Invoked. Email: '{user_google_email}', "
+        f"Action: {action}, Spreadsheet: {spreadsheet_id}"
+    )
+
+    result = await _manage_sheet_table_impl(
+        service=service,
+        spreadsheet_id=spreadsheet_id,
+        action=action,
+        table_id=table_id,
+        table_name=table_name,
+        range_name=range_name,
+        column_properties=column_properties,
+        header_color=header_color,
+        footer_color=footer_color,
+        first_band_color=first_band_color,
+        second_band_color=second_band_color,
+    )
+
+    table_ref = result.get("table_id") or "(id unavailable)"
+    text_output = (
+        f"Successfully {result['summary']} in spreadsheet {spreadsheet_id} "
+        f"for {user_google_email}. Table ID: {table_ref}."
+    )
+
+    logger.info(f"[manage_sheet_table] {result['summary']} for {user_google_email}")
     return text_output
 
 

--- a/tests/gsheets/test_manage_sheet_table.py
+++ b/tests/gsheets/test_manage_sheet_table.py
@@ -75,6 +75,40 @@ async def test_create_table_sends_add_table_with_grid_range():
     assert result["action"] == "create"
 
 
+@pytest.mark.parametrize(
+    "batch_response",
+    [
+        pytest.param({}, id="no-replies-key"),
+        pytest.param({"replies": []}, id="empty-replies-list"),
+        pytest.param({"replies": [{}]}, id="reply-without-addTable"),
+        pytest.param({"replies": [{"addTable": {}}]}, id="addTable-without-table"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_create_reports_missing_table_id_without_raising(batch_response):
+    """
+    A batchUpdate response that carries no usable table id must degrade to
+    table_id=None, not raise. An empty 'replies' list is the sharp edge here:
+    dict.get's default only applies when the key is absent, so indexing [0]
+    on an explicitly empty list raises IndexError.
+    """
+    mock_service = create_mock_service()
+    mock_service.spreadsheets().batchUpdate().execute = Mock(
+        return_value=batch_response
+    )
+
+    result = await _manage_sheet_table_impl(
+        service=mock_service,
+        spreadsheet_id="ss_1",
+        action="create",
+        table_name="Pipeline",
+        range_name="Sheet1!A1:C10",
+    )
+
+    assert result["table_id"] is None
+    assert result["action"] == "create"
+
+
 @pytest.mark.asyncio
 async def test_create_table_assigns_sequential_column_indexes():
     """columnIndex is table-relative and inferred from position when omitted."""

--- a/tests/gsheets/test_manage_sheet_table.py
+++ b/tests/gsheets/test_manage_sheet_table.py
@@ -1,0 +1,436 @@
+"""
+Unit tests for the Google Sheets manage_sheet_table tool.
+
+Covers create/update/delete of native Sheets tables (addTable / updateTable /
+deleteTable), column typing, dropdown column validation, and input validation.
+"""
+
+import os
+import sys
+
+import pytest
+from unittest.mock import Mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from core.utils import UserInputError
+from gsheets.sheets_tools import _manage_sheet_table_impl
+
+
+def create_mock_service(tables=None):
+    """Mock Sheets service exposing one sheet, plus optional existing tables."""
+    mock_service = Mock()
+
+    sheet = {"properties": {"sheetId": 0, "title": "Sheet1"}}
+    if tables is not None:
+        sheet["tables"] = tables
+
+    mock_service.spreadsheets().get().execute = Mock(return_value={"sheets": [sheet]})
+    mock_service.spreadsheets().batchUpdate().execute = Mock(
+        return_value={
+            "replies": [{"addTable": {"table": {"tableId": "tbl_generated"}}}]
+        }
+    )
+    return mock_service
+
+
+def get_requests(mock_service):
+    """Pull the requests list out of the last batchUpdate call."""
+    call_args = mock_service.spreadsheets().batchUpdate.call_args
+    return call_args[1]["body"]["requests"]
+
+
+# --------------------------------------------------------------------------
+# create
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_table_sends_add_table_with_grid_range():
+    """A minimal create maps the A1 range onto a GridRange and names the table."""
+    mock_service = create_mock_service()
+
+    result = await _manage_sheet_table_impl(
+        service=mock_service,
+        spreadsheet_id="ss_1",
+        action="create",
+        table_name="Pipeline",
+        range_name="Sheet1!A1:C10",
+    )
+
+    requests = get_requests(mock_service)
+    assert len(requests) == 1
+
+    table = requests[0]["addTable"]["table"]
+    assert table["name"] == "Pipeline"
+    assert table["range"] == {
+        "sheetId": 0,
+        "startRowIndex": 0,
+        "endRowIndex": 10,
+        "startColumnIndex": 0,
+        "endColumnIndex": 3,
+    }
+    assert "tableId" not in table, "tableId must be left for Sheets to generate"
+    assert result["table_id"] == "tbl_generated"
+    assert result["action"] == "create"
+
+
+@pytest.mark.asyncio
+async def test_create_table_assigns_sequential_column_indexes():
+    """columnIndex is table-relative and inferred from position when omitted."""
+    mock_service = create_mock_service()
+
+    await _manage_sheet_table_impl(
+        service=mock_service,
+        spreadsheet_id="ss_1",
+        action="create",
+        table_name="Pipeline",
+        range_name="Sheet1!A1:C10",
+        column_properties=[
+            {"columnName": "Client", "columnType": "TEXT"},
+            {"columnName": "Fee", "columnType": "CURRENCY"},
+            {"columnName": "Signed", "columnType": "DATE"},
+        ],
+    )
+
+    cols = get_requests(mock_service)[0]["addTable"]["table"]["columnProperties"]
+    assert [c["columnIndex"] for c in cols] == [0, 1, 2]
+    assert [c["columnName"] for c in cols] == ["Client", "Fee", "Signed"]
+    assert [c["columnType"] for c in cols] == ["TEXT", "CURRENCY", "DATE"]
+
+
+@pytest.mark.asyncio
+async def test_create_table_honours_explicit_column_index():
+    """An explicit columnIndex overrides the positional default."""
+    mock_service = create_mock_service()
+
+    await _manage_sheet_table_impl(
+        service=mock_service,
+        spreadsheet_id="ss_1",
+        action="create",
+        table_name="Pipeline",
+        range_name="Sheet1!A1:C10",
+        column_properties=[
+            {"columnIndex": 2, "columnName": "Third", "columnType": "TEXT"}
+        ],
+    )
+
+    cols = get_requests(mock_service)[0]["addTable"]["table"]["columnProperties"]
+    assert cols[0]["columnIndex"] == 2
+
+
+@pytest.mark.asyncio
+async def test_create_dropdown_column_builds_one_of_list_validation():
+    """A DROPDOWN column with values becomes a ONE_OF_LIST validation rule."""
+    mock_service = create_mock_service()
+
+    await _manage_sheet_table_impl(
+        service=mock_service,
+        spreadsheet_id="ss_1",
+        action="create",
+        table_name="Pipeline",
+        range_name="Sheet1!A1:C10",
+        column_properties=[
+            {
+                "columnName": "Status",
+                "columnType": "DROPDOWN",
+                "values": ["Open", "Won", "Lost"],
+            }
+        ],
+    )
+
+    col = get_requests(mock_service)[0]["addTable"]["table"]["columnProperties"][0]
+    condition = col["dataValidationRule"]["condition"]
+    assert condition["type"] == "ONE_OF_LIST"
+    assert condition["values"] == [
+        {"userEnteredValue": "Open"},
+        {"userEnteredValue": "Won"},
+        {"userEnteredValue": "Lost"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_accepts_json_encoded_column_properties():
+    """column_properties may arrive as a JSON string from an MCP client."""
+    mock_service = create_mock_service()
+
+    await _manage_sheet_table_impl(
+        service=mock_service,
+        spreadsheet_id="ss_1",
+        action="create",
+        table_name="Pipeline",
+        range_name="Sheet1!A1:B10",
+        column_properties='[{"columnName": "A", "columnType": "TEXT"}]',
+    )
+
+    cols = get_requests(mock_service)[0]["addTable"]["table"]["columnProperties"]
+    assert cols[0]["columnName"] == "A"
+
+
+@pytest.mark.asyncio
+async def test_create_applies_banding_colors():
+    """Header/footer/band colors are converted to rowsProperties color styles."""
+    mock_service = create_mock_service()
+
+    await _manage_sheet_table_impl(
+        service=mock_service,
+        spreadsheet_id="ss_1",
+        action="create",
+        table_name="Pipeline",
+        range_name="Sheet1!A1:C10",
+        header_color="#4285f4",
+        first_band_color="#ffffff",
+        second_band_color="#f1f3f4",
+    )
+
+    rows_props = get_requests(mock_service)[0]["addTable"]["table"]["rowsProperties"]
+    assert "headerColorStyle" in rows_props
+    assert "firstBandColorStyle" in rows_props
+    assert "secondBandColorStyle" in rows_props
+    assert rows_props["headerColorStyle"]["rgbColor"]["red"] == pytest.approx(
+        0x42 / 255, abs=1e-3
+    )
+    assert "footerColorStyle" not in rows_props
+
+
+@pytest.mark.asyncio
+async def test_create_without_sheet_prefix_uses_first_sheet():
+    """A bare A1 range resolves against the first sheet."""
+    mock_service = create_mock_service()
+
+    await _manage_sheet_table_impl(
+        service=mock_service,
+        spreadsheet_id="ss_1",
+        action="create",
+        table_name="Pipeline",
+        range_name="A1:C10",
+    )
+
+    table = get_requests(mock_service)[0]["addTable"]["table"]
+    assert table["range"]["sheetId"] == 0
+
+
+# --------------------------------------------------------------------------
+# update
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_renames_table_with_narrow_field_mask():
+    """Updating only the name must not send a wildcard field mask."""
+    mock_service = create_mock_service(tables=[{"tableId": "tbl_1", "name": "Old"}])
+
+    await _manage_sheet_table_impl(
+        service=mock_service,
+        spreadsheet_id="ss_1",
+        action="update",
+        table_id="tbl_1",
+        table_name="New",
+    )
+
+    req = get_requests(mock_service)[0]["updateTable"]
+    assert req["table"]["tableId"] == "tbl_1"
+    assert req["table"]["name"] == "New"
+    assert req["fields"] == "name"
+
+
+@pytest.mark.asyncio
+async def test_update_range_and_columns_builds_combined_mask():
+    """Each supplied field appears in the mask, comma separated and sorted."""
+    mock_service = create_mock_service(tables=[{"tableId": "tbl_1", "name": "Old"}])
+
+    await _manage_sheet_table_impl(
+        service=mock_service,
+        spreadsheet_id="ss_1",
+        action="update",
+        table_id="tbl_1",
+        range_name="Sheet1!A1:D20",
+        column_properties=[{"columnName": "A", "columnType": "TEXT"}],
+    )
+
+    req = get_requests(mock_service)[0]["updateTable"]
+    assert set(req["fields"].split(",")) == {"range", "columnProperties"}
+    assert req["table"]["range"]["endColumnIndex"] == 4
+
+
+@pytest.mark.asyncio
+async def test_update_requires_at_least_one_field():
+    """An update that changes nothing is a caller error, not a no-op API call."""
+    mock_service = create_mock_service(tables=[{"tableId": "tbl_1", "name": "Old"}])
+    mock_service.spreadsheets().batchUpdate.reset_mock()
+
+    with pytest.raises(UserInputError, match="at least one"):
+        await _manage_sheet_table_impl(
+            service=mock_service,
+            spreadsheet_id="ss_1",
+            action="update",
+            table_id="tbl_1",
+        )
+
+    mock_service.spreadsheets().batchUpdate.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# delete
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_table_sends_delete_request():
+    mock_service = create_mock_service(tables=[{"tableId": "tbl_1", "name": "Old"}])
+
+    result = await _manage_sheet_table_impl(
+        service=mock_service,
+        spreadsheet_id="ss_1",
+        action="delete",
+        table_id="tbl_1",
+    )
+
+    requests = get_requests(mock_service)
+    assert requests == [{"deleteTable": {"tableId": "tbl_1"}}]
+    assert result["action"] == "delete"
+
+
+# --------------------------------------------------------------------------
+# input validation
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_rejected():
+    mock_service = create_mock_service()
+
+    with pytest.raises(UserInputError, match="action"):
+        await _manage_sheet_table_impl(
+            service=mock_service, spreadsheet_id="ss_1", action="frobnicate"
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_requires_name_and_range():
+    mock_service = create_mock_service()
+
+    with pytest.raises(UserInputError, match="table_name"):
+        await _manage_sheet_table_impl(
+            service=mock_service,
+            spreadsheet_id="ss_1",
+            action="create",
+            range_name="Sheet1!A1:C10",
+        )
+
+    with pytest.raises(UserInputError, match="range_name"):
+        await _manage_sheet_table_impl(
+            service=mock_service,
+            spreadsheet_id="ss_1",
+            action="create",
+            table_name="Pipeline",
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_and_update_require_table_id():
+    mock_service = create_mock_service()
+
+    for action in ("update", "delete"):
+        with pytest.raises(UserInputError, match="table_id"):
+            await _manage_sheet_table_impl(
+                service=mock_service, spreadsheet_id="ss_1", action=action
+            )
+
+
+@pytest.mark.asyncio
+async def test_invalid_column_type_rejected():
+    mock_service = create_mock_service()
+
+    with pytest.raises(UserInputError, match="columnType"):
+        await _manage_sheet_table_impl(
+            service=mock_service,
+            spreadsheet_id="ss_1",
+            action="create",
+            table_name="Pipeline",
+            range_name="Sheet1!A1:C10",
+            column_properties=[{"columnName": "X", "columnType": "NOT_A_TYPE"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_values_on_non_dropdown_column_rejected():
+    """The API only allows column validation on DROPDOWN columns."""
+    mock_service = create_mock_service()
+
+    with pytest.raises(UserInputError, match="DROPDOWN"):
+        await _manage_sheet_table_impl(
+            service=mock_service,
+            spreadsheet_id="ss_1",
+            action="create",
+            table_name="Pipeline",
+            range_name="Sheet1!A1:C10",
+            column_properties=[
+                {"columnName": "X", "columnType": "TEXT", "values": ["a", "b"]}
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_dropdown_column_requires_values():
+    mock_service = create_mock_service()
+
+    with pytest.raises(UserInputError, match="values"):
+        await _manage_sheet_table_impl(
+            service=mock_service,
+            spreadsheet_id="ss_1",
+            action="create",
+            table_name="Pipeline",
+            range_name="Sheet1!A1:C10",
+            column_properties=[{"columnName": "X", "columnType": "DROPDOWN"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_integer_column_index_rejected():
+    """A bad columnIndex must error loudly, not silently fall back to position."""
+    mock_service = create_mock_service()
+
+    with pytest.raises(UserInputError, match="columnIndex"):
+        await _manage_sheet_table_impl(
+            service=mock_service,
+            spreadsheet_id="ss_1",
+            action="create",
+            table_name="Pipeline",
+            range_name="Sheet1!A1:C10",
+            column_properties=[
+                {"columnIndex": "second", "columnName": "X", "columnType": "TEXT"}
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_invalid_create_args_do_not_hit_the_api():
+    """Argument validation must happen before any network round trip."""
+    mock_service = create_mock_service()
+    mock_service.spreadsheets().get.reset_mock()
+
+    with pytest.raises(UserInputError):
+        await _manage_sheet_table_impl(
+            service=mock_service,
+            spreadsheet_id="ss_1",
+            action="create",
+            range_name="Sheet1!A1:C10",  # table_name missing
+        )
+
+    mock_service.spreadsheets().get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_column_properties_rejected():
+    mock_service = create_mock_service()
+
+    with pytest.raises(UserInputError, match="column_properties"):
+        await _manage_sheet_table_impl(
+            service=mock_service,
+            spreadsheet_id="ss_1",
+            action="create",
+            table_name="Pipeline",
+            range_name="Sheet1!A1:C10",
+            column_properties="{not json",
+        )

--- a/tests/gsheets/test_sheets_tool_tiers.py
+++ b/tests/gsheets/test_sheets_tool_tiers.py
@@ -1,0 +1,100 @@
+"""
+Guard test: every Sheets tool must be listed in core/tool_tiers.yaml.
+
+Tools are registered with @server.tool, but a server started with --tool-tier
+filters the registry down to the names listed in tool_tiers.yaml. A tool that
+is registered but never tiered is silently unreachable for every tiered
+deployment, with no error at startup. This test makes that failure loud.
+
+The tool list is read from the module's AST rather than from the live server so
+the result does not depend on which other tool modules a test session imported.
+"""
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHEETS_TOOLS_PATH = REPO_ROOT / "gsheets" / "sheets_tools.py"
+TOOL_TIERS_PATH = REPO_ROOT / "core" / "tool_tiers.yaml"
+
+
+def _is_server_tool_decorator(decorator: ast.expr) -> bool:
+    """Match @server.tool and @server.tool(...)."""
+    node = decorator.func if isinstance(decorator, ast.Call) else decorator
+    return isinstance(node, ast.Attribute) and node.attr == "tool"
+
+
+def registered_sheets_tool_names() -> set[str]:
+    """Names of every function in sheets_tools.py decorated with @server.tool."""
+    tree = ast.parse(SHEETS_TOOLS_PATH.read_text())
+
+    return {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and any(_is_server_tool_decorator(d) for d in node.decorator_list)
+    }
+
+
+def tiered_sheets_tool_names() -> set[str]:
+    """Every tool name listed under the `sheets` service in tool_tiers.yaml."""
+    config = yaml.safe_load(TOOL_TIERS_PATH.read_text())
+    sheets_config = config.get("sheets") or {}
+
+    names: set[str] = set()
+    for tier_tools in sheets_config.values():
+        if tier_tools:
+            names.update(tier_tools)
+    return names
+
+
+def test_ast_scan_finds_the_known_sheets_tools():
+    """Sanity-check the scanner itself, so a silent zero-match cannot pass."""
+    found = registered_sheets_tool_names()
+
+    assert "read_sheet_values" in found
+    assert "manage_conditional_formatting" in found
+    assert len(found) > 5
+
+
+def test_every_sheets_tool_is_assigned_to_a_tier():
+    """
+    A registered-but-untiered tool never reaches a --tool-tier deployment.
+    """
+    registered = registered_sheets_tool_names()
+    tiered = tiered_sheets_tool_names()
+
+    untiered = registered - tiered
+    assert not untiered, (
+        f"these Sheets tools are registered but missing from {TOOL_TIERS_PATH.name}, "
+        f"so --tool-tier deployments cannot see them: {sorted(untiered)}"
+    )
+
+
+def test_tier_entries_all_refer_to_real_tools():
+    """
+    Catch the reverse drift: a tier entry naming a tool that no longer exists.
+    Comment tools are attached separately by create_comment_tools.
+    """
+    registered = registered_sheets_tool_names()
+    tiered = tiered_sheets_tool_names()
+    dynamically_registered = {"list_spreadsheet_comments", "manage_spreadsheet_comment"}
+
+    dangling = tiered - registered - dynamically_registered
+    assert not dangling, (
+        f"tool_tiers.yaml lists Sheets tools that do not exist: {sorted(dangling)}"
+    )
+
+
+@pytest.mark.parametrize("tool_name", ["manage_sheet_table"])
+def test_specific_tools_are_tiered(tool_name):
+    """Explicit pin for tools whose tier entry is easy to forget."""
+    assert tool_name in registered_sheets_tool_names()
+    assert tool_name in tiered_sheets_tool_names()

--- a/tests/gsheets/test_table_column_types_drift.py
+++ b/tests/gsheets/test_table_column_types_drift.py
@@ -1,0 +1,81 @@
+"""
+Guard test pinning TABLE_COLUMN_TYPES to the Sheets discovery document.
+
+TABLE_COLUMN_TYPES is an allowlist used to reject a bad columnType with an
+actionable message instead of an opaque HTTP 400 from the API. That is only
+useful while the list matches the API.
+
+The two drift directions are deliberately treated differently:
+
+  * A value we allow that the API does not have is a real bug: we would send
+    it and the user would get the opaque 400 the allowlist exists to prevent.
+    That fails the test.
+
+  * A value the API has that we do not list is a missing feature, not a bug.
+    Failing on it would break routine dependency bumps, so it only warns.
+"""
+
+import json
+import os
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gsheets.sheets_helpers import TABLE_COLUMN_TYPES
+
+UNSPECIFIED = "COLUMN_TYPE_UNSPECIFIED"
+
+
+def _api_column_types() -> set[str]:
+    """ColumnType enum from the bundled discovery doc, minus the sentinel."""
+    try:
+        import googleapiclient
+    except ImportError:  # pragma: no cover - dependency is required at runtime
+        pytest.skip("google-api-python-client is not installed")
+
+    doc = (
+        Path(googleapiclient.__file__).parent
+        / "discovery_cache"
+        / "documents"
+        / "sheets.v4.json"
+    )
+    if not doc.is_file():
+        pytest.skip("bundled sheets.v4 discovery document not available")
+
+    schemas = json.loads(doc.read_text())["schemas"]
+    enum = schemas["TableColumnProperties"]["properties"]["columnType"]["enum"]
+    return set(enum) - {UNSPECIFIED}
+
+
+def test_no_column_type_we_allow_is_rejected_by_the_api():
+    """Hard failure: an entry the API does not recognise defeats the allowlist."""
+    stale = TABLE_COLUMN_TYPES - _api_column_types()
+
+    assert not stale, (
+        f"TABLE_COLUMN_TYPES contains values the Sheets API does not define: "
+        f"{sorted(stale)}. Remove them, or they will reach the API as a 400."
+    )
+
+
+def test_unspecified_sentinel_is_not_offered():
+    """The API documents COLUMN_TYPE_UNSPECIFIED as 'do not use'."""
+    assert UNSPECIFIED not in TABLE_COLUMN_TYPES
+
+
+def test_reports_column_types_the_api_added():
+    """
+    Soft signal: new API values are an opportunity, not a defect. Warn so a
+    dependency bump surfaces them without failing CI.
+    """
+    missing = _api_column_types() - TABLE_COLUMN_TYPES
+
+    if missing:
+        warnings.warn(
+            f"Sheets API defines column types not offered by manage_sheet_table: "
+            f"{sorted(missing)}. Consider adding them to TABLE_COLUMN_TYPES.",
+            stacklevel=2,
+        )


### PR DESCRIPTION
## Description

Adds `manage_sheet_table`, which wraps the Sheets `addTable` / `updateTable` / `deleteTable` requests.

The toolset can already read native tables (`list_sheet_tables`) and append rows to them (`append_table_rows`), but there is no way to create one. Both existing tools need a `tableId` that already exists, so a table has to be made by hand in the Sheets UI before either becomes usable. This closes that gap.

**Actions**

- **create** — name a range as a table, with optional typed columns and banded row colors. The range must include the header row.
- **update** — rename, resize, retype or recolor an existing table.
- **delete** — remove a table by id.

**Details worth calling out**

- The `update` field mask is built from the arguments actually supplied, never sent as `"*"`. An update that only renames a table cannot silently clear its column properties.
- `columnIndex` is table-relative, not sheet-relative. It is inferred from list position when omitted, since that is the part of this API most easily got wrong by hand.
- `DROPDOWN` columns take a `values` list and build a `TableColumnDataValidationRule` with a `ONE_OF_LIST` condition. The API only permits column validation on `DROPDOWN` columns, so supplying `values` for any other type is rejected up front with a message explaining why, instead of being sent and coming back as an opaque 400.
- All argument validation happens before any network call.

**Tier registration**

Registered under `sheets: complete` in `tool_tiers.yaml`. I've also added `tests/gsheets/test_sheets_tool_tiers.py`, because a tool registered with `@server.tool` but missing from `tool_tiers.yaml` is silently filtered out of every `--tool-tier` deployment with no startup error or warning. I hit exactly that while writing this. The test now catches it for any future Sheets tool, and catches the reverse case of a tier entry naming a tool that no longer exists.

**Enum drift guard**

`TABLE_COLUMN_TYPES` is an allowlist, so it is only useful while it matches the API. `test_table_column_types_drift.py` pins it to the discovery document bundled with `google-api-python-client`, treating the two drift directions differently on purpose:

- A value we allow that the API does not define **fails** the test. It defeats the allowlist and produces exactly the 400 the allowlist exists to prevent.
- A type the API has added that we do not list only **warns**. That is a missing feature rather than a defect, and failing on it would break routine dependency-bump PRs.

Happy to drop either test file if you'd rather not have them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

21 new tests covering create/update/delete, column typing and index inference, dropdown rule construction, banding colors, JSON-encoded input, field-mask narrowness, and argument validation.

Manually verified against the live Sheets API on two Google accounts: create a table, read it back and confirm the table, the `CURRENCY` column, the `DROPDOWN` column and its stored choices; rename via `updateTable` and confirm the column properties survived the narrow field mask; delete the table and confirm removal. 14/14 checks on each account.

**Note on the existing suite:** `tests/core/test_telemetry.py` has 7 failures on a clean checkout of `main` (v1.22.2) in my environment, before any of my changes. This PR does not affect them. Everything else passes: 1365 passed with that file excluded. `ruff check` and `ruff format --check` are clean.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

Purely additive: 1007 insertions, 0 deletions, no existing behavior changed.

Example — a client pipeline with a currency column and a status dropdown:

```
manage_sheet_table(
    action="create",
    spreadsheet_id="...",
    table_name="Pipeline",
    range_name="Sheet1!A1:C50",
    column_properties=[
        {"columnName": "Client", "columnType": "TEXT"},
        {"columnName": "Fee",    "columnType": "CURRENCY"},
        {"columnName": "Stage",  "columnType": "DROPDOWN",
         "values": ["Open", "Won", "Lost"]},
    ],
    header_color="#4285f4",
)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating, updating, and deleting native Google Sheets tables, including typed columns and dropdown validation.
  * Added table configuration for naming/ranges and header/footer/banding row colors.
  * Enabled the table management capability in the Sheets “complete” tool tier.

* **Bug Fixes**
  * Improved input validation for actions, required parameters, column types, column indexes, dropdown values, and color handling.

* **Tests**
  * Added extensive tests covering request payloads, field update behavior, error cases, tool-tier consistency, and column type drift protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->