### PR TITLE
fix: handle Drive resumable upload 308 responses

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -96,6 +96,8 @@ def _build_authorized_http(
 ) -> google_auth_httplib2.AuthorizedHttp:
     """Return credentialed HTTP with an explicit socket timeout."""
     http = httplib2.Http(timeout=timeout)
+    # Drive uses 308 Resume Incomplete with Range during resumable uploads, not a redirect.
+    http.redirect_codes = http.redirect_codes - {308}
     return google_auth_httplib2.AuthorizedHttp(credentials, http=http)
 
 

--- a/tests/auth/test_httplib2_timeout.py
+++ b/tests/auth/test_httplib2_timeout.py
@@ -12,6 +12,8 @@ from auth.google_auth import get_user_info
 def test_build_authorized_http_uses_explicit_timeout():
     mock_credentials = MagicMock()
     mock_http = MagicMock()
+    mock_http.redirect_codes = {300, 301, 302, 303, 307, 308}
+    before = mock_http.redirect_codes.copy()
     mock_authorized = MagicMock()
 
     with (
@@ -27,6 +29,9 @@ def test_build_authorized_http_uses_explicit_timeout():
 
     mock_http_cls.assert_called_once_with(timeout=42)
     mock_auth_http_cls.assert_called_once_with(mock_credentials, http=mock_http)
+    assert mock_http.redirect_codes == before - {308}
+    assert 308 not in mock_http.redirect_codes
+    assert {300, 301, 302, 303, 307} <= mock_http.redirect_codes
     assert result is mock_authorized
 
 

--- a/tests/auth/test_httplib2_timeout.py
+++ b/tests/auth/test_httplib2_timeout.py
@@ -13,7 +13,6 @@ def test_build_authorized_http_uses_explicit_timeout():
     mock_credentials = MagicMock()
     mock_http = MagicMock()
     mock_http.redirect_codes = {300, 301, 302, 303, 307, 308}
-    before = mock_http.redirect_codes.copy()
     mock_authorized = MagicMock()
 
     with (
@@ -29,9 +28,7 @@ def test_build_authorized_http_uses_explicit_timeout():
 
     mock_http_cls.assert_called_once_with(timeout=42)
     mock_auth_http_cls.assert_called_once_with(mock_credentials, http=mock_http)
-    assert mock_http.redirect_codes == before - {308}
-    assert 308 not in mock_http.redirect_codes
-    assert {300, 301, 302, 303, 307} <= mock_http.redirect_codes
+    assert mock_http.redirect_codes == {300, 301, 302, 303, 307}
     assert result is mock_authorized
 
 


### PR DESCRIPTION
## Summary

Drive resumable uploads use `308 Resume Incomplete` plus a `Range` header to acknowledge intermediate chunks. `httplib2` treats 308 as a redirect by default, so responses without a redirect `Location` header fail with `Redirected but the response is missing a Location: header` before the Google API client can continue the upload.

This removes only 308 from the redirect codes on the credentialed `httplib2.Http` instance. Other redirect handling remains unchanged.

## Tests

- `uv run --frozen pytest tests/auth/test_httplib2_timeout.py` — 4 passed
- `uv run --frozen ruff check auth/google_auth.py tests/auth/test_httplib2_timeout.py`
- `git diff --check`

The regression test verifies that 308 is removed while 300, 301, 302, 303, and 307 remain enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Drive resumable uploads by correctly handling `308 Resume Incomplete` responses.
  * Preserved other configured HTTP redirect behaviors while processing upload responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->