### PR TITLE
fix: harden OAuth, attachments, bind defaults, and container entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ venv/
 client_secret.json
 client_secrets.json
 .mcpregistry_*_token
+values-secrets.yaml
+**/values-secrets.yaml
+**/secrets.local.yaml
+*.pem
+*.key
 
 # ---- Logs --------------------------------------------------------------
 mcp_server_debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,9 @@ EXPOSE 8000
 ARG PORT
 EXPOSE ${PORT:-8000}
 
-# Health check (exec form; default container port)
+# Health check — resolve listener port like main.py: PORT, then WORKSPACE_MCP_PORT, then 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD curl -f http://127.0.0.1:8000/health || exit 1
+    CMD sh -c 'p="${PORT:-${WORKSPACE_MCP_PORT:-8000}}"; curl -f "http://127.0.0.1:${p}/health" || exit 1'
 
 # Optional tool selection via env (consumed by docker-entrypoint.sh, not shell CMD)
 ENV TOOL_TIER=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ COPY . .
 # Install Python dependencies using uv sync
 # --extra otel ships the OpenTelemetry SDK/exporter so tracing can be enabled at
 # runtime via OTEL_* env vars; it stays a no-op unless an OTLP endpoint is set.
-RUN uv sync --frozen --no-dev --extra disk --extra otel
+RUN uv sync --frozen --no-dev --extra disk --extra otel \
+    && chmod +x /app/docker-entrypoint.sh
 
 # Create non-root user for security
 RUN useradd --create-home --shell /bin/bash app \
@@ -34,14 +35,16 @@ EXPOSE 8000
 ARG PORT
 EXPOSE ${PORT:-8000}
 
-# Health check
+# Health check (exec form; default container port)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD sh -c 'curl -f http://localhost:${PORT:-8000}/health || exit 1'
+    CMD curl -f http://127.0.0.1:8000/health || exit 1
 
-# Set environment variables for Python startup args
+# Optional tool selection via env (consumed by docker-entrypoint.sh, not shell CMD)
 ENV TOOL_TIER=""
 ENV TOOLS=""
+# Containers typically need all interfaces; override locally with WORKSPACE_MCP_HOST=127.0.0.1
+ENV WORKSPACE_MCP_HOST="0.0.0.0"
 
-# Use entrypoint for the base command and CMD for args
-ENTRYPOINT ["/bin/sh", "-c"]
-CMD ["uv run main.py --transport streamable-http ${TOOL_TIER:+--tool-tier \"$TOOL_TIER\"} ${TOOLS:+--tools $TOOLS}"]
+# Exec-form entrypoint — no shell interpolation of TOOLS/TOOL_TIER
+ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["--transport", "streamable-http"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,7 +53,7 @@ brew install gitleaks   # or: pipx install detect-secrets
 #     - id: gitleaks
 
 # CI example
-gitleaks detect --source . --verbose
+gitleaks detect --source . --verbose --redact
 ```
 
 For more information on securing your use of the project, see https://workspacemcp.com/privacy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,24 @@ When using this MCP server, please ensure:
 4. Regularly rotate OAuth refresh tokens
 5. Limit OAuth scopes to only what's necessary
 6. Keep local file reads narrowly scoped. By default, path-based attachments are limited to `WORKSPACE_ATTACHMENT_DIR`; expanding `ALLOWED_FILE_DIRS` increases exposure to prompt-injection-driven exfiltration.
+7. Use `helm-chart/workspace-mcp/values-secrets.yaml.example` as a template; keep real Helm secrets in a gitignored `values-secrets.yaml` or inject via CI/CD secret managers.
+8. Enable secret scanning in CI (e.g. gitleaks, trufflehog) and optionally as a pre-commit hook to prevent committing OAuth client secrets, JWT signing keys, or `.env` files.
+
+### Recommended CI / pre-commit secret scanning
+
+```bash
+# One-time local install
+brew install gitleaks   # or: pipx install detect-secrets
+
+# Pre-commit example (.pre-commit-config.yaml)
+# - repo: https://github.com/gitleaks/gitleaks
+#   rev: v8.18.0
+#   hooks:
+#     - id: gitleaks
+
+# CI example
+gitleaks detect --source . --verbose
+```
 
 For more information on securing your use of the project, see https://workspacemcp.com/privacy
 

--- a/auth/credential_store.py
+++ b/auth/credential_store.py
@@ -10,7 +10,7 @@ import logging
 import os
 import re
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 from urllib.parse import quote, unquote
 
@@ -38,13 +38,23 @@ def _credentials_from_stored_data(creds_data: dict, user_email: str) -> Credenti
         try:
             expiry = datetime.fromisoformat(creds_data["expiry"])
             if expiry.tzinfo is not None:
-                expiry = expiry.replace(tzinfo=None)
+                # google-auth expects naive UTC; convert aware values first.
+                expiry = expiry.astimezone(timezone.utc).replace(tzinfo=None)
         except (ValueError, TypeError) as e:
             logger.warning(f"Could not parse expiry time for {user_email}: {e}")
 
     cfg_client_id, cfg_client_secret = _configured_oauth_client()
+    stored_client_id = creds_data.get("client_id")
+    if cfg_client_id and stored_client_id and cfg_client_id != stored_client_id:
+        logger.warning(
+            "OAuth client_id mismatch for %s: configured=%s stored=%s "
+            "(using configured value)",
+            user_email,
+            cfg_client_id,
+            stored_client_id,
+        )
     # Backward compatible: older files may still contain client_id/secret.
-    client_id = cfg_client_id or creds_data.get("client_id")
+    client_id = cfg_client_id or stored_client_id
     client_secret = cfg_client_secret or creds_data.get("client_secret")
 
     return Credentials(

--- a/auth/credential_store.py
+++ b/auth/credential_store.py
@@ -19,6 +19,57 @@ from google.oauth2.credentials import Credentials
 logger = logging.getLogger(__name__)
 
 
+def _configured_oauth_client() -> tuple[Optional[str], Optional[str]]:
+    """Load OAuth client_id/secret from application config (not from credential files)."""
+    try:
+        from auth.oauth_config import get_oauth_config
+
+        cfg = get_oauth_config()
+        return cfg.client_id, cfg.client_secret
+    except Exception as e:
+        logger.debug(f"Could not load OAuth client config: {e}")
+        return None, None
+
+
+def _credentials_from_stored_data(creds_data: dict, user_email: str) -> Credentials:
+    """Build Credentials, preferring app config over embedded client secrets."""
+    expiry = None
+    if creds_data.get("expiry"):
+        try:
+            expiry = datetime.fromisoformat(creds_data["expiry"])
+            if expiry.tzinfo is not None:
+                expiry = expiry.replace(tzinfo=None)
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Could not parse expiry time for {user_email}: {e}")
+
+    cfg_client_id, cfg_client_secret = _configured_oauth_client()
+    # Backward compatible: older files may still contain client_id/secret.
+    client_id = cfg_client_id or creds_data.get("client_id")
+    client_secret = cfg_client_secret or creds_data.get("client_secret")
+
+    return Credentials(
+        token=creds_data.get("token"),
+        refresh_token=creds_data.get("refresh_token"),
+        token_uri=creds_data.get("token_uri"),
+        client_id=client_id,
+        client_secret=client_secret,
+        scopes=creds_data.get("scopes"),
+        expiry=expiry,
+    )
+
+
+def _credential_payload_for_storage(credentials: Credentials) -> dict:
+    """Serialize credentials without persisting OAuth client secrets."""
+    return {
+        "token": credentials.token,
+        "refresh_token": credentials.refresh_token,
+        "token_uri": credentials.token_uri,
+        # client_id/client_secret intentionally omitted — loaded from app config
+        "scopes": credentials.scopes,
+        "expiry": credentials.expiry.isoformat() if credentials.expiry else None,
+    }
+
+
 class CredentialStore(ABC):
     """Abstract base class for credential storage."""
 
@@ -187,25 +238,7 @@ class LocalDirectoryCredentialStore(CredentialStore):
                 creds_data = json.load(f)
 
             # Parse expiry if present
-            expiry = None
-            if creds_data.get("expiry"):
-                try:
-                    expiry = datetime.fromisoformat(creds_data["expiry"])
-                    # Ensure timezone-naive datetime for Google auth library compatibility
-                    if expiry.tzinfo is not None:
-                        expiry = expiry.replace(tzinfo=None)
-                except (ValueError, TypeError) as e:
-                    logger.warning(f"Could not parse expiry time for {user_email}: {e}")
-
-            credentials = Credentials(
-                token=creds_data.get("token"),
-                refresh_token=creds_data.get("refresh_token"),
-                token_uri=creds_data.get("token_uri"),
-                client_id=creds_data.get("client_id"),
-                client_secret=creds_data.get("client_secret"),
-                scopes=creds_data.get("scopes"),
-                expiry=expiry,
-            )
+            credentials = _credentials_from_stored_data(creds_data, user_email)
 
             logger.debug(f"Loaded credentials for {user_email} from {creds_path}")
             return credentials
@@ -220,15 +253,7 @@ class LocalDirectoryCredentialStore(CredentialStore):
         """Store credentials to local JSON file."""
         creds_path = self._get_credential_path(user_email)
 
-        creds_data = {
-            "token": credentials.token,
-            "refresh_token": credentials.refresh_token,
-            "token_uri": credentials.token_uri,
-            "client_id": credentials.client_id,
-            "client_secret": credentials.client_secret,
-            "scopes": credentials.scopes,
-            "expiry": credentials.expiry.isoformat() if credentials.expiry else None,
-        }
+        creds_data = _credential_payload_for_storage(credentials)
 
         try:
             fd = os.open(str(creds_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
@@ -412,24 +437,7 @@ class GCSCredentialStore(CredentialStore):
             logger.error(f"Error parsing credentials for {user_email}: {e}")
             return None
 
-        expiry = None
-        if creds_data.get("expiry"):
-            try:
-                expiry = datetime.fromisoformat(creds_data["expiry"])
-                if expiry.tzinfo is not None:
-                    expiry = expiry.replace(tzinfo=None)
-            except (ValueError, TypeError) as e:
-                logger.warning(f"Could not parse expiry for {user_email}: {e}")
-
-        return Credentials(
-            token=creds_data.get("token"),
-            refresh_token=creds_data.get("refresh_token"),
-            token_uri=creds_data.get("token_uri"),
-            client_id=creds_data.get("client_id"),
-            client_secret=creds_data.get("client_secret"),
-            scopes=creds_data.get("scopes"),
-            expiry=expiry,
-        )
+        return _credentials_from_stored_data(creds_data, user_email)
 
     def store_credential(self, user_email: str, credentials: Credentials) -> bool:
         """Serialize and upload credentials using a generation precondition.
@@ -441,15 +449,7 @@ class GCSCredentialStore(CredentialStore):
         caller to abandon this attempt; the next credential refresh will
         read the latest state and try again.
         """
-        creds_data = {
-            "token": credentials.token,
-            "refresh_token": credentials.refresh_token,
-            "token_uri": credentials.token_uri,
-            "client_id": credentials.client_id,
-            "client_secret": credentials.client_secret,
-            "scopes": credentials.scopes,
-            "expiry": credentials.expiry.isoformat() if credentials.expiry else None,
-        }
+        creds_data = _credential_payload_for_storage(credentials)
         payload = json.dumps(creds_data).encode()
 
         blob = self._bucket.blob(self._blob_name(user_email))

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import os
+import threading
 import webbrowser
 
 from typing import List, Optional, Tuple, Dict, Any
@@ -160,24 +161,82 @@ def _find_any_credentials(
     return None, None
 
 
-def _email_from_verified_id_token(id_token_jwt: str) -> Optional[str]:
-    """Extract email from a Google id_token after full cryptographic verification."""
-    from auth.oauth_config import get_oauth_config
+_ID_TOKEN_VERIFY_TIMEOUT_SECONDS = 10
+_id_token_email_cache: Dict[str, Optional[str]] = {}
+_id_token_cache_lock = threading.Lock()
+_ID_TOKEN_CACHE_MAX = 256
 
-    client_id = get_oauth_config().client_id
-    if not client_id:
-        logger.debug("Cannot verify id_token without GOOGLE_OAUTH_CLIENT_ID")
-        return None
+
+def _resolve_oauth_client_id_for_verification() -> Optional[str]:
+    """Resolve OAuth client ID from config or the same client-secrets source as the flow."""
     try:
-        decoded = google_id_token.verify_oauth2_token(
-            id_token_jwt,
-            google_auth_requests.Request(),
-            audience=client_id,
-        )
-        return decoded.get("email")
+        from auth.oauth_config import get_oauth_config
+
+        client_id = get_oauth_config().client_id
+        if client_id:
+            return client_id
     except Exception as e:
-        logger.debug(f"id_token verification failed: {e}")
+        logger.debug(f"Could not load OAuth client_id from config: {e}")
+
+    try:
+        secrets = load_client_secrets(CONFIG_CLIENT_SECRETS_PATH)
+        return secrets.get("client_id")
+    except Exception as e:
+        logger.debug(f"Could not load OAuth client_id from client secrets: {e}")
         return None
+
+
+class _BoundedTimeoutRequest(google_auth_requests.Request):
+    """Request adapter that caps certificate-fetch timeouts."""
+
+    def __call__(
+        self, url, method="GET", body=None, headers=None, timeout=None, **kwargs
+    ):
+        return super().__call__(
+            url,
+            method=method,
+            body=body,
+            headers=headers,
+            timeout=_ID_TOKEN_VERIFY_TIMEOUT_SECONDS if timeout is None else timeout,
+            **kwargs,
+        )
+
+
+def _email_from_verified_id_token(id_token_jwt: str) -> Optional[str]:
+    """Extract email from a Google id_token after full cryptographic verification.
+
+    Results are cached per token string so repeated session saves avoid re-fetching
+    Google's certs. Callers on the event loop should use ``asyncio.to_thread``.
+    """
+    with _id_token_cache_lock:
+        if id_token_jwt in _id_token_email_cache:
+            return _id_token_email_cache[id_token_jwt]
+
+    client_id = _resolve_oauth_client_id_for_verification()
+    if not client_id:
+        logger.debug(
+            "Cannot verify id_token without a configured OAuth client ID "
+            "(env or client_secret.json)"
+        )
+        email: Optional[str] = None
+    else:
+        try:
+            decoded = google_id_token.verify_oauth2_token(
+                id_token_jwt,
+                _BoundedTimeoutRequest(),
+                audience=client_id,
+            )
+            email = decoded.get("email")
+        except Exception as e:
+            logger.debug(f"id_token verification failed: {e}")
+            email = None
+
+    with _id_token_cache_lock:
+        if len(_id_token_email_cache) >= _ID_TOKEN_CACHE_MAX:
+            # Drop an arbitrary old entry; tokens are short-lived JWTs.
+            _id_token_email_cache.pop(next(iter(_id_token_email_cache)), None)
+        _id_token_email_cache[id_token_jwt] = email
+    return email
 
 
 def save_credentials_to_session(session_id: str, credentials: Credentials):
@@ -938,7 +997,7 @@ async def handle_auth_callback(
 
         # If session_id is provided, also save to session cache for compatibility
         if session_id:
-            save_credentials_to_session(session_id, credentials)
+            await asyncio.to_thread(save_credentials_to_session, session_id, credentials)
 
         return user_google_email, credentials
 
@@ -1420,19 +1479,10 @@ async def get_authenticated_google_service(
 
     try:
         service = build(service_name, version, http=_build_authorized_http(credentials))
-        log_user_email = user_google_email
-
-        # Try to get email from credentials if needed for validation
-        if credentials and credentials.id_token:
-            token_email = _email_from_verified_id_token(credentials.id_token)
-            if token_email:
-                log_user_email = token_email
-                logger.info(f"[{tool_name}] Token email: {token_email}")
-
         logger.info(
-            f"[{tool_name}] Successfully authenticated {service_name} service for user: {log_user_email}"
+            f"[{tool_name}] Successfully authenticated {service_name} service for user: {user_google_email}"
         )
-        return service, log_user_email
+        return service, user_google_email
 
     except Exception as e:
         error_msg = f"[{tool_name}] Failed to build {service_name} service: {str(e)}"

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -3,7 +3,6 @@
 import asyncio
 import hashlib
 import json
-import jwt
 import logging
 import os
 import webbrowser
@@ -28,11 +27,14 @@ from auth.oauth_config import (
     is_stateless_mode,
     is_trust_gateway_identity,
 )
+from auth.oauthlib_transport import oauthlib_insecure_transport_scope
 from core.config import (
     get_transport_mode,
     get_oauth_redirect_uri,
 )
 from core.context import get_fastmcp_session_id
+from google.oauth2 import id_token as google_id_token
+from google.auth.transport import requests as google_auth_requests
 
 # Try to import FastMCP dependencies (may not be available in all environments)
 try:
@@ -158,18 +160,32 @@ def _find_any_credentials(
     return None, None
 
 
+def _email_from_verified_id_token(id_token_jwt: str) -> Optional[str]:
+    """Extract email from a Google id_token after full cryptographic verification."""
+    from auth.oauth_config import get_oauth_config
+
+    client_id = get_oauth_config().client_id
+    if not client_id:
+        logger.debug("Cannot verify id_token without GOOGLE_OAUTH_CLIENT_ID")
+        return None
+    try:
+        decoded = google_id_token.verify_oauth2_token(
+            id_token_jwt,
+            google_auth_requests.Request(),
+            audience=client_id,
+        )
+        return decoded.get("email")
+    except Exception as e:
+        logger.debug(f"id_token verification failed: {e}")
+        return None
+
+
 def save_credentials_to_session(session_id: str, credentials: Credentials):
     """Saves user credentials using OAuth21SessionStore."""
     # Get user email from credentials if possible
     user_email = None
     if credentials and credentials.id_token:
-        try:
-            decoded_token = jwt.decode(
-                credentials.id_token, options={"verify_signature": False}
-            )
-            user_email = decoded_token.get("email")
-        except Exception as e:
-            logger.debug(f"Could not decode id_token to get email: {e}")
+        user_email = _email_from_verified_id_token(credentials.id_token)
 
     if user_email:
         store = get_oauth21_session_store()
@@ -534,13 +550,8 @@ async def start_auth_flow(
     # Note: Caller should ensure OAuth callback is available before calling this function
 
     try:
-        if "OAUTHLIB_INSECURE_TRANSPORT" not in os.environ and (
-            "localhost" in redirect_uri or "127.0.0.1" in redirect_uri
-        ):  # Use passed redirect_uri
-            logger.warning(
-                "OAUTHLIB_INSECURE_TRANSPORT not set. Setting it for localhost/local development."
-            )
-            os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
+        # Note: Caller should ensure OAuth callback is available before calling this function
+        # Insecure transport is scoped only during token exchange (see handle_oauth_callback).
 
         oauth_state = os.urandom(16).hex()
         current_scopes = get_current_scopes()
@@ -690,9 +701,8 @@ async def handle_auth_callback(
         redirect_uri: The redirect URI.
         credentials_base_dir: Base directory for credential files.
         session_id: Optional MCP session ID to associate with the credentials.
-        allow_missing_state_fallback: Whether to recover a missing callback state
-            from the most recently stored OAuth state. Only enable for local stdio
-            callbacks where there is no multi-user session context.
+        allow_missing_state_fallback: Deprecated and ignored. OAuth state is
+            always required; single-user mode no longer bypasses CSRF protection.
         client_secrets_path: (Deprecated) Path to client secrets file. Ignored if environment variables are set.
 
     Returns:
@@ -710,13 +720,6 @@ async def handle_auth_callback(
                 "The 'client_secrets_path' parameter is deprecated. Use GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET environment variables instead."
             )
 
-        # Allow HTTP for localhost in development
-        if "OAUTHLIB_INSECURE_TRANSPORT" not in os.environ:
-            logger.warning(
-                "OAUTHLIB_INSECURE_TRANSPORT not set. Setting it for localhost development."
-            )
-            os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
-
         # Allow partial scope grants without raising an exception.
         # When users decline some scopes on Google's consent screen,
         # oauthlib raises because the granted scopes differ from requested.
@@ -728,35 +731,16 @@ async def handle_auth_callback(
         state_values = parse_qs(parsed_response.query).get("state")
         state = state_values[0] if state_values else None
 
-        if state:
-            state_info = store.validate_and_consume_oauth_state(
-                state, session_id=session_id
-            )
-        elif (
-            allow_missing_state_fallback
-            and os.getenv("MCP_SINGLE_USER_MODE") == "1"
-            and session_id is None
-        ):
-            # stdio mode fallback: state may be absent from Google's redirect
-            # (e.g. when prompt=select_account is used with revoked credentials).
-            # Use the most recently stored state to recover the PKCE code_verifier.
-            logger.warning(
-                "OAuth callback missing state parameter; using most recent stored state (single-user stdio fallback)"
-            )
-            state_info = store.consume_latest_oauth_state(
-                initiating_session_id=session_id,
-                allow_any_session=True,
-            )
-            if not state_info:
-                raise ValueError(
-                    "Missing OAuth state parameter and no stored state available"
-                )
-        else:
+        if not state:
             raise ValueError("Missing OAuth state parameter")
+
+        state_info = store.validate_and_consume_oauth_state(
+            state, session_id=session_id
+        )
 
         logger.debug(
             "OAuth callback state %s for session %s",
-            (state[:8] if state else "<fallback>"),
+            state[:8],
             state_info.get("session_id") or "<unknown>",
         )
 
@@ -777,12 +761,13 @@ async def handle_auth_callback(
             autogenerate_code_verifier=False,
         )
 
-        # Exchange the authorization code for credentials
-        # Note: fetch_token will use the redirect_uri configured in the flow
+        # Exchange the authorization code for credentials.
+        # Scope insecure transport to this loopback exchange only (no process-wide leak).
         try:
-            await asyncio.to_thread(
-                flow.fetch_token, authorization_response=authorization_response
-            )
+            with oauthlib_insecure_transport_scope(redirect_uri):
+                await asyncio.to_thread(
+                    flow.fetch_token, authorization_response=authorization_response
+                )
             credentials = flow.credentials
         except Exception as exc:
             if _is_pkce_verifier_not_needed_error(exc):
@@ -1439,17 +1424,10 @@ async def get_authenticated_google_service(
 
         # Try to get email from credentials if needed for validation
         if credentials and credentials.id_token:
-            try:
-                # Decode without verification (just to get email for logging)
-                decoded_token = jwt.decode(
-                    credentials.id_token, options={"verify_signature": False}
-                )
-                token_email = decoded_token.get("email")
-                if token_email:
-                    log_user_email = token_email
-                    logger.info(f"[{tool_name}] Token email: {token_email}")
-            except Exception as e:
-                logger.debug(f"[{tool_name}] Could not decode id_token: {e}")
+            token_email = _email_from_verified_id_token(credentials.id_token)
+            if token_email:
+                log_user_email = token_email
+                logger.info(f"[{tool_name}] Token email: {token_email}")
 
         logger.info(
             f"[{tool_name}] Successfully authenticated {service_name} service for user: {log_user_email}"

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -15,7 +15,6 @@ import socket
 import uvicorn
 
 from fastapi import FastAPI, Request
-from fastapi.responses import FileResponse, JSONResponse
 from typing import Optional
 from urllib.parse import urlparse
 from urllib.error import HTTPError, URLError
@@ -115,36 +114,14 @@ class MinimalOAuthServer:
 
     def _setup_attachment_route(self):
         """Setup the attachment serving route."""
-        from core.attachment_storage import get_attachment_storage
 
         @self.app.get("/attachments/{file_id}")
         async def serve_attachment(file_id: str, request: Request):
             """Serve a stored attachment file (requires HMAC download token)."""
-            from core.attachment_tokens import verify_attachment_token
+            from core.attachment_storage import serve_attachment_response
 
             token = request.query_params.get("token")
-            if not verify_attachment_token(file_id, token):
-                return JSONResponse({"error": "Unauthorized"}, status_code=401)
-
-            storage = get_attachment_storage()
-            metadata = storage.get_attachment_metadata(file_id)
-
-            if not metadata:
-                return JSONResponse(
-                    {"error": "Attachment not found or expired"}, status_code=404
-                )
-
-            file_path = storage.get_attachment_path(file_id)
-            if not file_path:
-                return JSONResponse(
-                    {"error": "Attachment file not found"}, status_code=404
-                )
-
-            return FileResponse(
-                path=str(file_path),
-                filename=metadata["filename"],
-                media_type=metadata["mime_type"],
-            )
+            return serve_attachment_response(file_id, token)
 
     def is_actually_running(self) -> bool:
         """

--- a/auth/oauth_callback_server.py
+++ b/auth/oauth_callback_server.py
@@ -99,8 +99,6 @@ class MinimalOAuthServer:
                     authorization_response=str(request.url),
                     redirect_uri=redirect_uri,
                     session_id=None,
-                    allow_missing_state_fallback=os.getenv("MCP_SINGLE_USER_MODE")
-                    == "1",
                 )
 
                 logger.info(
@@ -121,7 +119,13 @@ class MinimalOAuthServer:
 
         @self.app.get("/attachments/{file_id}")
         async def serve_attachment(file_id: str, request: Request):
-            """Serve a stored attachment file."""
+            """Serve a stored attachment file (requires HMAC download token)."""
+            from core.attachment_tokens import verify_attachment_token
+
+            token = request.query_params.get("token")
+            if not verify_attachment_token(file_id, token):
+                return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
             storage = get_attachment_storage()
             metadata = storage.get_attachment_metadata(file_id)
 

--- a/auth/oauthlib_transport.py
+++ b/auth/oauthlib_transport.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Iterator, Optional
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
 _ENV_KEY = "OAUTHLIB_INSECURE_TRANSPORT"
+_lock = threading.Lock()
+_active_scopes = 0
+_saved_env_value: Optional[str] = None
+_had_preexisting = False
 
 
 def _is_loopback_redirect(redirect_uri: str) -> bool:
@@ -25,24 +30,37 @@ def _is_loopback_redirect(redirect_uri: str) -> bool:
 def oauthlib_insecure_transport_scope(redirect_uri: str) -> Iterator[None]:
     """Temporarily allow HTTP OAuth redirects for loopback only.
 
-    Does not permanently mutate process-wide env. If the operator already set
-    ``OAUTHLIB_INSECURE_TRANSPORT``, that value is left unchanged. For non-loopback
-    redirects, insecure transport is never enabled here.
+    Overlapping scopes are serialized with a lock and reference-counted so the
+    env var is set once on first enter and restored (or removed) only when the
+    last scope exits. Pre-existing operator values are preserved.
     """
     if not _is_loopback_redirect(redirect_uri):
         yield
         return
 
-    already_set = _ENV_KEY in os.environ
-    if already_set:
-        yield
-        return
+    global _active_scopes, _saved_env_value, _had_preexisting
 
-    os.environ[_ENV_KEY] = "1"
-    logger.debug(
-        "Temporarily enabling %s for loopback OAuth redirect", _ENV_KEY
-    )
+    with _lock:
+        if _active_scopes == 0:
+            _had_preexisting = _ENV_KEY in os.environ
+            _saved_env_value = os.environ.get(_ENV_KEY) if _had_preexisting else None
+            if not _had_preexisting:
+                os.environ[_ENV_KEY] = "1"
+                logger.debug(
+                    "Temporarily enabling %s for loopback OAuth redirect", _ENV_KEY
+                )
+        _active_scopes += 1
+
     try:
         yield
     finally:
-        os.environ.pop(_ENV_KEY, None)
+        with _lock:
+            _active_scopes -= 1
+            if _active_scopes == 0:
+                if _had_preexisting:
+                    if _saved_env_value is not None:
+                        os.environ[_ENV_KEY] = _saved_env_value
+                else:
+                    os.environ.pop(_ENV_KEY, None)
+                _saved_env_value = None
+                _had_preexisting = False

--- a/auth/oauthlib_transport.py
+++ b/auth/oauthlib_transport.py
@@ -1,0 +1,48 @@
+"""Scoped helpers for oauthlib insecure-transport (localhost only)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from typing import Iterator
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+_ENV_KEY = "OAUTHLIB_INSECURE_TRANSPORT"
+
+
+def _is_loopback_redirect(redirect_uri: str) -> bool:
+    try:
+        host = (urlparse(redirect_uri).hostname or "").lower()
+    except Exception:
+        return False
+    return host in {"localhost", "127.0.0.1", "::1"}
+
+
+@contextmanager
+def oauthlib_insecure_transport_scope(redirect_uri: str) -> Iterator[None]:
+    """Temporarily allow HTTP OAuth redirects for loopback only.
+
+    Does not permanently mutate process-wide env. If the operator already set
+    ``OAUTHLIB_INSECURE_TRANSPORT``, that value is left unchanged. For non-loopback
+    redirects, insecure transport is never enabled here.
+    """
+    if not _is_loopback_redirect(redirect_uri):
+        yield
+        return
+
+    already_set = _ENV_KEY in os.environ
+    if already_set:
+        yield
+        return
+
+    os.environ[_ENV_KEY] = "1"
+    logger.debug(
+        "Temporarily enabling %s for loopback OAuth redirect", _ENV_KEY
+    )
+    try:
+        yield
+    finally:
+        os.environ.pop(_ENV_KEY, None)

--- a/auth/port_resolver.py
+++ b/auth/port_resolver.py
@@ -72,7 +72,7 @@ def resolve_port(
     Reads defaults from env when args are None:
       WORKSPACE_MCP_PORT (default 8000)                  -- preferred port
       WORKSPACE_MCP_PORT_FALLBACK_COUNT (default 4)      -- fallback slots
-      WORKSPACE_MCP_HOST (default 0.0.0.0)               -- bind host
+      WORKSPACE_MCP_HOST (default 127.0.0.1)              -- bind host
 
     Side effect: mutates os.environ["WORKSPACE_MCP_PORT"] to the resolved port,
     so every downstream reader (auth.oauth_config singleton on next reload,

--- a/auth/port_resolver.py
+++ b/auth/port_resolver.py
@@ -105,7 +105,7 @@ def resolve_port(
                 f"WORKSPACE_MCP_PORT_FALLBACK_COUNT must be an integer, got {raw!r}"
             ) from exc
     if host is None:
-        host = os.getenv("WORKSPACE_MCP_HOST", "0.0.0.0")
+        host = os.getenv("WORKSPACE_MCP_HOST", "127.0.0.1")
 
     candidates = _candidate_ports(preferred, fallback_count)
     for port in candidates:

--- a/core/attachment_storage.py
+++ b/core/attachment_storage.py
@@ -309,4 +309,7 @@ def get_attachment_url(file_id: str) -> str:
     else:
         base_url = f"{WORKSPACE_MCP_BASE_URI}:{WORKSPACE_MCP_PORT}"
 
-    return f"{base_url}/attachments/{file_id}"
+    from core.attachment_tokens import mint_attachment_token
+
+    token = mint_attachment_token(file_id)
+    return f"{base_url}/attachments/{file_id}?token={token}"

--- a/core/attachment_storage.py
+++ b/core/attachment_storage.py
@@ -313,3 +313,31 @@ def get_attachment_url(file_id: str) -> str:
 
     token = mint_attachment_token(file_id)
     return f"{base_url}/attachments/{file_id}?token={token}"
+
+
+def serve_attachment_response(file_id: str, token: Optional[str]):
+    """Validate token and return a FileResponse or error JSONResponse."""
+    from starlette.responses import FileResponse, JSONResponse
+
+    from core.attachment_tokens import verify_attachment_token
+
+    if not verify_attachment_token(file_id, token):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
+    storage = get_attachment_storage()
+    metadata = storage.get_attachment_metadata(file_id)
+
+    if not metadata:
+        return JSONResponse(
+            {"error": "Attachment not found or expired"}, status_code=404
+        )
+
+    file_path = storage.get_attachment_path(file_id)
+    if not file_path:
+        return JSONResponse({"error": "Attachment file not found"}, status_code=404)
+
+    return FileResponse(
+        path=str(file_path),
+        filename=metadata["filename"],
+        media_type=metadata["mime_type"],
+    )

--- a/core/attachment_tokens.py
+++ b/core/attachment_tokens.py
@@ -1,0 +1,51 @@
+"""HMAC-signed tokens for temporary attachment download URLs."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS = 3600
+
+
+def _signing_key() -> bytes:
+    material = (
+        os.getenv("WORKSPACE_ATTACHMENT_SIGNING_KEY", "").strip()
+        or os.getenv("FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY", "").strip()
+        or os.getenv("GOOGLE_OAUTH_CLIENT_SECRET", "").strip()
+        or "workspace-mcp-dev-attachment-key"
+    )
+    return material.encode("utf-8")
+
+
+def mint_attachment_token(
+    file_id: str, ttl_seconds: int = DEFAULT_TTL_SECONDS
+) -> str:
+    """Return ``{exp}.{hex_hmac}`` bound to ``file_id``."""
+    exp = int(time.time()) + max(1, int(ttl_seconds))
+    msg = f"{file_id}.{exp}".encode("utf-8")
+    sig = hmac.new(_signing_key(), msg, hashlib.sha256).hexdigest()
+    return f"{exp}.{sig}"
+
+
+def verify_attachment_token(file_id: str, token: Optional[str]) -> bool:
+    """Validate an attachment download token."""
+    if not token or "." not in token:
+        return False
+    try:
+        exp_str, sig = token.split(".", 1)
+        exp = int(exp_str)
+    except (ValueError, TypeError):
+        return False
+    if exp < int(time.time()):
+        return False
+    expected = hmac.new(
+        _signing_key(), f"{file_id}.{exp}".encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, sig)

--- a/core/attachment_tokens.py
+++ b/core/attachment_tokens.py
@@ -6,6 +6,8 @@ import hashlib
 import hmac
 import logging
 import os
+import secrets
+import threading
 import time
 from typing import Optional
 
@@ -13,15 +15,31 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TTL_SECONDS = 3600
 
+_generated_key: Optional[bytes] = None
+_key_lock = threading.Lock()
+
 
 def _signing_key() -> bytes:
     material = (
         os.getenv("WORKSPACE_ATTACHMENT_SIGNING_KEY", "").strip()
         or os.getenv("FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY", "").strip()
         or os.getenv("GOOGLE_OAUTH_CLIENT_SECRET", "").strip()
-        or "workspace-mcp-dev-attachment-key"
     )
-    return material.encode("utf-8")
+    if material:
+        return material.encode("utf-8")
+
+    global _generated_key
+    with _key_lock:
+        if _generated_key is None:
+            _generated_key = secrets.token_bytes(32)
+            logger.warning(
+                "No attachment signing key configured; using a random "
+                "process-stable key. Attachment URLs become invalid after a "
+                "process restart. Set WORKSPACE_ATTACHMENT_SIGNING_KEY (or "
+                "FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY / "
+                "GOOGLE_OAUTH_CLIENT_SECRET) for stable tokens."
+            )
+        return _generated_key
 
 
 def mint_attachment_token(

--- a/core/rate_limit.py
+++ b/core/rate_limit.py
@@ -1,0 +1,100 @@
+"""Simple thread-safe sliding-window rate limiter for ASGI HTTP routes."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections import defaultdict, deque
+from typing import Deque, Dict, Tuple
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+        return value if value > 0 else default
+    except ValueError:
+        return default
+
+
+class RateLimitMiddleware:
+    """Per-client IP sliding-window rate limits with path-class budgets."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+        self._lock = threading.Lock()
+        self._hits: Dict[Tuple[str, str], Deque[float]] = defaultdict(deque)
+        self._oauth_limit = _int_env("WORKSPACE_RATE_LIMIT_OAUTH_PER_MINUTE", 20)
+        self._attachment_limit = _int_env(
+            "WORKSPACE_RATE_LIMIT_ATTACHMENT_PER_MINUTE", 60
+        )
+        self._health_limit = _int_env("WORKSPACE_RATE_LIMIT_HEALTH_PER_MINUTE", 120)
+        self._default_limit = _int_env("WORKSPACE_RATE_LIMIT_DEFAULT_PER_MINUTE", 180)
+        self._window = 60.0
+        self._enabled = os.getenv("WORKSPACE_RATE_LIMIT_ENABLED", "true").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+
+    def _client_ip(self, scope: Scope) -> str:
+        headers = dict(scope.get("headers") or [])
+        forwarded = headers.get(b"x-forwarded-for")
+        if forwarded:
+            return forwarded.decode("latin-1").split(",")[0].strip() or "unknown"
+        client = scope.get("client")
+        if client and client[0]:
+            return str(client[0])
+        return "unknown"
+
+    def _bucket_and_limit(self, path: str) -> Tuple[str, int]:
+        if path.startswith("/oauth") or path in {"/callback", "/auth/callback"}:
+            return "oauth", self._oauth_limit
+        if path.startswith("/attachments/"):
+            return "attachment", self._attachment_limit
+        if path in {"/", "/health", "/health/details"}:
+            return "health", self._health_limit
+        return "default", self._default_limit
+
+    def _allow(self, key: Tuple[str, str], limit: int) -> bool:
+        now = time.monotonic()
+        with self._lock:
+            q = self._hits[key]
+            cutoff = now - self._window
+            while q and q[0] < cutoff:
+                q.popleft()
+            if len(q) >= limit:
+                return False
+            q.append(now)
+            return True
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not self._enabled or scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path") or ""
+        bucket, limit = self._bucket_and_limit(path)
+        ip = self._client_ip(scope)
+        if not self._allow((ip, bucket), limit):
+            logger.warning(
+                "Rate limit exceeded ip=%s bucket=%s path=%s", ip, bucket, path
+            )
+            response = JSONResponse(
+                {"error": "Rate limit exceeded. Please retry later."},
+                status_code=429,
+                headers={"Retry-After": "60"},
+            )
+            await response(scope, receive, send)
+            return
+
+        await self.app(scope, receive, send)

--- a/core/rate_limit.py
+++ b/core/rate_limit.py
@@ -7,7 +7,7 @@ import os
 import threading
 import time
 from collections import defaultdict, deque
-from typing import Deque, Dict, Tuple
+from typing import Deque, Dict, Set, Tuple
 
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -24,6 +24,13 @@ def _int_env(name: str, default: int) -> int:
         return value if value > 0 else default
     except ValueError:
         return default
+
+
+def _trusted_proxy_ips() -> Set[str]:
+    raw = os.getenv("WORKSPACE_TRUSTED_PROXY_IPS", "").strip()
+    if not raw:
+        return set()
+    return {part.strip() for part in raw.split(",") if part.strip()}
 
 
 class RateLimitMiddleware:
@@ -45,16 +52,23 @@ class RateLimitMiddleware:
             "true",
             "yes",
         }
+        self._trusted_proxies = _trusted_proxy_ips()
 
-    def _client_ip(self, scope: Scope) -> str:
-        headers = dict(scope.get("headers") or [])
-        forwarded = headers.get(b"x-forwarded-for")
-        if forwarded:
-            return forwarded.decode("latin-1").split(",")[0].strip() or "unknown"
+    def _direct_client_ip(self, scope: Scope) -> str:
         client = scope.get("client")
         if client and client[0]:
             return str(client[0])
         return "unknown"
+
+    def _client_ip(self, scope: Scope) -> str:
+        direct = self._direct_client_ip(scope)
+        # Only trust X-Forwarded-For when the immediate peer is a configured proxy.
+        if direct in self._trusted_proxies:
+            headers = dict(scope.get("headers") or [])
+            forwarded = headers.get(b"x-forwarded-for")
+            if forwarded:
+                return forwarded.decode("latin-1").split(",")[0].strip() or "unknown"
+        return direct
 
     def _bucket_and_limit(self, path: str) -> Tuple[str, int]:
         if path.startswith("/oauth") or path in {"/callback", "/auth/callback"}:
@@ -72,6 +86,11 @@ class RateLimitMiddleware:
             cutoff = now - self._window
             while q and q[0] < cutoff:
                 q.popleft()
+            if not q:
+                # Drop empty deques after pruning; re-create for this allowed hit.
+                self._hits.pop(key, None)
+                self._hits[key].append(now)
+                return True
             if len(q) >= limit:
                 return False
             q.append(now)

--- a/core/server.py
+++ b/core/server.py
@@ -62,9 +62,6 @@ session_middleware = Middleware(MCPSessionMiddleware)
 # an allowlist; the scheme itself is the trust boundary.
 TRUSTED_ORIGIN_SCHEMES = frozenset({"vscode-webview"})
 
-
-_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
-
 # Default authority ports per scheme, used to compare an Origin against the Host
 # header that received the request (a same-origin check).
 _DEFAULT_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443}
@@ -106,10 +103,13 @@ def _get_allowed_http_origins() -> set[str]:
 
 def _is_origin_allowed(origin: str) -> bool:
     parsed = urlparse(origin)
+    # Scheme-only trust for IDE webviews whose host is a per-session GUID and
+    # cannot be enumerated in an allowlist. Browser pages cannot forge this
+    # forbidden Origin header.
     if parsed.scheme in TRUSTED_ORIGIN_SCHEMES:
         return True
-    if parsed.hostname in _LOOPBACK_HOSTS:
-        return True
+    # Loopback Origins are NOT blanket-trusted: require explicit allowlist entry
+    # (or same-origin-as-Host, checked by the middleware separately).
     normalized = _normalize_parsed(parsed)
     if not normalized:
         return False
@@ -167,6 +167,10 @@ class OriginValidationMiddleware:
 
 origin_validation_middleware = Middleware(OriginValidationMiddleware)
 
+from core.rate_limit import RateLimitMiddleware
+
+rate_limit_middleware = Middleware(RateLimitMiddleware)
+
 
 class WellKnownCacheControlMiddleware:
     """Force no-cache headers for OAuth well-known discovery endpoints."""
@@ -216,16 +220,17 @@ class SecureFastMCP(FastMCP):
         app = super().http_app(**kwargs)
 
         # Add middleware in order (first added = outermost layer)
-        app.user_middleware.insert(0, well_known_cache_control_middleware)
-        app.user_middleware.insert(1, origin_validation_middleware)
+        app.user_middleware.insert(0, rate_limit_middleware)
+        app.user_middleware.insert(1, well_known_cache_control_middleware)
+        app.user_middleware.insert(2, origin_validation_middleware)
 
         # Session Management - extracts session info for MCP context
-        app.user_middleware.insert(2, session_middleware)
+        app.user_middleware.insert(3, session_middleware)
 
         # Rebuild middleware stack
         app.middleware_stack = app.build_middleware_stack()
         logger.debug(
-            "Added middleware stack: WellKnownCacheControl, OriginValidation, "
+            "Added middleware stack: RateLimit, WellKnownCacheControl, OriginValidation, "
             "Session Management"
         )
         return app
@@ -403,10 +408,10 @@ def configure_server_for_http():
         ) -> bytes:
             """Validate JWT signing key override and derive the final JWT key."""
             if jwt_signing_key_override:
-                if len(jwt_signing_key_override) < 12:
-                    logger.warning(
-                        "OAuth 2.1: FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY is less than 12 characters; "
-                        "use a longer secret to improve key derivation strength."
+                if len(jwt_signing_key_override.encode("utf-8")) < 32:
+                    raise ValueError(
+                        "OAuth 2.1: FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY must be "
+                        "at least 32 bytes. Refusing to start with a weak signing key."
                     )
                 return derive_jwt_key(
                     low_entropy_material=jwt_signing_key_override,
@@ -735,13 +740,33 @@ def get_auth_provider() -> Optional[GoogleProvider]:
 @server.custom_route("/", methods=["GET"])
 @server.custom_route("/health", methods=["GET"])
 async def health_check(request: Request):
+    """Unauthenticated liveness probe — no version or config disclosure."""
+    return JSONResponse({"status": "ok"})
+
+
+@server.custom_route("/health/details", methods=["GET"])
+async def health_details(request: Request):
+    """Authenticated health details (shared token or bearer present)."""
+    expected = os.getenv("WORKSPACE_HEALTH_TOKEN", "").strip()
+    provided = (
+        request.headers.get("x-health-token")
+        or request.query_params.get("token")
+        or ""
+    ).strip()
+    auth_header = (request.headers.get("authorization") or "").strip()
+    authorized = bool(expected and provided and provided == expected) or bool(
+        auth_header.lower().startswith("bearer ") and len(auth_header) > 16
+    )
+    if not authorized:
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
     try:
         version = metadata.version("workspace-mcp")
     except metadata.PackageNotFoundError:
         version = "dev"
     return JSONResponse(
         {
-            "status": "healthy",
+            "status": "ok",
             "service": "workspace-mcp",
             "version": version,
             "transport": get_transport_mode(),
@@ -751,10 +776,15 @@ async def health_check(request: Request):
 
 @server.custom_route("/attachments/{file_id}", methods=["GET"])
 async def serve_attachment(request: Request):
-    """Serve a stored attachment file."""
+    """Serve a stored attachment file (requires HMAC download token)."""
     from core.attachment_storage import get_attachment_storage
+    from core.attachment_tokens import verify_attachment_token
 
     file_id = request.path_params["file_id"]
+    token = request.query_params.get("token")
+    if not verify_attachment_token(file_id, token):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
     storage = get_attachment_storage()
     metadata = storage.get_attachment_metadata(file_id)
 

--- a/core/server.py
+++ b/core/server.py
@@ -35,7 +35,7 @@ from core.config import (
     set_transport_mode as _set_transport_mode,
     get_oauth_redirect_uri as get_oauth_redirect_uri_for_current_mode,
 )
-from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastmcp import FastMCP
 from fastmcp.server.auth.providers.google import GoogleProvider
 from mcp.types import ToolAnnotations, Icon
@@ -50,6 +50,11 @@ logger = logging.getLogger(__name__)
 
 _auth_provider: Optional[GoogleProvider] = None
 _legacy_callback_registered = False
+
+
+class WeakJwtSigningKeyError(Exception):
+    """Raised when FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY is too short."""
+
 
 session_middleware = Middleware(MCPSessionMiddleware)
 
@@ -108,8 +113,10 @@ def _is_origin_allowed(origin: str) -> bool:
     # forbidden Origin header.
     if parsed.scheme in TRUSTED_ORIGIN_SCHEMES:
         return True
-    # Loopback Origins are NOT blanket-trusted: require explicit allowlist entry
-    # (or same-origin-as-Host, checked by the middleware separately).
+    # Loopback Origins are NOT blanket-trusted: require an explicit allowlist entry
+    # via OAUTH_ALLOWED_ORIGINS (or same-origin-as-Host, checked by the middleware
+    # separately). Cross-port local browser clients (e.g. http://localhost:5173)
+    # may receive 403 unless that origin is listed.
     normalized = _normalize_parsed(parsed)
     if not normalized:
         return False
@@ -409,7 +416,7 @@ def configure_server_for_http():
             """Validate JWT signing key override and derive the final JWT key."""
             if jwt_signing_key_override:
                 if len(jwt_signing_key_override.encode("utf-8")) < 32:
-                    raise ValueError(
+                    raise WeakJwtSigningKeyError(
                         "OAuth 2.1: FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY must be "
                         "at least 32 bytes. Refusing to start with a weak signing key."
                     )
@@ -746,16 +753,26 @@ async def health_check(request: Request):
 
 @server.custom_route("/health/details", methods=["GET"])
 async def health_details(request: Request):
-    """Authenticated health details (shared token or bearer present)."""
+    """Authenticated health details (requires WORKSPACE_HEALTH_TOKEN)."""
+    import hmac
+
     expected = os.getenv("WORKSPACE_HEALTH_TOKEN", "").strip()
+    if not expected:
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
     provided = (
         request.headers.get("x-health-token")
         or request.query_params.get("token")
         or ""
     ).strip()
     auth_header = (request.headers.get("authorization") or "").strip()
-    authorized = bool(expected and provided and provided == expected) or bool(
-        auth_header.lower().startswith("bearer ") and len(auth_header) > 16
+    if auth_header.lower().startswith("bearer "):
+        provided = provided or auth_header[7:].strip()
+
+    authorized = bool(
+        provided
+        and len(provided) == len(expected)
+        and hmac.compare_digest(provided, expected)
     )
     if not authorized:
         return JSONResponse({"error": "Unauthorized"}, status_code=401)
@@ -777,31 +794,11 @@ async def health_details(request: Request):
 @server.custom_route("/attachments/{file_id}", methods=["GET"])
 async def serve_attachment(request: Request):
     """Serve a stored attachment file (requires HMAC download token)."""
-    from core.attachment_storage import get_attachment_storage
-    from core.attachment_tokens import verify_attachment_token
+    from core.attachment_storage import serve_attachment_response
 
     file_id = request.path_params["file_id"]
     token = request.query_params.get("token")
-    if not verify_attachment_token(file_id, token):
-        return JSONResponse({"error": "Unauthorized"}, status_code=401)
-
-    storage = get_attachment_storage()
-    metadata = storage.get_attachment_metadata(file_id)
-
-    if not metadata:
-        return JSONResponse(
-            {"error": "Attachment not found or expired"}, status_code=404
-        )
-
-    file_path = storage.get_attachment_path(file_id)
-    if not file_path:
-        return JSONResponse({"error": "Attachment file not found"}, status_code=404)
-
-    return FileResponse(
-        path=str(file_path),
-        filename=metadata["filename"],
-        media_type=metadata["mime_type"],
-    )
+    return serve_attachment_response(file_id, token)
 
 
 async def legacy_oauth2_callback(request: Request) -> HTMLResponse:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Secure Docker entrypoint: exec-form friendly, no shell-form CMD interpolation.
+set -eu
+
+# Preserve any args passed via CMD / `docker run ...`
+set -- "$@"
+
+if [ -n "${TOOL_TIER:-}" ]; then
+  set -- "$@" --tool-tier "${TOOL_TIER}"
+fi
+
+if [ -n "${TOOLS:-}" ]; then
+  set -- "$@" --tools
+  # TOOLS is a space-separated list of tool group names; quote each token.
+  # shellcheck disable=SC2086
+  for tool in ${TOOLS}; do
+    set -- "$@" "${tool}"
+  done
+fi
+
+exec uv run main.py "$@"

--- a/docs/SECURITY_FIXES.md
+++ b/docs/SECURITY_FIXES.md
@@ -58,7 +58,8 @@ schemas, and auth architecture are preserved unless a change was required for se
 
 ### V8 — Origin validation
 - **Root cause:** Any `localhost` Origin accepted.
-- **Change:** Loopback Origins must be allowlisted (or same-origin-as-Host). `vscode-webview://` scheme trust retained (IDE GUID hosts).
+- **Change:** Blanket loopback Origin trust was removed. Loopback Origins must be allowlisted via `OAUTH_ALLOWED_ORIGINS` (or same-origin-as-Host). `vscode-webview://` scheme trust retained (IDE GUID hosts).
+- **Upgrade note:** Cross-port local browser clients (e.g. `http://localhost:5173`) may now receive 403 unless listed in `OAUTH_ALLOWED_ORIGINS`.
 - **Regression:** Server’s own `base_url` remains allowlisted; add `OAUTH_ALLOWED_ORIGINS` for extra local ports.
 
 ### V9 — Health disclosure

--- a/docs/SECURITY_FIXES.md
+++ b/docs/SECURITY_FIXES.md
@@ -1,0 +1,92 @@
+# Security Fixes Summary — Google Workspace MCP
+
+This document summarizes the vulnerability fixes applied. Public APIs, request/response
+schemas, and auth architecture are preserved unless a change was required for security.
+
+| ID | Issue | Status |
+|----|-------|--------|
+| V1 | `OAUTHLIB_INSECURE_TRANSPORT` process-wide | Fixed |
+| V2 | JWT `id_token` without signature verify | Fixed |
+| V3 | `client_secret` in user credential files | Fixed |
+| V4 | Secret manifests / git hygiene | Fixed (templates + gitignore + docs) |
+| V5 | Unauthenticated attachment downloads | Fixed (HMAC tokens) |
+| V6 | OAuth state validation bypass | Fixed |
+| V7 | Default bind `0.0.0.0` | Fixed → `127.0.0.1` |
+| V8 | Blanket localhost Origin trust | Fixed (allowlist + same-origin) |
+| V9 | Health info disclosure | Fixed |
+| V10 | Weak JWT signing key | Fixed (reject &lt; 32 bytes) |
+| V11 | No rate limiting | Fixed |
+| V12 | GitLab token in clone URL | N/A (not present in this repo) |
+| V13 | Shell-form Docker ENTRYPOINT | Fixed (exec-form + wrapper) |
+
+## Per-vulnerability notes
+
+### V1 — OAUTHLIB_INSECURE_TRANSPORT
+- **Root cause:** Code set `os.environ["OAUTHLIB_INSECURE_TRANSPORT"]=1` permanently.
+- **Change:** `auth/oauthlib_transport.py` context manager scopes insecure HTTP to loopback token exchange only; auto-set removed from `start_auth_flow` / callback.
+- **Regression:** Explicit operator env still honored; localhost OAuth still works via temporary scope.
+
+### V2 — id_token verification
+- **Root cause:** `jwt.decode(..., verify_signature=False)`.
+- **Change:** `_email_from_verified_id_token()` uses `google.oauth2.id_token.verify_oauth2_token()` (aud/iss/exp/signature).
+- **Regression:** Same email extraction path; fails closed if client_id missing or token invalid.
+
+### V3 — Client secrets in credential files
+- **Root cause:** Store wrote `client_id`/`client_secret` into per-user JSON/GCS objects.
+- **Change:** Persist tokens/scopes/expiry only; reconstruct client creds from `GOOGLE_OAUTH_*` config; still read old files for backward compatibility.
+- **Regression:** Existing credential files continue to load; new writes omit secrets.
+
+### V4 — Secret manifests
+- **Root cause:** Risk of committing real Helm secret values.
+- **Change:** `values-secrets.yaml.example`, gitignore entries, SECURITY.md CI/gitleaks guidance. Helm `secret.yaml` template unchanged (still values-driven).
+- **Regression:** Deploy via `-f values-secrets.yaml` as documented.
+
+### V5 — Attachment auth
+- **Root cause:** `/attachments/{id}` served anyone who guessed/leaked the UUID.
+- **Change:** HMAC download tokens (`core/attachment_tokens.py`); URLs from `get_attachment_url` include `?token=`; routes require valid token.
+- **Regression:** Local disk short-circuit in Gmail tools still works; HTTP downloads need the signed URL.
+
+### V6 — OAuth state
+- **Root cause:** Single-user mode could consume “latest” state without `state` param.
+- **Change:** Missing `state` always raises; callback no longer passes fallback flag.
+- **Regression:** Normal OAuth redirects that include `state` unchanged.
+
+### V7 — Bind address
+- **Root cause:** Default host `0.0.0.0`.
+- **Change:** Default `127.0.0.1` in `main.py` / `port_resolver` / `fastmcp.json`. Docker sets `WORKSPACE_MCP_HOST=0.0.0.0` explicitly for containers.
+- **Regression:** Explicit `WORKSPACE_MCP_HOST` still wins.
+
+### V8 — Origin validation
+- **Root cause:** Any `localhost` Origin accepted.
+- **Change:** Loopback Origins must be allowlisted (or same-origin-as-Host). `vscode-webview://` scheme trust retained (IDE GUID hosts).
+- **Regression:** Server’s own `base_url` remains allowlisted; add `OAUTH_ALLOWED_ORIGINS` for extra local ports.
+
+### V9 — Health disclosure
+- **Root cause:** `/health` returned version/transport.
+- **Change:** Public `/` and `/health` return `{"status":"ok"}` only; `/health/details` requires health token or Bearer.
+- **Regression:** K8s probes using `/health` still succeed (status ok).
+
+### V10 — Weak JWT key
+- **Root cause:** Keys &lt; 12 chars only warned.
+- **Change:** Startup raises if signing key &lt; 32 bytes.
+- **Regression:** Strong keys unchanged; short keys must be rotated (intentional break).
+
+### V11 — Rate limiting
+- **Root cause:** No app-level HTTP rate limits.
+- **Change:** `RateLimitMiddleware` (sliding window, per-IP, path-class budgets). Configurable via `WORKSPACE_RATE_LIMIT_*`; disable with `WORKSPACE_RATE_LIMIT_ENABLED=false`.
+- **Regression:** Normal traffic well under defaults.
+
+### V12 — GitLab token URL
+- Not applicable — no GitLab clone-URL token pattern in this repository.
+
+### V13 — Docker ENTRYPOINT
+- **Root cause:** `ENTRYPOINT ["/bin/sh","-c"]` + interpolated `TOOLS`.
+- **Change:** `docker-entrypoint.sh` + exec-form `ENTRYPOINT`/`CMD`.
+- **Regression:** Same CLI flags via CMD/env; container explicitly sets bind host.
+
+## Suggested tests (implemented where existing suites covered)
+- Attachment: missing token → 401; valid token → 200
+- Origin: `localhost:5173` rejected without allowlist; allowlisted/same-origin OK
+- Bind host defaults to `127.0.0.1` for OAuth 2.1 without env override
+- Missing OAuth state rejected even with `MCP_SINGLE_USER_MODE=1`
+- Unit: attachment token mint/verify; oauthlib transport scope restore

--- a/fastmcp.json
+++ b/fastmcp.json
@@ -14,8 +14,7 @@
     "port": 8000,
     "log_level": "INFO",
     "env": {
-      "MCP_ENABLE_OAUTH21": "true",
-      "OAUTHLIB_INSECURE_TRANSPORT": "1"
+      "MCP_ENABLE_OAUTH21": "true"
     }
   }
 }

--- a/fastmcp.json
+++ b/fastmcp.json
@@ -10,7 +10,7 @@
   },
   "deployment": {
     "transport": "http",
-    "host": "0.0.0.0",
+    "host": "127.0.0.1",
     "port": 8000,
     "log_level": "INFO",
     "env": {

--- a/helm-chart/workspace-mcp/values-secrets.yaml.example
+++ b/helm-chart/workspace-mcp/values-secrets.yaml.example
@@ -1,6 +1,7 @@
 # Example secrets overlay for Helm.
-# Copy to values-secrets.yaml (gitignored) and fill in real values:
-#   cp values-secrets.yaml.example values-secrets.yaml
+# Copy to values-secrets.yaml (gitignored) and fill in real values
+# (commands assume repository root as the working directory):
+#   cp helm-chart/workspace-mcp/values-secrets.yaml.example values-secrets.yaml
 #   helm upgrade --install workspace-mcp ./helm-chart/workspace-mcp \
 #     -f values.yaml -f values-secrets.yaml
 #

--- a/helm-chart/workspace-mcp/values-secrets.yaml.example
+++ b/helm-chart/workspace-mcp/values-secrets.yaml.example
@@ -1,0 +1,14 @@
+# Example secrets overlay for Helm.
+# Copy to values-secrets.yaml (gitignored) and fill in real values:
+#   cp values-secrets.yaml.example values-secrets.yaml
+#   helm upgrade --install workspace-mcp ./helm-chart/workspace-mcp \
+#     -f values.yaml -f values-secrets.yaml
+#
+# Never commit values-secrets.yaml. Prefer CI secret injection
+# (Sealed Secrets, External Secrets, Vault, or --set-file) in production.
+
+secrets:
+  googleOAuth:
+    clientId: "REPLACE_WITH_GOOGLE_OAUTH_CLIENT_ID"
+    clientSecret: "REPLACE_WITH_GOOGLE_OAUTH_CLIENT_SECRET"
+    # userEmail: "optional-service-account-user@example.com"

--- a/main.py
+++ b/main.py
@@ -145,7 +145,9 @@ def add_startup_notice(message: str) -> None:
 def resolve_bind_host_for_transport(transport: str) -> str:
     """Choose a safe default bind host for the selected transport/auth mode."""
     configured_host = os.getenv("WORKSPACE_MCP_HOST")
-    host = configured_host or "0.0.0.0"
+    # Default to loopback; operators must explicitly set WORKSPACE_MCP_HOST=0.0.0.0
+    # (or another address) to expose the server on all interfaces.
+    host = configured_host or "127.0.0.1"
     if transport != "streamable-http":
         return host
 

--- a/tests/auth/test_google_auth_callback_refresh_token.py
+++ b/tests/auth/test_google_auth_callback_refresh_token.py
@@ -360,11 +360,11 @@ async def test_callback_missing_state_rejects_explicit_fallback_outside_single_u
 
 
 @pytest.mark.asyncio
-async def test_callback_missing_state_uses_explicit_single_user_stdio_fallback(
+async def test_callback_missing_state_always_rejected_even_in_single_user_mode(
     monkeypatch,
 ):
+    """OAuth state is mandatory — single-user mode must not bypass CSRF protection."""
     monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
-    callback_credentials = _make_credentials(refresh_token="callback-refresh-token")
     oauth_store = _DummyOAuthStore(
         session_credentials=None,
         latest_state_info={
@@ -372,37 +372,21 @@ async def test_callback_missing_state_uses_explicit_single_user_stdio_fallback(
             "code_verifier": "stdio-verifier",
         },
     )
-    credential_store = _DummyCredentialStore(existing_credentials=None)
 
-    monkeypatch.setattr(
-        "auth.google_auth.create_oauth_flow",
-        lambda **kwargs: _DummyFlow(callback_credentials),  # noqa: ARG005
-    )
     monkeypatch.setattr(
         "auth.google_auth.get_oauth21_session_store", lambda: oauth_store
     )
-    monkeypatch.setattr(
-        "auth.google_auth.get_credential_store", lambda: credential_store
-    )
-    monkeypatch.setattr(
-        "auth.google_auth.get_user_info",
-        lambda credentials: {"email": "user@gmail.com"},  # noqa: ARG005
-    )
-    monkeypatch.setattr(
-        "auth.google_auth.save_credentials_to_session", lambda *args: None
-    )
-    monkeypatch.setattr("auth.google_auth.is_stateless_mode", lambda: False)
 
-    _email, credentials = await handle_auth_callback(
-        scopes=["scope.a"],
-        authorization_response="http://localhost/callback?code=code123",
-        redirect_uri="http://localhost/callback",
-        session_id=None,
-        allow_missing_state_fallback=True,
-    )
+    with pytest.raises(ValueError, match="Missing OAuth state parameter"):
+        await handle_auth_callback(
+            scopes=["scope.a"],
+            authorization_response="http://localhost/callback?code=code123",
+            redirect_uri="http://localhost/callback",
+            session_id=None,
+            allow_missing_state_fallback=True,
+        )
 
-    assert credentials.refresh_token == "callback-refresh-token"
-    assert oauth_store.latest_calls == [(None, True)]
+    assert oauth_store.latest_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/auth/test_oauth_callback_server.py
+++ b/tests/auth/test_oauth_callback_server.py
@@ -287,10 +287,11 @@ def test_oauth_callback_missing_state_fallback_follows_single_user_mode(monkeypa
     response = TestClient(server.app).get("/oauth2callback?code=code123")
 
     assert response.status_code == 200
-    assert calls[-1]["allow_missing_state_fallback"] is False
+    assert "allow_missing_state_fallback" not in calls[-1]
 
     monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
     response = TestClient(server.app).get("/oauth2callback?code=code123")
 
     assert response.status_code == 200
-    assert calls[-1]["allow_missing_state_fallback"] is True
+    # Single-user mode must not bypass OAuth state validation.
+    assert "allow_missing_state_fallback" not in calls[-1]

--- a/tests/auth/test_oauth_callback_server.py
+++ b/tests/auth/test_oauth_callback_server.py
@@ -262,7 +262,7 @@ def test_ensure_stdio_callback_starts_server_on_demand(monkeypatch):
     assert calls == [("stdio", 8042, "http://localhost")]
 
 
-def test_oauth_callback_missing_state_fallback_follows_single_user_mode(monkeypatch):
+def test_oauth_callback_never_passes_missing_state_fallback(monkeypatch):
     calls = []
 
     async def fake_handle_auth_callback(**kwargs):

--- a/tests/core/test_attachment_route.py
+++ b/tests/core/test_attachment_route.py
@@ -59,16 +59,58 @@ async def test_serve_attachment_uses_path_param_file_id(monkeypatch, tmp_path):
 async def test_serve_attachment_rejects_missing_token(monkeypatch, tmp_path):
     class DummyStorage:
         def get_attachment_metadata(self, _file_id):
-            return {"filename": "sample.pdf", "mime_type": "application/pdf"}
+            raise AssertionError("storage must not be reached without a valid token")
 
         def get_attachment_path(self, _file_id):
-            return tmp_path / "sample.pdf"
+            raise AssertionError("storage must not be reached without a valid token")
 
     monkeypatch.setattr(
         "core.attachment_storage.get_attachment_storage", lambda: DummyStorage()
     )
 
     response = await serve_attachment(_build_request("abc123"))
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_serve_attachment_rejects_token_for_different_file_id(monkeypatch):
+    class DummyStorage:
+        def get_attachment_metadata(self, _file_id):
+            raise AssertionError("storage must not be reached for wrong-file token")
+
+        def get_attachment_path(self, _file_id):
+            raise AssertionError("storage must not be reached for wrong-file token")
+
+    monkeypatch.setattr(
+        "core.attachment_storage.get_attachment_storage", lambda: DummyStorage()
+    )
+
+    token = mint_attachment_token("other-file")
+    response = await serve_attachment(_build_request("abc123", token))
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_serve_attachment_rejects_expired_token(monkeypatch):
+    class DummyStorage:
+        def get_attachment_metadata(self, _file_id):
+            raise AssertionError("storage must not be reached for expired token")
+
+        def get_attachment_path(self, _file_id):
+            raise AssertionError("storage must not be reached for expired token")
+
+    monkeypatch.setattr(
+        "core.attachment_storage.get_attachment_storage", lambda: DummyStorage()
+    )
+
+    fixed_now = 1_700_000_000
+    monkeypatch.setattr("core.attachment_tokens.time.time", lambda: fixed_now)
+    token = mint_attachment_token("abc123", ttl_seconds=1)
+    monkeypatch.setattr("core.attachment_tokens.time.time", lambda: fixed_now + 10)
+
+    response = await serve_attachment(_build_request("abc123", token))
     assert isinstance(response, JSONResponse)
     assert response.status_code == 401
 

--- a/tests/core/test_attachment_route.py
+++ b/tests/core/test_attachment_route.py
@@ -2,10 +2,12 @@ import pytest
 from starlette.requests import Request
 from starlette.responses import FileResponse, JSONResponse
 
+from core.attachment_tokens import mint_attachment_token
 from core.server import serve_attachment
 
 
-def _build_request(file_id: str) -> Request:
+def _build_request(file_id: str, token: str | None = None) -> Request:
+    query = f"token={token}".encode() if token else b""
     scope = {
         "type": "http",
         "asgi": {"version": "3.0"},
@@ -14,7 +16,7 @@ def _build_request(file_id: str) -> Request:
         "scheme": "http",
         "path": f"/attachments/{file_id}",
         "raw_path": f"/attachments/{file_id}".encode(),
-        "query_string": b"",
+        "query_string": query,
         "headers": [],
         "client": ("127.0.0.1", 12345),
         "server": ("localhost", 8000),
@@ -45,11 +47,30 @@ async def test_serve_attachment_uses_path_param_file_id(monkeypatch, tmp_path):
         "core.attachment_storage.get_attachment_storage", lambda: DummyStorage()
     )
 
-    response = await serve_attachment(_build_request("abc123"))
+    token = mint_attachment_token("abc123")
+    response = await serve_attachment(_build_request("abc123", token))
 
     assert captured["file_id"] == "abc123"
     assert isinstance(response, FileResponse)
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_serve_attachment_rejects_missing_token(monkeypatch, tmp_path):
+    class DummyStorage:
+        def get_attachment_metadata(self, _file_id):
+            return {"filename": "sample.pdf", "mime_type": "application/pdf"}
+
+        def get_attachment_path(self, _file_id):
+            return tmp_path / "sample.pdf"
+
+    monkeypatch.setattr(
+        "core.attachment_storage.get_attachment_storage", lambda: DummyStorage()
+    )
+
+    response = await serve_attachment(_build_request("abc123"))
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 401
 
 
 @pytest.mark.asyncio
@@ -62,7 +83,8 @@ async def test_serve_attachment_404_when_metadata_missing(monkeypatch):
         "core.attachment_storage.get_attachment_storage", lambda: DummyStorage()
     )
 
-    response = await serve_attachment(_build_request("missing"))
+    token = mint_attachment_token("missing")
+    response = await serve_attachment(_build_request("missing", token))
 
     assert isinstance(response, JSONResponse)
     assert response.status_code == 404

--- a/tests/core/test_well_known_cache_control_middleware.py
+++ b/tests/core/test_well_known_cache_control_middleware.py
@@ -75,8 +75,13 @@ def test_origin_validation_rejects_untrusted_browser_origin(monkeypatch):
     assert (
         client.get("/health", headers={"Origin": "http://evil.test"}).status_code == 403
     )
+    # Loopback Origins are allowlist-only (no blanket localhost trust).
     assert (
         client.get("/health", headers={"Origin": "http://localhost:5173"}).status_code
+        == 403
+    )
+    assert (
+        client.get("/health", headers={"Origin": "http://localhost:8000"}).status_code
         == 200
     )
     assert client.get("/health").status_code == 200

--- a/tests/test_main_permissions_tier.py
+++ b/tests/test_main_permissions_tier.py
@@ -124,7 +124,7 @@ def test_resolve_bind_host_preserves_oauth21_streamable_http_default(monkeypatch
     )
     monkeypatch.delenv("WORKSPACE_MCP_HOST", raising=False)
 
-    assert main.resolve_bind_host_for_transport("streamable-http") == "0.0.0.0"
+    assert main.resolve_bind_host_for_transport("streamable-http") == "127.0.0.1"
 
 
 def test_validate_streamable_http_auth_rejects_unconfigured_oauth21(


### PR DESCRIPTION
## Summary
- Scope `OAUTHLIB_INSECURE_TRANSPORT` to loopback token exchange; verify Google `id_token`s; stop writing `client_id`/`client_secret` into per-user credential stores (config-backed reconstruction with backward-compatible reads).
- Require HMAC tokens for `/attachments/{id}`, always validate OAuth `state`, default bind to `127.0.0.1`, tighten Origin allowlisting, slim public `/health`, reject JWT signing keys under 32 bytes, and add configurable HTTP rate limiting.
- Switch Docker to an exec-form entrypoint wrapper; add Helm `values-secrets.yaml.example`, gitignore hygiene, and security-scanning guidance.

## Test plan
- [ ] OAuth login still succeeds for localhost redirect (with or without explicit `OAUTHLIB_INSECURE_TRANSPORT`)
- [ ] Missing OAuth `state` is rejected even with `MCP_SINGLE_USER_MODE=1`
- [ ] Existing credential files still load; newly saved files omit client secrets
- [ ] Attachment URL from `get_attachment_url` downloads; URL without `token` returns 401
- [ ] `/health` returns only `{"status":"ok"}`; `/health/details` requires token/Bearer
- [ ] Default bind is `127.0.0.1`; `WORKSPACE_MCP_HOST=0.0.0.0` still works
- [ ] Short `FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY` (<32 bytes) fails startup
- [ ] `uv run pytest tests/core/test_attachment_route.py tests/core/test_well_known_cache_control_middleware.py tests/test_main_permissions_tier.py tests/auth/test_oauth_callback_server.py tests/auth/test_google_auth_callback_refresh_token.py`
- [ ] Docker image builds and starts with `ENTRYPOINT ./docker-entrypoint.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened OAuth state and Google ID-token validation.
  - Secured attachment downloads with expiring access tokens.
  - Added request rate limiting and stronger JWT signing-key requirements.
  - Improved origin validation and reduced health endpoint disclosure.
  - Improved credential handling to avoid storing client secrets.

- **Configuration**
  - Services now default to local-only binding when no host is configured.
  - Docker deployments support configurable tools, transport options, and ports.

- **Documentation**
  - Added security fix documentation and Helm secret-management guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->