### PR TITLE
enh: address logging in streamable with legacy auth scenario

### DIFF
--- a/auth/auth_info_middleware.py
+++ b/auth/auth_info_middleware.py
@@ -438,13 +438,20 @@ class AuthInfoMiddleware(Middleware):
                 token_fp = "none"
                 token_kind = "no_bearer"
             session_id = getattr(context.fastmcp_context, "session_id", None)
-            logger.warning(
-                f"[AuthInfoMiddleware] No authenticated user resolved "
-                f"reason=all_auth_paths_failed "
-                f"token={token_fp} "
-                f"token_kind={token_kind} "
-                f"session_id={session_id}"
+            expected_legacy_http_no_bearer = (
+                transport_mode == "streamable-http"
+                and token_kind == "no_bearer"
+                and not get_oauth_config().is_oauth21_enabled()
+                and not is_trust_gateway_identity()
             )
+            if not expected_legacy_http_no_bearer:
+                logger.warning(
+                    f"[AuthInfoMiddleware] No authenticated user resolved "
+                    f"reason=all_auth_paths_failed "
+                    f"token={token_fp} "
+                    f"token_kind={token_kind} "
+                    f"session_id={session_id}"
+                )
 
     async def on_call_tool(self, context: MiddlewareContext, call_next):
         """Extract auth info from token and set in context state"""

--- a/tests/auth/test_auth_info_middleware.py
+++ b/tests/auth/test_auth_info_middleware.py
@@ -1,3 +1,4 @@
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -229,3 +230,61 @@ async def test_on_call_tool_requests_authorization_header_when_default_headers_a
     assert observed["token"] == "ya29.token"
     assert fastmcp_context.state["authenticated_user_email"] == "user@example.com"
     assert fastmcp_context.state["authenticated_via"] == "bearer_token"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("transport", "oauth21_enabled", "headers", "expect_warning"),
+    [
+        ("streamable-http", False, {}, False),
+        (
+            "streamable-http",
+            False,
+            {"authorization": "Bearer invalid-token"},
+            True,
+        ),
+        ("streamable-http", True, {}, True),
+        ("stdio", False, {}, True),
+    ],
+)
+async def test_unresolved_auth_warning_is_suppressed_only_for_legacy_http_no_bearer(
+    monkeypatch,
+    caplog,
+    transport,
+    oauth21_enabled,
+    headers,
+    expect_warning,
+):
+    middleware = AuthInfoMiddleware()
+    fastmcp_context = _FakeFastMCPContext()
+    fastmcp_context.session_id = None
+    context = SimpleNamespace(fastmcp_context=fastmcp_context)
+
+    monkeypatch.setattr("auth.auth_info_middleware.get_access_token", lambda: None)
+    monkeypatch.setattr(
+        "auth.auth_info_middleware.get_http_headers", lambda **kwargs: headers
+    )
+    monkeypatch.setattr(
+        "auth.auth_info_middleware.get_oauth_config",
+        lambda: SimpleNamespace(
+            is_oauth21_enabled=lambda: oauth21_enabled,
+        ),
+    )
+    monkeypatch.setattr(
+        "auth.auth_info_middleware.is_trust_gateway_identity", lambda: False
+    )
+    monkeypatch.setattr("core.config.get_transport_mode", lambda: transport)
+    monkeypatch.setattr(
+        "auth.oauth21_session_store.get_oauth21_session_store",
+        lambda: SimpleNamespace(get_single_user_email=lambda: None),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="auth.auth_info_middleware"):
+        await middleware._process_request_for_auth(context)
+
+    unresolved_warnings = [
+        record
+        for record in caplog.records
+        if "reason=all_auth_paths_failed" in record.getMessage()
+    ]
+    assert bool(unresolved_warnings) is expect_warning


### PR DESCRIPTION
Closes #971 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bearer authentication schemes are now recognized regardless of letter casing.
  * Reduced unnecessary authentication warning messages for legacy HTTP requests without bearer credentials.
  * Authentication warnings continue to appear for invalid credentials and other supported authentication scenarios.

* **Tests**
  * Added coverage to verify authentication recognition and warning behavior across legacy HTTP, OAuth-enabled HTTP, bearer-token, and standard input transports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->