### PR TITLE
gchat: request spaces scope for get_messages and search_messages

### DIFF
--- a/gchat/chat_tools.py
+++ b/gchat/chat_tools.py
@@ -198,7 +198,7 @@ async def list_spaces(
 )
 @require_multiple_services(
     [
-        {"service_type": "chat", "scopes": "chat_read", "param_name": "chat_service"},
+        {"service_type": "chat", "scopes": ["chat_read", "chat_spaces_readonly"], "param_name": "chat_service"},
         {
             "service_type": "people",
             "scopes": "contacts_read",
@@ -379,7 +379,7 @@ async def send_message(
 )
 @require_multiple_services(
     [
-        {"service_type": "chat", "scopes": "chat_read", "param_name": "chat_service"},
+        {"service_type": "chat", "scopes": ["chat_read", "chat_spaces_readonly"], "param_name": "chat_service"},
         {
             "service_type": "people",
             "scopes": "contacts_read",


### PR DESCRIPTION
Withdrawn by the author — closing this out.

For anyone who lands here from a search: `get_messages` and `search_messages` call `GetSpace` internally but declare only the `chat_read` scope group, so they fail wherever the credential carries exactly the declared scopes. Adding `chat_spaces_readonly` alongside `chat_read` on those two tools resolves it.