### PR TITLE
fix(drive): exclude trashed files from search_drive_files by default

### DIFF
--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -175,6 +175,10 @@ def format_permission_info(permission: Dict[str, Any]) -> str:
     return base
 
 
+# Matches an explicit trashed clause anywhere in a Drive query, e.g. "trashed = true".
+# Used both for structured-query detection and to avoid double-adding a trashed filter.
+TRASHED_CLAUSE_PATTERN = re.compile(r"\btrashed\s*=\s*(true|false)\b", re.IGNORECASE)
+
 # Precompiled regex patterns for Drive query detection
 DRIVE_QUERY_PATTERNS = [
     re.compile(r'\b\w+\s*(=|!=|>|<)\s*[\'"].*?[\'"]', re.IGNORECASE),  # field = 'value'
@@ -182,7 +186,7 @@ DRIVE_QUERY_PATTERNS = [
     re.compile(r"\bcontains\b", re.IGNORECASE),  # contains operator
     re.compile(r"\bin\s+parents\b", re.IGNORECASE),  # in parents
     re.compile(r"\bhas\s*\{", re.IGNORECASE),  # has {properties}
-    re.compile(r"\btrashed\s*=\s*(true|false)\b", re.IGNORECASE),  # trashed=true/false
+    TRASHED_CLAUSE_PATTERN,  # trashed=true/false
     re.compile(r"\bstarred\s*=\s*(true|false)\b", re.IGNORECASE),  # starred=true/false
     re.compile(
         r'[\'"][^\'"]+[\'"]\s+in\s+parents', re.IGNORECASE

--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -176,8 +176,10 @@ def format_permission_info(permission: Dict[str, Any]) -> str:
 
 
 # Matches an explicit trashed clause anywhere in a Drive query, e.g. "trashed = true".
-# Used both for structured-query detection and to avoid double-adding a trashed filter.
-TRASHED_CLAUSE_PATTERN = re.compile(r"\btrashed\s*=\s*(true|false)\b", re.IGNORECASE)
+# Drive accepts both = and != on boolean fields, so `trashed != false` is just as much
+# a caller-supplied filter as `trashed = true`. Used both for structured-query detection
+# and to avoid double-adding a trashed filter.
+TRASHED_CLAUSE_PATTERN = re.compile(r"\btrashed\s*!?=\s*(true|false)\b", re.IGNORECASE)
 
 # Matches a Drive query string literal, including backslash escapes, in either quote
 # style: 'a\'b' or "a\"b". Used to blank out literals before looking for operators, so
@@ -186,7 +188,7 @@ QUERY_STRING_LITERAL_PATTERN = re.compile(r"'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*
 
 
 def has_explicit_trashed_clause(query: str) -> bool:
-    """Return True when `query` contains a real `trashed = true/false` predicate.
+    """Return True when `query` contains a real `trashed =`/`!=` `true/false` predicate.
 
     Quoted values are blanked out first, so a search for a filename that happens to
     contain the text (``name contains 'trashed=false'``) is not read as the caller
@@ -203,7 +205,7 @@ DRIVE_QUERY_PATTERNS = [
     re.compile(r"\bcontains\b", re.IGNORECASE),  # contains operator
     re.compile(r"\bin\s+parents\b", re.IGNORECASE),  # in parents
     re.compile(r"\bhas\s*\{", re.IGNORECASE),  # has {properties}
-    TRASHED_CLAUSE_PATTERN,  # trashed=true/false
+    TRASHED_CLAUSE_PATTERN,  # trashed =/!= true/false
     re.compile(r"\bstarred\s*=\s*(true|false)\b", re.IGNORECASE),  # starred=true/false
     re.compile(
         r'[\'"][^\'"]+[\'"]\s+in\s+parents', re.IGNORECASE

--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -179,6 +179,23 @@ def format_permission_info(permission: Dict[str, Any]) -> str:
 # Used both for structured-query detection and to avoid double-adding a trashed filter.
 TRASHED_CLAUSE_PATTERN = re.compile(r"\btrashed\s*=\s*(true|false)\b", re.IGNORECASE)
 
+# Matches a Drive query string literal, including backslash escapes, in either quote
+# style: 'a\'b' or "a\"b". Used to blank out literals before looking for operators, so
+# text that merely *looks* like a predicate inside a value is not mistaken for one.
+QUERY_STRING_LITERAL_PATTERN = re.compile(r"'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\"")
+
+
+def has_explicit_trashed_clause(query: str) -> bool:
+    """Return True when `query` contains a real `trashed = true/false` predicate.
+
+    Quoted values are blanked out first, so a search for a filename that happens to
+    contain the text (``name contains 'trashed=false'``) is not read as the caller
+    having already filtered by trash state.
+    """
+    without_literals = QUERY_STRING_LITERAL_PATTERN.sub("''", query)
+    return bool(TRASHED_CLAUSE_PATTERN.search(without_literals))
+
+
 # Precompiled regex patterns for Drive query detection
 DRIVE_QUERY_PATTERNS = [
     re.compile(r'\b\w+\s*(=|!=|>|<)\s*[\'"].*?[\'"]', re.IGNORECASE),  # field = 'value'

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -126,7 +126,7 @@ async def search_drive_files(
                                   Defaults to None (Drive API default ordering).
         include_trashed (bool): Whether to include files in the trash. Defaults to False, matching
                                 the Drive web UI and `list_drive_items`. Ignored when `query` already
-                                contains its own `trashed = true/false` clause, which always wins.
+                                contains its own `trashed` clause (`=` or `!=`), which always wins.
 
     Returns:
         str: A formatted list of found files/folders with their details (ID, name, type, and optionally size, modified time, link).

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -44,6 +44,7 @@ from gdrive.drive_helpers import (
     GOOGLE_SHEETS_MIME_TYPE,
     GOOGLE_SLIDES_IMPORT_FORMATS,
     GOOGLE_SLIDES_MIME_TYPE,
+    TRASHED_CLAUSE_PATTERN,
     UPLOAD_CHUNK_SIZE_BYTES,
     _resolve_import_media,
     _stream_url_with_validation,
@@ -93,6 +94,7 @@ async def search_drive_files(
     file_type: Optional[str] = None,
     detailed: bool = True,
     order_by: Optional[str] = None,
+    include_trashed: bool = False,
 ) -> str:
     """
     Searches for files and folders within a user's Google Drive, including shared drives.
@@ -122,13 +124,17 @@ async def search_drive_files(
                                   'name', 'name_natural', 'quotaBytesUsed', 'recency', 'sharedWithMeTime',
                                   'starred', 'viewedByMeTime'. Example: 'modifiedTime desc' or 'folder,modifiedTime desc,name'.
                                   Defaults to None (Drive API default ordering).
+        include_trashed (bool): Whether to include files in the trash. Defaults to False, matching
+                                the Drive web UI and `list_drive_items`. Ignored when `query` already
+                                contains its own `trashed = true/false` clause, which always wins.
 
     Returns:
         str: A formatted list of found files/folders with their details (ID, name, type, and optionally size, modified time, link).
              Includes a nextPageToken line when more results are available.
     """
     logger.info(
-        f"[search_drive_files] Invoked. Email: '{user_google_email}', Query: '{query}', file_type: '{file_type}'"
+        f"[search_drive_files] Invoked. Email: '{user_google_email}', Query: '{query}', "
+        f"file_type: '{file_type}', include_trashed: {include_trashed}"
     )
 
     # Check if the query looks like a structured Drive query or free text
@@ -146,6 +152,15 @@ async def search_drive_files(
         final_query = f"fullText contains '{escaped_query}'"
         logger.info(
             f"[search_drive_files] Reformatting free text query '{query}' to '{final_query}'"
+        )
+
+    # Drive's files.list returns trashed items unless told otherwise. Hide them by
+    # default so search agrees with list_drive_items and the Drive web UI, but never
+    # override an explicit trashed clause the caller wrote themselves.
+    if not include_trashed and not TRASHED_CLAUSE_PATTERN.search(final_query):
+        final_query = f"({final_query}) and trashed=false"
+        logger.info(
+            "[search_drive_files] Excluding trashed items (include_trashed=False)"
         )
 
     if file_type is not None:

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -44,7 +44,6 @@ from gdrive.drive_helpers import (
     GOOGLE_SHEETS_MIME_TYPE,
     GOOGLE_SLIDES_IMPORT_FORMATS,
     GOOGLE_SLIDES_MIME_TYPE,
-    TRASHED_CLAUSE_PATTERN,
     UPLOAD_CHUNK_SIZE_BYTES,
     _resolve_import_media,
     _stream_url_with_validation,
@@ -52,6 +51,7 @@ from gdrive.drive_helpers import (
     check_public_link_permission,
     format_permission_info,
     get_drive_image_url,
+    has_explicit_trashed_clause,
     resolve_drive_item,
     resolve_file_type_mime,
     resolve_folder_id,
@@ -157,7 +157,7 @@ async def search_drive_files(
     # Drive's files.list returns trashed items unless told otherwise. Hide them by
     # default so search agrees with list_drive_items and the Drive web UI, but never
     # override an explicit trashed clause the caller wrote themselves.
-    if not include_trashed and not TRASHED_CLAUSE_PATTERN.search(final_query):
+    if not include_trashed and not has_explicit_trashed_clause(final_query):
         final_query = f"({final_query}) and trashed=false"
         logger.info(
             "[search_drive_files] Excluding trashed items (include_trashed=False)"

--- a/skills/managing-google-workspace/references/drive.md
+++ b/skills/managing-google-workspace/references/drive.md
@@ -29,6 +29,7 @@ Search for files and folders across My Drive and shared drives.
 | file_type | string | no | | Friendly name (`folder`, `document`/`doc`, `spreadsheet`/`sheet`, `presentation`/`slides`, `form`, `drawing`, `pdf`, `shortcut`, `script`, `site`, `jam`/`jamboard`) or raw MIME type |
 | detailed | boolean | no | true | Include size, modified time, and link |
 | order_by | string | no | | Sort order (see Sort Order below) |
+| include_trashed | boolean | no | false | Include files in the trash. A `trashed = true/false` clause written into `query` always wins over this flag |
 
 ### list_drive_items
 List files and folders in a specific folder.
@@ -196,6 +197,8 @@ Search for a file by name and check if it has public link sharing enabled.
 ## Drive Search Query Operators
 
 The `query` parameter of `search_drive_files` uses Google Drive query syntax (e.g. `name contains`, `mimeType =`, `'id' in parents`, `modifiedTime >`, `trashed =`, `sharedWithMe`). Combine with `and`/`or`/`not`.
+
+**Trash:** both `search_drive_files` and `list_drive_items` exclude trashed files by default. To see trashed files, either pass `include_trashed=true` to `search_drive_files` or write an explicit `trashed = true` clause into `query` — an explicit clause always wins over the flag.
 
 ---
 

--- a/skills/managing-google-workspace/references/drive.md
+++ b/skills/managing-google-workspace/references/drive.md
@@ -29,7 +29,7 @@ Search for files and folders across My Drive and shared drives.
 | file_type | string | no | | Friendly name (`folder`, `document`/`doc`, `spreadsheet`/`sheet`, `presentation`/`slides`, `form`, `drawing`, `pdf`, `shortcut`, `script`, `site`, `jam`/`jamboard`) or raw MIME type |
 | detailed | boolean | no | true | Include size, modified time, and link |
 | order_by | string | no | | Sort order (see Sort Order below) |
-| include_trashed | boolean | no | false | Include files in the trash. A `trashed = true/false` clause written into `query` always wins over this flag |
+| include_trashed | boolean | no | false | Include files in the trash. A `trashed` clause (`=` or `!=`) written into `query` always wins over this flag |
 
 ### list_drive_items
 List files and folders in a specific folder.

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -2072,3 +2072,101 @@ async def test_update_drive_file_metadata_only_uploads_no_media(mock_resolve_ite
     update_kwargs = mock_service.files.return_value.update.call_args.kwargs
     assert "media_body" not in update_kwargs
     assert "Successfully updated file" in result
+
+
+# ---------------------------------------------------------------------------
+# search_drive_files — trashed filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_drive_files_excludes_trashed_by_default():
+    """Free-text search hides trashed items, matching list_drive_items and the Drive UI."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {"files": []}
+
+    await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="budget",
+    )
+
+    call_kwargs = mock_service.files.return_value.list.call_args.kwargs
+    assert call_kwargs["q"] == "(fullText contains 'budget') and trashed=false"
+
+
+@pytest.mark.asyncio
+async def test_search_drive_files_excludes_trashed_for_structured_query():
+    """A structured query without a trashed clause also gets trashed=false appended."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {"files": []}
+
+    await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="name contains 'report'",
+    )
+
+    call_kwargs = mock_service.files.return_value.list.call_args.kwargs
+    assert call_kwargs["q"] == "(name contains 'report') and trashed=false"
+
+
+@pytest.mark.asyncio
+async def test_search_drive_files_include_trashed_leaves_query_untouched():
+    """include_trashed=True restores the old pass-through behavior."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {"files": []}
+
+    await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="name contains 'report'",
+        include_trashed=True,
+    )
+
+    call_kwargs = mock_service.files.return_value.list.call_args.kwargs
+    assert call_kwargs["q"] == "name contains 'report'"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    [
+        "name contains 'report' and trashed=true",
+        "name contains 'report' and trashed = true",
+        "TRASHED=FALSE and name contains 'report'",
+    ],
+)
+async def test_search_drive_files_respects_explicit_trashed_clause(query):
+    """A caller-supplied trashed clause wins; no second clause is appended."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {"files": []}
+
+    await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query=query,
+    )
+
+    call_kwargs = mock_service.files.return_value.list.call_args.kwargs
+    assert call_kwargs["q"] == query
+
+
+@pytest.mark.asyncio
+async def test_search_drive_files_trashed_filter_composes_with_file_type():
+    """The trashed filter and the mimeType filter both land in the final query."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {"files": []}
+
+    await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query="budget",
+        file_type="pdf",
+    )
+
+    call_kwargs = mock_service.files.return_value.list.call_args.kwargs
+    assert call_kwargs["q"] == (
+        "((fullText contains 'budget') and trashed=false) "
+        "and mimeType = 'application/pdf'"
+    )

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -15,7 +15,10 @@ import os
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from gdrive.drive_helpers import build_drive_list_params
+from gdrive.drive_helpers import (
+    build_drive_list_params,
+    has_explicit_trashed_clause,
+)
 from gdrive.drive_tools import (
     create_drive_file,
     get_drive_file_permissions,
@@ -2170,3 +2173,41 @@ async def test_search_drive_files_trashed_filter_composes_with_file_type():
         "((fullText contains 'budget') and trashed=false) "
         "and mimeType = 'application/pdf'"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    [
+        "name contains 'trashed=false'",
+        "name contains 'trashed = true' and modifiedTime > '2024-01-01'",
+        'name contains "trashed=true"',
+    ],
+)
+async def test_search_drive_files_quoted_trashed_text_is_not_a_clause(query):
+    """A `trashed` predicate inside a quoted value is data, not a filter."""
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {"files": []}
+
+    await _unwrap(search_drive_files)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        query=query,
+    )
+
+    call_kwargs = mock_service.files.return_value.list.call_args.kwargs
+    assert call_kwargs["q"] == f"({query}) and trashed=false"
+
+
+def test_has_explicit_trashed_clause_ignores_quoted_literals():
+    """The detector sees real predicates and skips quoted look-alikes."""
+    assert has_explicit_trashed_clause("trashed=true")
+    assert has_explicit_trashed_clause("name contains 'report' and trashed = false")
+    assert has_explicit_trashed_clause("TRASHED=FALSE and name contains 'x'")
+    # A real clause still counts even when a quoted look-alike sits beside it.
+    assert has_explicit_trashed_clause("trashed=true and name contains 'trashed=false'")
+
+    assert not has_explicit_trashed_clause("name contains 'trashed=false'")
+    assert not has_explicit_trashed_clause('name contains "trashed=true"')
+    assert not has_explicit_trashed_clause(r"name contains 'it\'s trashed=true'")
+    assert not has_explicit_trashed_clause("budget")

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -2138,6 +2138,10 @@ async def test_search_drive_files_include_trashed_leaves_query_untouched():
         "name contains 'report' and trashed=true",
         "name contains 'report' and trashed = true",
         "TRASHED=FALSE and name contains 'report'",
+        # Drive accepts != on booleans; `trashed != false` means "only trashed", so
+        # appending `and trashed=false` would silently return nothing.
+        "name contains 'report' and trashed != false",
+        "name contains 'report' and trashed!=true",
     ],
 )
 async def test_search_drive_files_respects_explicit_trashed_clause(query):
@@ -2204,10 +2208,13 @@ def test_has_explicit_trashed_clause_ignores_quoted_literals():
     assert has_explicit_trashed_clause("trashed=true")
     assert has_explicit_trashed_clause("name contains 'report' and trashed = false")
     assert has_explicit_trashed_clause("TRASHED=FALSE and name contains 'x'")
+    assert has_explicit_trashed_clause("trashed != false")
+    assert has_explicit_trashed_clause("name contains 'report' and trashed!=true")
     # A real clause still counts even when a quoted look-alike sits beside it.
     assert has_explicit_trashed_clause("trashed=true and name contains 'trashed=false'")
 
     assert not has_explicit_trashed_clause("name contains 'trashed=false'")
     assert not has_explicit_trashed_clause('name contains "trashed=true"')
+    assert not has_explicit_trashed_clause("name contains 'trashed != false'")
     assert not has_explicit_trashed_clause(r"name contains 'it\'s trashed=true'")
     assert not has_explicit_trashed_clause("budget")


### PR DESCRIPTION
## Description

`search_drive_files` returns files that are in the trash. `list_drive_items` does not — it builds `f"'{folder_id}' in parents and trashed=false"` ([drive_tools.py](https://github.com/taylorwilsdon/google_workspace_mcp/blob/main/gdrive/drive_tools.py)) — and neither does the Drive web UI. Search is the outlier because it passes the caller's query through verbatim and appends nothing.

The disagreement is actively misleading rather than merely inconsistent. `update_drive_file(trashed=True)` is the only delete path exposed over MCP, so the natural verification loop is trash → search → confirm gone. Today that loop reports failure on a successful trash, and I've watched an agent conclude from it that the trash write path was broken when it was fine.

Verified live against v1.22.2, file `1Nf2i87…`:

- trashed via `update_drive_file(trashed=true)`; Drive API confirmed `{"trashed": true, "explicitlyTrashed": true}`
- `search_drive_files("name contains 'trash-test'")` → **still returns the file**
- `search_drive_files("name contains 'trash-test' and trashed=false")` → `No files found`

### The change

- New `include_trashed: bool = False` parameter on `search_drive_files`.
- When it's `False`, `and trashed=false` is appended to the final query.
- The query is user-supplied and may already contain its own `trashed = true/false` clause, so the existing trashed regex in `DRIVE_QUERY_PATTERNS` is hoisted to `TRASHED_CLAUSE_PATTERN` and reused to detect that case. An explicit clause always wins and is never double-added.
- `include_trashed=True` restores the previous pass-through behavior exactly.
- Ordering is safe with the existing `file_type` filter: `((fullText contains 'x') and trashed=false) and mimeType = '…'`.

**Behavior change, intentional:** callers who relied on the old implicit inclusion of trashed results now need `include_trashed=True` or an explicit `trashed = true` clause. Happy to flip the default to `True` and make this purely additive if you'd rather not change existing behavior in a point release — but I think matching `list_drive_items` and the Drive UI is the right default, and the current behavior mostly surprises people.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

7 new tests in `tests/gdrive/test_drive_tools.py`:

| Test | Asserts |
|------|---------|
| `…excludes_trashed_by_default` | free-text → `(fullText contains 'budget') and trashed=false` |
| `…excludes_trashed_for_structured_query` | structured → `(name contains 'report') and trashed=false` |
| `…include_trashed_leaves_query_untouched` | opt-in → query passed through verbatim |
| `…respects_explicit_trashed_clause` (×3) | `trashed=true`, `trashed = true`, `TRASHED=FALSE` all pass through unchanged |
| `…trashed_filter_composes_with_file_type` | trashed + mimeType filters compose correctly |

```
uv run pytest tests/gdrive tests/core -q
232 passed
```

`uvx ruff check` error count is unchanged from `main` (no new lint findings); `uvx ruff format --check` is clean on all touched files.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

Related to #915 (permanent Drive file delete) — same corner of the API. That issue is about the missing hard-delete path; this PR is about the observation path lying about the soft-delete path that already exists.

Docs updated: the `search_drive_files` parameter table and the "Drive Search Query Operators" section in `skills/managing-google-workspace/references/drive.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drive searches now exclude trashed files by default.
  * Added an `include_trashed` option to include trashed items.
  * If the query contains an explicit `trashed = true/false` predicate, it overrides the flag.
* **Bug Fixes**
  * Improved handling of `trashed=...` inside quoted text so it’s treated as data, not a filter.
* **Documentation**
  * Updated Drive search docs with “Trash” guidance and override behavior.
* **Tests**
  * Expanded coverage for default trash filtering, explicit predicate variations, and quoted edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->