### PR TITLE
fix: scope AuthInfoMiddleware identity to the current request

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -9,6 +9,13 @@ on:
 permissions:
   contents: read
 
+env:
+  # Pinned deliberately: ruff 0.16 expands the default rule set and changes
+  # formatter behaviour, which would rewrite the entire codebase. Bump this
+  # (and the `ruff` dev dependency in pyproject.toml) as a standalone,
+  # reviewed migration rather than letting `uvx` float to latest.
+  RUFF_VERSION: '0.15.22'
+
 jobs:
   autofix:
     if: github.event.pull_request.head.repo.full_name == github.repository
@@ -29,8 +36,8 @@ jobs:
       # Same-repo only (guarded by job `if`), so we still avoid `uv sync`
       # to keep behaviour consistent and minimise blast radius.
       run: |
-        uvx ruff check --fix
-        uvx ruff format
+        uvx ruff@${{ env.RUFF_VERSION }} check --fix
+        uvx ruff@${{ env.RUFF_VERSION }} format
     - name: Commit and push fixes
       run: |
         git diff --quiet && exit 0
@@ -57,5 +64,5 @@ jobs:
       # keeps the validation step safe to run on untrusted fork PR code.
       # For same-repo PRs, this runs after autofix commits any formatting fixes.
       run: |
-        uvx ruff check
-        uvx ruff format --check
+        uvx ruff@${{ env.RUFF_VERSION }} check
+        uvx ruff@${{ env.RUFF_VERSION }} format --check

--- a/auth/auth_info_middleware.py
+++ b/auth/auth_info_middleware.py
@@ -14,18 +14,14 @@ from auth.gateway_identity import GatewayIdentityError, extract_email_from_asser
 from auth.oauth21_session_store import ensure_session_from_access_token
 from auth.oauth_config import get_oauth_config, is_trust_gateway_identity
 from auth.oauth_types import WorkspaceAccessToken
+from auth.request_identity import (
+    get_request_identity,
+    reset_request_identity,
+    set_request_identity,
+)
 
 # Configure logging
 logger = logging.getLogger(__name__)
-
-_AUTH_IDENTITY_STATE_KEYS = (
-    "authenticated_user_email",
-    "authenticated_via",
-    "user_email",
-    "username",
-    "auth_provider_type",
-    "token_type",
-)
 
 
 def _token_fingerprint(token: str) -> str:
@@ -35,33 +31,23 @@ def _token_fingerprint(token: str) -> str:
     return f"{token[:8]}…(len={len(token)})"
 
 
-async def _set_request_auth_state(fastmcp_context, **state) -> None:
-    """Store auth identity for the current MCP request only.
-
-    FastMCP ``set_state`` defaults to session-scoped MemoryStore (24h TTL). Clients
-    that open a fresh MCP session per tool call (common in gateways) would otherwise
-    accumulate unbounded keys. Request-scoped state (``serializable=False``) is enough
-    because AuthInfoMiddleware re-runs on every tool/prompt call.
-    """
-    for key, value in state.items():
-        await fastmcp_context.set_state(key, value, serializable=False)
-
-
 class AuthInfoMiddleware(Middleware):
     """
     Middleware to extract authentication information from JWT tokens
     and populate the FastMCP context state for use in tools and prompts.
     """
 
-    def __init__(self):
-        super().__init__()
-        self.auth_provider_type = "GoogleProvider"
-
     async def _process_request_for_auth(self, context: MiddlewareContext):
         """Helper to extract, verify, and store auth info from a request."""
         if not context.fastmcp_context:
             logger.warning("No fastmcp_context available")
             return
+
+        # Shadow any identity inherited from session state before any auth path
+        # runs. Paths below may fail and still fall through to the tool, so this
+        # is what guarantees an unauthenticated request reads None rather than an
+        # earlier request's principal.
+        await reset_request_identity(context.fastmcp_context)
 
         authenticated_user = None
         auth_via = None
@@ -71,11 +57,6 @@ class AuthInfoMiddleware(Middleware):
         # trusted source in this mode (MCP_ENABLE_OAUTH21 is off — the proxy owns the handshake).
         if is_trust_gateway_identity():
             try:
-                # FastMCP state is session-scoped by default. Remove any identity left by
-                # legacy authentication before installing this request's verified identity.
-                for state_key in _AUTH_IDENTITY_STATE_KEYS:
-                    await context.fastmcp_context.delete_state(state_key)
-
                 header_name = get_oauth_config().gateway_identity_header
                 hdrs = get_http_headers(include={header_name}) or {}
                 assertion = hdrs.get(header_name)
@@ -94,12 +75,10 @@ class AuthInfoMiddleware(Middleware):
                         "Trusted-gateway identity assertion failed verification"
                     )
 
-                await _set_request_auth_state(
+                await set_request_identity(
                     context.fastmcp_context,
-                    authenticated_user_email=verified_email,
-                    authenticated_via="gateway_assertion",
-                    user_email=verified_email,
-                    username=verified_email,
+                    email=verified_email,
+                    via="gateway_assertion",
                 )
                 logger.info("✓ Authenticated via gateway_assertion: %s", verified_email)
                 return
@@ -129,11 +108,10 @@ class AuthInfoMiddleware(Middleware):
                     logger.info(
                         f"✓ Using FastMCP validated token for user: {user_email}"
                     )
-                    await _set_request_auth_state(
+                    await set_request_identity(
                         context.fastmcp_context,
-                        authenticated_user_email=user_email,
-                        authenticated_via="fastmcp_oauth",
-                        access_token=access_token,
+                        email=user_email,
+                        via="fastmcp_oauth",
                     )
                     authenticated_user = user_email
                     auth_via = "fastmcp_oauth"
@@ -232,15 +210,10 @@ class AuthInfoMiddleware(Middleware):
                                             user_email,
                                             mcp_session_id,
                                         )
-                                        await _set_request_auth_state(
+                                        await set_request_identity(
                                             context.fastmcp_context,
-                                            access_token=access_token,
-                                            auth_provider_type=self.auth_provider_type,
-                                            token_type="google_oauth",
-                                            user_email=user_email,
-                                            username=user_email,
-                                            authenticated_user_email=user_email,
-                                            authenticated_via="bearer_token",
+                                            email=user_email,
+                                            via="bearer_token",
                                         )
                                         authenticated_user = user_email
                                         auth_via = "bearer_token"
@@ -315,11 +288,10 @@ class AuthInfoMiddleware(Middleware):
                                 f"Using recent stdio session for {requested_user}"
                             )
                             # In stdio mode, we can trust the user has authenticated recently
-                            await _set_request_auth_state(
+                            await set_request_identity(
                                 context.fastmcp_context,
-                                authenticated_user_email=requested_user,
-                                authenticated_via="stdio_session",
-                                auth_provider_type="oauth21_stdio",
+                                email=requested_user,
+                                via="stdio_session",
                             )
                             authenticated_user = requested_user
                             auth_via = "stdio_session"
@@ -337,13 +309,10 @@ class AuthInfoMiddleware(Middleware):
                             logger.debug(
                                 f"Defaulting to single stdio OAuth session for {single_user}"
                             )
-                            await _set_request_auth_state(
+                            await set_request_identity(
                                 context.fastmcp_context,
-                                authenticated_user_email=single_user,
-                                authenticated_via="stdio_single_session",
-                                auth_provider_type="oauth21_stdio",
-                                user_email=single_user,
-                                username=single_user,
+                                email=single_user,
+                                via="stdio_single_session",
                             )
                             authenticated_user = single_user
                             auth_via = "stdio_single_session"
@@ -367,11 +336,10 @@ class AuthInfoMiddleware(Middleware):
                         bound_user = store.get_user_by_mcp_session(mcp_session_id)
                         if bound_user:
                             logger.debug(f"MCP session bound to {bound_user}")
-                            await _set_request_auth_state(
+                            await set_request_identity(
                                 context.fastmcp_context,
-                                authenticated_user_email=bound_user,
-                                authenticated_via="mcp_session_binding",
-                                auth_provider_type="oauth21_session",
+                                email=bound_user,
+                                via="mcp_session_binding",
                             )
                             authenticated_user = bound_user
                             auth_via = "mcp_session_binding"
@@ -381,12 +349,8 @@ class AuthInfoMiddleware(Middleware):
         # Single exit point with logging
         if authenticated_user:
             logger.info(f"✓ Authenticated via {auth_via}: {authenticated_user}")
-            auth_email = await context.fastmcp_context.get_state(
-                "authenticated_user_email"
-            )
-            logger.debug(
-                f"Context state after auth: authenticated_user_email={auth_email}"
-            )
+            identity = await get_request_identity(context.fastmcp_context)
+            logger.debug(f"Request identity after auth: {identity}")
         else:
             try:
                 auth_header = (get_http_headers() or {}).get("authorization", "")

--- a/auth/auth_info_middleware.py
+++ b/auth/auth_info_middleware.py
@@ -6,9 +6,8 @@ import asyncio
 import logging
 import time
 
+from fastmcp.server.dependencies import get_access_token, get_http_headers
 from fastmcp.server.middleware import Middleware, MiddlewareContext
-from fastmcp.server.dependencies import get_access_token
-from fastmcp.server.dependencies import get_http_headers
 
 from auth.external_oauth_provider import get_session_time
 from auth.gateway_identity import GatewayIdentityError, extract_email_from_assertion

--- a/auth/auth_info_middleware.py
+++ b/auth/auth_info_middleware.py
@@ -36,6 +36,18 @@ def _token_fingerprint(token: str) -> str:
     return f"{token[:8]}…(len={len(token)})"
 
 
+async def _set_request_auth_state(fastmcp_context, **state) -> None:
+    """Store auth identity for the current MCP request only.
+
+    FastMCP ``set_state`` defaults to session-scoped MemoryStore (24h TTL). Clients
+    that open a fresh MCP session per tool call (common in gateways) would otherwise
+    accumulate unbounded keys. Request-scoped state (``serializable=False``) is enough
+    because AuthInfoMiddleware re-runs on every tool/prompt call.
+    """
+    for key, value in state.items():
+        await fastmcp_context.set_state(key, value, serializable=False)
+
+
 class AuthInfoMiddleware(Middleware):
     """
     Middleware to extract authentication information from JWT tokens
@@ -83,27 +95,12 @@ class AuthInfoMiddleware(Middleware):
                         "Trusted-gateway identity assertion failed verification"
                     )
 
-                # These values are authoritative only for this request. In particular, do
-                # not persist them in FastMCP's session-scoped state store.
-                await context.fastmcp_context.set_state(
-                    "authenticated_user_email",
-                    verified_email,
-                    serializable=False,
-                )
-                await context.fastmcp_context.set_state(
-                    "authenticated_via",
-                    "gateway_assertion",
-                    serializable=False,
-                )
-                await context.fastmcp_context.set_state(
-                    "user_email",
-                    verified_email,
-                    serializable=False,
-                )
-                await context.fastmcp_context.set_state(
-                    "username",
-                    verified_email,
-                    serializable=False,
+                await _set_request_auth_state(
+                    context.fastmcp_context,
+                    authenticated_user_email=verified_email,
+                    authenticated_via="gateway_assertion",
+                    user_email=verified_email,
+                    username=verified_email,
                 )
                 logger.info("✓ Authenticated via gateway_assertion: %s", verified_email)
                 return
@@ -133,14 +130,11 @@ class AuthInfoMiddleware(Middleware):
                     logger.info(
                         f"✓ Using FastMCP validated token for user: {user_email}"
                     )
-                    await context.fastmcp_context.set_state(
-                        "authenticated_user_email", user_email
-                    )
-                    await context.fastmcp_context.set_state(
-                        "authenticated_via", "fastmcp_oauth"
-                    )
-                    await context.fastmcp_context.set_state(
-                        "access_token", access_token, serializable=False
+                    await _set_request_auth_state(
+                        context.fastmcp_context,
+                        authenticated_user_email=user_email,
+                        authenticated_via="fastmcp_oauth",
+                        access_token=access_token,
                     )
                     authenticated_user = user_email
                     auth_via = "fastmcp_oauth"
@@ -231,12 +225,6 @@ class AuthInfoMiddleware(Middleware):
                                                 email=user_email,
                                             )
 
-                                        # Store in context state - this is the authoritative authentication state
-                                        await context.fastmcp_context.set_state(
-                                            "access_token",
-                                            access_token,
-                                            serializable=False,
-                                        )
                                         mcp_session_id = getattr(
                                             context.fastmcp_context, "session_id", None
                                         )
@@ -245,25 +233,15 @@ class AuthInfoMiddleware(Middleware):
                                             user_email,
                                             mcp_session_id,
                                         )
-                                        await context.fastmcp_context.set_state(
-                                            "auth_provider_type",
-                                            self.auth_provider_type,
-                                        )
-                                        await context.fastmcp_context.set_state(
-                                            "token_type", "google_oauth"
-                                        )
-                                        await context.fastmcp_context.set_state(
-                                            "user_email", user_email
-                                        )
-                                        await context.fastmcp_context.set_state(
-                                            "username", user_email
-                                        )
-                                        # Set the definitive authentication state
-                                        await context.fastmcp_context.set_state(
-                                            "authenticated_user_email", user_email
-                                        )
-                                        await context.fastmcp_context.set_state(
-                                            "authenticated_via", "bearer_token"
+                                        await _set_request_auth_state(
+                                            context.fastmcp_context,
+                                            access_token=access_token,
+                                            auth_provider_type=self.auth_provider_type,
+                                            token_type="google_oauth",
+                                            user_email=user_email,
+                                            username=user_email,
+                                            authenticated_user_email=user_email,
+                                            authenticated_via="bearer_token",
                                         )
                                         authenticated_user = user_email
                                         auth_via = "bearer_token"
@@ -338,14 +316,11 @@ class AuthInfoMiddleware(Middleware):
                                 f"Using recent stdio session for {requested_user}"
                             )
                             # In stdio mode, we can trust the user has authenticated recently
-                            await context.fastmcp_context.set_state(
-                                "authenticated_user_email", requested_user
-                            )
-                            await context.fastmcp_context.set_state(
-                                "authenticated_via", "stdio_session"
-                            )
-                            await context.fastmcp_context.set_state(
-                                "auth_provider_type", "oauth21_stdio"
+                            await _set_request_auth_state(
+                                context.fastmcp_context,
+                                authenticated_user_email=requested_user,
+                                authenticated_via="stdio_session",
+                                auth_provider_type="oauth21_stdio",
                             )
                             authenticated_user = requested_user
                             auth_via = "stdio_session"
@@ -363,20 +338,13 @@ class AuthInfoMiddleware(Middleware):
                             logger.debug(
                                 f"Defaulting to single stdio OAuth session for {single_user}"
                             )
-                            await context.fastmcp_context.set_state(
-                                "authenticated_user_email", single_user
-                            )
-                            await context.fastmcp_context.set_state(
-                                "authenticated_via", "stdio_single_session"
-                            )
-                            await context.fastmcp_context.set_state(
-                                "auth_provider_type", "oauth21_stdio"
-                            )
-                            await context.fastmcp_context.set_state(
-                                "user_email", single_user
-                            )
-                            await context.fastmcp_context.set_state(
-                                "username", single_user
+                            await _set_request_auth_state(
+                                context.fastmcp_context,
+                                authenticated_user_email=single_user,
+                                authenticated_via="stdio_single_session",
+                                auth_provider_type="oauth21_stdio",
+                                user_email=single_user,
+                                username=single_user,
                             )
                             authenticated_user = single_user
                             auth_via = "stdio_single_session"
@@ -400,14 +368,11 @@ class AuthInfoMiddleware(Middleware):
                         bound_user = store.get_user_by_mcp_session(mcp_session_id)
                         if bound_user:
                             logger.debug(f"MCP session bound to {bound_user}")
-                            await context.fastmcp_context.set_state(
-                                "authenticated_user_email", bound_user
-                            )
-                            await context.fastmcp_context.set_state(
-                                "authenticated_via", "mcp_session_binding"
-                            )
-                            await context.fastmcp_context.set_state(
-                                "auth_provider_type", "oauth21_session"
+                            await _set_request_auth_state(
+                                context.fastmcp_context,
+                                authenticated_user_email=bound_user,
+                                authenticated_via="mcp_session_binding",
+                                auth_provider_type="oauth21_session",
                             )
                             authenticated_user = bound_user
                             auth_via = "mcp_session_binding"

--- a/auth/gateway_identity.py
+++ b/auth/gateway_identity.py
@@ -26,6 +26,7 @@ from jwt import PyJWKClient
 from pydantic.networks import validate_email
 
 from auth.oauth_config import get_oauth_config
+from auth.request_identity import get_request_identity
 
 logger = logging.getLogger(__name__)
 
@@ -60,24 +61,13 @@ def require_gateway_principal(authenticated_user: Any, authenticated_via: Any) -
 
 async def get_verified_gateway_principal(context=None) -> str:
     """Resolve the authoritative gateway principal from the active FastMCP request."""
-    if context is None:
-        try:
-            from fastmcp.server.dependencies import get_context
-
-            context = get_context()
-        except Exception as exc:
-            raise GatewayIdentityError(
-                "Trusted-gateway principal is unavailable outside an MCP request"
-            ) from exc
-
-    if context is None:
+    identity = await get_request_identity(context)
+    if identity is None:
         raise GatewayIdentityError(
             "Trusted-gateway principal is unavailable outside an MCP request"
         )
 
-    authenticated_user = await context.get_state("authenticated_user_email")
-    authenticated_via = await context.get_state("authenticated_via")
-    return require_gateway_principal(authenticated_user, authenticated_via)
+    return require_gateway_principal(identity.email, identity.via)
 
 
 # PyJWKClient caches fetched keys (and refreshes on unknown kid). Cache one client per

--- a/auth/request_identity.py
+++ b/auth/request_identity.py
@@ -1,0 +1,89 @@
+"""Request-scoped authenticated identity for the active MCP request.
+
+``AuthInfoMiddleware`` re-derives the caller's identity on every tool and prompt
+call and records it here. Both keys are written with ``serializable=False``, which
+keeps them in FastMCP's request-scoped dict (``Context._request_state``) rather
+than the session-scoped state store. That matters twice over:
+
+* Identity cannot outlive the request it was derived from. A client that opens a
+  fresh MCP session per tool call no longer accumulates state-store keys, and a
+  request that fails authentication cannot observe an earlier request's principal.
+* Concurrent requests sharing one MCP session each get their own identity instead
+  of racing over a single session-scoped key.
+
+``reset_request_identity`` shadows both keys with ``None`` at request entry.
+``Context.get_state`` tests membership in the request-scoped dict before falling
+back to the session store, so a ``None`` shadow neutralises any legacy
+session-scoped identity without deleting it. Nothing in this module reclaims store
+memory: residue left in a caller-supplied ``session_state_store`` stays put and
+expires on FastMCP's own TTL. It simply cannot be read while a request is in
+flight.
+
+Every identity write goes through this module so that no authentication path can
+accidentally choose session scope.
+"""
+
+import logging
+from typing import NamedTuple
+
+from fastmcp import Context
+from fastmcp.server.dependencies import get_context
+
+logger = logging.getLogger(__name__)
+
+# The only two identity keys any code reads. Deliberately not a general-purpose
+# auth-state bag: extra keys were removed because nothing consumed them.
+_REQUEST_IDENTITY_STATE_KEYS = ("authenticated_user_email", "authenticated_via")
+_EMAIL_KEY, _VIA_KEY = _REQUEST_IDENTITY_STATE_KEYS
+
+
+class RequestIdentity(NamedTuple):
+    """The principal resolved for the current request, if any."""
+
+    email: str | None
+    via: str | None
+
+
+async def reset_request_identity(ctx: Context) -> None:
+    """Shadow any inherited identity with request-scoped ``None``.
+
+    Call once at request entry, before any authentication path runs, so a request
+    that resolves no principal reads ``None`` instead of falling through to a
+    session-scoped value left by an earlier request.
+    """
+    for key in _REQUEST_IDENTITY_STATE_KEYS:
+        await ctx.set_state(key, None, serializable=False)
+
+
+async def set_request_identity(ctx: Context, *, email: str, via: str) -> None:
+    """Record the verified principal for the current request only.
+
+    ``via`` names the authentication path that resolved ``email`` and is itself
+    security-relevant: ``require_gateway_principal`` accepts a principal only when
+    it came from ``gateway_assertion``.
+    """
+    await ctx.set_state(_EMAIL_KEY, email, serializable=False)
+    await ctx.set_state(_VIA_KEY, via, serializable=False)
+
+
+async def get_request_identity(ctx: Context | None = None) -> RequestIdentity | None:
+    """Return the current request's principal, or ``None`` outside an MCP request.
+
+    ``ctx`` defaults to the ambient FastMCP context. ``None`` is returned when
+    there is no usable request context at all -- either no active ``Context``, or
+    one whose MCP session is not yet established -- which lets callers raise their
+    own domain error rather than leaking a FastMCP ``RuntimeError``. A live request
+    that simply failed to authenticate yields ``RequestIdentity(None, None)``.
+    """
+    try:
+        if ctx is None:
+            ctx = get_context()
+        return RequestIdentity(
+            email=await ctx.get_state(_EMAIL_KEY),
+            via=await ctx.get_state(_VIA_KEY),
+        )
+    except RuntimeError as exc:
+        # FastMCP raises RuntimeError both for "no active context" and for
+        # "session not established yet" (state keys are session-prefixed).
+        logger.debug("No usable MCP request context for identity lookup: %s", exc)
+        return None

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -15,6 +15,7 @@ from googleapiclient.discovery import build
 from fastmcp.server.dependencies import get_access_token, get_context
 from auth.google_auth import get_authenticated_google_service, GoogleAuthenticationError
 from auth.gateway_identity import require_gateway_principal
+from auth.request_identity import get_request_identity
 from core.config import USER_GOOGLE_EMAIL as _ENV_USER_EMAIL
 from auth.oauth21_session_store import (
     get_auth_provider,
@@ -95,11 +96,11 @@ async def _get_auth_context(
     """
     try:
         ctx = get_context()
-        if not ctx:
+        identity = await get_request_identity(ctx)
+        if identity is None:
             return None, None, None
 
-        authenticated_user = await ctx.get_state("authenticated_user_email")
-        auth_method = await ctx.get_state("authenticated_via")
+        authenticated_user, auth_method = identity
         mcp_session_id = ctx.session_id if hasattr(ctx, "session_id") else None
 
         # Opt-in: enrich the active tool-call span with the human-readable user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dev = [
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",
     "requests>=2.32.3",
-    "ruff>=0.12.4",
+    "ruff>=0.15.22,<0.16",
     "tomlkit>=0.13.3",
     "twine>=5.0.0",
 ]
@@ -127,7 +127,7 @@ dev = [
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",
     "requests>=2.32.3",
-    "ruff>=0.12.4",
+    "ruff>=0.15.22,<0.16",
     "tomlkit>=0.13.3",
     "twine>=5.0.0",
 ]

--- a/tests/auth/conftest.py
+++ b/tests/auth/conftest.py
@@ -1,0 +1,36 @@
+"""Shared fixtures for auth tests."""
+
+import pytest
+
+from auth import oauth_config
+
+# Trusted-gateway mode is the first branch in AuthInfoMiddleware, so ambient values
+# for these silently reroute every middleware test.
+_GATEWAY_ENV_VARS = (
+    "MCP_TRUST_GATEWAY_IDENTITY",
+    "GATEWAY_IDENTITY_HEADER",
+    "GATEWAY_IDENTITY_JWKS_URL",
+    "GATEWAY_IDENTITY_AUDIENCE",
+    "GATEWAY_IDENTITY_ISSUER",
+    "GATEWAY_IDENTITY_ALGORITHMS",
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_gateway_config(monkeypatch):
+    """Run each auth test against a gateway-disabled config, then restore.
+
+    ``get_oauth_config`` memoises a module-level singleton (auth/oauth_config.py),
+    so both halves matter: clearing the env before the reload stops ambient
+    configuration from leaking in, and reloading again on teardown stops a test that
+    set gateway variables from leaving a contaminated singleton behind for whatever
+    runs next.
+    """
+    for var in _GATEWAY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    oauth_config.reload_oauth_config()
+    try:
+        yield
+    finally:
+        monkeypatch.undo()
+        oauth_config.reload_oauth_config()

--- a/tests/auth/test_auth_info_middleware.py
+++ b/tests/auth/test_auth_info_middleware.py
@@ -61,7 +61,7 @@ async def test_on_call_tool_includes_authorization_header_for_bearer_auth(
 
     monkeypatch.setattr("core.server.get_auth_provider", lambda: _FakeProvider())
 
-    async def _noop_ensure_session(*args, **kwargs):  # noqa: ARG001
+    async def _noop_ensure_session(*args, **kwargs):
         return None
 
     monkeypatch.setattr(
@@ -244,7 +244,7 @@ async def test_on_call_tool_requests_authorization_header_when_default_headers_a
 
     monkeypatch.setattr("core.server.get_auth_provider", lambda: _FakeProvider())
 
-    async def _noop_ensure_session(*args, **kwargs):  # noqa: ARG001
+    async def _noop_ensure_session(*args, **kwargs):
         return None
 
     monkeypatch.setattr(

--- a/tests/auth/test_auth_info_middleware.py
+++ b/tests/auth/test_auth_info_middleware.py
@@ -81,6 +81,43 @@ async def test_on_call_tool_includes_authorization_header_for_bearer_auth(
     assert observed["token"] == "ya29.token"
     assert fastmcp_context.state["authenticated_user_email"] == "user@example.com"
     assert fastmcp_context.state["authenticated_via"] == "bearer_token"
+    assert fastmcp_context.state_serializable["authenticated_user_email"] is False
+    assert fastmcp_context.state_serializable["authenticated_via"] is False
+    assert fastmcp_context.state_serializable["access_token"] is False
+    assert fastmcp_context.state_serializable["user_email"] is False
+    assert fastmcp_context.state_serializable["username"] is False
+    assert fastmcp_context.state_serializable["auth_provider_type"] is False
+    assert fastmcp_context.state_serializable["token_type"] is False
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_oauth_identity_is_request_scoped(monkeypatch):
+    middleware = AuthInfoMiddleware()
+    fastmcp_context = _FakeFastMCPContext()
+    context = SimpleNamespace(fastmcp_context=fastmcp_context)
+    access_token = SimpleNamespace(
+        email="passthrough@local",
+        claims={"email": "passthrough@local"},
+    )
+
+    monkeypatch.setattr(
+        "auth.auth_info_middleware.get_access_token", lambda: access_token
+    )
+    monkeypatch.setattr(
+        "auth.auth_info_middleware.get_http_headers",
+        lambda *args, **kwargs: pytest.fail(
+            "fastmcp_oauth path must not fall through to bearer header parsing"
+        ),
+    )
+
+    await middleware._process_request_for_auth(context)
+
+    assert fastmcp_context.state["authenticated_user_email"] == "passthrough@local"
+    assert fastmcp_context.state["authenticated_via"] == "fastmcp_oauth"
+    assert fastmcp_context.state["access_token"] is access_token
+    assert fastmcp_context.state_serializable["authenticated_user_email"] is False
+    assert fastmcp_context.state_serializable["authenticated_via"] is False
+    assert fastmcp_context.state_serializable["access_token"] is False
 
 
 @pytest.mark.asyncio
@@ -229,3 +266,5 @@ async def test_on_call_tool_requests_authorization_header_when_default_headers_a
     assert observed["token"] == "ya29.token"
     assert fastmcp_context.state["authenticated_user_email"] == "user@example.com"
     assert fastmcp_context.state["authenticated_via"] == "bearer_token"
+    assert fastmcp_context.state_serializable["authenticated_user_email"] is False
+    assert fastmcp_context.state_serializable["authenticated_via"] is False

--- a/tests/auth/test_auth_info_middleware.py
+++ b/tests/auth/test_auth_info_middleware.py
@@ -5,6 +5,11 @@ import pytest
 from auth.auth_info_middleware import AuthInfoMiddleware
 from auth.gateway_identity import GatewayIdentityError
 
+# The only identity keys any consumer reads. Asserting the exact set is what stops a
+# write-only key from creeping back in: every extra key used to cost a session-scoped
+# state-store entry per MCP session.
+IDENTITY_KEYS = {"authenticated_user_email", "authenticated_via"}
+
 
 class _FakeFastMCPContext:
     def __init__(self):
@@ -24,6 +29,58 @@ class _FakeFastMCPContext:
         self.deleted_state.append(key)
         self.state.pop(key, None)
         self.state_serializable.pop(key, None)
+
+
+def assert_request_scoped_identity(ctx, *, email, via):
+    """Assert exactly the two live keys were written, request-scoped, with no deletes."""
+    assert set(ctx.state) == IDENTITY_KEYS
+    assert ctx.state["authenticated_user_email"] == email
+    assert ctx.state["authenticated_via"] == via
+    # serializable=False keeps identity in Context._request_state instead of the
+    # session-scoped store, so it dies with the request that derived it.
+    assert all(scoped is False for scoped in ctx.state_serializable.values())
+    # The stale-identity defence is a request-scoped shadow, not a store delete;
+    # nothing here should be reaching into the session store.
+    assert ctx.deleted_state == []
+
+
+def _stub_google_provider(monkeypatch, observed, email="user@example.com"):
+    class _FakeProvider:
+        async def verify_token(self, token):
+            observed["token"] = token
+            return SimpleNamespace(
+                email=email,
+                claims={"email": email},
+                client_id="google",
+                scopes=["scope-a"],
+                expires_at=1234567890,
+                sub=email,
+            )
+
+    monkeypatch.setattr("core.server.get_auth_provider", lambda: _FakeProvider())
+
+    async def _noop_ensure_session(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "auth.auth_info_middleware.ensure_session_from_access_token",
+        _noop_ensure_session,
+    )
+
+
+def _stub_session_store(monkeypatch, **methods):
+    """Session store whose lookups all miss, unless a test overrides one."""
+    behaviour = {
+        "has_session": lambda email: False,
+        "get_single_user_email": lambda: None,
+        "get_user_by_mcp_session": lambda session_id: None,
+        **methods,
+    }
+    store = SimpleNamespace(**behaviour)
+    monkeypatch.setattr(
+        "auth.oauth21_session_store.get_oauth21_session_store", lambda: store
+    )
+    return store
 
 
 @pytest.mark.asyncio
@@ -46,28 +103,7 @@ async def test_on_call_tool_includes_authorization_header_for_bearer_auth(
         "auth.auth_info_middleware.get_http_headers",
         fake_get_http_headers,
     )
-
-    class _FakeProvider:
-        async def verify_token(self, token):
-            observed["token"] = token
-            return SimpleNamespace(
-                email="user@example.com",
-                claims={"email": "user@example.com"},
-                client_id="google",
-                scopes=["scope-a"],
-                expires_at=1234567890,
-                sub="user@example.com",
-            )
-
-    monkeypatch.setattr("core.server.get_auth_provider", lambda: _FakeProvider())
-
-    async def _noop_ensure_session(*args, **kwargs):
-        return None
-
-    monkeypatch.setattr(
-        "auth.auth_info_middleware.ensure_session_from_access_token",
-        _noop_ensure_session,
-    )
+    _stub_google_provider(monkeypatch, observed)
 
     async def call_next(ctx):
         assert ctx is context
@@ -79,15 +115,9 @@ async def test_on_call_tool_includes_authorization_header_for_bearer_auth(
     assert observed["args"] == ()
     assert observed["kwargs"] == {"include": {"authorization"}}
     assert observed["token"] == "ya29.token"
-    assert fastmcp_context.state["authenticated_user_email"] == "user@example.com"
-    assert fastmcp_context.state["authenticated_via"] == "bearer_token"
-    assert fastmcp_context.state_serializable["authenticated_user_email"] is False
-    assert fastmcp_context.state_serializable["authenticated_via"] is False
-    assert fastmcp_context.state_serializable["access_token"] is False
-    assert fastmcp_context.state_serializable["user_email"] is False
-    assert fastmcp_context.state_serializable["username"] is False
-    assert fastmcp_context.state_serializable["auth_provider_type"] is False
-    assert fastmcp_context.state_serializable["token_type"] is False
+    assert_request_scoped_identity(
+        fastmcp_context, email="user@example.com", via="bearer_token"
+    )
 
 
 @pytest.mark.asyncio
@@ -112,16 +142,13 @@ async def test_fastmcp_oauth_identity_is_request_scoped(monkeypatch):
 
     await middleware._process_request_for_auth(context)
 
-    assert fastmcp_context.state["authenticated_user_email"] == "passthrough@local"
-    assert fastmcp_context.state["authenticated_via"] == "fastmcp_oauth"
-    assert fastmcp_context.state["access_token"] is access_token
-    assert fastmcp_context.state_serializable["authenticated_user_email"] is False
-    assert fastmcp_context.state_serializable["authenticated_via"] is False
-    assert fastmcp_context.state_serializable["access_token"] is False
+    assert_request_scoped_identity(
+        fastmcp_context, email="passthrough@local", via="fastmcp_oauth"
+    )
 
 
 @pytest.mark.asyncio
-async def test_gateway_identity_is_request_scoped_and_clears_stale_state(monkeypatch):
+async def test_gateway_identity_shadows_stale_session_state(monkeypatch):
     middleware = AuthInfoMiddleware()
     fastmcp_context = _FakeFastMCPContext()
     fastmcp_context.state.update(
@@ -158,12 +185,9 @@ async def test_gateway_identity_is_request_scoped_and_clears_stale_state(monkeyp
 
     await middleware._process_request_for_auth(context)
 
-    assert fastmcp_context.state["authenticated_user_email"] == "verified@example.com"
-    assert fastmcp_context.state["authenticated_via"] == "gateway_assertion"
-    assert fastmcp_context.state_serializable["authenticated_user_email"] is False
-    assert fastmcp_context.state_serializable["authenticated_via"] is False
-    assert "authenticated_user_email" in fastmcp_context.deleted_state
-    assert "authenticated_via" in fastmcp_context.deleted_state
+    assert_request_scoped_identity(
+        fastmcp_context, email="verified@example.com", via="gateway_assertion"
+    )
 
 
 @pytest.mark.asyncio
@@ -205,7 +229,117 @@ async def test_gateway_identity_failure_does_not_fall_back(
     with pytest.raises(GatewayIdentityError):
         await middleware._process_request_for_auth(context)
 
-    assert "authenticated_user_email" not in fastmcp_context.state
+    # Shadowed to None by request entry, so the stale principal is unreadable even
+    # though the request aborted before any identity was installed.
+    assert fastmcp_context.state["authenticated_user_email"] is None
+
+
+@pytest.mark.asyncio
+async def test_stdio_requested_user_identity_is_request_scoped(monkeypatch):
+    middleware = AuthInfoMiddleware()
+    fastmcp_context = _FakeFastMCPContext()
+    context = SimpleNamespace(
+        fastmcp_context=fastmcp_context,
+        request=SimpleNamespace(params={"user_google_email": "stdio@example.com"}),
+    )
+
+    monkeypatch.setattr("auth.auth_info_middleware.get_access_token", lambda: None)
+    monkeypatch.setattr(
+        "auth.auth_info_middleware.get_http_headers", lambda *args, **kwargs: {}
+    )
+    monkeypatch.setattr("core.config.get_transport_mode", lambda: "stdio")
+    _stub_session_store(
+        monkeypatch, has_session=lambda email: email == "stdio@example.com"
+    )
+
+    await middleware._process_request_for_auth(context)
+
+    assert_request_scoped_identity(
+        fastmcp_context, email="stdio@example.com", via="stdio_session"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stdio_single_session_identity_is_request_scoped(monkeypatch):
+    middleware = AuthInfoMiddleware()
+    fastmcp_context = _FakeFastMCPContext()
+    context = SimpleNamespace(fastmcp_context=fastmcp_context)
+
+    monkeypatch.setattr("auth.auth_info_middleware.get_access_token", lambda: None)
+    monkeypatch.setattr(
+        "auth.auth_info_middleware.get_http_headers", lambda *args, **kwargs: {}
+    )
+    monkeypatch.setattr("core.config.get_transport_mode", lambda: "stdio")
+    _stub_session_store(monkeypatch, get_single_user_email=lambda: "solo@example.com")
+
+    await middleware._process_request_for_auth(context)
+
+    assert_request_scoped_identity(
+        fastmcp_context, email="solo@example.com", via="stdio_single_session"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_session_binding_identity_is_request_scoped(monkeypatch):
+    middleware = AuthInfoMiddleware()
+    fastmcp_context = _FakeFastMCPContext()
+    context = SimpleNamespace(fastmcp_context=fastmcp_context)
+
+    monkeypatch.setattr("auth.auth_info_middleware.get_access_token", lambda: None)
+    monkeypatch.setattr(
+        "auth.auth_info_middleware.get_http_headers", lambda *args, **kwargs: {}
+    )
+    monkeypatch.setattr("core.config.get_transport_mode", lambda: "streamable-http")
+    _stub_session_store(
+        monkeypatch,
+        get_user_by_mcp_session=lambda session_id: (
+            "bound@example.com" if session_id == "session-123" else None
+        ),
+    )
+
+    await middleware._process_request_for_auth(context)
+
+    assert_request_scoped_identity(
+        fastmcp_context, email="bound@example.com", via="mcp_session_binding"
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_auth_shadows_stale_session_identity(monkeypatch):
+    """A request that resolves no principal must not inherit an earlier one.
+
+    Every non-gateway path falls through to the tool on failure, so without the
+    request-entry shadow FastMCP's get_state would fall back to whatever
+    session-scoped identity a previous request left behind.
+    """
+    middleware = AuthInfoMiddleware()
+    fastmcp_context = _FakeFastMCPContext()
+    fastmcp_context.state.update(
+        {
+            "authenticated_user_email": "stale@example.com",
+            "authenticated_via": "bearer_token",
+        }
+    )
+    context = SimpleNamespace(fastmcp_context=fastmcp_context)
+
+    monkeypatch.setattr("auth.auth_info_middleware.get_access_token", lambda: None)
+    monkeypatch.setattr(
+        "auth.auth_info_middleware.get_http_headers", lambda *args, **kwargs: {}
+    )
+    monkeypatch.setattr("core.config.get_transport_mode", lambda: "streamable-http")
+    _stub_session_store(monkeypatch)
+
+    async def call_next(ctx):
+        return "ok"
+
+    assert await middleware.on_call_tool(context, call_next) == "ok"
+
+    assert set(fastmcp_context.state) == IDENTITY_KEYS
+    assert fastmcp_context.state["authenticated_user_email"] is None
+    assert fastmcp_context.state["authenticated_via"] is None
+    assert all(
+        scoped is False for scoped in fastmcp_context.state_serializable.values()
+    )
 
 
 @pytest.mark.asyncio
@@ -229,28 +363,7 @@ async def test_on_call_tool_requests_authorization_header_when_default_headers_a
         "auth.auth_info_middleware.get_http_headers",
         fake_get_http_headers,
     )
-
-    class _FakeProvider:
-        async def verify_token(self, token):
-            observed["token"] = token
-            return SimpleNamespace(
-                email="user@example.com",
-                claims={"email": "user@example.com"},
-                client_id="google",
-                scopes=["scope-a"],
-                expires_at=1234567890,
-                sub="user@example.com",
-            )
-
-    monkeypatch.setattr("core.server.get_auth_provider", lambda: _FakeProvider())
-
-    async def _noop_ensure_session(*args, **kwargs):
-        return None
-
-    monkeypatch.setattr(
-        "auth.auth_info_middleware.ensure_session_from_access_token",
-        _noop_ensure_session,
-    )
+    _stub_google_provider(monkeypatch, observed)
 
     async def call_next(ctx):
         assert ctx is context
@@ -264,7 +377,6 @@ async def test_on_call_tool_requests_authorization_header_when_default_headers_a
         {"args": (), "kwargs": {"include": {"authorization"}}},
     ]
     assert observed["token"] == "ya29.token"
-    assert fastmcp_context.state["authenticated_user_email"] == "user@example.com"
-    assert fastmcp_context.state["authenticated_via"] == "bearer_token"
-    assert fastmcp_context.state_serializable["authenticated_user_email"] is False
-    assert fastmcp_context.state_serializable["authenticated_via"] is False
+    assert_request_scoped_identity(
+        fastmcp_context, email="user@example.com", via="bearer_token"
+    )

--- a/tests/auth/test_auth_state_scoping.py
+++ b/tests/auth/test_auth_state_scoping.py
@@ -1,0 +1,172 @@
+"""Integration coverage for request-scoped auth identity against a real FastMCP server.
+
+The unit tests in test_auth_info_middleware.py drive a fake context, so they can only
+prove AuthInfoMiddleware asks for ``serializable=False`` -- not that FastMCP's scoping
+behaves as the design assumes. These tests run the real middleware on a real server, so
+the properties stay pinned across a FastMCP upgrade:
+
+* middleware-written identity reaches the tool body in the same request (it does,
+  because Context.__aenter__ shares ``_request_state`` by reference with the nested
+  context that runs the tool);
+* it does not survive into the next request;
+* concurrent requests on one MCP session do not observe each other's principal;
+* a fresh session state store stays empty;
+* a store pre-seeded with legacy identity keeps its entries -- the design shadows
+  rather than deletes -- yet those entries cannot influence a request read.
+"""
+
+import asyncio
+from contextvars import ContextVar
+
+import pytest
+from fastmcp import Client, Context, FastMCP
+from fastmcp.server.middleware import Middleware
+
+from auth.auth_info_middleware import AuthInfoMiddleware
+from auth.request_identity import get_request_identity
+
+pytestmark = pytest.mark.asyncio
+
+# Set per request from the tool arguments, so concurrent calls cannot race over a
+# single shared slot -- otherwise the isolation test would be exercising the stub.
+_active_caller: ContextVar[str | None] = ContextVar("active_caller", default=None)
+
+
+def _session_state_keys(server: FastMCP) -> list[str]:
+    """Every key in the server's session-scoped state store.
+
+    Reaches into FastMCP internals deliberately, and in exactly one place: this is the
+    surface whose unbounded growth motivated request-scoped identity, and it has no
+    public accessor. A FastMCP upgrade that relocates it should break only here.
+    """
+    return sorted(
+        key
+        for collection in server._state_storage._cache.values()
+        for key in collection.keys()
+    )
+
+
+class _StashCaller(Middleware):
+    """Publish the in-flight call's ``caller`` argument to a request-local var."""
+
+    async def on_call_tool(self, context, call_next):
+        token = _active_caller.set((context.message.arguments or {}).get("caller"))
+        try:
+            return await call_next(context)
+        finally:
+            _active_caller.reset(token)
+
+
+def _build_server(monkeypatch, authenticates):
+    """Server wired with the real middleware, authenticating via the fastmcp_oauth path.
+
+    ``authenticates`` maps a caller name to the email its validated access token should
+    carry, or None to simulate a request that resolves no principal.
+    """
+    server = FastMCP("scoping-test")
+    # Added first, so it wraps AuthInfoMiddleware and runs before it.
+    server.add_middleware(_StashCaller())
+    server.add_middleware(AuthInfoMiddleware())
+    seen: list[tuple[str | None, str | None, str | None]] = []
+
+    @server.tool
+    async def whoami(caller: str, ctx: Context) -> str:
+        identity = await get_request_identity(ctx)
+        seen.append((caller, identity.email, identity.via))
+        return str(identity.email)
+
+    @server.tool
+    async def seed_legacy_state(caller: str, ctx: Context) -> str:
+        """Write session-scoped identity the way pre-fix code did."""
+        await ctx.set_state("authenticated_user_email", "legacy@x")
+        await ctx.set_state("authenticated_via", "bearer_token")
+        return ctx.session_id
+
+    def fake_get_access_token():
+        email = authenticates(_active_caller.get())
+        if email is None:
+            return None
+        return type("_Tok", (), {"email": email, "claims": {"email": email}})()
+
+    monkeypatch.setattr(
+        "auth.auth_info_middleware.get_access_token", fake_get_access_token
+    )
+    monkeypatch.setattr(
+        "auth.auth_info_middleware.get_http_headers", lambda *args, **kwargs: {}
+    )
+    monkeypatch.setattr("core.config.get_transport_mode", lambda: "streamable-http")
+    return server, seen
+
+
+async def test_identity_reaches_tool_and_leaves_store_empty(monkeypatch):
+    server, seen = _build_server(monkeypatch, lambda caller: f"{caller}@x")
+
+    async with Client(server) as client:
+        for caller in ("a", "b", "c"):
+            await client.call_tool("whoami", {"caller": caller})
+
+    assert seen == [
+        ("a", "a@x", "fastmcp_oauth"),
+        ("b", "b@x", "fastmcp_oauth"),
+        ("c", "c@x", "fastmcp_oauth"),
+    ]
+    # The leak this change exists to fix: identity must never reach the store.
+    assert _session_state_keys(server) == []
+
+
+async def test_identity_does_not_survive_into_the_next_request(monkeypatch):
+    server, seen = _build_server(
+        monkeypatch, lambda caller: "first@x" if caller == "first" else None
+    )
+
+    async with Client(server) as client:
+        await client.call_tool("whoami", {"caller": "first"})
+        await client.call_tool("whoami", {"caller": "second"})
+
+    # The second request authenticates nobody, and must not inherit the first's principal.
+    assert seen == [("first", "first@x", "fastmcp_oauth"), ("second", None, None)]
+    assert _session_state_keys(server) == []
+
+
+async def test_concurrent_requests_on_one_session_are_isolated(monkeypatch):
+    server, seen = _build_server(monkeypatch, lambda caller: f"{caller}@x")
+
+    async with Client(server) as client:
+        await asyncio.gather(
+            client.call_tool("whoami", {"caller": "alice"}),
+            client.call_tool("whoami", {"caller": "bob"}),
+        )
+
+    # Under session-scoped state both requests collide on one key and the loser reads
+    # the other's identity; request scope gives each its own.
+    assert sorted(seen) == [
+        ("alice", "alice@x", "fastmcp_oauth"),
+        ("bob", "bob@x", "fastmcp_oauth"),
+    ]
+    assert _session_state_keys(server) == []
+
+
+async def test_seeded_legacy_identity_is_shadowed_but_retained(monkeypatch):
+    """Legacy session-scoped identity stays in the store and stays unreadable.
+
+    Deliberately not asserting an empty store: the design shadows with a request-scoped
+    None rather than deleting, so residue in a caller-supplied ``session_state_store``
+    is expected to remain and to expire on FastMCP's own TTL.
+    """
+    server, seen = _build_server(monkeypatch, lambda caller: None)
+
+    async with Client(server) as client:
+        result = await client.call_tool("seed_legacy_state", {"caller": "seed"})
+        session_id = result.content[0].text
+        seeded = [
+            f"{session_id}:authenticated_user_email",
+            f"{session_id}:authenticated_via",
+        ]
+        assert _session_state_keys(server) == seeded
+
+        await client.call_tool("whoami", {"caller": "later"})
+
+    # The later request reads None rather than the seeded principal...
+    assert seen == [("later", None, None)]
+    # ...while the seeded entries remain in the store, undeleted.
+    assert _session_state_keys(server) == seeded

--- a/uv.lock
+++ b/uv.lock
@@ -2385,7 +2385,7 @@ wheels = [
 
 [[package]]
 name = "workspace-mcp"
-version = "1.22.2"
+version = "1.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -1954,27 +1954,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.10"
+version = "0.15.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728 }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362 },
-    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122 },
-    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005 },
-    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450 },
-    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597 },
-    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645 },
-    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289 },
-    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266 },
-    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418 },
-    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416 },
-    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053 },
-    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302 },
-    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074 },
-    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051 },
-    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964 },
-    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044 },
-    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607 },
+    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258 },
+    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477 },
+    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716 },
+    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644 },
+    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719 },
+    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494 },
+    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370 },
+    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098 },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422 },
+    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683 },
+    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295 },
+    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640 },
+    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077 },
+    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980 },
+    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165 },
+    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297 },
+    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172 },
 ]
 
 [[package]]
@@ -2511,7 +2511,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", marker = "extra == 'dev'", specifier = ">=2.32.3" },
     { name = "requests", marker = "extra == 'test'", specifier = ">=2.32.3" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.4" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.22,<0.16" },
     { name = "tomlkit", marker = "extra == 'dev'", specifier = ">=0.13.3" },
     { name = "tomlkit", marker = "extra == 'release'", specifier = ">=0.13.3" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -2528,7 +2528,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "requests", specifier = ">=2.32.3" },
-    { name = "ruff", specifier = ">=0.12.4" },
+    { name = "ruff", specifier = ">=0.15.22,<0.16" },
     { name = "tomlkit", specifier = ">=0.13.3" },
     { name = "twine", specifier = ">=5.0.0" },
 ]


### PR DESCRIPTION
Avoid FastMCP session MemoryStore retention when clients open a new session per tool call; identity is re-derived on every request.

## Description
AuthInfoMiddleware wrote identity (and related) state via FastMCP `set_state`, which defaults to session-scoped MemoryStore (24h TTL). The gateway assertion path already used `serializable=False`; FastMCP OAuth, bearer, and stdio/session paths did not.

When a client opens a **new MCP session per tool call**, those keys accumulate without bound and contribute to RSS growth / OOM on long-lived workers. This PR routes all identity / `access_token` writes through `_set_request_auth_state(..., serializable=False)` so state lives only for the current request. Middleware re-runs on every tool/prompt call, so request-scoped state is enough.

### Memory bench (main vs this fix)
Same workload: prod-inspired tool mix, heavy mocked payloads, 20 users × 300 calls (6 000 total), concurrency 40.

| | main | this fix |
|---|---:|---:|
| MemoryStore keys (final) | **12 002** | **0** |
| RSS Δ | **+50.5 MiB** | **+18.7 MiB** |
| RSS peak | 161 MiB | 146 MiB |

Keys on main grow linearly (~2 per session). The fix eliminates that leak; remaining RSS movement is a separate large-payload / allocator-ratchet issue.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Unit tests assert bearer and FastMCP OAuth identity writes use `serializable=False`.

This does not by itself eliminate all RSS climb under heavy Drive/Gmail payloads; consider follow-up size caps and/or worker recycle for the allocator ratchet.

---

**⚠️ IMPORTANT:** This repository requires that you enable "Allow edits from maintainers" when creating your pull request. This allows maintainers to make small fixes and improvements directly to your branch, speeding up the review process.

To enable this setting:
1. When creating the PR, check the "Allow edits from maintainers" checkbox
2. If you've already created the PR, you can enable this in the PR sidebar under "Allow edits from maintainers"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication handling across gateway, OAuth, Google bearer-token, standard input/output, and session-based flows.
  - Authentication identities are now isolated to individual requests, preventing stale state from carrying between requests.
  - Improved consistency when resolving authenticated users and authentication methods.
  - Authentication identity details are excluded from serialized session state.

- **Tests**
  - Added coverage for concurrent and sequential request isolation, failed authentication scenarios, OAuth behavior, and supported authentication methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->