### PR TITLE
Fix Docs styling payload bugs (#998) + per-edge cell/paragraph border support

### DIFF
--- a/gdocs/docs_helpers.py
+++ b/gdocs/docs_helpers.py
@@ -209,7 +209,7 @@ def build_text_style(
     italic: bool = None,
     underline: bool = None,
     strikethrough: bool = None,
-    font_size: int = None,
+    font_size: float = None,
     font_family: str = None,
     font_weight: int = None,
     text_color: str = None,
@@ -324,6 +324,11 @@ def build_paragraph_style(
     page_break_before: Optional[bool] = None,
     spacing_mode: Optional[str] = None,
     shading_color: Optional[str] = None,
+    border_edges: Optional[List[str]] = None,
+    border_color: Optional[str] = None,
+    border_width: Optional[float] = None,
+    border_padding: Optional[float] = None,
+    border_dash: Optional[str] = None,
 ) -> tuple[Dict[str, Any], list[str]]:
     """
     Build paragraph style object for Google Docs API requests.
@@ -449,6 +454,51 @@ def build_paragraph_style(
         }
         fields.append("shading")
 
+    # kenorai enhancement 2026-08-04: paragraph borders (the callout left-rule pattern).
+    # ParagraphBorder requires color, width, padding and dashStyle all set.
+    if border_color is not None or border_width is not None or border_edges:
+        dash = (border_dash or "SOLID").upper()
+        if dash not in VALID_DASH_STYLES:
+            raise ValueError(
+                f"border_dash must be one of {', '.join(VALID_DASH_STYLES)}, got '{border_dash}'"
+            )
+        para_border = {
+            "color": _build_optional_color(
+                border_color if border_color is not None else "#000000",
+                "border_color",
+            ),
+            "width": {
+                "magnitude": border_width if border_width is not None else 1,
+                "unit": "PT",
+            },
+            "padding": {
+                "magnitude": border_padding if border_padding is not None else 4,
+                "unit": "PT",
+            },
+            "dashStyle": dash,
+        }
+        edge_map = {
+            "top": "borderTop",
+            "bottom": "borderBottom",
+            "left": "borderLeft",
+            "right": "borderRight",
+            "between": "borderBetween",
+        }
+        if border_edges:
+            selected = []
+            for edge in border_edges:
+                edge_key = str(edge).strip().lower()
+                if edge_key not in edge_map:
+                    raise ValueError(
+                        f"border_edges entries must be one of {sorted(edge_map)}, got '{edge}'"
+                    )
+                selected.append(edge_map[edge_key])
+        else:
+            selected = ["borderTop", "borderBottom", "borderLeft", "borderRight"]
+        for border_name in selected:
+            paragraph_style[border_name] = dict(para_border)
+            fields.append(border_name)
+
     return paragraph_style, fields
 
 
@@ -473,9 +523,11 @@ def build_document_style(
     fields: List[str] = []
 
     if background_color is not None:
-        document_style["background"] = _build_optional_color(
-            background_color, "background_color"
-        )
+        # DocumentStyle.background is type Background{color: OptionalColor{color: Color}}
+        # — three levels of nesting, not two (kenorai patch 2026-08-04).
+        document_style["background"] = {
+            "color": _build_optional_color(background_color, "background_color")
+        }
         fields.append("background")
 
     for value, field_name in (
@@ -617,6 +669,7 @@ def build_table_cell_style(
     padding_left: float = None,
     padding_right: float = None,
     content_alignment: str = None,
+    border_edges: Optional[List[str]] = None,
 ) -> tuple[Dict[str, Any], list[str]]:
     """
     Build a table cell style object for Google Docs API requests.
@@ -638,16 +691,42 @@ def build_table_cell_style(
     fields = []
 
     if border_color is not None or border_width is not None:
-        border_style = {}
+        # kenorai patch 2026-08-04: TableCellBorder requires color, width AND dashStyle
+        # all set; dashStyle must not be UNSPECIFIED or the API 400s. Default the missing
+        # members so a color-only or width-only call still forms a valid border.
+        # kenorai enhancement: border_edges limits the border to named edges
+        # (["top","bottom","left","right"]); default = all four (uniform).
+        border_style = {"dashStyle": "SOLID"}
 
-        if border_width is not None:
-            border_style["width"] = {"magnitude": border_width, "unit": "PT"}
+        border_style["width"] = {
+            "magnitude": border_width if border_width is not None else 1,
+            "unit": "PT",
+        }
 
-        if border_color is not None:
-            rgb = _normalize_color(border_color, "border_color")
-            border_style["color"] = {"color": {"rgbColor": rgb}}
+        rgb = _normalize_color(
+            border_color if border_color is not None else "#000000", "border_color"
+        )
+        border_style["color"] = {"color": {"rgbColor": rgb}}
 
-        for border_name in ("borderTop", "borderBottom", "borderLeft", "borderRight"):
+        edge_map = {
+            "top": "borderTop",
+            "bottom": "borderBottom",
+            "left": "borderLeft",
+            "right": "borderRight",
+        }
+        if border_edges:
+            selected = []
+            for edge in border_edges:
+                edge_key = str(edge).strip().lower()
+                if edge_key not in edge_map:
+                    raise ValueError(
+                        f"border_edges entries must be one of {sorted(edge_map)}, got '{edge}'"
+                    )
+                selected.append(edge_map[edge_key])
+        else:
+            selected = list(edge_map.values())
+
+        for border_name in selected:
             table_cell_style[border_name] = border_style.copy()
             fields.append(border_name)
 
@@ -757,7 +836,7 @@ def create_format_text_request(
     italic: bool = None,
     underline: bool = None,
     strikethrough: bool = None,
-    font_size: int = None,
+    font_size: float = None,
     font_family: str = None,
     font_weight: int = None,
     text_color: str = None,
@@ -838,6 +917,11 @@ def create_update_paragraph_style_request(
     page_break_before: Optional[bool] = None,
     spacing_mode: Optional[str] = None,
     shading_color: Optional[str] = None,
+    border_edges: Optional[List[str]] = None,
+    border_color: Optional[str] = None,
+    border_width: Optional[float] = None,
+    border_padding: Optional[float] = None,
+    border_dash: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """
     Create an updateParagraphStyle request for Google Docs API.
@@ -877,6 +961,11 @@ def create_update_paragraph_style_request(
         page_break_before=page_break_before,
         spacing_mode=spacing_mode,
         shading_color=shading_color,
+        border_edges=border_edges,
+        border_color=border_color,
+        border_width=border_width,
+        border_padding=border_padding,
+        border_dash=border_dash,
     )
 
     if not paragraph_style:
@@ -974,6 +1063,7 @@ def create_update_table_cell_style_request(
     row_span: int = None,
     column_span: int = None,
     tab_id: Optional[str] = None,
+    border_edges: Optional[List[str]] = None,
 ) -> Optional[Dict[str, Any]]:
     """
     Create an updateTableCellStyle request for Google Docs API.
@@ -1007,6 +1097,7 @@ def create_update_table_cell_style_request(
         padding_left=padding_left,
         padding_right=padding_right,
         content_alignment=content_alignment,
+        border_edges=border_edges,
     )
     if not table_cell_style:
         return None

--- a/gdocs/docs_helpers.py
+++ b/gdocs/docs_helpers.py
@@ -368,12 +368,20 @@ def build_paragraph_style(
         page_break_before: Always start paragraph on a new page
         spacing_mode: Paragraph spacing mode - NEVER_COLLAPSE or COLLAPSE_LISTS
         shading_color: Paragraph shading/background color as hex string "#RRGGBB"
+        border_edges: Border edges to update; omit for all four outer edges
+        border_color: Border color as hex string "#RRGGBB"
+        border_width: Border width in points
+        border_padding: Border padding in points
+        border_dash: Border dash style (SOLID, DOT, or DASH)
 
     Returns:
         Tuple of (paragraph_style_dict, list_of_field_names)
     """
     paragraph_style = {}
     fields = []
+
+    if border_edges is not None and not border_edges:
+        raise ValueError("border_edges must contain at least one edge")
 
     if named_style_type is not None:
         if named_style_type not in VALID_NAMED_STYLE_TYPES:
@@ -471,14 +479,13 @@ def build_paragraph_style(
         }
         fields.append("shading")
 
-    # kenorai enhancement 2026-08-04: paragraph borders (the callout left-rule pattern).
     # ParagraphBorder requires color, width, padding and dashStyle all set.
     if (
         border_color is not None
         or border_width is not None
         or border_padding is not None
         or border_dash is not None
-        or border_edges
+        or border_edges is not None
     ):
         dash = (border_dash or "SOLID").upper()
         if dash not in VALID_DASH_STYLES:
@@ -501,7 +508,7 @@ def build_paragraph_style(
             "dashStyle": dash,
         }
         edge_map = PARAGRAPH_BORDER_EDGE_MAP
-        if border_edges:
+        if border_edges is not None:
             selected = []
             for edge in border_edges:
                 edge_key = str(edge).strip().lower()
@@ -540,8 +547,7 @@ def build_document_style(
     fields: List[str] = []
 
     if background_color is not None:
-        # DocumentStyle.background is type Background{color: OptionalColor{color: Color}}
-        # — three levels of nesting, not two (kenorai patch 2026-08-04).
+        # DocumentStyle.background wraps an OptionalColor in a Background object.
         document_style["background"] = {
             "color": _build_optional_color(background_color, "background_color")
         }
@@ -700,6 +706,7 @@ def build_table_cell_style(
         padding_left: Left padding in points
         padding_right: Right padding in points
         content_alignment: Vertical content alignment ("TOP", "MIDDLE", "BOTTOM")
+        border_edges: Border edges to update; omit for all four edges
 
     Returns:
         Tuple of (table_cell_style_dict, list_of_field_names)
@@ -707,12 +714,12 @@ def build_table_cell_style(
     table_cell_style = {}
     fields = []
 
-    if border_color is not None or border_width is not None or border_edges:
-        # kenorai patch 2026-08-04: TableCellBorder requires color, width AND dashStyle
-        # all set; dashStyle must not be UNSPECIFIED or the API 400s. Default the missing
-        # members so a color-only or width-only call still forms a valid border.
-        # kenorai enhancement: border_edges limits the border to named edges
-        # (["top","bottom","left","right"]); default = all four (uniform).
+    if border_edges is not None and not border_edges:
+        raise ValueError("border_edges must contain at least one edge")
+
+    if border_color is not None or border_width is not None or border_edges is not None:
+        # TableCellBorder requires color, width and dashStyle. Default missing
+        # members so color-only or width-only calls still form valid borders.
         border_style = {"dashStyle": "SOLID"}
 
         border_style["width"] = {
@@ -726,7 +733,7 @@ def build_table_cell_style(
         border_style["color"] = {"color": {"rgbColor": rgb}}
 
         edge_map = TABLE_BORDER_EDGE_MAP
-        if border_edges:
+        if border_edges is not None:
             selected = []
             for edge in border_edges:
                 edge_key = str(edge).strip().lower()

--- a/gdocs/docs_helpers.py
+++ b/gdocs/docs_helpers.py
@@ -51,6 +51,23 @@ VALID_DASH_STYLES = (
     "DASH",
 )
 
+# Border edge name -> ParagraphStyle/TableCellStyle field. Paragraphs additionally
+# support "between"; table cells do not.
+PARAGRAPH_BORDER_EDGE_MAP = {
+    "top": "borderTop",
+    "bottom": "borderBottom",
+    "left": "borderLeft",
+    "right": "borderRight",
+    "between": "borderBetween",
+}
+
+TABLE_BORDER_EDGE_MAP = {
+    "top": "borderTop",
+    "bottom": "borderBottom",
+    "left": "borderLeft",
+    "right": "borderRight",
+}
+
 VALID_SECTION_TYPES = (
     "CONTINUOUS",
     "NEXT_PAGE",
@@ -456,7 +473,13 @@ def build_paragraph_style(
 
     # kenorai enhancement 2026-08-04: paragraph borders (the callout left-rule pattern).
     # ParagraphBorder requires color, width, padding and dashStyle all set.
-    if border_color is not None or border_width is not None or border_edges:
+    if (
+        border_color is not None
+        or border_width is not None
+        or border_padding is not None
+        or border_dash is not None
+        or border_edges
+    ):
         dash = (border_dash or "SOLID").upper()
         if dash not in VALID_DASH_STYLES:
             raise ValueError(
@@ -477,13 +500,7 @@ def build_paragraph_style(
             },
             "dashStyle": dash,
         }
-        edge_map = {
-            "top": "borderTop",
-            "bottom": "borderBottom",
-            "left": "borderLeft",
-            "right": "borderRight",
-            "between": "borderBetween",
-        }
+        edge_map = PARAGRAPH_BORDER_EDGE_MAP
         if border_edges:
             selected = []
             for edge in border_edges:
@@ -690,7 +707,7 @@ def build_table_cell_style(
     table_cell_style = {}
     fields = []
 
-    if border_color is not None or border_width is not None:
+    if border_color is not None or border_width is not None or border_edges:
         # kenorai patch 2026-08-04: TableCellBorder requires color, width AND dashStyle
         # all set; dashStyle must not be UNSPECIFIED or the API 400s. Default the missing
         # members so a color-only or width-only call still forms a valid border.
@@ -708,12 +725,7 @@ def build_table_cell_style(
         )
         border_style["color"] = {"color": {"rgbColor": rgb}}
 
-        edge_map = {
-            "top": "borderTop",
-            "bottom": "borderBottom",
-            "left": "borderLeft",
-            "right": "borderRight",
-        }
+        edge_map = TABLE_BORDER_EDGE_MAP
         if border_edges:
             selected = []
             for edge in border_edges:

--- a/gdocs/docs_tables.py
+++ b/gdocs/docs_tables.py
@@ -285,6 +285,7 @@ def build_table_style_requests(
         background_color=style_options.get("background_color"),
         border_color=style_options.get("border_color"),
         border_width=style_options.get("border_width"),
+        border_edges=style_options.get("border_edges"),
     )
     if style_request:
         requests.append(style_request)

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -466,7 +466,7 @@ async def modify_doc_text(
     italic: bool = None,
     underline: bool = None,
     strikethrough: bool = None,
-    font_size: int = None,
+    font_size: float = None,
     font_family: str = None,
     font_weight: int = None,
     text_color: str = None,
@@ -2135,6 +2135,11 @@ async def update_paragraph_style(
     page_break_before: bool = None,
     spacing_mode: str = None,
     shading_color: str = None,
+    border_edges: list = None,
+    border_color: str = None,
+    border_width: float = None,
+    border_padding: float = None,
+    border_dash: str = None,
     list_type: str = None,
     list_nesting_level: int = None,
     bullet_preset: str = None,
@@ -2284,6 +2289,11 @@ async def update_paragraph_style(
         page_break_before,
         spacing_mode,
         shading_color,
+        border_edges,
+        border_color,
+        border_width,
+        border_padding,
+        border_dash,
     )
     if paragraph_style_request:
         requests.append(paragraph_style_request)

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -60,7 +60,7 @@ from gdocs.docs_markdown import (
     parse_drive_comments,
 )
 from gdocs.docs_markdown_writer import markdown_to_docs_requests
-from gdocs.operation_schemas import BatchDocOperations
+from gdocs.operation_schemas import BatchDocOperations, ParagraphBorderEdge
 
 # Import operation managers for complex business logic
 from gdocs.managers import (
@@ -1165,14 +1165,17 @@ async def batch_update_doc(
                                    space_above, space_below, named_style_type,
                                    direction, keep_lines_together, keep_with_next,
                                    avoid_widow_and_orphan, page_break_before,
-                                   spacing_mode, shading_color, tab_id, segment_id
+                                   spacing_mode, shading_color, border_edges,
+                                   border_color, border_width, border_padding,
+                                   border_dash, tab_id, segment_id
       update_table_cell_style
                        - required: table_start_index (int)
                          optional: background_color, border_color, border_width,
                                    padding_top, padding_bottom, padding_left,
                                    padding_right (float, points),
                                    content_alignment ("TOP"|"MIDDLE"|"BOTTOM"),
-                                   row_index, column_index, row_span, column_span
+                                   row_index, column_index, row_span, column_span,
+                                   border_edges ("top"|"bottom"|"left"|"right")
                          Use inspect_doc_structure to find table_start_index from
                          table_details[].start_index. If row/column values are
                          omitted, the style is applied to the entire table.
@@ -2135,7 +2138,7 @@ async def update_paragraph_style(
     page_break_before: bool = None,
     spacing_mode: str = None,
     shading_color: str = None,
-    border_edges: list = None,
+    border_edges: list[ParagraphBorderEdge] = None,
     border_color: str = None,
     border_width: float = None,
     border_padding: float = None,
@@ -2179,6 +2182,12 @@ async def update_paragraph_style(
         page_break_before: Start the paragraph on a new page
         spacing_mode: 'NEVER_COLLAPSE' or 'COLLAPSE_LISTS'
         shading_color: Paragraph shading/background color (#RRGGBB)
+        border_edges: Paragraph border edges to update ('top', 'bottom', 'left',
+                      'right', or 'between'); omit to update all four outer edges
+        border_color: Border color (#RRGGBB; defaults to black)
+        border_width: Border width in points (defaults to 1)
+        border_padding: Border padding in points (defaults to 4)
+        border_dash: Border dash style ('SOLID', 'DOT', or 'DASH'; defaults to 'SOLID')
         list_type: Create a list from existing paragraphs ('UNORDERED' for bullets, 'ORDERED' for numbers, 'CHECKBOX' for checklists)
         list_nesting_level: Nesting level for lists (0-8, where 0 is top level, default is 0)
                            Use higher levels for nested/indented list items
@@ -2242,6 +2251,30 @@ async def update_paragraph_style(
     if named_style_type is not None and heading_level is not None:
         return "Error: heading_level and named_style_type are mutually exclusive; provide only one"
 
+    paragraph_style_params = [
+        heading_level,
+        alignment,
+        line_spacing,
+        indent_first_line,
+        indent_start,
+        indent_end,
+        space_above,
+        space_below,
+        named_style_type,
+        direction,
+        keep_lines_together,
+        keep_with_next,
+        avoid_widow_and_orphan,
+        page_break_before,
+        spacing_mode,
+        shading_color,
+        border_edges,
+        border_color,
+        border_width,
+        border_padding,
+        border_dash,
+    ]
+
     validator = ValidationManager()
     is_valid, error_msg = validator.validate_paragraph_style_params(
         heading_level=heading_level,
@@ -2266,7 +2299,8 @@ async def update_paragraph_style(
         border_padding=border_padding,
         border_dash=border_dash,
     )
-    if not is_valid and list_type_value is None:
+    has_paragraph_style = any(param is not None for param in paragraph_style_params)
+    if not is_valid and (has_paragraph_style or list_type_value is None):
         return f"Error: {error_msg}"
 
     # Create batch update requests
@@ -2362,6 +2396,11 @@ async def update_paragraph_style(
             ("page_break_before", page_break_before),
             ("spacing_mode", spacing_mode),
             ("shading_color", shading_color),
+            ("border_edges", border_edges),
+            ("border_color", border_color),
+            ("border_width", border_width),
+            ("border_padding", border_padding),
+            ("border_dash", border_dash),
         ]
         if value is not None
     ]

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -2260,6 +2260,11 @@ async def update_paragraph_style(
         page_break_before=page_break_before,
         spacing_mode=spacing_mode,
         shading_color=shading_color,
+        border_edges=border_edges,
+        border_color=border_color,
+        border_width=border_width,
+        border_padding=border_padding,
+        border_dash=border_dash,
     )
     if not is_valid and list_type_value is None:
         return f"Error: {error_msg}"

--- a/gdocs/managers/batch_operation_manager.py
+++ b/gdocs/managers/batch_operation_manager.py
@@ -473,6 +473,7 @@ class BatchOperationManager:
                     column_index=op.get("column_index"),
                     row_span=op.get("row_span"),
                     column_span=op.get("column_span"),
+                    border_edges=op.get("border_edges"),
                 )
             )
             if not is_valid:

--- a/gdocs/managers/batch_operation_manager.py
+++ b/gdocs/managers/batch_operation_manager.py
@@ -404,6 +404,11 @@ class BatchOperationManager:
                 op.get("page_break_before"),
                 op.get("spacing_mode"),
                 op.get("shading_color"),
+                op.get("border_edges"),
+                op.get("border_color"),
+                op.get("border_width"),
+                op.get("border_padding"),
+                op.get("border_dash"),
             )
 
             if not request:
@@ -488,6 +493,7 @@ class BatchOperationManager:
                 row_span=op.get("row_span"),
                 column_span=op.get("column_span"),
                 tab_id=tab_id,
+                border_edges=op.get("border_edges"),
             )
 
             if not request:
@@ -1035,6 +1041,11 @@ class BatchOperationManager:
                         "page_break_before",
                         "spacing_mode",
                         "shading_color",
+                        "border_edges",
+                        "border_color",
+                        "border_width",
+                        "border_padding",
+                        "border_dash",
                         "segment_id",
                         "tab_id",
                     ],
@@ -1055,6 +1066,7 @@ class BatchOperationManager:
                         "column_index",
                         "row_span",
                         "column_span",
+                        "border_edges",
                     ],
                     "description": "Apply table cell styling to an entire table or a targeted cell range",
                 },

--- a/gdocs/managers/batch_operation_manager.py
+++ b/gdocs/managers/batch_operation_manager.py
@@ -420,6 +420,8 @@ class BatchOperationManager:
                 "indent_end",
                 "space_above",
                 "space_below",
+                "border_width",
+                "border_padding",
             }
             _SUFFIX = {
                 "heading_level": lambda v: f"H{v}",
@@ -444,6 +446,11 @@ class BatchOperationManager:
                 ("page_break_before", "page break before"),
                 ("spacing_mode", "spacing mode"),
                 ("shading_color", "shading"),
+                ("border_edges", "border edges"),
+                ("border_color", "border color"),
+                ("border_width", "border width"),
+                ("border_padding", "border padding"),
+                ("border_dash", "border dash"),
             ]:
                 if op.get(param) is not None:
                     raw = op[param]
@@ -510,6 +517,7 @@ class BatchOperationManager:
                 ("padding_left", "padding left"),
                 ("padding_right", "padding right"),
                 ("content_alignment", "content alignment"),
+                ("border_edges", "border edges"),
             ]:
                 if op.get(param) is not None:
                     value = (

--- a/gdocs/managers/validation_manager.py
+++ b/gdocs/managers/validation_manager.py
@@ -169,7 +169,7 @@ class ValidationManager:
         italic: Optional[bool] = None,
         underline: Optional[bool] = None,
         strikethrough: Optional[bool] = None,
-        font_size: Optional[int] = None,
+        font_size: Optional[float] = None,
         font_family: Optional[str] = None,
         font_weight: Optional[int] = None,
         text_color: Optional[str] = None,
@@ -243,10 +243,11 @@ class ValidationManager:
 
         # Validate font size
         if font_size is not None:
-            if not isinstance(font_size, int):
+            # kenorai patch 2026-08-04: fractional point sizes are valid (Dimension.magnitude is a number).
+            if not isinstance(font_size, (int, float)) or isinstance(font_size, bool):
                 return (
                     False,
-                    f"font_size must be an integer, got {type(font_size).__name__}",
+                    f"font_size must be a number, got {type(font_size).__name__}",
                 )
 
             min_size, max_size = self.validation_rules["font_size_range"]
@@ -354,6 +355,11 @@ class ValidationManager:
         page_break_before: Optional[bool] = None,
         spacing_mode: Optional[str] = None,
         shading_color: Optional[str] = None,
+        border_edges: Optional[list] = None,
+        border_color: Optional[str] = None,
+        border_width: Optional[float] = None,
+        border_padding: Optional[float] = None,
+        border_dash: Optional[str] = None,
     ) -> Tuple[bool, str]:
         """
         Validate paragraph style parameters.
@@ -389,6 +395,12 @@ class ValidationManager:
             page_break_before,
             spacing_mode,
             shading_color,
+            # kenorai enhancement 2026-08-04: paragraph borders
+            border_edges,
+            border_color,
+            border_width,
+            border_padding,
+            border_dash,
         ]
         if all(param is None for param in style_params):
             return (
@@ -1156,6 +1168,11 @@ class ValidationManager:
                     op.get("page_break_before"),
                     op.get("spacing_mode"),
                     op.get("shading_color"),
+                    border_edges=op.get("border_edges"),
+                    border_color=op.get("border_color"),
+                    border_width=op.get("border_width"),
+                    border_padding=op.get("border_padding"),
+                    border_dash=op.get("border_dash"),
                 )
                 if not is_valid:
                     return (

--- a/gdocs/managers/validation_manager.py
+++ b/gdocs/managers/validation_manager.py
@@ -20,6 +20,9 @@ from gdocs.docs_helpers import (
     VALID_COLUMN_SEPARATOR_STYLES,
     VALID_DOCUMENT_MODES,
     VALID_BULLET_PRESETS,
+    VALID_DASH_STYLES,
+    PARAGRAPH_BORDER_EDGE_MAP,
+    TABLE_BORDER_EDGE_MAP,
 )
 
 logger = logging.getLogger(__name__)
@@ -515,6 +518,77 @@ class ValidationManager:
         if not is_valid:
             return False, error_msg
 
+        is_valid, error_msg = self.validate_border_edges(
+            border_edges, PARAGRAPH_BORDER_EDGE_MAP
+        )
+        if not is_valid:
+            return False, error_msg
+
+        is_valid, error_msg = self.validate_color_param(border_color, "border_color")
+        if not is_valid:
+            return False, error_msg
+
+        if border_width is not None:
+            if isinstance(border_width, bool) or not isinstance(
+                border_width, (int, float)
+            ):
+                return (
+                    False,
+                    f"border_width must be a number, got {type(border_width).__name__}",
+                )
+            if border_width <= 0:
+                return False, f"border_width must be positive, got {border_width}"
+
+        if border_padding is not None:
+            if isinstance(border_padding, bool) or not isinstance(
+                border_padding, (int, float)
+            ):
+                return (
+                    False,
+                    f"border_padding must be a number, got {type(border_padding).__name__}",
+                )
+            if border_padding < 0:
+                return (
+                    False,
+                    f"border_padding must be non-negative, got {border_padding}",
+                )
+
+        if border_dash is not None:
+            if not isinstance(border_dash, str):
+                return (
+                    False,
+                    f"border_dash must be a string, got {type(border_dash).__name__}",
+                )
+            if border_dash.upper() not in VALID_DASH_STYLES:
+                return (
+                    False,
+                    "border_dash must be one of: "
+                    f"{', '.join(VALID_DASH_STYLES)}, got '{border_dash}'",
+                )
+
+        return True, ""
+
+    def validate_border_edges(
+        self, border_edges: Optional[list], edge_map: Dict[str, str]
+    ) -> Tuple[bool, str]:
+        """Validate a border_edges list against the allowed edge names."""
+        if border_edges is None:
+            return True, ""
+
+        if not isinstance(border_edges, (list, tuple)):
+            return (
+                False,
+                f"border_edges must be a list, got {type(border_edges).__name__}",
+            )
+
+        for edge in border_edges:
+            if not isinstance(edge, str) or edge.strip().lower() not in edge_map:
+                return (
+                    False,
+                    f"border_edges entries must be one of: {', '.join(sorted(edge_map))}, "
+                    f"got '{edge}'",
+                )
+
         return True, ""
 
     def validate_named_range_operation(
@@ -767,6 +841,7 @@ class ValidationManager:
         column_index: Optional[int] = None,
         row_span: Optional[int] = None,
         column_span: Optional[int] = None,
+        border_edges: Optional[list] = None,
     ) -> Tuple[bool, str]:
         """
         Validate table cell style parameters for updateTableCellStyle requests.
@@ -784,6 +859,8 @@ class ValidationManager:
             column_index: Optional starting column index for a targeted cell range
             row_span: Optional row span for a targeted cell range
             column_span: Optional column span for a targeted cell range
+            border_edges: Optional list of edges to border ("top", "bottom",
+                "left", "right"); defaults to all four
 
         Returns:
             Tuple of (is_valid, error_message)
@@ -799,14 +876,21 @@ class ValidationManager:
                 padding_left,
                 padding_right,
                 content_alignment,
+                border_edges,
             )
         ):
             return (
                 False,
                 "At least one table cell style parameter must be provided "
-                "(background_color, border_color, border_width, padding_top, "
+                "(background_color, border_color, border_width, border_edges, padding_top, "
                 "padding_bottom, padding_left, padding_right, or content_alignment)",
             )
+
+        is_valid, error_msg = self.validate_border_edges(
+            border_edges, TABLE_BORDER_EDGE_MAP
+        )
+        if not is_valid:
+            return False, error_msg
 
         is_valid, error_msg = self.validate_color_param(
             background_color, "background_color"
@@ -1212,6 +1296,7 @@ class ValidationManager:
                     op.get("column_index"),
                     op.get("row_span"),
                     op.get("column_span"),
+                    border_edges=op.get("border_edges"),
                 )
                 if not is_valid:
                     return (

--- a/gdocs/managers/validation_manager.py
+++ b/gdocs/managers/validation_manager.py
@@ -6,6 +6,7 @@ extracting validation patterns from individual tool functions.
 """
 
 import logging
+import math
 from typing import Dict, Any, List, Tuple, Optional
 from urllib.parse import urlparse
 
@@ -246,7 +247,6 @@ class ValidationManager:
 
         # Validate font size
         if font_size is not None:
-            # kenorai patch 2026-08-04: fractional point sizes are valid (Dimension.magnitude is a number).
             if not isinstance(font_size, (int, float)) or isinstance(font_size, bool):
                 return (
                     False,
@@ -377,6 +377,11 @@ class ValidationManager:
             space_above: Space above paragraph in points
             space_below: Space below paragraph in points
             named_style_type: Direct named style (TITLE, SUBTITLE, HEADING_1..6, NORMAL_TEXT)
+            border_edges: Paragraph border edges to update
+            border_color: Paragraph border color as #RRGGBB
+            border_width: Paragraph border width in points
+            border_padding: Paragraph border padding in points
+            border_dash: Paragraph border dash style
 
         Returns:
             Tuple of (is_valid, error_message)
@@ -398,7 +403,6 @@ class ValidationManager:
             page_break_before,
             spacing_mode,
             shading_color,
-            # kenorai enhancement 2026-08-04: paragraph borders
             border_edges,
             border_color,
             border_width,
@@ -408,7 +412,7 @@ class ValidationManager:
         if all(param is None for param in style_params):
             return (
                 False,
-                "At least one paragraph style parameter must be provided (heading_level, alignment, line_spacing, indent_first_line, indent_start, indent_end, space_above, space_below, named_style_type, direction, keep_lines_together, keep_with_next, avoid_widow_and_orphan, page_break_before, spacing_mode, or shading_color)",
+                "At least one paragraph style parameter must be provided (heading_level, alignment, line_spacing, indent_first_line, indent_start, indent_end, space_above, space_below, named_style_type, direction, keep_lines_together, keep_with_next, avoid_widow_and_orphan, page_break_before, spacing_mode, shading_color, border_edges, border_color, border_width, border_padding, or border_dash)",
             )
 
         if heading_level is not None and named_style_type is not None:
@@ -536,6 +540,8 @@ class ValidationManager:
                     False,
                     f"border_width must be a number, got {type(border_width).__name__}",
                 )
+            if not math.isfinite(border_width):
+                return False, f"border_width must be finite, got {border_width}"
             if border_width <= 0:
                 return False, f"border_width must be positive, got {border_width}"
 
@@ -547,6 +553,8 @@ class ValidationManager:
                     False,
                     f"border_padding must be a number, got {type(border_padding).__name__}",
                 )
+            if not math.isfinite(border_padding):
+                return False, f"border_padding must be finite, got {border_padding}"
             if border_padding < 0:
                 return (
                     False,
@@ -580,6 +588,9 @@ class ValidationManager:
                 False,
                 f"border_edges must be a list, got {type(border_edges).__name__}",
             )
+
+        if not border_edges:
+            return False, "border_edges must contain at least one edge"
 
         for edge in border_edges:
             if not isinstance(edge, str) or edge.strip().lower() not in edge_map:

--- a/gdocs/operation_schemas.py
+++ b/gdocs/operation_schemas.py
@@ -8,7 +8,7 @@ LLMs receive a machine-readable contract instead of a free-form object array.
 from __future__ import annotations
 
 import json
-from typing import Annotated, Any, Literal, Optional, Union
+from typing import Annotated, Any, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, BeforeValidator, model_validator
 
@@ -89,7 +89,7 @@ class FormatTextOperation(SegmentTargetDocOperation):
     italic: Optional[bool] = None
     underline: Optional[bool] = None
     strikethrough: Optional[bool] = None
-    font_size: Optional[int] = None
+    font_size: Optional[float] = None
     font_family: Optional[str] = None
     font_weight: Optional[int] = None
     text_color: Optional[str] = None
@@ -120,6 +120,12 @@ class UpdateParagraphStyleOperation(SegmentTargetDocOperation):
     page_break_before: Optional[bool] = None
     spacing_mode: Optional[str] = None
     shading_color: Optional[str] = None
+    # kenorai enhancement 2026-08-04: paragraph borders
+    border_edges: Optional[List[str]] = None
+    border_color: Optional[str] = None
+    border_width: Optional[float] = None
+    border_padding: Optional[float] = None
+    border_dash: Optional[str] = None
 
 
 class UpdateTableCellStyleOperation(StrictDocOperation):
@@ -137,6 +143,8 @@ class UpdateTableCellStyleOperation(StrictDocOperation):
     column_index: Optional[int] = None
     row_span: Optional[int] = None
     column_span: Optional[int] = None
+    # kenorai enhancement 2026-08-04: per-edge borders ("top","bottom","left","right")
+    border_edges: Optional[List[str]] = None
 
 
 class InsertTableOperation(SegmentTargetDocOperation):

--- a/gdocs/operation_schemas.py
+++ b/gdocs/operation_schemas.py
@@ -8,9 +8,13 @@ LLMs receive a machine-readable contract instead of a free-form object array.
 from __future__ import annotations
 
 import json
-from typing import Annotated, Any, List, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, BeforeValidator, model_validator
+
+
+ParagraphBorderEdge = Literal["top", "bottom", "left", "right", "between"]
+TableBorderEdge = Literal["top", "bottom", "left", "right"]
 
 
 def _coerce_json_str_to_list(v: Any) -> Any:
@@ -120,8 +124,11 @@ class UpdateParagraphStyleOperation(SegmentTargetDocOperation):
     page_break_before: Optional[bool] = None
     spacing_mode: Optional[str] = None
     shading_color: Optional[str] = None
-    # kenorai enhancement 2026-08-04: paragraph borders
-    border_edges: Optional[List[str]] = None
+    border_edges: Optional[list[ParagraphBorderEdge]] = Field(
+        default=None,
+        min_length=1,
+        description="Paragraph border edges to update; omit to update top, bottom, left, and right.",
+    )
     border_color: Optional[str] = None
     border_width: Optional[float] = None
     border_padding: Optional[float] = None
@@ -143,8 +150,11 @@ class UpdateTableCellStyleOperation(StrictDocOperation):
     column_index: Optional[int] = None
     row_span: Optional[int] = None
     column_span: Optional[int] = None
-    # kenorai enhancement 2026-08-04: per-edge borders ("top","bottom","left","right")
-    border_edges: Optional[List[str]] = None
+    border_edges: Optional[list[TableBorderEdge]] = Field(
+        default=None,
+        min_length=1,
+        description="Table-cell border edges to update; omit to update all four edges.",
+    )
 
 
 class InsertTableOperation(SegmentTargetDocOperation):

--- a/tests/gdocs/golden/docs_tool_schemas.json
+++ b/tests/gdocs/golden/docs_tool_schemas.json
@@ -1757,15 +1757,24 @@
             "anyOf": [
               {
                 "items": {
+                  "enum": [
+                    "top",
+                    "bottom",
+                    "left",
+                    "right",
+                    "between"
+                  ],
                   "type": "string"
                 },
+                "minItems": 1,
                 "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "default": null
+            "default": null,
+            "description": "Paragraph border edges to update; omit to update top, bottom, left, and right."
           },
           "border_color": {
             "anyOf": [
@@ -2161,15 +2170,23 @@
             "anyOf": [
               {
                 "items": {
+                  "enum": [
+                    "top",
+                    "bottom",
+                    "left",
+                    "right"
+                  ],
                   "type": "string"
                 },
+                "minItems": 1,
                 "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "default": null
+            "default": null,
+            "description": "Table-cell border edges to update; omit to update all four edges."
           }
         },
         "required": [

--- a/tests/gdocs/golden/docs_tool_schemas.json
+++ b/tests/gdocs/golden/docs_tool_schemas.json
@@ -61,7 +61,7 @@
       },
       "font_size": {
         "default": null,
-        "type": "integer",
+        "type": "number",
         "description": "Font size in points"
       },
       "font_family": {
@@ -606,7 +606,7 @@
           "font_size": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "number"
               },
               {
                 "type": "null"
@@ -1752,6 +1752,64 @@
               }
             ],
             "default": null
+          },
+          "border_edges": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "border_color": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "border_width": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "border_padding": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "border_dash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
           }
         },
         "required": [
@@ -2092,6 +2150,20 @@
             "anyOf": [
               {
                 "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "border_edges": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
               },
               {
                 "type": "null"

--- a/tests/gdocs/test_advanced_doc_formatting.py
+++ b/tests/gdocs/test_advanced_doc_formatting.py
@@ -27,6 +27,13 @@ def _unwrap(tool):
 
 
 class TestAdvancedTextStyle:
+    def test_fractional_font_size(self):
+        style, fields = build_text_style(font_size=10.5)
+
+        assert style["fontSize"] == {"magnitude": 10.5, "unit": "PT"}
+        assert fields == ["fontSize"]
+        assert ValidationManager().validate_text_formatting_params(font_size=10.5)[0]
+
     def test_weight_baseline_small_caps_and_clear_link(self):
         style, fields = build_text_style(
             font_family="Roboto",
@@ -87,6 +94,13 @@ class TestAdvancedRequestBuilders:
         inner = request["updateDocumentStyle"]
         assert inner["tabId"] == "tab-123"
         assert inner["documentStyle"]["marginTop"] == {"magnitude": 72, "unit": "PT"}
+        assert inner["documentStyle"]["background"] == {
+            "color": {
+                "color": {
+                    "rgbColor": {"red": 1.0, "green": 1.0, "blue": 1.0}
+                }
+            }
+        }
         assert inner["documentStyle"]["pageSize"]["width"] == {
             "magnitude": 612,
             "unit": "PT",

--- a/tests/gdocs/test_paragraph_style.py
+++ b/tests/gdocs/test_paragraph_style.py
@@ -7,11 +7,20 @@ Covers the helpers, validation, and batch manager integration.
 import pytest
 from unittest.mock import AsyncMock, Mock
 
+from gdocs import docs_tools
 from gdocs.docs_helpers import (
     build_paragraph_style,
     create_update_paragraph_style_request,
 )
 from gdocs.managers.validation_manager import ValidationManager
+
+
+def _unwrap(tool):
+    """Unwrap the decorated tool function to the original implementation."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
 
 
 class TestBuildParagraphStyle:
@@ -51,6 +60,29 @@ class TestBuildParagraphStyle:
         )
         assert len(fields) == 3
         assert style["alignment"] == "CENTER"
+
+    def test_paragraph_border_applies_only_selected_edge(self):
+        style, fields = build_paragraph_style(
+            border_edges=["left"],
+            border_color="#FF0000",
+            border_width=2.5,
+            border_padding=4,
+            border_dash="DASH",
+        )
+
+        assert fields == ["borderLeft"]
+        assert style["borderLeft"] == {
+            "color": {
+                "color": {"rgbColor": {"red": 1.0, "green": 0.0, "blue": 0.0}}
+            },
+            "width": {"magnitude": 2.5, "unit": "PT"},
+            "padding": {"magnitude": 4, "unit": "PT"},
+            "dashStyle": "DASH",
+        }
+
+    def test_empty_border_edges_rejected(self):
+        with pytest.raises(ValueError, match="at least one edge"):
+            build_paragraph_style(border_edges=[], border_color="#FF0000")
 
 
 class TestCreateUpdateParagraphStyleRequest:
@@ -111,6 +143,25 @@ class TestValidateParagraphStyleParams:
         )
         assert not is_valid
         assert "mutually exclusive" in msg
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("border_width", float("nan")),
+            ("border_width", float("inf")),
+            ("border_padding", float("nan")),
+            ("border_padding", float("inf")),
+        ],
+    )
+    def test_non_finite_border_dimensions_rejected(self, vm, field, value):
+        is_valid, msg = vm.validate_paragraph_style_params(**{field: value})
+        assert not is_valid
+        assert f"{field} must be finite" in msg
+
+    def test_empty_border_edges_rejected(self, vm):
+        is_valid, msg = vm.validate_paragraph_style_params(border_edges=[])
+        assert not is_valid
+        assert "at least one edge" in msg
 
     def test_batch_validation_wired_up(self, vm):
         valid_ops = [
@@ -178,6 +229,20 @@ class TestBatchManagerIntegration:
         }
         assert "paragraph style 0-20" in desc
 
+    def test_border_only_request_has_useful_description(self, manager):
+        op = {
+            "type": "update_paragraph_style",
+            "start_index": 1,
+            "end_index": 20,
+            "border_edges": ["left"],
+            "border_width": 2,
+        }
+
+        _, desc = manager._build_operation_request(op, "update_paragraph_style")
+
+        assert "border edges: ['left']" in desc
+        assert "border width: 2pt" in desc
+
     @pytest.mark.asyncio
     async def test_end_to_end_execute(self, manager):
         manager._execute_batch_requests = AsyncMock(return_value={"replies": [{}]})
@@ -211,3 +276,41 @@ class TestBatchManagerIntegration:
         )
         assert success
         assert meta["operations_count"] == 1
+
+
+class TestPublicToolWiring:
+    @pytest.fixture()
+    def service(self):
+        mock_service = Mock()
+        mock_service.documents().batchUpdate().execute.return_value = {"replies": [{}]}
+        return mock_service
+
+    @pytest.mark.asyncio
+    async def test_list_formatting_does_not_bypass_border_validation(self, service):
+        result = await _unwrap(docs_tools.update_paragraph_style)(
+            service=service,
+            user_google_email="user@example.com",
+            document_id="a" * 25,
+            start_index=1,
+            end_index=10,
+            border_width=-1,
+            list_type="UNORDERED",
+        )
+
+        assert result == "Error: border_width must be positive, got -1"
+        service.documents.return_value.batchUpdate.return_value.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_only_formatting_remains_valid(self, service):
+        result = await _unwrap(docs_tools.update_paragraph_style)(
+            service=service,
+            user_google_email="user@example.com",
+            document_id="a" * 25,
+            start_index=1,
+            end_index=10,
+            list_type="UNORDERED",
+        )
+
+        assert "unordered list" in result
+        request = service.documents.return_value.batchUpdate.call_args.kwargs["body"]
+        assert "createParagraphBullets" in request["requests"][0]

--- a/tests/gdocs/test_table_cell_style.py
+++ b/tests/gdocs/test_table_cell_style.py
@@ -49,6 +49,35 @@ class TestBuildTableCellStyle:
             }
         assert fields == ["borderTop", "borderBottom", "borderLeft", "borderRight"]
 
+    @pytest.mark.parametrize(
+        ("kwargs", "expected_width", "expected_color"),
+        [
+            ({"border_color": "#FF0000"}, 1, {"red": 1.0, "green": 0.0, "blue": 0.0}),
+            ({"border_width": 2.0}, 2.0, {"red": 0.0, "green": 0.0, "blue": 0.0}),
+        ],
+    )
+    def test_partial_border_inputs_build_complete_solid_border(
+        self, kwargs, expected_width, expected_color
+    ):
+        style, _ = build_table_cell_style(**kwargs)
+
+        for border in style.values():
+            assert border["dashStyle"] == "SOLID"
+            assert border["width"] == {"magnitude": expected_width, "unit": "PT"}
+            assert border["color"]["color"]["rgbColor"] == expected_color
+
+    def test_border_edges_limit_updated_sides(self):
+        style, fields = build_table_cell_style(
+            border_color="#FF0000", border_edges=["bottom"]
+        )
+
+        assert fields == ["borderBottom"]
+        assert set(style) == {"borderBottom"}
+
+    def test_empty_border_edges_rejected(self):
+        with pytest.raises(ValueError, match="at least one edge"):
+            build_table_cell_style(border_edges=[], border_color="#FF0000")
+
 
 class TestCreateUpdateTableCellStyleRequest:
     def test_entire_table_request(self):
@@ -108,6 +137,11 @@ class TestValidateTableCellStyle:
             }
         ]
         assert vm.validate_batch_operations(ops)[0]
+
+    def test_empty_border_edges_rejected(self, vm):
+        is_valid, msg = vm.validate_table_cell_style_params(border_edges=[])
+        assert not is_valid
+        assert "at least one edge" in msg
 
 
 class TestBuildTableCellStylePadding:
@@ -215,6 +249,18 @@ class TestBatchManagerIntegration:
                 },
                 "update_table_cell_style",
             )
+
+    def test_border_edges_are_in_description(self, manager):
+        _, desc = manager._build_operation_request(
+            {
+                "type": "update_table_cell_style",
+                "table_start_index": 42,
+                "border_edges": ["bottom"],
+            },
+            "update_table_cell_style",
+        )
+
+        assert "border edges: ['bottom']" in desc
 
     @pytest.mark.asyncio
     async def test_end_to_end_execute_table_cell_style(self, manager):


### PR DESCRIPTION
Fixes #998 — the three Docs styling payload bugs, plus a small feature that falls out of the same code paths.

## Fixes (all verified against the live Docs API)

1. **`update_document_style` background color 400** — `DocumentStyle.background` is type `Background{color: OptionalColor{color: Color}}`; the builder produced one level short (`background.color.rgbColor`). Now wrapped correctly.
2. **`update_table_cell_style` border 400 (`DASH_STYLE_UNSPECIFIED`)** — `TableCellBorder` requires color, width and dashStyle all set. `dashStyle: SOLID` is now always set, and missing width/color default to 1pt/#000000 so color-only or width-only calls form a valid border.
3. **Integer-only `font_size`** — annotations and the validator's `isinstance` check now accept floats (`Dimension.magnitude` is a number; 10.5pt etc. are valid).

## Features

- **`border_edges` on `update_table_cell_style`** — limit borders to named edges (`["top"|"bottom"|"left"|"right"]`); omitted = all four (backward compatible). Enables header-row bottom rules without boxing every cell.
- **Paragraph borders on `update_paragraph_style`** — `border_edges` (also `"between"`), `border_color`, `border_width`, `border_padding` (default 4pt), `border_dash` (default SOLID). Makes the shaded-callout-with-left-rule pattern fully API-authorable. Threaded through the standalone tool, batch operation schema/manager, and validation.

## Testing

Verified end-to-end against live Google Docs on a production document set: page backgrounds apply; 0.5pt fractional-width borders apply; 10.5pt sizes apply; bottom-only 1.5pt header rules and left-only 3pt paragraph borders render correctly (PDF-export verified). Existing all-edges behavior unchanged when `border_edges` is omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable paragraph and table-cell borders with edge selection, color, width, padding, and dash styles.
  * Added support for fractional font sizes in text formatting.
* **Bug Fixes**
  * Corrected document background color formatting for Google Docs compatibility.
  * Improved border defaults and validation for complete, valid formatting requests.
* **Improvements**
  * Added border options to batch styling operations.
  * Expanded formatting schemas to support border and font-size options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->