### PR TITLE
feat(gmail): derive reply headers, recipients and quote on send_gmail_message

### DIFF
--- a/gmail/gmail_helpers.py
+++ b/gmail/gmail_helpers.py
@@ -197,6 +197,98 @@ def _parse_date_header(
     return None, None
 
 
+def _parse_message_id_chain(header_value: Optional[str]) -> list[str]:
+    """Extract Message-IDs from a reply header value."""
+    if not header_value:
+        return []
+
+    message_ids = re.findall(r"<[^>]+>", header_value)
+    if message_ids:
+        return message_ids
+
+    return header_value.split()
+
+
+def _derive_reply_headers(
+    thread_message_ids: list[str],
+    in_reply_to: Optional[str],
+    references: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Fill missing reply headers while preserving caller intent."""
+    derived_in_reply_to = in_reply_to
+    derived_references = references
+
+    if not thread_message_ids:
+        return derived_in_reply_to, derived_references
+
+    if not derived_in_reply_to:
+        reference_chain = _parse_message_id_chain(derived_references)
+        derived_in_reply_to = (
+            reference_chain[-1] if reference_chain else thread_message_ids[-1]
+        )
+
+    if not derived_references:
+        if derived_in_reply_to and derived_in_reply_to in thread_message_ids:
+            reply_index = thread_message_ids.index(derived_in_reply_to)
+            derived_references = " ".join(thread_message_ids[: reply_index + 1])
+        elif derived_in_reply_to:
+            derived_references = derived_in_reply_to
+        else:
+            derived_references = " ".join(thread_message_ids)
+
+    return derived_in_reply_to, derived_references
+
+
+def _derive_reply_all_recipients(
+    target: Mapping[str, Any],
+    exclude: set[str],
+    to: Optional[str],
+    cc: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Fill missing reply-all recipients from the message being answered.
+
+    To = whoever sent it (Reply-To when set, else From). Cc = every other
+    participant, minus `exclude` and minus anyone already in To. Caller-supplied
+    values win, mirroring _derive_reply_headers.
+
+    `exclude` applies to To as well as Cc, so replying to a message the account
+    sent itself derives no recipient rather than addressing the account; the
+    caller passes `to` explicitly for that case.
+
+    Only the authenticated address and the selected Send As alias can be excluded
+    reliably: a caller sending under several aliases still has to post-filter,
+    which is why this is opt-in rather than applied to every threaded send.
+    """
+    excluded = {addr.lower() for addr in exclude if addr}
+    sender = target.get("reply_to") or target.get("from") or ""
+
+    derived_to = to
+    if not derived_to:
+        derived_to = ", ".join(
+            addr
+            for _name, addr in getaddresses([sender])
+            if addr and addr.lower() not in excluded
+        )
+
+    derived_cc = cc
+    if not derived_cc:
+        seen = {addr.lower() for _n, addr in getaddresses([derived_to or ""]) if addr}
+        seen |= excluded
+        others = []
+        # The sender leads the Cc candidates so an explicit `to` that redirects the
+        # reply still keeps the person being replied to on it. When To was derived
+        # from the sender they are already in `seen`, so this is a no-op there.
+        for _name, addr in getaddresses(
+            [sender, target.get("to", ""), target.get("cc", "")]
+        ):
+            if addr and addr.lower() not in seen:
+                seen.add(addr.lower())
+                others.append(addr)
+        derived_cc = ", ".join(others) or None
+
+    return derived_to or None, derived_cc
+
+
 def _analyze_thread_ownership_impl(
     thread_response: dict,
     user_google_email: str,

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -911,6 +911,10 @@ def _derive_reply_all_recipients(
     reached, minus `exclude` and minus anyone already in To. Caller-supplied
     values win, mirroring _derive_reply_headers.
 
+    `exclude` applies to To as well as Cc, so replying to a message the account
+    sent itself derives no recipient rather than addressing the account; the
+    caller passes `to` explicitly for that case.
+
     Only the authenticated address can be excluded reliably: a caller sending
     under several aliases still has to post-filter, which is why this is opt-in
     rather than applied to every threaded send.
@@ -920,7 +924,11 @@ def _derive_reply_all_recipients(
     derived_to = to
     if not derived_to:
         sender = target.get("reply_to") or target.get("from") or ""
-        derived_to = ", ".join(addr for _name, addr in getaddresses([sender]) if addr)
+        derived_to = ", ".join(
+            addr
+            for _name, addr in getaddresses([sender])
+            if addr and addr.lower() not in excluded
+        )
 
     derived_cc = cc
     if not derived_cc:
@@ -2437,6 +2445,12 @@ async def send_gmail_message(
         raise UserInputError(
             "Both 'subject' and 'body' are required when sending a message "
             "(they are optional only when forwarding via 'forward_message_id')."
+        )
+
+    if reply_all and not thread_id:
+        raise UserInputError(
+            "'reply_all' requires a thread_id: the recipients are derived from "
+            "the message being replied to."
         )
 
     if not to and not (thread_id and reply_all):

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2272,7 +2272,7 @@ async def send_gmail_message(
     quote_original: Annotated[
         bool,
         Field(
-            description="Whether to include the message being replied to as a quoted original. Requires thread_id. Defaults to false.",
+            description="Whether to include the message being replied to as a quoted original. Only has an effect when thread_id is provided. Defaults to false.",
         ),
     ] = False,
     reply_all: Annotated[
@@ -2324,7 +2324,7 @@ async def send_gmail_message(
             Non-benign failures such as quota/rate-limit or API errors raise ToolError and abort
             the send.
         quote_original (bool): Whether to append the message being replied to as a quoted
-            original. Requires thread_id.
+            original. Only has an effect when thread_id is provided.
         reply_all (bool): Whether to derive reply-all recipients from the thread: To = the
             sender being replied to, Cc = the other participants, excluding the authenticated
             account. Requires thread_id. Explicit to/cc win over the derived values.
@@ -2771,7 +2771,7 @@ async def draft_gmail_message(
     quote_original: Annotated[
         bool,
         Field(
-            description="Whether to include the original message as a quoted reply. Requires thread_id. Defaults to false.",
+            description="Whether to include the original message as a quoted reply. Only has an effect when thread_id is provided. Defaults to false.",
         ),
     ] = False,
 ) -> str:
@@ -2809,8 +2809,8 @@ async def draft_gmail_message(
             Non-benign failures such as quota/rate-limit or API errors raise ToolError and abort
             the draft.
         quote_original (bool): Whether to include the original message as a quoted reply.
-            Requires thread_id to be provided. When enabled, fetches the original message
-            and appends it below the signature. Defaults to False.
+            Only has an effect when thread_id is provided. When enabled, fetches the
+            original message and appends it below the signature. Defaults to False.
 
     Returns:
         str: Confirmation message with the created draft's ID.

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -13,7 +13,7 @@ import mimetypes
 import html
 from html.parser import HTMLParser
 from pathlib import Path
-from typing import Annotated, Optional, List, Dict, Literal, Any
+from typing import Annotated, Optional, List, Dict, Literal, Any, Set
 from urllib.parse import unquote, urlparse, urlunsplit
 
 from email.message import EmailMessage
@@ -911,29 +911,29 @@ def _derive_reply_headers(
 
 def _derive_reply_all_recipients(
     target: Dict[str, Any],
-    exclude: set,
+    exclude: Set[str],
     to: Optional[str],
     cc: Optional[str],
 ) -> tuple[Optional[str], Optional[str]]:
     """Fill missing reply-all recipients from the message being answered.
 
-    To = whoever sent it (Reply-To when set, else From). Cc = everyone else it
-    reached, minus `exclude` and minus anyone already in To. Caller-supplied
+    To = whoever sent it (Reply-To when set, else From). Cc = every other
+    participant, minus `exclude` and minus anyone already in To. Caller-supplied
     values win, mirroring _derive_reply_headers.
 
     `exclude` applies to To as well as Cc, so replying to a message the account
     sent itself derives no recipient rather than addressing the account; the
     caller passes `to` explicitly for that case.
 
-    Only the authenticated address can be excluded reliably: a caller sending
-    under several aliases still has to post-filter, which is why this is opt-in
-    rather than applied to every threaded send.
+    Only the authenticated address and the selected Send As alias can be excluded
+    reliably: a caller sending under several aliases still has to post-filter,
+    which is why this is opt-in rather than applied to every threaded send.
     """
     excluded = {addr.lower() for addr in exclude if addr}
+    sender = target.get("reply_to") or target.get("from") or ""
 
     derived_to = to
     if not derived_to:
-        sender = target.get("reply_to") or target.get("from") or ""
         derived_to = ", ".join(
             addr
             for _name, addr in getaddresses([sender])
@@ -945,7 +945,12 @@ def _derive_reply_all_recipients(
         seen = {addr.lower() for _n, addr in getaddresses([derived_to or ""]) if addr}
         seen |= excluded
         others = []
-        for _name, addr in getaddresses([target.get("to", ""), target.get("cc", "")]):
+        # The sender leads the Cc candidates so an explicit `to` that redirects the
+        # reply still keeps the person being replied to on it. When To was derived
+        # from the sender they are already in `seen`, so this is a no-op there.
+        for _name, addr in getaddresses(
+            [sender, target.get("to", ""), target.get("cc", "")]
+        ):
             if addr and addr.lower() not in seen:
                 seen.add(addr.lower())
                 others.append(addr)
@@ -2515,7 +2520,8 @@ async def send_gmail_message(
             original. Only has an effect when thread_id is provided.
         reply_all (bool): Whether to derive reply-all recipients from the thread: To = the
             sender being replied to, Cc = the other participants, excluding the authenticated
-            account. Requires thread_id. Explicit to/cc win over the derived values.
+            account. Requires thread_id. Explicit to/cc win over the derived values; an
+            explicit 'to' moves the sender being replied to into the derived Cc.
 
     Returns:
         str: Confirmation message with the sent email's message ID.
@@ -2611,6 +2617,12 @@ async def send_gmail_message(
     # Forwarding reuses the original message's content, so it follows a dedicated
     # path that fetches and quotes the source message.
     if forward_message_id:
+        # 'to' is optional on the signature only so a reply_all send can derive it;
+        # a forward has no thread to derive from, so it still requires one.
+        if not to:
+            raise UserInputError(
+                "'to' is required when forwarding via 'forward_message_id'."
+            )
         logger.info(
             f"[send_gmail_message] Forwarding message '{forward_message_id}' to '{to}' for '{user_google_email}'"
         )

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -19,7 +19,7 @@ from urllib.parse import unquote, urlparse, urlunsplit
 
 from email.message import EmailMessage
 from email.policy import SMTP
-from email.utils import formataddr
+from email.utils import formataddr, getaddresses
 
 import httpx
 from mcp.types import ToolAnnotations
@@ -897,6 +897,43 @@ def _derive_reply_headers(
             derived_references = " ".join(thread_message_ids)
 
     return derived_in_reply_to, derived_references
+
+
+def _derive_reply_all_recipients(
+    target: Dict[str, Any],
+    exclude: set,
+    to: Optional[str],
+    cc: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Fill missing reply-all recipients from the message being answered.
+
+    To = whoever sent it (Reply-To when set, else From). Cc = everyone else it
+    reached, minus `exclude` and minus anyone already in To. Caller-supplied
+    values win, mirroring _derive_reply_headers.
+
+    Only the authenticated address can be excluded reliably: a caller sending
+    under several aliases still has to post-filter, which is why this is opt-in
+    rather than applied to every threaded send.
+    """
+    excluded = {addr.lower() for addr in exclude if addr}
+
+    derived_to = to
+    if not derived_to:
+        sender = target.get("reply_to") or target.get("from") or ""
+        derived_to = ", ".join(addr for _name, addr in getaddresses([sender]) if addr)
+
+    derived_cc = cc
+    if not derived_cc:
+        seen = {addr.lower() for _n, addr in getaddresses([derived_to or ""]) if addr}
+        seen |= excluded
+        others = []
+        for _name, addr in getaddresses([target.get("to", ""), target.get("cc", "")]):
+            if addr and addr.lower() not in seen:
+                seen.add(addr.lower())
+                others.append(addr)
+        derived_cc = ", ".join(others) or None
+
+    return derived_to or None, derived_cc
 
 
 async def _fetch_thread_reply_context(
@@ -2140,7 +2177,12 @@ async def get_gmail_attachment_content(
 async def send_gmail_message(
     service,
     user_google_email: str,
-    to: Annotated[str, Field(description="Recipient email address.")],
+    to: Annotated[
+        Optional[str],
+        Field(
+            description="Recipient email address. Optional when replying with reply_all=True, which derives it from the thread.",
+        ),
+    ] = None,
     subject: Annotated[
         Optional[str],
         Field(
@@ -2219,6 +2261,18 @@ async def send_gmail_message(
             description="Whether to append the Gmail signature from Settings > Signature when available. Defaults to true.",
         ),
     ] = True,
+    quote_original: Annotated[
+        bool,
+        Field(
+            description="Whether to include the message being replied to as a quoted original. Requires thread_id. Defaults to false.",
+        ),
+    ] = False,
+    reply_all: Annotated[
+        bool,
+        Field(
+            description="Whether to derive reply-all recipients from the thread: To = the sender being replied to, Cc = the other participants, excluding the authenticated account. Requires thread_id. Explicit to/cc win. Defaults to false.",
+        ),
+    ] = False,
 ) -> str:
     """
     Sends an email using the user's Gmail account. Supports new emails, replies, and
@@ -2261,6 +2315,11 @@ async def send_gmail_message(
             (e.g., missing gmail.settings.basic scope), the send proceeds without a signature.
             Non-benign failures such as quota/rate-limit or API errors raise ToolError and abort
             the send.
+        quote_original (bool): Whether to append the message being replied to as a quoted
+            original. Requires thread_id.
+        reply_all (bool): Whether to derive reply-all recipients from the thread: To = the
+            sender being replied to, Cc = the other participants, excluding the authenticated
+            account. Requires thread_id. Explicit to/cc win over the derived values.
 
     Returns:
         str: Confirmation message with the sent email's message ID.
@@ -2329,6 +2388,16 @@ async def send_gmail_message(
             references="<original@gmail.com> <message123@gmail.com>"
         )
 
+        # Send a reply-all with the original quoted, deriving headers and
+        # recipients from the thread
+        send_gmail_message(
+            subject="Re: Meeting tomorrow",
+            body="Thanks for the update!",
+            thread_id="thread_123",
+            reply_all=True,
+            quote_original=True
+        )
+
         # Forward a message with a note
         send_gmail_message(
             to="user@example.com",
@@ -2370,6 +2439,12 @@ async def send_gmail_message(
             "(they are optional only when forwarding via 'forward_message_id')."
         )
 
+    if not to and not (thread_id and reply_all):
+        raise UserInputError(
+            "'to' is required unless replying with reply_all=True and a thread_id, "
+            "which derives the recipients from the thread."
+        )
+
     logger.info(
         f"[send_gmail_message] Invoked. Email: '{user_google_email}', Subject: '{subject}', Attachments: {len(attachments) if attachments else 0}"
     )
@@ -2378,16 +2453,57 @@ async def send_gmail_message(
     # Use from_email (Send As alias) if provided, otherwise default to authenticated user
     sender_email = from_email or user_google_email
 
+    # A reply's headers, recipients and quoted original are all derivable from the
+    # thread, so a caller should not have to assemble them by hand. Mirrors
+    # draft_gmail_message; one thread fetch serves all three.
+    reply_context = None
+    if thread_id and (quote_original or reply_all or not in_reply_to or not references):
+        reply_context = await _fetch_thread_reply_context(
+            service,
+            thread_id,
+            in_reply_to=in_reply_to,
+            include_bodies=quote_original,
+        )
+
+    if thread_id and (not in_reply_to or not references):
+        in_reply_to, references = _derive_reply_headers(
+            reply_context.get("message_ids", []) if reply_context else [],
+            in_reply_to,
+            references,
+        )
+
+    target_reply = reply_context.get("target") if reply_context else None
+    if reply_all and target_reply:
+        to, cc = _derive_reply_all_recipients(
+            target_reply, {user_google_email, sender_email}, to, cc
+        )
+    if not to:
+        raise UserInputError(
+            f"Could not derive a recipient from thread '{thread_id}'. Pass 'to' explicitly."
+        )
+
     # Optionally append the Gmail signature from send-as settings, mirroring
     # draft_gmail_message so sent mail respects the user's Settings > Signature.
-    send_body_content = body
+    signature_html = ""
     if include_signature:
         signature_html = await _get_send_as_signature_html_for_tool(
             service, from_email=sender_email
         )
-        send_body_content = _append_signature_to_body(
-            send_body_content, body_format, signature_html
+
+    if quote_original and target_reply:
+        send_body_content = _build_quoted_reply_body(
+            body,
+            body_format,
+            signature_html,
+            {
+                "sender": target_reply.get("from") or "unknown",
+                "date": target_reply.get("date", ""),
+                "text_body": target_reply.get("text_body", ""),
+                "html_body": target_reply.get("html_body", ""),
+            },
         )
+    else:
+        send_body_content = _append_signature_to_body(body, body_format, signature_html)
 
     resolved_attachments = await _resolve_url_attachments(attachments)
     raw_message, thread_id_final, attached_count, attachment_errors = (

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -13,12 +13,12 @@ import mimetypes
 import html
 from html.parser import HTMLParser
 from pathlib import Path
-from typing import Annotated, Optional, List, Dict, Literal, Any, Set
+from typing import Annotated, Optional, List, Dict, Literal, Any
 from urllib.parse import unquote, urlparse, urlunsplit
 
 from email.message import EmailMessage
 from email.policy import SMTP
-from email.utils import formataddr, getaddresses
+from email.utils import formataddr
 
 import httpx
 from mcp.types import ToolAnnotations
@@ -61,6 +61,8 @@ from gmail.gmail_helpers import (
     RAW_BODY_TRUNCATE_LIMIT,
     _analyze_thread_ownership_impl,
     _build_forward_content,
+    _derive_reply_all_recipients,
+    _derive_reply_headers,
     _fetch_with_retry,
     _is_benign_signature_http_error,
     _retryable_result_ids,
@@ -865,98 +867,6 @@ def _extract_headers(payload: dict, header_names: List[str]) -> Dict[str, str]:
             else:
                 headers[target_name] = value
     return headers
-
-
-def _parse_message_id_chain(header_value: Optional[str]) -> List[str]:
-    """Extract Message-IDs from a reply header value."""
-    if not header_value:
-        return []
-
-    message_ids = re.findall(r"<[^>]+>", header_value)
-    if message_ids:
-        return message_ids
-
-    return header_value.split()
-
-
-def _derive_reply_headers(
-    thread_message_ids: List[str],
-    in_reply_to: Optional[str],
-    references: Optional[str],
-) -> tuple[Optional[str], Optional[str]]:
-    """Fill missing reply headers while preserving caller intent."""
-    derived_in_reply_to = in_reply_to
-    derived_references = references
-
-    if not thread_message_ids:
-        return derived_in_reply_to, derived_references
-
-    if not derived_in_reply_to:
-        reference_chain = _parse_message_id_chain(derived_references)
-        derived_in_reply_to = (
-            reference_chain[-1] if reference_chain else thread_message_ids[-1]
-        )
-
-    if not derived_references:
-        if derived_in_reply_to and derived_in_reply_to in thread_message_ids:
-            reply_index = thread_message_ids.index(derived_in_reply_to)
-            derived_references = " ".join(thread_message_ids[: reply_index + 1])
-        elif derived_in_reply_to:
-            derived_references = derived_in_reply_to
-        else:
-            derived_references = " ".join(thread_message_ids)
-
-    return derived_in_reply_to, derived_references
-
-
-def _derive_reply_all_recipients(
-    target: Dict[str, Any],
-    exclude: Set[str],
-    to: Optional[str],
-    cc: Optional[str],
-) -> tuple[Optional[str], Optional[str]]:
-    """Fill missing reply-all recipients from the message being answered.
-
-    To = whoever sent it (Reply-To when set, else From). Cc = every other
-    participant, minus `exclude` and minus anyone already in To. Caller-supplied
-    values win, mirroring _derive_reply_headers.
-
-    `exclude` applies to To as well as Cc, so replying to a message the account
-    sent itself derives no recipient rather than addressing the account; the
-    caller passes `to` explicitly for that case.
-
-    Only the authenticated address and the selected Send As alias can be excluded
-    reliably: a caller sending under several aliases still has to post-filter,
-    which is why this is opt-in rather than applied to every threaded send.
-    """
-    excluded = {addr.lower() for addr in exclude if addr}
-    sender = target.get("reply_to") or target.get("from") or ""
-
-    derived_to = to
-    if not derived_to:
-        derived_to = ", ".join(
-            addr
-            for _name, addr in getaddresses([sender])
-            if addr and addr.lower() not in excluded
-        )
-
-    derived_cc = cc
-    if not derived_cc:
-        seen = {addr.lower() for _n, addr in getaddresses([derived_to or ""]) if addr}
-        seen |= excluded
-        others = []
-        # The sender leads the Cc candidates so an explicit `to` that redirects the
-        # reply still keeps the person being replied to on it. When To was derived
-        # from the sender they are already in `seen`, so this is a no-op there.
-        for _name, addr in getaddresses(
-            [sender, target.get("to", ""), target.get("cc", "")]
-        ):
-            if addr and addr.lower() not in seen:
-                seen.add(addr.lower())
-                others.append(addr)
-        derived_cc = ", ".join(others) or None
-
-    return derived_to or None, derived_cc
 
 
 async def _fetch_thread_reply_context(

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2381,7 +2381,7 @@ async def send_gmail_message(
     reply_all: Annotated[
         bool,
         Field(
-            description="Whether to derive reply-all recipients from the thread: To = the sender being replied to, Cc = the other participants, excluding the authenticated account. Requires thread_id. Explicit to/cc win. Defaults to false.",
+            description="Whether to derive reply-all recipients from the thread: To = the sender being replied to, Cc = the other participants, excluding the authenticated account and from_email. Requires thread_id. Explicit to/cc win; when cc is omitted the sender being replied to is added to the derived Cc if they are not already in To. Defaults to false.",
         ),
     ] = False,
 ) -> str:
@@ -2430,8 +2430,10 @@ async def send_gmail_message(
             original. Only has an effect when thread_id is provided.
         reply_all (bool): Whether to derive reply-all recipients from the thread: To = the
             sender being replied to, Cc = the other participants, excluding the authenticated
-            account. Requires thread_id. Explicit to/cc win over the derived values; an
-            explicit 'to' moves the sender being replied to into the derived Cc.
+            account and from_email. Requires thread_id. Explicit to/cc win over the derived
+            values; when cc is omitted, the sender being replied to is added to the derived Cc
+            unless they are already in To (so an explicit 'to' that redirects the reply still
+            keeps them on it).
 
     Returns:
         str: Confirmation message with the sent email's message ID.

--- a/tests/gmail/test_draft_gmail_message.py
+++ b/tests/gmail/test_draft_gmail_message.py
@@ -950,3 +950,192 @@ async def test_send_gmail_message_with_url_attachment(monkeypatch):
     raw_bytes = base64.urlsafe_b64decode(create_kwargs["body"]["raw"])
     assert b"Content-Disposition: attachment;" in raw_bytes
     assert b"doc.pdf" in raw_bytes
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_message_autofills_reply_headers_from_thread():
+    mock_service = Mock()
+    mock_service.users().messages().send().execute.return_value = {"id": "sent_reply"}
+    mock_service.users().threads().get().execute.return_value = _thread_response(
+        "<msg1@example.com>",
+        "<msg2@example.com>",
+    )
+
+    await _unwrap(send_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        to="recipient@example.com",
+        subject="Re: Meeting tomorrow",
+        body="Thanks for the update.",
+        thread_id="thread123",
+        include_signature=False,
+    )
+
+    send_kwargs = (
+        mock_service.users.return_value.messages.return_value.send.call_args.kwargs
+    )
+    parsed = _parse_raw_message(send_kwargs["body"]["raw"])
+    assert parsed["In-Reply-To"] == "<msg2@example.com>"
+    assert parsed["References"] == "<msg1@example.com> <msg2@example.com>"
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_message_preserves_caller_reply_headers():
+    mock_service = Mock()
+    mock_service.users().messages().send().execute.return_value = {"id": "sent_reply"}
+    mock_service.users().threads().get().execute.return_value = _thread_response(
+        "<msg1@example.com>",
+        "<msg2@example.com>",
+    )
+
+    await _unwrap(send_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        to="recipient@example.com",
+        subject="Re: Meeting tomorrow",
+        body="Thanks.",
+        thread_id="thread123",
+        in_reply_to="<msg1@example.com>",
+        references="<msg1@example.com>",
+        include_signature=False,
+    )
+
+    send_kwargs = (
+        mock_service.users.return_value.messages.return_value.send.call_args.kwargs
+    )
+    parsed = _parse_raw_message(send_kwargs["body"]["raw"])
+    assert parsed["In-Reply-To"] == "<msg1@example.com>"
+    assert parsed["References"] == "<msg1@example.com>"
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_message_quotes_original_when_requested():
+    mock_service = Mock()
+    mock_service.users().messages().send().execute.return_value = {"id": "sent_reply"}
+    mock_service.users().threads().get().execute.return_value = {
+        "messages": [
+            _thread_message(
+                "<msg1@example.com>",
+                from_value="Alice Example <alice@example.com>",
+                text="Original plain text",
+            )
+        ]
+    }
+
+    await _unwrap(send_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        to="recipient@example.com",
+        subject="Re: Meeting tomorrow",
+        body="Thanks for the update.",
+        thread_id="thread123",
+        quote_original=True,
+        include_signature=False,
+    )
+
+    send_kwargs = (
+        mock_service.users.return_value.messages.return_value.send.call_args.kwargs
+    )
+    parsed = _parse_raw_message(send_kwargs["body"]["raw"])
+    payload = parsed.get_content()
+    assert "Alice Example <alice@example.com> wrote:" in payload
+    assert "> Original plain text" in payload
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_message_reply_all_derives_recipients():
+    mock_service = Mock()
+    mock_service.users().messages().send().execute.return_value = {"id": "sent_reply"}
+    mock_service.users().threads().get().execute.return_value = {
+        "messages": [
+            _thread_message(
+                "<msg1@example.com>",
+                from_value="Alice Example <alice@example.com>",
+                to_value="user@example.com, bob@example.com",
+                cc_value="carol@example.com",
+            )
+        ]
+    }
+
+    await _unwrap(send_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        subject="Re: Meeting tomorrow",
+        body="Thanks all.",
+        thread_id="thread123",
+        reply_all=True,
+        include_signature=False,
+    )
+
+    send_kwargs = (
+        mock_service.users.return_value.messages.return_value.send.call_args.kwargs
+    )
+    parsed = _parse_raw_message(send_kwargs["body"]["raw"])
+    assert parsed["To"] == "alice@example.com"
+    # The authenticated account is dropped; everyone else on the message is kept.
+    assert parsed["Cc"] == "bob@example.com, carol@example.com"
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_message_reply_all_prefers_reply_to_and_explicit_cc():
+    mock_service = Mock()
+    mock_service.users().messages().send().execute.return_value = {"id": "sent_reply"}
+    mock_service.users().threads().get().execute.return_value = {
+        "messages": [
+            _thread_message(
+                "<msg1@example.com>",
+                from_value="noreply@example.com",
+                reply_to="alice@example.com",
+                to_value="user@example.com, bob@example.com",
+            )
+        ]
+    }
+
+    await _unwrap(send_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        subject="Re: Meeting tomorrow",
+        body="Thanks.",
+        thread_id="thread123",
+        reply_all=True,
+        cc="explicit@example.com",
+        include_signature=False,
+    )
+
+    send_kwargs = (
+        mock_service.users.return_value.messages.return_value.send.call_args.kwargs
+    )
+    parsed = _parse_raw_message(send_kwargs["body"]["raw"])
+    assert parsed["To"] == "alice@example.com"
+    assert parsed["Cc"] == "explicit@example.com"
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_message_requires_to_without_reply_all():
+    mock_service = Mock()
+
+    with pytest.raises((UserInputError, ToolError)):
+        await _unwrap(send_gmail_message)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            subject="Hello",
+            body="Hi there!",
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_message_does_not_fetch_thread_for_a_new_message():
+    mock_service = Mock()
+    mock_service.users().messages().send().execute.return_value = {"id": "sent123"}
+    mock_service.users.return_value.threads.return_value.get.reset_mock()
+
+    await _unwrap(send_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        to="recipient@example.com",
+        subject="Hello",
+        body="Hi there!",
+        include_signature=False,
+    )
+
+    assert mock_service.users.return_value.threads.return_value.get.call_count == 0

--- a/tests/gmail/test_draft_gmail_message.py
+++ b/tests/gmail/test_draft_gmail_message.py
@@ -1111,6 +1111,83 @@ async def test_send_gmail_message_reply_all_prefers_reply_to_and_explicit_cc():
 
 
 @pytest.mark.asyncio
+async def test_send_gmail_message_reply_all_never_addresses_the_account_itself():
+    mock_service = Mock()
+    mock_service.users().messages().send().execute.return_value = {"id": "sent_reply"}
+    mock_service.users().threads().get().execute.return_value = {
+        "messages": [
+            _thread_message(
+                "<msg1@example.com>",
+                from_value="user@example.com",
+                to_value="alice@example.com",
+                cc_value="bob@example.com",
+            )
+        ]
+    }
+
+    mock_service.users.return_value.messages.return_value.send.reset_mock()
+
+    # The message being replied to was sent by the account, so there is no
+    # sender to reply to; deriving one would address the account itself.
+    with pytest.raises((UserInputError, ToolError)):
+        await _unwrap(send_gmail_message)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            subject="Re: Meeting tomorrow",
+            body="One more thing.",
+            thread_id="thread123",
+            reply_all=True,
+            include_signature=False,
+        )
+
+    assert mock_service.users.return_value.messages.return_value.send.called is False
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_message_reply_all_excludes_the_send_as_alias_from_to():
+    mock_service = Mock()
+    mock_service.users().messages().send().execute.return_value = {"id": "sent_reply"}
+    mock_service.users().threads().get().execute.return_value = {
+        "messages": [
+            _thread_message(
+                "<msg1@example.com>",
+                from_value="Alias <alias@example.com>",
+                to_value="alice@example.com",
+                cc_value="bob@example.com",
+            )
+        ]
+    }
+
+    with pytest.raises((UserInputError, ToolError)):
+        await _unwrap(send_gmail_message)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            from_email="alias@example.com",
+            subject="Re: Meeting tomorrow",
+            body="One more thing.",
+            thread_id="thread123",
+            reply_all=True,
+            include_signature=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_message_reply_all_requires_a_thread_id():
+    mock_service = Mock()
+
+    with pytest.raises((UserInputError, ToolError)):
+        await _unwrap(send_gmail_message)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            to="recipient@example.com",
+            subject="Hello",
+            body="Hi there!",
+            reply_all=True,
+            include_signature=False,
+        )
+
+
+@pytest.mark.asyncio
 async def test_send_gmail_message_requires_to_without_reply_all():
     mock_service = Mock()
 

--- a/tests/gmail/test_draft_gmail_message.py
+++ b/tests/gmail/test_draft_gmail_message.py
@@ -1146,6 +1146,41 @@ async def test_send_gmail_message_reply_all_prefers_reply_to_and_explicit_cc():
 
 
 @pytest.mark.asyncio
+async def test_send_gmail_message_reply_all_moves_sender_to_cc_when_to_is_explicit():
+    mock_service = Mock()
+    mock_service.users().messages().send().execute.return_value = {"id": "sent_reply"}
+    mock_service.users().threads().get().execute.return_value = {
+        "messages": [
+            _thread_message(
+                "<msg1@example.com>",
+                from_value="Alice Example <alice@example.com>",
+                to_value="user@example.com, bob@example.com",
+                cc_value="carol@example.com",
+            )
+        ]
+    }
+
+    await _unwrap(send_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        to="dave@example.com",
+        subject="Re: Meeting tomorrow",
+        body="Looping in Dave.",
+        thread_id="thread123",
+        reply_all=True,
+        include_signature=False,
+    )
+
+    send_kwargs = (
+        mock_service.users.return_value.messages.return_value.send.call_args.kwargs
+    )
+    parsed = _parse_raw_message(send_kwargs["body"]["raw"])
+    assert parsed["To"] == "dave@example.com"
+    # Redirecting To must not drop Alice from the reply-all entirely.
+    assert parsed["Cc"] == "alice@example.com, bob@example.com, carol@example.com"
+
+
+@pytest.mark.asyncio
 async def test_send_gmail_message_reply_all_never_addresses_the_account_itself():
     mock_service = Mock()
     mock_service.users().messages().send().execute.return_value = {"id": "sent_reply"}
@@ -1164,7 +1199,7 @@ async def test_send_gmail_message_reply_all_never_addresses_the_account_itself()
 
     # The message being replied to was sent by the account, so there is no
     # sender to reply to; deriving one would address the account itself.
-    with pytest.raises((UserInputError, ToolError)):
+    with pytest.raises(UserInputError, match="Could not derive a recipient"):
         await _unwrap(send_gmail_message)(
             service=mock_service,
             user_google_email="user@example.com",
@@ -1195,7 +1230,7 @@ async def test_send_gmail_message_reply_all_excludes_the_send_as_alias_from_to()
 
     mock_service.users.return_value.messages.return_value.send.reset_mock()
 
-    with pytest.raises((UserInputError, ToolError)):
+    with pytest.raises(UserInputError, match="Could not derive a recipient"):
         await _unwrap(send_gmail_message)(
             service=mock_service,
             user_google_email="user@example.com",
@@ -1214,7 +1249,7 @@ async def test_send_gmail_message_reply_all_excludes_the_send_as_alias_from_to()
 async def test_send_gmail_message_reply_all_requires_a_thread_id():
     mock_service = Mock()
 
-    with pytest.raises((UserInputError, ToolError)):
+    with pytest.raises(UserInputError, match="'reply_all' requires a thread_id"):
         await _unwrap(send_gmail_message)(
             service=mock_service,
             user_google_email="user@example.com",
@@ -1234,13 +1269,31 @@ async def test_send_gmail_message_reply_all_requires_a_thread_id():
 async def test_send_gmail_message_requires_to_without_reply_all():
     mock_service = Mock()
 
-    with pytest.raises((UserInputError, ToolError)):
+    with pytest.raises(UserInputError, match="'to' is required"):
         await _unwrap(send_gmail_message)(
             service=mock_service,
             user_google_email="user@example.com",
             subject="Hello",
             body="Hi there!",
         )
+
+
+@pytest.mark.asyncio
+async def test_send_gmail_message_requires_to_when_forwarding():
+    mock_service = Mock()
+
+    # 'to' is optional on the signature only so reply_all can derive it; a
+    # forward has no thread to derive from and must still be rejected here
+    # rather than by Gmail's API.
+    with pytest.raises(UserInputError, match="'to' is required when forwarding"):
+        await _unwrap(send_gmail_message)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            body="FYI - see below.",
+            forward_message_id="abc123",
+        )
+
+    mock_service.users.return_value.messages.return_value.get.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/gmail/test_draft_gmail_message.py
+++ b/tests/gmail/test_draft_gmail_message.py
@@ -1140,7 +1140,7 @@ async def test_send_gmail_message_reply_all_never_addresses_the_account_itself()
             include_signature=False,
         )
 
-    assert mock_service.users.return_value.messages.return_value.send.called is False
+    mock_service.users.return_value.messages.return_value.send.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1158,6 +1158,8 @@ async def test_send_gmail_message_reply_all_excludes_the_send_as_alias_from_to()
         ]
     }
 
+    mock_service.users.return_value.messages.return_value.send.reset_mock()
+
     with pytest.raises((UserInputError, ToolError)):
         await _unwrap(send_gmail_message)(
             service=mock_service,
@@ -1169,6 +1171,8 @@ async def test_send_gmail_message_reply_all_excludes_the_send_as_alias_from_to()
             reply_all=True,
             include_signature=False,
         )
+
+    mock_service.users.return_value.messages.return_value.send.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1185,6 +1189,10 @@ async def test_send_gmail_message_reply_all_requires_a_thread_id():
             reply_all=True,
             include_signature=False,
         )
+
+    mock_service.users.return_value.messages.return_value.send.assert_not_called()
+    # Validation runs before the thread fetch, so no API call is made at all.
+    mock_service.users.return_value.threads.return_value.get.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #898.

## Problem

`draft_gmail_message` can build a reply from a `thread_id`: it derives `in_reply_to`/`references` and can quote the original via `quote_original`. `send_gmail_message` cannot. A caller sending a reply therefore hand-assembles the Message-ID, the References chain and the quoted history — the work a mail client's Reply button does — and it is easy to get wrong. A dropped or malformed reference threads the message nowhere in clients that thread on Message-ID rather than on Gmail's `thread_id`, and the failure is silent: Gmail's own thread still looks correct because it has the `thread_id`, so nothing surfaces unless someone reads the raw MIME.

#898 asks for the two halves of this on the send path. This wires them up, reusing the helpers the draft path already uses.

## Changes

- **`quote_original`** — append the message being replied to, through the existing `_build_quoted_reply_body`. Same semantics as on `draft_gmail_message`.
- **`reply_all`** — `To` = the sender being replied to (`Reply-To` when set, else `From`); `Cc` = the other participants on that message. Both sides drop the authenticated account and the `Send As` alias, so a reply-all to a message the account itself sent derives no recipient rather than addressing the account; the caller passes `to` for that case. Explicit `to`/`cc` win, mirroring how `_derive_reply_headers` preserves caller intent. Requires a `thread_id` — the recipients come from the message being replied to, so without a thread there is nothing to derive.
- **Reply headers are auto-derived** on a threaded send when the caller omits them, as they already are for drafts.
- **`to` becomes optional**, as it already is on `draft_gmail_message`, and is required unless a `reply_all` reply can derive it. Distinct `UserInputError`s cover the missing-`to` case, a thread that yields no recipient, and `reply_all` without a `thread_id`.

One thread fetch serves all three derivations, and a non-reply send does not fetch at all (covered by a test).

`reply_all` is opt-in rather than applied to every threaded send, per the scope note in #898: only the authenticated address and the selected alias can be excluded reliably, so a caller sending under several aliases still post-filters.

## Tests

Ten added to `tests/gmail/test_draft_gmail_message.py`, which already covers `send_gmail_message`: header auto-derivation, caller headers preserved, quoting, reply-all recipients, `Reply-To` preferred over `From` with an explicit `cc` winning, the account and the `Send As` alias each excluded from a derived `To`, `reply_all` rejected without a `thread_id`, `to` required without `reply_all`, and no thread fetch for a new message.

Full suite: 1536 passed, 2 skipped. `ruff check` and `ruff format` clean.

## Notes

- Kept deliberately small to limit conflict surface with #878, which refactors much of `gmail_tools.py`. If #878 lands first I am happy to rebase onto it.
- `quote_original` with no `thread_id` stays a no-op here, matching `draft_gmail_message`'s current behaviour; both tools now document it as "only has an effect when thread_id is provided" rather than claiming it requires one. Making it an error instead is defensible, but that is a breaking change to a shipped tool, so it is not in this PR. Say the word and I will add it.
- `draft_gmail_message` does not get `reply_all` here — the helper is generic, so wiring it there too is a couple of lines if you would rather the two tools stay symmetric. Say the word and I will add it.



## Summary by CodeRabbit

* **New Features**
  * Added reply-all support for threaded Gmail messages, including automatic recipient and reply-header handling.
  * Added an option to include the original message with attribution and signature when replying.
  * Explicit recipients and reply headers take precedence over automatically derived values.
  * Recipient validation remains enforced for new messages and standard replies.

* **Documentation**
  * Updated usage documentation and examples for threaded replies and quoted originals.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reply-all support for threaded Gmail messages, including automatic recipient detection.
  * Added optional quoted-original content with signature and attribution.
  * Automatically fills missing reply headers from the selected thread while preserving explicit values.
  * Allows the recipient field to be omitted for reply-all messages with a thread.
  * Prevents replies from addressing the sending account or its aliases.
  * Added validation for required recipients, threads, and forwarding details.

* **Documentation**
  * Updated usage guidance and examples for threaded replies and quoted originals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->