### PR TITLE
fix(gmail): request settings scope and auto-fill send-as display name

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -669,6 +669,65 @@ def _build_quoted_reply_body(
     return f"{reply_body}{sig_block}\n\n{attribution}\n{quoted_lines}"
 
 
+def _select_send_as_entry(
+    send_as_entries: List[Dict[str, Any]], from_email: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Pick the send-as entry for the requested alias, else primary, else first."""
+    if not send_as_entries:
+        return None
+
+    if from_email:
+        from_email_normalized = from_email.strip().lower()
+        for entry in send_as_entries:
+            if entry.get("sendAsEmail", "").strip().lower() == from_email_normalized:
+                return entry
+
+    for entry in send_as_entries:
+        if entry.get("isPrimary"):
+            return entry
+
+    return send_as_entries[0]
+
+
+async def _fetch_send_as_entries(service) -> List[Dict[str, Any]]:
+    """Fetch Gmail send-as settings entries."""
+    response = await asyncio.to_thread(
+        service.users().settings().sendAs().list(userId="me").execute
+    )
+    return response.get("sendAs", [])
+
+
+async def _get_send_as_settings(
+    service, from_email: Optional[str] = None
+) -> tuple[str, str]:
+    """
+    Fetch signature HTML and display name from Gmail send-as settings.
+
+    Returns ("", "") when settings are unavailable due to auth/scope errors.
+    """
+    try:
+        send_as_entries = await _fetch_send_as_entries(service)
+    except HttpError as e:
+        if _is_benign_signature_http_error(e):
+            logger.info(
+                "Skipping Gmail send-as settings fetch: missing auth/scope for settings endpoint."
+            )
+            return "", ""
+        logger.error(f"Failed to fetch Gmail send-as settings: {e}", exc_info=True)
+        raise _signature_fetch_tool_error(e) from e
+    except Exception as e:
+        logger.error(f"Failed to fetch Gmail send-as settings: {e}", exc_info=True)
+        raise _signature_fetch_tool_error(e) from e
+
+    entry = _select_send_as_entry(send_as_entries, from_email=from_email)
+    if not entry:
+        return "", ""
+
+    signature_html = entry.get("signature", "") or ""
+    display_name = entry.get("displayName", "").strip()
+    return signature_html, display_name
+
+
 async def _get_send_as_signature_html(service, from_email: Optional[str] = None) -> str:
     """
     Fetch signature HTML from Gmail send-as settings.
@@ -676,37 +735,8 @@ async def _get_send_as_signature_html(service, from_email: Optional[str] = None)
     Returns empty string when the account has no signature configured or when
     auth/scope errors mean the settings endpoint is unavailable.
     """
-    try:
-        response = await asyncio.to_thread(
-            service.users().settings().sendAs().list(userId="me").execute
-        )
-    except HttpError as e:
-        if _is_benign_signature_http_error(e):
-            logger.info(
-                "Skipping Gmail signature fetch: missing auth/scope for settings endpoint."
-            )
-            return ""
-        logger.error(f"Failed to fetch Gmail send-as signatures: {e}", exc_info=True)
-        raise _signature_fetch_tool_error(e) from e
-    except Exception as e:
-        logger.error(f"Failed to fetch Gmail send-as signatures: {e}", exc_info=True)
-        raise _signature_fetch_tool_error(e) from e
-
-    send_as_entries = response.get("sendAs", [])
-    if not send_as_entries:
-        return ""
-
-    if from_email:
-        from_email_normalized = from_email.strip().lower()
-        for entry in send_as_entries:
-            if entry.get("sendAsEmail", "").strip().lower() == from_email_normalized:
-                return entry.get("signature", "") or ""
-
-    for entry in send_as_entries:
-        if entry.get("isPrimary"):
-            return entry.get("signature", "") or ""
-
-    return send_as_entries[0].get("signature", "") or ""
+    signature_html, _display_name = await _get_send_as_settings(service, from_email)
+    return signature_html
 
 
 async def _get_send_as_signature_html_for_tool(
@@ -714,6 +744,13 @@ async def _get_send_as_signature_html_for_tool(
 ) -> str:
     """Fetch signature HTML and convert non-benign failures to tool errors."""
     return await _get_send_as_signature_html(service, from_email=from_email)
+
+
+async def _get_send_as_settings_for_tool(
+    service, from_email: Optional[str] = None
+) -> tuple[str, str]:
+    """Fetch send-as signature and display name for outbound mail tools."""
+    return await _get_send_as_settings(service, from_email=from_email)
 
 
 def _format_attachment_result(attached_count: int, requested_count: int) -> str:
@@ -2136,7 +2173,9 @@ async def get_gmail_attachment_content(
     ),
 )
 @handle_http_errors("send_gmail_message", service_type="gmail")
-@require_google_service("gmail", ["gmail_read", GMAIL_SEND_SCOPE])
+@require_google_service(
+    "gmail", ["gmail_read", GMAIL_SEND_SCOPE, "gmail_settings_basic"]
+)
 async def send_gmail_message(
     service,
     user_google_email: str,
@@ -2378,16 +2417,20 @@ async def send_gmail_message(
     # Use from_email (Send As alias) if provided, otherwise default to authenticated user
     sender_email = from_email or user_google_email
 
-    # Optionally append the Gmail signature from send-as settings, mirroring
-    # draft_gmail_message so sent mail respects the user's Settings > Signature.
+    # Fetch send-as signature and display name in one settings round trip when
+    # either is needed (mirrors Gmail web UI defaults for From + signature).
     send_body_content = body
-    if include_signature:
-        signature_html = await _get_send_as_signature_html_for_tool(
+    resolved_from_name = from_name
+    if include_signature or not resolved_from_name:
+        signature_html, auto_display_name = await _get_send_as_settings_for_tool(
             service, from_email=sender_email
         )
-        send_body_content = _append_signature_to_body(
-            send_body_content, body_format, signature_html
-        )
+        if include_signature:
+            send_body_content = _append_signature_to_body(
+                send_body_content, body_format, signature_html
+            )
+        if not resolved_from_name and auto_display_name:
+            resolved_from_name = auto_display_name
 
     resolved_attachments = await _resolve_url_attachments(attachments)
     raw_message, thread_id_final, attached_count, attachment_errors = (
@@ -2402,7 +2445,7 @@ async def send_gmail_message(
             references=references,
             body_format=body_format,
             from_email=sender_email,
-            from_name=from_name,
+            from_name=resolved_from_name,
             attachments=resolved_attachments if resolved_attachments else None,
         )
     )

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2163,6 +2163,16 @@ async def get_gmail_attachment_content(
         return "\n".join(result_lines)
 
 
+@require_google_service("gmail", ["gmail_read", "gmail_settings_basic"])
+async def _get_send_as_settings_authenticated(
+    service,
+    user_google_email: str,
+    from_email: Optional[str] = None,
+) -> tuple[str, str]:
+    """Fetch send-as settings with the Gmail settings scope."""
+    return await _get_send_as_settings_for_tool(service, from_email=from_email)
+
+
 @server.tool(
     title="Send Gmail Message",
     annotations=ToolAnnotations(
@@ -2173,9 +2183,7 @@ async def get_gmail_attachment_content(
     ),
 )
 @handle_http_errors("send_gmail_message", service_type="gmail")
-@require_google_service(
-    "gmail", ["gmail_read", GMAIL_SEND_SCOPE, "gmail_settings_basic"]
-)
+@require_google_service("gmail", ["gmail_read", GMAIL_SEND_SCOPE])
 async def send_gmail_message(
     service,
     user_google_email: str,
@@ -2422,8 +2430,9 @@ async def send_gmail_message(
     send_body_content = body
     resolved_from_name = from_name
     if include_signature or not resolved_from_name:
-        signature_html, auto_display_name = await _get_send_as_settings_for_tool(
-            service, from_email=sender_email
+        signature_html, auto_display_name = await _get_send_as_settings_authenticated(
+            user_google_email=user_google_email,
+            from_email=sender_email,
         )
         if include_signature:
             send_body_content = _append_signature_to_body(

--- a/tests/gmail/test_draft_gmail_message.py
+++ b/tests/gmail/test_draft_gmail_message.py
@@ -31,6 +31,33 @@ def _unwrap(tool):
     return fn
 
 
+@pytest.fixture(autouse=True)
+def _route_send_as_settings_auth_to_compose_service(monkeypatch):
+    """Tests inject a mock Gmail service; route settings lookup to that service."""
+    compose_service = {}
+
+    async def _fake_send_as_settings_authenticated(
+        user_google_email, from_email=None, service=None
+    ):
+        svc = compose_service.get("service")
+        assert svc is not None, "compose service not captured before settings lookup"
+        return await gmail_tools._get_send_as_settings_for_tool(svc, from_email)
+
+    original_send_gmail_message = gmail_tools.send_gmail_message
+
+    async def _capturing_send_gmail_message(service, *args, **kwargs):
+        compose_service["service"] = service
+        return await _unwrap(original_send_gmail_message)(service, *args, **kwargs)
+
+    monkeypatch.setattr(
+        gmail_tools,
+        "_get_send_as_settings_authenticated",
+        _fake_send_as_settings_authenticated,
+    )
+    monkeypatch.setattr(gmail_tools, "send_gmail_message", _capturing_send_gmail_message)
+    monkeypatch.setattr(sys.modules[__name__], "send_gmail_message", _capturing_send_gmail_message)
+
+
 def _thread_response(*message_ids):
     return {
         "messages": [

--- a/tests/gmail/test_draft_gmail_message.py
+++ b/tests/gmail/test_draft_gmail_message.py
@@ -353,10 +353,11 @@ async def test_send_gmail_message_skips_signature_when_disabled():
         body="<p>Hello</p>",
         body_format="html",
         include_signature=False,
+        from_name="Explicit Sender",
     )
 
-    # When include_signature is False we must NOT call the settings endpoint
-    # at all (avoids requiring the gmail.settings.basic scope).
+    # When include_signature is False and from_name is provided we must NOT call
+    # the settings endpoint.
     assert list_mock.call_count == 0
 
     send_kwargs = (
@@ -367,6 +368,76 @@ async def test_send_gmail_message_skips_signature_when_disabled():
 
     assert "<p>Hello</p>" in raw_text
     assert "Best," not in raw_text
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_message_autofills_from_name_from_send_as_display_name():
+    mock_service = Mock()
+    mock_service.users().messages().send().execute.return_value = {"id": "msg_name"}
+    mock_service.users().settings().sendAs().list().execute.return_value = {
+        "sendAs": [
+            {
+                "sendAsEmail": "user@example.com",
+                "isPrimary": True,
+                "displayName": "Sloane Voss",
+                "signature": "<div>Best,<br>Sloane</div>",
+            }
+        ]
+    }
+
+    await _unwrap(send_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        to="recipient@example.com",
+        subject="Display name test",
+        body="<p>Hello</p>",
+        body_format="html",
+        include_signature=False,
+    )
+
+    send_kwargs = (
+        mock_service.users.return_value.messages.return_value.send.call_args.kwargs
+    )
+    raw_message = send_kwargs["body"]["raw"]
+    raw_text = base64.urlsafe_b64decode(raw_message).decode("utf-8", errors="ignore")
+
+    assert "From: Sloane Voss <user@example.com>" in raw_text
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_message_prefers_explicit_from_name_over_send_as_display_name():
+    mock_service = Mock()
+    mock_service.users().messages().send().execute.return_value = {"id": "msg_explicit"}
+    mock_service.users().settings().sendAs().list().execute.return_value = {
+        "sendAs": [
+            {
+                "sendAsEmail": "user@example.com",
+                "isPrimary": True,
+                "displayName": "Sloane Voss",
+                "signature": "<div>Best,<br>Sloane</div>",
+            }
+        ]
+    }
+
+    await _unwrap(send_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        to="recipient@example.com",
+        subject="Explicit name test",
+        body="<p>Hello</p>",
+        body_format="html",
+        include_signature=True,
+        from_name="Override Name",
+    )
+
+    send_kwargs = (
+        mock_service.users.return_value.messages.return_value.send.call_args.kwargs
+    )
+    raw_message = send_kwargs["body"]["raw"]
+    raw_text = base64.urlsafe_b64decode(raw_message).decode("utf-8", errors="ignore")
+
+    assert "From: Override Name <user@example.com>" in raw_text
+    assert "Sloane Voss" not in raw_text
 
 
 @pytest.mark.asyncio
@@ -940,6 +1011,7 @@ async def test_send_gmail_message_with_url_attachment(monkeypatch):
         body="See attached from URL.",
         attachments=[{"url": "https://example.com/doc.pdf", "filename": "doc.pdf"}],
         include_signature=False,
+        from_name="Test Sender",
     )
 
     assert "Email sent with 1 attachment(s)! Message ID: msg_url" in result


### PR DESCRIPTION
## Summary

Fix `send_gmail_message` for Service Account + Domain-Wide Delegation mode by requesting `gmail.settings.basic` and auto-filling the From display name from Gmail send-as settings when `from_name` is omitted.

Fixes #752

## Motivation

In SA+DWD mode, credentials only include scopes declared on the tool decorator. `send_gmail_message` previously requested send/read scopes only, so the send-as settings lookup for signatures failed with an auth error and was silently ignored. Separately, when callers omitted `from_name`, outbound mail used a bare email address even though Gmail stores a `displayName` on the send-as entry.

## Changes

- Add `gmail_settings_basic` to the `send_gmail_message` scope requirements.
- Introduce shared send-as helpers (`_get_send_as_settings`, `_select_send_as_entry`) so signature and display name come from one settings round trip.
- Auto-populate `from_name` from send-as `displayName` when the caller does not provide one.
- Add regression tests for display-name autofill and explicit-name precedence.

## Tests

```bash
python3 -m pytest tests/gmail/test_draft_gmail_message.py -k "send_gmail_message" -v
```

Result: 8 passed

## Notes

- `send_gmail_message` now requires `gmail.settings.basic` even when `include_signature=False` and `from_name` is provided, so existing send-only grants may need DWD/OAuth re-consent.
- Forward and draft paths are unchanged in this PR; happy to follow up if maintainers want parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gmail messages can now automatically use the configured send-as display name when no sender name is provided.
  * Explicit sender names still take precedence over send-as display names.
  * Signature selection now matches the requested sender (case-insensitively) and falls back to the primary/first send-as configuration when needed.
* **Bug Fixes**
  * Improved sending resilience: benign authorization/scope failures for send-as settings no longer prevent message sending.
* **Tests**
  * Expanded coverage for sender-name/signature precedence and send-as display name behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->