### PR TITLE
fix(gdrive): read Shared Drive permissions via permissions.list

### DIFF
--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -46,6 +46,55 @@ def check_public_link_permission(permissions: List[Dict[str, Any]]) -> bool:
     )
 
 
+def list_all_permissions(service, file_id: str) -> List[Dict[str, Any]]:
+    """
+    Return the complete permission set for a file, including Shared Drive items.
+
+    files.get() does NOT populate the inline `permissions` field (nor the `shared`
+    boolean) for items that live in a Shared Drive, even when supportsAllDrives=True
+    is passed. permissions.list() is the only reliable source in that case. This
+    helper paginates and always sets supportsAllDrives=True.
+    """
+    permissions: List[Dict[str, Any]] = []
+    page_token = None
+    while True:
+        resp = (
+            service.permissions()
+            .list(
+                fileId=file_id,
+                supportsAllDrives=True,
+                pageSize=100,
+                pageToken=page_token,
+                fields=(
+                    "nextPageToken, permissions(id, type, role, emailAddress, "
+                    "domain, expirationTime, permissionDetails, allowFileDiscovery)"
+                ),
+            )
+            .execute()
+        )
+        permissions.extend(resp.get("permissions", []))
+        page_token = resp.get("nextPageToken")
+        if not page_token:
+            break
+    return permissions
+
+
+def derive_shared_state(file_metadata: Dict[str, Any], permissions: List[Dict[str, Any]]) -> bool:
+    """
+    Determine whether a file is shared.
+
+    The Drive API omits the `shared` boolean for Shared Drive items, so derive it
+    from the driveId and the resolved permission set instead of trusting `shared`.
+    """
+    if file_metadata.get("shared"):
+        return True
+    if file_metadata.get("driveId"):
+        return True
+    if any(p.get("type") in ("anyone", "domain") for p in permissions):
+        return True
+    return len([p for p in permissions if p.get("type") in ("user", "group")]) > 1
+
+
 def format_public_sharing_error(file_name: str, file_id: str) -> str:
     """
     Format error message for files without public sharing.

--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -79,7 +79,9 @@ def list_all_permissions(service, file_id: str) -> List[Dict[str, Any]]:
     return permissions
 
 
-def derive_shared_state(file_metadata: Dict[str, Any], permissions: List[Dict[str, Any]]) -> bool:
+def derive_shared_state(
+    file_metadata: Dict[str, Any], permissions: List[Dict[str, Any]]
+) -> bool:
     """
     Determine whether a file is shared.
 

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -1719,7 +1719,7 @@ async def check_drive_file_public_access(
         service.files()
         .get(
             fileId=file_id,
-            fields="id, name, mimeType, permissions, webViewLink, webContentLink, shared",
+            fields="id, name, mimeType, driveId, permissions, webViewLink, webContentLink, shared",
             supportsAllDrives=True,
         )
         .execute
@@ -1738,7 +1738,7 @@ async def check_drive_file_public_access(
             f"File: {file_metadata['name']}",
             f"ID: {file_id}",
             f"Type: {file_metadata['mimeType']}",
-            f"Shared: {file_metadata.get('shared', False)}",
+            f"Shared: {derive_shared_state(file_metadata, permissions)}",
             "",
         ]
     )

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -49,6 +49,8 @@ from gdrive.drive_helpers import (
     _stream_url_with_validation,
     build_drive_list_params,
     check_public_link_permission,
+    list_all_permissions,
+    derive_shared_state,
     format_permission_info,
     get_drive_image_url,
     has_explicit_trashed_clause,
@@ -1536,6 +1538,13 @@ async def get_drive_file_permissions(
         )
 
         # Format the response
+        # Resolve permissions up front: Shared Drive items omit inline permissions
+        # (and the `shared` boolean) on files.get(), so fetch via permissions.list().
+        _perms_for_shared = file_metadata.get("permissions", [])
+        if file_metadata.get("driveId"):
+            _perms_for_shared = await asyncio.to_thread(
+                list_all_permissions, service, file_id
+            )
         parents = file_metadata.get("parents")
         parent_str = ", ".join(parents) if parents else "None (root or orphaned)"
         owners = file_metadata.get("owners") or []
@@ -1571,7 +1580,7 @@ async def get_drive_file_permissions(
             [
                 "",
                 "Sharing Status:",
-                f"  Shared: {file_metadata.get('shared', False)}",
+                f"  Shared: {derive_shared_state(file_metadata, _perms_for_shared)}",
             ]
         )
 
@@ -1582,8 +1591,8 @@ async def get_drive_file_permissions(
                 f"  Shared by: {sharing_user.get('displayName', 'Unknown')} ({sharing_user.get('emailAddress', 'Unknown')})"
             )
 
-        # Process permissions
-        permissions = file_metadata.get("permissions", [])
+        # Process permissions (already resolved above as _perms_for_shared)
+        permissions = _perms_for_shared
         if permissions:
             output_parts.append(f"  Number of permissions: {len(permissions)}")
             output_parts.append("  Permissions:")
@@ -1717,6 +1726,10 @@ async def check_drive_file_public_access(
     )
 
     permissions = file_metadata.get("permissions", [])
+    # Shared Drive items do not return inline permissions on files.get(); fall
+    # back to permissions.list() so 'anyone with link' surfaces correctly.
+    if file_metadata.get("driveId"):
+        permissions = await asyncio.to_thread(list_all_permissions, service, file_id)
 
     has_public_link = check_public_link_permission(permissions)
 

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -2303,3 +2303,54 @@ async def test_get_drive_file_permissions_my_drive_uses_inline(mock_resolve):
     # inline path used → permissions.list must NOT be called
     mock_service.permissions.return_value.list.return_value.execute.assert_not_called()
     assert "NOT shared with 'Anyone with the link'" in result
+
+
+# ---------------------------------------------------------------------------
+# check_drive_file_public_access — Shared Drive public access
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_drive_item", new_callable=AsyncMock)
+async def test_check_drive_file_public_access_shared_drive(mock_resolve):
+    """
+    For a Shared Drive file, files.get() returns no inline permissions, so the
+    public-access check must request driveId and fall back to permissions.list()
+    to detect the 'anyone with link' grant.
+    """
+    from gdrive.drive_tools import check_drive_file_public_access
+
+    mock_resolve.return_value = ("file123", {})
+    mock_service = Mock()
+    mock_service.files().list().execute.return_value = {
+        "files": [
+            {
+                "id": "file123",
+                "name": "spec.pdf",
+                "mimeType": "application/pdf",
+                "webViewLink": "https://drive.google.com/file/d/file123/view",
+            }
+        ]
+    }
+    mock_service.files().get().execute.return_value = {
+        "id": "file123",
+        "name": "spec.pdf",
+        "mimeType": "application/pdf",
+        "driveId": "0ASharedDriveId",
+        "webViewLink": "https://drive.google.com/file/d/file123/view",
+    }
+    mock_service.permissions().list().execute.return_value = {
+        "permissions": [
+            {"id": "anyoneWithLink", "type": "anyone", "role": "reader"},
+        ]
+    }
+
+    result = await _unwrap(check_drive_file_public_access)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        file_name="spec.pdf",
+        drive_id="0ASharedDriveId",
+    )
+
+    assert "PUBLIC ACCESS ENABLED" in result
+    assert "Shared: True" in result

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -2580,5 +2580,15 @@ async def test_check_drive_file_public_access_shared_drive(mock_resolve):
         drive_id="0ASharedDriveId",
     )
 
+    get_kwargs = mock_service.files.return_value.get.call_args.kwargs
+    assert "driveId" in get_kwargs["fields"]
+    assert get_kwargs["supportsAllDrives"] is True
+
+    permissions_list_kwargs = (
+        mock_service.permissions.return_value.list.call_args.kwargs
+    )
+    assert "fileId" in permissions_list_kwargs
+    assert permissions_list_kwargs["supportsAllDrives"] is True
+
     assert "PUBLIC ACCESS ENABLED" in result
     assert "Shared: True" in result

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -2218,3 +2218,88 @@ def test_has_explicit_trashed_clause_ignores_quoted_literals():
     assert not has_explicit_trashed_clause("name contains 'trashed != false'")
     assert not has_explicit_trashed_clause(r"name contains 'it\'s trashed=true'")
     assert not has_explicit_trashed_clause("budget")
+
+
+# ---------------------------------------------------------------------------
+# get_drive_file_permissions — Shared Drive permission read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_drive_item", new_callable=AsyncMock)
+async def test_get_drive_file_permissions_shared_drive_uses_permissions_list(
+    mock_resolve,
+):
+    """
+    For Shared Drive items, files.get() returns no inline `permissions` (and no
+    `shared` boolean). The tool must fall back to permissions.list() so an
+    'anyone with link' grant is surfaced instead of misreporting the file as
+    private.
+    """
+    mock_resolve.return_value = ("file123", {})
+    mock_service = Mock()
+    # files.get() on a Shared Drive item: driveId present, no permissions, no shared
+    mock_service.files().get().execute.return_value = {
+        "id": "file123",
+        "name": "spec.pdf",
+        "mimeType": "application/pdf",
+        "driveId": "0ASharedDriveId",
+        "parents": ["parent1"],
+        "webViewLink": "https://drive.google.com/file/d/file123/view",
+    }
+    # permissions.list() returns the real set, including anyone-with-link
+    mock_service.permissions().list().execute.return_value = {
+        "permissions": [
+            {"id": "anyoneWithLink", "type": "anyone", "role": "reader"},
+            {
+                "id": "1",
+                "type": "user",
+                "role": "organizer",
+                "emailAddress": "owner@example.com",
+            },
+        ]
+    }
+
+    result = await _unwrap(get_drive_file_permissions)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        file_id="file123",
+    )
+
+    assert "Shared: True" in result
+    assert "Anyone with the link" in result
+    assert "This file is shared with 'Anyone with the link'" in result
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_drive_item", new_callable=AsyncMock)
+async def test_get_drive_file_permissions_my_drive_uses_inline(mock_resolve):
+    """My Drive files keep the inline permissions path (no extra permissions.list)."""
+    mock_resolve.return_value = ("file456", {})
+    mock_service = Mock()
+    mock_service.files().get().execute.return_value = {
+        "id": "file456",
+        "name": "private.pdf",
+        "mimeType": "application/pdf",
+        "shared": False,
+        "parents": ["parent1"],
+        "permissions": [
+            {
+                "id": "1",
+                "type": "user",
+                "role": "owner",
+                "emailAddress": "user@example.com",
+            }
+        ],
+        "webViewLink": "https://drive.google.com/file/d/file456/view",
+    }
+
+    result = await _unwrap(get_drive_file_permissions)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        file_id="file456",
+    )
+
+    # inline path used → permissions.list must NOT be called
+    mock_service.permissions.return_value.list.return_value.execute.assert_not_called()
+    assert "NOT shared with 'Anyone with the link'" in result


### PR DESCRIPTION
## Problem

`get_drive_file_permissions` and `check_drive_file_public_access` read the inline
`permissions` field returned by `files.get()`. For items in a **Shared Drive**, the
Drive API does not populate that field — nor the `shared` boolean — even when
`supportsAllDrives=True` is passed. As a result every Shared Drive file is reported
as private / "not shared with 'anyone with the link'", even when it is shared
"Anyone with the link". My Drive files are unaffected because `files.get()` does
populate their inline permissions.

## Reproduction

1. Put a file in a Shared Drive (not "My Drive") and share it "Anyone with the link → Viewer".
2. Call `get_drive_file_permissions(file_id=...)` (or `check_drive_file_public_access`).
3. Result: `Shared: False`, "No additional permissions (private file)", "❌ NOT shared with 'Anyone with the link'".

Verified directly against the Drive API on such a file:
`files.get(fields="…permissions…,shared", supportsAllDrives=True)` returns neither
`permissions` nor `shared`, while `permissions.list(fileId, supportsAllDrives=True)`
returns the full set including `{type: anyone, role: reader}`.

## Fix

When the file is in a Shared Drive (`driveId` present), resolve permissions via a
paginated `permissions.list(..., supportsAllDrives=True)` instead of the empty
inline field, and derive the "Shared" state from the resolved permission set rather
than the `shared` boolean. My Drive behaviour is unchanged (inline permissions
remain the source, no extra API call). Adds `list_all_permissions` and
`derive_shared_state` helpers in `drive_helpers.py`.

## Test

`tests/gdrive/test_drive_tools.py`: adds a Shared Drive case (fallback surfaces the
`anyone` grant) and a My Drive case (inline path, no extra `permissions.list` call).
The `tests/gdrive` suite passes (98 tests).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Drive permission reporting for Shared Drive files.
  * Shared status and public-link access are now determined more accurately.
  * Permission details, including organizer access, are displayed consistently across Shared Drive and My Drive files.
  * Permission results now include complete access details, even when they are not included in the initial file information.
  * Permission reporting now handles large permission sets and paginated results more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->