### PR TITLE
enh: add presenter notes to google slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ This project is [MIT licensed](LICENSE) — not "open core," not "source availab
 </td>
 <td align="center" width="25%">
 <h3>🖼️</h3><a href="https://workspacemcp.com/google-slides"><b>Slides</b></a><br>
-<sub>7 tools - create, batch update,<br>thumbnails, comments</sub>
+<sub>7 tools - create, batch update,<br>speaker notes, thumbnails, comments</sub>
 </td>
 <td align="center" width="25%">
 <h3>📋</h3><a href="https://workspacemcp.com/google-forms"><b>Forms</b></a><br>

--- a/gslides/slides_helpers.py
+++ b/gslides/slides_helpers.py
@@ -10,7 +10,8 @@ from typing import Any, Dict, List, Set, Tuple
 from core.utils import UserInputError
 
 _PRESENTATION_PAGE_ID_FIELDS = (
-    "slides(objectId,slideProperties(notesPage(objectId))),"
+    "slides(objectId,slideProperties(notesPage(objectId,"
+    "notesProperties(speakerNotesObjectId)))),"
     "masters(objectId),layouts(objectId),notesMaster(objectId)"
 )
 
@@ -148,7 +149,15 @@ def _find_created_slide_ids(requests: List[Dict[str, Any]]) -> Set[str]:
     return slide_ids
 
 
-async def _get_presentation_slide_ids(service, presentation_id: str) -> Set[str]:
+async def _get_presentation_page_ids(
+    service, presentation_id: str
+) -> Tuple[Set[str], Dict[str, str]]:
+    """Return every page object ID plus a notes page ID -> speaker notes shape ID map.
+
+    The speaker notes shape is the only writable part of a notes page, so the map
+    lets an insertText aimed at a notes page be redirected to the shape that can
+    actually hold the text. See https://developers.google.com/slides/api/guides/notes
+    """
     result = await asyncio.to_thread(
         service.presentations()
         .get(
@@ -163,14 +172,20 @@ async def _get_presentation_slide_ids(service, presentation_id: str) -> Set[str]
         for page in result.get(page_type, [])
         if isinstance(page.get("objectId"), str)
     }
+    speaker_notes_shapes: Dict[str, str] = {}
     for slide in result.get("slides", []):
-        notes_id = slide.get("slideProperties", {}).get("notesPage", {}).get("objectId")
-        if isinstance(notes_id, str):
-            page_ids.add(notes_id)
+        notes_page = slide.get("slideProperties", {}).get("notesPage", {})
+        notes_id = notes_page.get("objectId")
+        if not isinstance(notes_id, str):
+            continue
+        page_ids.add(notes_id)
+        shape_id = notes_page.get("notesProperties", {}).get("speakerNotesObjectId")
+        if isinstance(shape_id, str) and shape_id:
+            speaker_notes_shapes[notes_id] = shape_id
     notes_master = result.get("notesMaster")
     if isinstance(notes_master, dict) and isinstance(notes_master.get("objectId"), str):
         page_ids.add(notes_master["objectId"])
-    return page_ids
+    return page_ids, speaker_notes_shapes
 
 
 async def validate_insert_text_targets(
@@ -180,27 +195,41 @@ async def validate_insert_text_targets(
     if not insert_text_targets:
         return
 
-    slide_ids = _find_created_slide_ids(requests)
-    slide_ids.update(await _get_presentation_slide_ids(service, presentation_id))
+    page_ids = _find_created_slide_ids(requests)
+    presentation_page_ids, speaker_notes_shapes = await _get_presentation_page_ids(
+        service, presentation_id
+    )
+    page_ids.update(presentation_page_ids)
 
     invalid_targets = [
         (index, object_id)
         for index, object_id in insert_text_targets
-        if object_id in slide_ids
+        if object_id in page_ids
     ]
     if not invalid_targets:
         return
 
-    invalid_refs = ", ".join(
-        f"requests[{index}].insertText.objectId='{object_id}'"
-        for index, object_id in invalid_targets
-    )
-    raise UserInputError(
-        "Invalid Slides batch update request: "
-        f"{invalid_refs} targets a slide/page object. The Slides API only allows "
-        "insertText on text-capable shapes or table cells. Create a text box or "
-        "shape first with createShape, set elementProperties.pageObjectId to the "
-        "slide ID, then insertText into the new shape objectId. For existing "
-        "content, call get_page and use a Shape or Table element ID, not the "
-        "Page ID."
-    )
+    problems = []
+    has_non_notes_target = False
+    for index, object_id in invalid_targets:
+        ref = f"requests[{index}].insertText.objectId='{object_id}'"
+        shape_id = speaker_notes_shapes.get(object_id)
+        if shape_id:
+            problems.append(
+                f"{ref} targets a notes page. Speaker notes text lives in the notes "
+                f"shape on that page, so use objectId '{shape_id}' instead."
+            )
+        else:
+            has_non_notes_target = True
+            problems.append(f"{ref} targets a slide/page object.")
+
+    message = "Invalid Slides batch update request: " + " ".join(problems)
+    if has_non_notes_target:
+        message += (
+            " The Slides API only allows insertText on text-capable shapes or table "
+            "cells. Create a text box or shape first with createShape, set "
+            "elementProperties.pageObjectId to the slide ID, then insertText into "
+            "the new shape objectId. For existing content, call get_page and use a "
+            "Shape or Table element ID, not the Page ID."
+        )
+    raise UserInputError(message)

--- a/gslides/slides_tools.py
+++ b/gslides/slides_tools.py
@@ -6,7 +6,7 @@ This module provides MCP tools for interacting with Google Slides API.
 
 import logging
 import asyncio
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from mcp.types import ToolAnnotations
 
@@ -147,6 +147,38 @@ def _describe_elements(
     return info
 
 
+def _speaker_notes_shape(slide: Dict[str, Any]) -> Tuple[Optional[str], str]:
+    """Return ``(speaker_notes_object_id, current_notes_text)`` for a slide resource.
+
+    A slide's speaker notes live in the single BODY placeholder shape on its notes
+    page, identified by ``notesProperties.speakerNotesObjectId``. Only that shape's
+    text is writable; the rest of the notes page and the notes master are read-only.
+    The shape itself is occasionally absent for slides that have never had notes, in
+    which case the ID resolves but no text element exists yet. See:
+    https://developers.google.com/slides/api/guides/notes
+    """
+    notes_page = slide.get("slideProperties", {}).get("notesPage", {})
+    notes_object_id = notes_page.get("notesProperties", {}).get("speakerNotesObjectId")
+    if not notes_object_id:
+        return None, ""
+    for element in notes_page.get("pageElements", []):
+        if element.get("objectId") == notes_object_id:
+            return notes_object_id, _extract_shape_text(element.get("shape"))
+    return notes_object_id, ""
+
+
+def _describe_speaker_notes(slide: Dict[str, Any], indent: str = "    ") -> List[str]:
+    """Build lines describing a slide's speaker notes shape ID and current notes text."""
+    notes_object_id, notes_text = _speaker_notes_shape(slide)
+    if not notes_object_id:
+        return [f"{indent}Speaker Notes: none (slide has no notes placeholder)"]
+    lines = [line.rstrip() for line in notes_text.split("\n") if line.strip()]
+    header = f"{indent}Speaker Notes Shape ID: {notes_object_id}"
+    if not lines:
+        return [f"{header}, Notes: empty"]
+    return [f"{header}, Notes:"] + [f"{indent}  > {line}" for line in lines]
+
+
 @server.tool(
     title="Create Presentation",
     annotations=ToolAnnotations(
@@ -204,7 +236,10 @@ async def create_presentation(
 @handle_http_errors("get_presentation", is_read_only=True, service_type="slides")
 @require_google_service("slides", "slides_read")
 async def get_presentation(
-    service, user_google_email: str, presentation_id: str
+    service,
+    user_google_email: str,
+    presentation_id: str,
+    include_speaker_notes: bool = False,
 ) -> str:
     """
     Get details about a Google Slides presentation.
@@ -212,12 +247,18 @@ async def get_presentation(
     Args:
         user_google_email (str): The user's Google email address. Required.
         presentation_id (str): The ID of the presentation to retrieve.
+        include_speaker_notes (bool): Also report each slide's speaker (presenter)
+            notes and the object ID of the shape holding them. Pass True when you
+            need to read or edit notes: that shape ID is the only valid target for
+            insertText/deleteText on notes, and batch_update_presentation writes
+            notes by deleting the shape's existing text and inserting new text.
+            Defaults to False.
 
     Returns:
         str: Details about the presentation including title, slides count, and metadata.
     """
     logger.info(
-        f"[get_presentation] Invoked. Email: '{user_google_email}', ID: '{presentation_id}'"
+        f"[get_presentation] Invoked. Email: '{user_google_email}', ID: '{presentation_id}', Notes: {include_speaker_notes}"
     )
 
     result = await asyncio.to_thread(
@@ -257,6 +298,10 @@ async def get_presentation(
         slides_info.append(
             f"  Slide {i}: ID {slide_id}, {len(page_elements)} element(s), text: {slide_text if slide_text else 'empty'}"
         )
+        # The unfiltered presentations.get response already carries each slide's
+        # notesPage, so reporting notes costs no extra API call.
+        if include_speaker_notes:
+            slides_info.extend(_describe_speaker_notes(slide))
 
     confirmation_message = f"""Presentation Details for {user_google_email}:
 - Title: {title}
@@ -302,6 +347,13 @@ async def batch_update_presentation(
         or shape first with createShape, set elementProperties.pageObjectId to
         the slide ID, and then insertText into that shape objectId. To edit
         existing text, call get_page and use a Shape or Table element ID.
+
+        To write speaker (presenter) notes, call get_presentation with
+        include_speaker_notes=True to get the slide's speaker notes shape ID,
+        then target that ID: deleteText with textRange {"type": "ALL"} to clear
+        the existing notes (omit this when they are already empty, which errors),
+        followed by insertText at insertionIndex 0. The notes page ID is not a
+        valid target.
 
     Args:
         user_google_email (str): The user's Google email address. Required.

--- a/skills/managing-google-workspace/SKILL.md
+++ b/skills/managing-google-workspace/SKILL.md
@@ -168,6 +168,7 @@ For parameters: [references/sheets.md](references/sheets.md)
 | Get slide thumbnail | `get_page_thumbnail` |
 | Create presentation | `create_presentation` |
 | Batch update | `batch_update_presentation` |
+| Speaker notes | `get_presentation` (`include_speaker_notes`) + `batch_update_presentation` |
 | Comments | `manage_presentation_comment` / `list_presentation_comments` |
 
 For parameters: [references/slides.md](references/slides.md)

--- a/skills/managing-google-workspace/references/slides.md
+++ b/skills/managing-google-workspace/references/slides.md
@@ -20,6 +20,7 @@ Get presentation metadata: title, slide count, and slide object IDs.
 |-----------|------|----------|---------|-------|
 | user_google_email | string | yes | | |
 | presentation_id | string | yes | | |
+| include_speaker_notes | boolean | no | false | Also report each slide's speaker notes shape ID and current notes text |
 
 ### get_page
 Get details about a specific slide, including its elements and layout.
@@ -105,7 +106,9 @@ Each slide has a notes page, and the notes text lives in the single shape on it 
 ]
 ```
 
-Omit the `deleteText` request when the notes are already empty -- deleting an empty range is an API error. To append, read the existing text first and insert the concatenated result. To clear notes, send `deleteText` alone.
+Omit the `deleteText` request when the notes are already empty -- deleting an empty range is an API error. To clear notes, send `deleteText` alone.
+
+Appending uses the same clear-then-insert pair: read the existing notes, then insert `existing + new` as one `insertText` at index 0. Inserting only the new text without the `deleteText` duplicates the existing notes, and the notes text reported by `get_presentation` is normalized (blank lines dropped, trailing whitespace stripped), so its length cannot be used as an `insertionIndex` -- `insertionIndex` counts Unicode code units in the shape's actual text.
 
 If an `insertText` accidentally targets the notes page instead of the notes shape, the error response names the correct shape ID to retry with.
 

--- a/skills/managing-google-workspace/references/slides.md
+++ b/skills/managing-google-workspace/references/slides.md
@@ -5,6 +5,7 @@ MCP tools for reading, creating, and updating Google Slides presentations. All t
 ## Contents
 - Reading Presentations: get_presentation, get_page, get_page_thumbnail
 - Creating & Updating: create_presentation, batch_update_presentation
+- Speaker Notes
 - Comments: list_presentation_comments, manage_presentation_comment
 - Tips
 
@@ -69,7 +70,7 @@ Each item in `requests` is a dict with exactly one key corresponding to a Slides
 | `createSlide` | Add a new slide |
 | `deleteObject` | Delete a slide or element |
 | `createShape` | Add a shape (rectangle, text box, etc.) |
-| `insertText` | Insert text into a shape or table cell |
+| `insertText` | Insert text into a shape or table cell (including the speaker notes shape) |
 | `deleteText` | Delete text from an element |
 | `updateTextStyle` | Apply text formatting (bold, color, font, size) |
 | `updateParagraphStyle` | Set alignment, spacing, bullet style |
@@ -84,6 +85,29 @@ Each item in `requests` is a dict with exactly one key corresponding to a Slides
 | `duplicateObject` | Duplicate a slide or element |
 
 See the [Slides API reference](https://developers.google.com/slides/api/reference/rest/v1/presentations/batchUpdate) for full request schemas.
+
+---
+
+## Speaker Notes
+
+Speaker notes (presenter notes) are editable -- there are no dedicated tools, they go through the two tools above.
+
+Each slide has a notes page, and the notes text lives in the single shape on it identified by `speakerNotesObjectId`. Only that shape's text is writable; the rest of the notes page and the notes master are read-only. That shape ID is **not** returned by `get_page`, and the notes *page* ID is **not** a valid `insertText` target.
+
+**Read**: call `get_presentation` with `include_speaker_notes=true`. Each slide then reports its `Speaker Notes Shape ID` and current notes text. This costs no extra API call.
+
+**Write**: pass that shape ID to `batch_update_presentation`. To replace notes, clear then insert:
+
+```json
+[
+  {"deleteText": {"objectId": "<speaker notes shape ID>", "textRange": {"type": "ALL"}}},
+  {"insertText": {"objectId": "<speaker notes shape ID>", "insertionIndex": 0, "text": "Full narration here."}}
+]
+```
+
+Omit the `deleteText` request when the notes are already empty -- deleting an empty range is an API error. To append, read the existing text first and insert the concatenated result. To clear notes, send `deleteText` alone.
+
+If an `insertText` accidentally targets the notes page instead of the notes shape, the error response names the correct shape ID to retry with.
 
 ---
 
@@ -117,6 +141,8 @@ Create, reply to, or resolve a comment.
 **Object IDs**: Every slide and element has a unique `objectId`. Use `get_presentation` to discover slide IDs and `get_page` to discover element IDs within a slide. You can assign custom object IDs when creating elements (useful for referencing them in subsequent requests within the same batch).
 
 **Adding text**: `insertText.objectId` must be a text-capable shape or table object ID, not the slide/page ID. To place new text on a slide, create a text box or shape first with `createShape` and `elementProperties.pageObjectId` set to the slide ID, then call `insertText` using the new shape `objectId`.
+
+**Keep slides skimmable**: put short headlines and bullets on the slide itself and move the narration -- full sentences, context, talking points -- into speaker notes (see above). Never create a separate document for notes.
 
 **Coordinate system**: Positions and sizes use EMU (English Metric Units). 1 inch = 914400 EMU. Standard slide dimensions are 10 inches wide (9144000 EMU) by 5.625 inches tall (5143500 EMU).
 

--- a/tests/test_slides_tools.py
+++ b/tests/test_slides_tools.py
@@ -7,7 +7,9 @@ from gslides.slides_tools import (
     _describe_elements,
     _extract_shape_text,
     _iter_text_bearing_elements,
+    _speaker_notes_shape,
     batch_update_presentation,
+    get_presentation,
 )
 
 
@@ -150,7 +152,7 @@ async def test_batch_update_rejects_insert_text_targeting_other_page_ids():
     presentations.get.assert_called_once_with(
         presentationId="presentation-1",
         fields=(
-            "slides(objectId,slideProperties(notesPage(objectId))),masters(objectId),layouts(objectId),notesMaster(objectId)"
+            "slides(objectId,slideProperties(notesPage(objectId,notesProperties(speakerNotesObjectId)))),masters(objectId),layouts(objectId),notesMaster(objectId)"
         ),
     )
     presentations.batchUpdate.assert_not_called()
@@ -437,3 +439,179 @@ def test_describe_elements_keeps_shape_without_text_simple():
 def test_describe_elements_handles_empty_and_none_input():
     assert _describe_elements([]) == []
     assert _describe_elements(None) == []
+
+
+# --- Tests for speaker notes reporting and insertText redirection ---
+
+
+def _slide_with_notes(slide_id="slide_1", notes_object_id="notes_shape_1", text=None):
+    """Build a slide resource carrying a notes page, as presentations.get returns."""
+    notes_page = {
+        "objectId": f"{slide_id}_notes",
+        "notesProperties": {"speakerNotesObjectId": notes_object_id}
+        if notes_object_id
+        else {},
+        "pageElements": [],
+    }
+    if text is not None:
+        element = _text_shape(text)
+        element["objectId"] = notes_object_id
+        notes_page["pageElements"].append(element)
+    return {
+        "objectId": slide_id,
+        "slideProperties": {"notesPage": notes_page},
+    }
+
+
+def test_speaker_notes_shape_returns_id_and_text():
+    slide = _slide_with_notes(text="Talk track\n")
+    assert _speaker_notes_shape(slide) == ("notes_shape_1", "Talk track\n")
+
+
+def test_speaker_notes_shape_handles_missing_shape_and_missing_id():
+    assert _speaker_notes_shape(_slide_with_notes()) == ("notes_shape_1", "")
+    assert _speaker_notes_shape(_slide_with_notes(notes_object_id=None)) == (None, "")
+    assert _speaker_notes_shape({}) == (None, "")
+
+
+@pytest.mark.asyncio
+async def test_get_presentation_omits_speaker_notes_by_default():
+    service, _ = _build_slides_service(
+        presentation={"slides": [_slide_with_notes("slide_1", "notes_1", "Talk\n")]}
+    )
+
+    result = await _unwrap(get_presentation)(
+        service=service,
+        user_google_email="user@example.com",
+        presentation_id="presentation-1",
+    )
+
+    assert "Speaker Notes" not in result
+    assert "notes_1" not in result
+
+
+@pytest.mark.asyncio
+async def test_get_presentation_reports_speaker_notes_when_requested():
+    service, _ = _build_slides_service(
+        presentation={
+            "slides": [
+                _slide_with_notes(
+                    "slide_1", "notes_1", "Opening remarks\nSecond line\n"
+                ),
+                _slide_with_notes("slide_2", "notes_2"),
+                _slide_with_notes("slide_3", notes_object_id=None),
+            ]
+        }
+    )
+
+    result = await _unwrap(get_presentation)(
+        service=service,
+        user_google_email="user@example.com",
+        presentation_id="presentation-1",
+        include_speaker_notes=True,
+    )
+
+    assert "    Speaker Notes Shape ID: notes_1, Notes:" in result
+    assert "      > Opening remarks" in result
+    assert "      > Second line" in result
+    assert "    Speaker Notes Shape ID: notes_2, Notes: empty" in result
+    assert "    Speaker Notes: none (slide has no notes placeholder)" in result
+
+
+@pytest.mark.asyncio
+async def test_batch_update_redirects_insert_text_from_notes_page_to_notes_shape():
+    service, presentations = _build_slides_service(
+        presentation={
+            "slides": [_slide_with_notes("slide_1", "notes_shape_1")],
+        }
+    )
+
+    with pytest.raises(UserInputError) as exc_info:
+        await _unwrap(batch_update_presentation)(
+            service=service,
+            user_google_email="user@example.com",
+            presentation_id="presentation-1",
+            requests=[
+                {
+                    "insertText": {
+                        "objectId": "slide_1_notes",
+                        "insertionIndex": 0,
+                        "text": "Talk track",
+                    }
+                }
+            ],
+        )
+
+    message = str(exc_info.value)
+    assert "requests[0].insertText.objectId='slide_1_notes'" in message
+    assert "targets a notes page" in message
+    assert "use objectId 'notes_shape_1' instead" in message
+    # The createShape guidance is wrong for notes and must not be appended.
+    assert "createShape" not in message
+    presentations.batchUpdate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_batch_update_keeps_shape_guidance_when_a_slide_id_is_also_targeted():
+    service, _ = _build_slides_service(
+        presentation={"slides": [_slide_with_notes("slide_1", "notes_shape_1")]}
+    )
+
+    with pytest.raises(UserInputError) as exc_info:
+        await _unwrap(batch_update_presentation)(
+            service=service,
+            user_google_email="user@example.com",
+            presentation_id="presentation-1",
+            requests=[
+                {
+                    "insertText": {
+                        "objectId": "slide_1_notes",
+                        "insertionIndex": 0,
+                        "text": "Notes",
+                    }
+                },
+                {
+                    "insertText": {
+                        "objectId": "slide_1",
+                        "insertionIndex": 0,
+                        "text": "Title",
+                    }
+                },
+            ],
+        )
+
+    message = str(exc_info.value)
+    assert "use objectId 'notes_shape_1' instead" in message
+    assert "requests[1].insertText.objectId='slide_1' targets a slide/page object" in (
+        message
+    )
+    assert "createShape" in message
+
+
+@pytest.mark.asyncio
+async def test_batch_update_allows_insert_text_into_the_speaker_notes_shape():
+    service, presentations = _build_slides_service(
+        presentation={
+            "slides": [_slide_with_notes("slide_1", "notes_shape_1", "Old\n")]
+        }
+    )
+    requests = [
+        {"deleteText": {"objectId": "notes_shape_1", "textRange": {"type": "ALL"}}},
+        {
+            "insertText": {
+                "objectId": "notes_shape_1",
+                "insertionIndex": 0,
+                "text": "New talk track",
+            }
+        },
+    ]
+
+    result = await _unwrap(batch_update_presentation)(
+        service=service,
+        user_google_email="user@example.com",
+        presentation_id="presentation-1",
+        requests=requests,
+    )
+
+    assert presentations.batchUpdate.call_args.kwargs["body"] == {"requests": requests}
+    assert "Batch Update Completed" in result

--- a/uv.lock
+++ b/uv.lock
@@ -2423,7 +2423,7 @@ wheels = [
 
 [[package]]
 name = "workspace-mcp"
-version = "1.23.0"
+version = "1.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional speaker-notes retrieval for Google Slides presentations, including notes text and editable shape IDs.
  - Added support for replacing, appending, and clearing speaker notes through presentation updates.
  - Improved handling of slides with missing or empty notes.

- **Bug Fixes**
  - Notes-page text updates now identify the correct speaker-notes target and provide clearer guidance for invalid targets.

- **Documentation**
  - Updated Slides tool references and workflows with speaker-notes usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->