### PR TITLE
fix(gmail): retry 429/5xx rate-limited sub-requests in batch fetches

### DIFF
--- a/gmail/gmail_helpers.py
+++ b/gmail/gmail_helpers.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import html
 import logging
+import ssl
 from collections import Counter
 from datetime import datetime, timezone
 from email.utils import getaddresses, parseaddr, parsedate_to_datetime
-from typing import Any, Literal, Optional
+from typing import Any, Callable, Iterable, Literal, Mapping, Optional
 
 from fastmcp.exceptions import ToolError as ToolExecutionError
 from googleapiclient.errors import HttpError
@@ -81,6 +83,72 @@ def _is_benign_signature_http_error(error: HttpError) -> bool:
 
 def _signature_fetch_tool_error(error: Exception) -> ToolExecutionError:
     return ToolExecutionError(f"Failed to fetch Gmail send-as signatures: {error}")
+
+
+def _is_retryable_error(error: Any) -> bool:
+    """Whether an error is transient and safe to retry.
+
+    Covers SSL errors, HTTP 429 (rate limit), 5xx, and quota/rate-limit markers
+    in the error body. Reads are idempotent so retrying these is safe.
+    """
+    if isinstance(error, ssl.SSLError):
+        return True
+    if isinstance(error, HttpError):
+        status = _http_error_status(error)
+        if status is not None and (status == 429 or status >= 500):
+            return True
+        return _is_quota_or_rate_limit_error(error)
+    return False
+
+
+async def _fetch_with_retry(
+    build_request: Callable[[], Any],
+    item_id: str,
+    item_label: str,
+    log_prefix: str,
+    max_retries: int = 3,
+) -> tuple[str, Optional[dict], Optional[Exception]]:
+    """Execute a Gmail read request, retrying transient failures.
+
+    `build_request` is re-invoked per attempt so each retry gets a fresh
+    request object. Backs off exponentially (1s, 2s, 4s) on retryable errors;
+    anything else is returned to the caller immediately. Returns
+    `(item_id, response, error)` with exactly one of response/error set.
+    """
+    last_error: Optional[Exception] = None
+    for attempt in range(max_retries + 1):
+        try:
+            response = await asyncio.to_thread(build_request().execute)
+            return item_id, response, None
+        except Exception as error:
+            last_error = error
+            if not _is_retryable_error(error) or attempt == max_retries:
+                break
+            delay = 2**attempt
+            logger.warning(
+                f"[{log_prefix}] Retryable error for {item_label} {item_id} on "
+                f"attempt {attempt + 1}: {error}. Retrying in {delay}s..."
+            )
+            await asyncio.sleep(delay)
+
+    logger.error(f"[{log_prefix}] Failed to fetch {item_label} {item_id}: {last_error}")
+    return item_id, None, last_error
+
+
+def _retryable_result_ids(
+    results: Mapping[str, Mapping[str, Any]], item_ids: Iterable[str]
+) -> list[str]:
+    """IDs whose batch sub-request failed with a transient, retryable error.
+
+    The batch API reports per-sub-request errors inside an otherwise successful
+    response, so these are invisible to any client-side retry and have to be
+    re-fetched individually.
+    """
+    return [
+        item_id
+        for item_id in item_ids
+        if _is_retryable_error(results.get(item_id, {}).get("error"))
+    ]
 
 
 def _parse_date_header(

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -551,7 +551,7 @@ async def _fetch_message_with_retry(
     (429 rate limit / 5xx / quota markers). Message reads are idempotent, so
     retrying is safe.
     """
-    for attempt in range(max_retries):
+    for attempt in range(max_retries + 1):
         try:
             message = await asyncio.to_thread(
                 _build_message_get_request(
@@ -560,7 +560,7 @@ async def _fetch_message_with_retry(
             )
             return message_id, message, None
         except ssl.SSLError as ssl_error:
-            if attempt < max_retries - 1:
+            if attempt < max_retries:
                 delay = 2**attempt
                 logger.warning(
                     f"[{log_prefix}] SSL error for message {message_id} on attempt {attempt + 1}: {ssl_error}. Retrying in {delay}s..."
@@ -572,7 +572,7 @@ async def _fetch_message_with_retry(
                 )
                 return message_id, None, ssl_error
         except Exception as exc:
-            if _is_retryable_error(exc) and attempt < max_retries - 1:
+            if _is_retryable_error(exc) and attempt < max_retries:
                 delay = 2**attempt
                 logger.warning(
                     f"[{log_prefix}] Retryable error for message {message_id} on attempt {attempt + 1}: {exc}. Retrying in {delay}s..."
@@ -1973,6 +1973,8 @@ async def get_gmail_messages_content_batch(
             """Callback for batch requests"""
             results[request_id] = {"data": response, "error": exception}
 
+        batch_completed = False
+
         # Try to use batch API
         try:
             batch = service.new_batch_http_request(callback=_batch_callback)
@@ -1990,6 +1992,7 @@ async def get_gmail_messages_content_batch(
 
             # Execute batch request
             await asyncio.to_thread(batch.execute)
+            batch_completed = True
 
         except Exception as batch_error:
             # Fallback to sequential processing instead of parallel to prevent SSL exhaustion
@@ -2018,12 +2021,16 @@ async def get_gmail_messages_content_batch(
         # (e.g. 429 rate limit). The batch API reports per-sub-request errors
         # inside a successful response, so they are invisible to any
         # client-side retry; re-fetch only the failed IDs and merge.
-        retryable_ids = [
-            mid
-            for mid in chunk_ids
-            if results.get(mid, {}).get("error")
-            and _is_retryable_error(results[mid]["error"])
-        ]
+        retryable_ids = (
+            [
+                mid
+                for mid in chunk_ids
+                if results.get(mid, {}).get("error")
+                and _is_retryable_error(results[mid]["error"])
+            ]
+            if batch_completed
+            else []
+        )
         if retryable_ids:
             logger.warning(
                 f"[get_gmail_messages_content_batch] {len(retryable_ids)}/{len(chunk_ids)} "
@@ -3335,7 +3342,7 @@ async def get_gmail_threads_content_batch(
 
         async def fetch_thread_with_retry(tid: str, max_retries: int = 3):
             """Fetch a single thread with exponential backoff retry for transient errors"""
-            for attempt in range(max_retries):
+            for attempt in range(max_retries + 1):
                 try:
                     thread = await asyncio.to_thread(
                         service.users()
@@ -3345,7 +3352,7 @@ async def get_gmail_threads_content_batch(
                     )
                     return tid, thread, None
                 except ssl.SSLError as ssl_error:
-                    if attempt < max_retries - 1:
+                    if attempt < max_retries:
                         # Exponential backoff: 1s, 2s, 4s
                         delay = 2**attempt
                         logger.warning(
@@ -3358,7 +3365,7 @@ async def get_gmail_threads_content_batch(
                         )
                         return tid, None, ssl_error
                 except Exception as e:
-                    if _is_retryable_error(e) and attempt < max_retries - 1:
+                    if _is_retryable_error(e) and attempt < max_retries:
                         delay = 2**attempt
                         logger.warning(
                             f"[get_gmail_threads_content_batch] Retryable error for thread {tid} on attempt {attempt + 1}: {e}. Retrying in {delay}s..."
@@ -3366,6 +3373,8 @@ async def get_gmail_threads_content_batch(
                         await asyncio.sleep(delay)
                     else:
                         return tid, None, e
+
+        batch_completed = False
 
         # Try to use batch API
         try:
@@ -3377,6 +3386,7 @@ async def get_gmail_threads_content_batch(
 
             # Execute batch request
             await asyncio.to_thread(batch.execute)
+            batch_completed = True
 
         except Exception as batch_error:
             # Fallback to sequential processing instead of parallel to prevent SSL exhaustion
@@ -3394,12 +3404,16 @@ async def get_gmail_threads_content_batch(
         # Re-fetch sub-requests that failed with retryable (transient) errors
         # (e.g. 429 rate limit); retryable errors surface per-sub-request inside
         # a successful batch response and are invisible to client-side retries.
-        retryable_ids = [
-            tid
-            for tid in chunk_ids
-            if results.get(tid, {}).get("error")
-            and _is_retryable_error(results[tid]["error"])
-        ]
+        retryable_ids = (
+            [
+                tid
+                for tid in chunk_ids
+                if results.get(tid, {}).get("error")
+                and _is_retryable_error(results[tid]["error"])
+            ]
+            if batch_completed
+            else []
+        )
         if retryable_ids:
             logger.warning(
                 f"[get_gmail_threads_content_batch] {len(retryable_ids)}/{len(chunk_ids)} "

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -62,7 +62,9 @@ from gmail.gmail_helpers import (
     RAW_BODY_TRUNCATE_LIMIT,
     _analyze_thread_ownership_impl,
     _build_forward_content,
+    _http_error_status,
     _is_benign_signature_http_error,
+    _is_quota_or_rate_limit_error,
     _signature_fetch_tool_error,
 )
 
@@ -70,6 +72,7 @@ logger = logging.getLogger(__name__)
 
 GMAIL_BATCH_SIZE = 25
 GMAIL_REQUEST_DELAY = 0.1
+GMAIL_RATE_LIMIT_BACKOFF = 2.0
 HTML_BODY_TRUNCATE_LIMIT = 20000
 LOW_VALUE_TEXT_PLACEHOLDERS = (
     "your client does not support html",
@@ -515,6 +518,22 @@ def _validate_message_batch_options(
         )
 
 
+def _is_retryable_error(error: Exception) -> bool:
+    """Whether an error is transient and safe to retry.
+
+    Covers HTTP 429 (rate limit), 5xx, and quota/rate-limit markers in the
+    error body. Reads are idempotent so retrying these is safe.
+    """
+    if isinstance(error, ssl.SSLError):
+        return True
+    if isinstance(error, HttpError):
+        status = _http_error_status(error)
+        if status is not None and (status == 429 or status >= 500):
+            return True
+        return _is_quota_or_rate_limit_error(error)
+    return False
+
+
 async def _fetch_message_with_retry(
     service,
     message_id: str,
@@ -522,7 +541,12 @@ async def _fetch_message_with_retry(
     log_prefix: str,
     max_retries: int = 3,
 ):
-    """Fetch a single Gmail message with SSL retry handling."""
+    """Fetch a single Gmail message with retry handling.
+
+    Retries on transient failures: SSL errors and retryable HTTP statuses
+    (429 rate limit / 5xx / quota markers). Message reads are idempotent, so
+    retrying is safe.
+    """
     for attempt in range(max_retries):
         try:
             message = await asyncio.to_thread(
@@ -544,7 +568,14 @@ async def _fetch_message_with_retry(
                 )
                 return message_id, None, ssl_error
         except Exception as exc:
-            return message_id, None, exc
+            if _is_retryable_error(exc) and attempt < max_retries - 1:
+                delay = 2**attempt
+                logger.warning(
+                    f"[{log_prefix}] Retryable error for message {message_id} on attempt {attempt + 1}: {exc}. Retrying in {delay}s..."
+                )
+                await asyncio.sleep(delay)
+            else:
+                return message_id, None, exc
 
 
 async def _fetch_raw_message_contents(
@@ -1836,6 +1867,38 @@ async def get_gmail_messages_content_batch(
                 # Brief delay between requests to allow connection cleanup
                 await asyncio.sleep(GMAIL_REQUEST_DELAY)
 
+        # Re-fetch sub-requests that failed with retryable (transient) errors
+        # (e.g. 429 rate limit). The batch API reports per-sub-request errors
+        # inside a successful response, so they are invisible to any
+        # client-side retry; re-fetch only the failed IDs and merge.
+        retryable_ids = [
+            mid
+            for mid in chunk_ids
+            if results.get(mid, {}).get("error")
+            and _is_retryable_error(results[mid]["error"])
+        ]
+        if retryable_ids:
+            logger.warning(
+                f"[get_gmail_messages_content_batch] {len(retryable_ids)}/{len(chunk_ids)} "
+                f"messages failed with retryable errors; re-fetching: {retryable_ids}"
+            )
+            # Backoff briefly so the rate limit has time to reset.
+            await asyncio.sleep(GMAIL_RATE_LIMIT_BACKOFF)
+            for mid in retryable_ids:
+                message_format: Literal["metadata", "full"] = (
+                    "metadata"
+                    if format == "metadata" or body_format == "raw"
+                    else "full"
+                )
+                mid_result, msg_data, error = await _fetch_message_with_retry(
+                    service,
+                    message_id=mid,
+                    message_format=message_format,
+                    log_prefix="get_gmail_messages_content_batch",
+                )
+                results[mid_result] = {"data": msg_data, "error": error}
+                await asyncio.sleep(GMAIL_REQUEST_DELAY)
+
         raw_contents: Optional[Dict[str, str]] = None
         if format != "metadata" and body_format == "raw":
             raw_message_ids = [
@@ -3123,6 +3186,40 @@ async def get_gmail_threads_content_batch(
         chunk_ids = thread_ids[chunk_start : chunk_start + GMAIL_BATCH_SIZE]
         results: Dict[str, Dict] = {}
 
+        async def fetch_thread_with_retry(tid: str, max_retries: int = 3):
+            """Fetch a single thread with exponential backoff retry for transient errors"""
+            for attempt in range(max_retries):
+                try:
+                    thread = await asyncio.to_thread(
+                        service.users()
+                        .threads()
+                        .get(userId="me", id=tid, format="full")
+                        .execute
+                    )
+                    return tid, thread, None
+                except ssl.SSLError as ssl_error:
+                    if attempt < max_retries - 1:
+                        # Exponential backoff: 1s, 2s, 4s
+                        delay = 2**attempt
+                        logger.warning(
+                            f"[get_gmail_threads_content_batch] SSL error for thread {tid} on attempt {attempt + 1}: {ssl_error}. Retrying in {delay}s..."
+                        )
+                        await asyncio.sleep(delay)
+                    else:
+                        logger.error(
+                            f"[get_gmail_threads_content_batch] SSL error for thread {tid} on final attempt: {ssl_error}"
+                        )
+                        return tid, None, ssl_error
+                except Exception as e:
+                    if _is_retryable_error(e) and attempt < max_retries - 1:
+                        delay = 2**attempt
+                        logger.warning(
+                            f"[get_gmail_threads_content_batch] Retryable error for thread {tid} on attempt {attempt + 1}: {e}. Retrying in {delay}s..."
+                        )
+                        await asyncio.sleep(delay)
+                    else:
+                        return tid, None, e
+
         # Try to use batch API
         try:
             batch = service.new_batch_http_request(callback=_batch_callback)
@@ -3140,38 +3237,31 @@ async def get_gmail_threads_content_batch(
                 f"[get_gmail_threads_content_batch] Batch API failed, falling back to sequential processing: {batch_error}"
             )
 
-            async def fetch_thread_with_retry(tid: str, max_retries: int = 3):
-                """Fetch a single thread with exponential backoff retry for SSL errors"""
-                for attempt in range(max_retries):
-                    try:
-                        thread = await asyncio.to_thread(
-                            service.users()
-                            .threads()
-                            .get(userId="me", id=tid, format="full")
-                            .execute
-                        )
-                        return tid, thread, None
-                    except ssl.SSLError as ssl_error:
-                        if attempt < max_retries - 1:
-                            # Exponential backoff: 1s, 2s, 4s
-                            delay = 2**attempt
-                            logger.warning(
-                                f"[get_gmail_threads_content_batch] SSL error for thread {tid} on attempt {attempt + 1}: {ssl_error}. Retrying in {delay}s..."
-                            )
-                            await asyncio.sleep(delay)
-                        else:
-                            logger.error(
-                                f"[get_gmail_threads_content_batch] SSL error for thread {tid} on final attempt: {ssl_error}"
-                            )
-                            return tid, None, ssl_error
-                    except Exception as e:
-                        return tid, None, e
-
             # Process threads sequentially with small delays to prevent connection exhaustion
             for tid in chunk_ids:
                 tid_result, thread_data, error = await fetch_thread_with_retry(tid)
                 results[tid_result] = {"data": thread_data, "error": error}
                 # Brief delay between requests to allow connection cleanup
+                await asyncio.sleep(GMAIL_REQUEST_DELAY)
+
+        # Re-fetch sub-requests that failed with retryable (transient) errors
+        # (e.g. 429 rate limit); retryable errors surface per-sub-request inside
+        # a successful batch response and are invisible to client-side retries.
+        retryable_ids = [
+            tid
+            for tid in chunk_ids
+            if results.get(tid, {}).get("error")
+            and _is_retryable_error(results[tid]["error"])
+        ]
+        if retryable_ids:
+            logger.warning(
+                f"[get_gmail_threads_content_batch] {len(retryable_ids)}/{len(chunk_ids)} "
+                f"threads failed with retryable errors; re-fetching: {retryable_ids}"
+            )
+            await asyncio.sleep(GMAIL_RATE_LIMIT_BACKOFF)
+            for tid in retryable_ids:
+                tid_result, thread_data, error = await fetch_thread_with_retry(tid)
+                results[tid_result] = {"data": thread_data, "error": error}
                 await asyncio.sleep(GMAIL_REQUEST_DELAY)
 
         # Process results for this chunk

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -9,7 +9,6 @@ import asyncio
 import base64
 import binascii
 import re
-import ssl
 import mimetypes
 import html
 from html.parser import HTMLParser
@@ -62,9 +61,9 @@ from gmail.gmail_helpers import (
     RAW_BODY_TRUNCATE_LIMIT,
     _analyze_thread_ownership_impl,
     _build_forward_content,
-    _http_error_status,
+    _fetch_with_retry,
     _is_benign_signature_http_error,
-    _is_quota_or_rate_limit_error,
+    _retryable_result_ids,
     _signature_fetch_tool_error,
 )
 
@@ -522,22 +521,6 @@ def _validate_message_batch_options(
         )
 
 
-def _is_retryable_error(error: Exception) -> bool:
-    """Whether an error is transient and safe to retry.
-
-    Covers HTTP 429 (rate limit), 5xx, and quota/rate-limit markers in the
-    error body. Reads are idempotent so retrying these is safe.
-    """
-    if isinstance(error, ssl.SSLError):
-        return True
-    if isinstance(error, HttpError):
-        status = _http_error_status(error)
-        if status is not None and (status == 429 or status >= 500):
-            return True
-        return _is_quota_or_rate_limit_error(error)
-    return False
-
-
 async def _fetch_message_with_retry(
     service,
     message_id: str,
@@ -545,41 +528,32 @@ async def _fetch_message_with_retry(
     log_prefix: str,
     max_retries: int = 3,
 ):
-    """Fetch a single Gmail message with retry handling.
+    """Fetch a single Gmail message, retrying transient failures."""
+    return await _fetch_with_retry(
+        lambda: _build_message_get_request(
+            service, message_id=message_id, message_format=message_format
+        ),
+        item_id=message_id,
+        item_label="message",
+        log_prefix=log_prefix,
+        max_retries=max_retries,
+    )
 
-    Retries on transient failures: SSL errors and retryable HTTP statuses
-    (429 rate limit / 5xx / quota markers). Message reads are idempotent, so
-    retrying is safe.
-    """
-    for attempt in range(max_retries + 1):
-        try:
-            message = await asyncio.to_thread(
-                _build_message_get_request(
-                    service, message_id=message_id, message_format=message_format
-                ).execute
-            )
-            return message_id, message, None
-        except ssl.SSLError as ssl_error:
-            if attempt < max_retries:
-                delay = 2**attempt
-                logger.warning(
-                    f"[{log_prefix}] SSL error for message {message_id} on attempt {attempt + 1}: {ssl_error}. Retrying in {delay}s..."
-                )
-                await asyncio.sleep(delay)
-            else:
-                logger.error(
-                    f"[{log_prefix}] SSL error for message {message_id} on final attempt: {ssl_error}"
-                )
-                return message_id, None, ssl_error
-        except Exception as exc:
-            if _is_retryable_error(exc) and attempt < max_retries:
-                delay = 2**attempt
-                logger.warning(
-                    f"[{log_prefix}] Retryable error for message {message_id} on attempt {attempt + 1}: {exc}. Retrying in {delay}s..."
-                )
-                await asyncio.sleep(delay)
-            else:
-                return message_id, None, exc
+
+async def _fetch_thread_with_retry(
+    service,
+    thread_id: str,
+    log_prefix: str,
+    max_retries: int = 3,
+):
+    """Fetch a single Gmail thread, retrying transient failures."""
+    return await _fetch_with_retry(
+        lambda: service.users().threads().get(userId="me", id=thread_id, format="full"),
+        item_id=thread_id,
+        item_label="thread",
+        log_prefix=log_prefix,
+        max_retries=max_retries,
+    )
 
 
 async def _fetch_raw_message_contents(
@@ -1963,6 +1937,9 @@ async def get_gmail_messages_content_batch(
     _validate_message_batch_options(format, body_format)
 
     output_messages = []
+    message_format: Literal["metadata", "full"] = (
+        "metadata" if format == "metadata" or body_format == "raw" else "full"
+    )
 
     # Process in smaller chunks to prevent SSL connection exhaustion
     for chunk_start in range(0, len(message_ids), GMAIL_BATCH_SIZE):
@@ -1980,14 +1957,9 @@ async def get_gmail_messages_content_batch(
             batch = service.new_batch_http_request(callback=_batch_callback)
 
             for mid in chunk_ids:
-                if format == "metadata" or body_format == "raw":
-                    req = _build_message_get_request(
-                        service, message_id=mid, message_format="metadata"
-                    )
-                else:
-                    req = _build_message_get_request(
-                        service, message_id=mid, message_format="full"
-                    )
+                req = _build_message_get_request(
+                    service, message_id=mid, message_format=message_format
+                )
                 batch.add(req, request_id=mid)
 
             # Execute batch request
@@ -2002,11 +1974,6 @@ async def get_gmail_messages_content_batch(
 
             # Process messages sequentially with small delays to prevent connection exhaustion
             for mid in chunk_ids:
-                message_format: Literal["metadata", "full"] = (
-                    "metadata"
-                    if format == "metadata" or body_format == "raw"
-                    else "full"
-                )
                 mid_result, msg_data, error = await _fetch_message_with_retry(
                     service,
                     message_id=mid,
@@ -2017,19 +1984,11 @@ async def get_gmail_messages_content_batch(
                 # Brief delay between requests to allow connection cleanup
                 await asyncio.sleep(GMAIL_REQUEST_DELAY)
 
-        # Re-fetch sub-requests that failed with retryable (transient) errors
-        # (e.g. 429 rate limit). The batch API reports per-sub-request errors
-        # inside a successful response, so they are invisible to any
-        # client-side retry; re-fetch only the failed IDs and merge.
+        # Sub-requests that failed with a transient error (e.g. 429 rate limit)
+        # inside an otherwise successful batch response: re-fetch only those IDs
+        # and merge. The sequential fallback has already exhausted its retries.
         retryable_ids = (
-            [
-                mid
-                for mid in chunk_ids
-                if results.get(mid, {}).get("error")
-                and _is_retryable_error(results[mid]["error"])
-            ]
-            if batch_completed
-            else []
+            _retryable_result_ids(results, chunk_ids) if batch_completed else []
         )
         if retryable_ids:
             logger.warning(
@@ -2039,11 +1998,6 @@ async def get_gmail_messages_content_batch(
             # Backoff briefly so the rate limit has time to reset.
             await asyncio.sleep(GMAIL_RATE_LIMIT_BACKOFF)
             for mid in retryable_ids:
-                message_format: Literal["metadata", "full"] = (
-                    "metadata"
-                    if format == "metadata" or body_format == "raw"
-                    else "full"
-                )
                 mid_result, msg_data, error = await _fetch_message_with_retry(
                     service,
                     message_id=mid,
@@ -3340,40 +3294,6 @@ async def get_gmail_threads_content_batch(
         chunk_ids = thread_ids[chunk_start : chunk_start + GMAIL_BATCH_SIZE]
         results: Dict[str, Dict] = {}
 
-        async def fetch_thread_with_retry(tid: str, max_retries: int = 3):
-            """Fetch a single thread with exponential backoff retry for transient errors"""
-            for attempt in range(max_retries + 1):
-                try:
-                    thread = await asyncio.to_thread(
-                        service.users()
-                        .threads()
-                        .get(userId="me", id=tid, format="full")
-                        .execute
-                    )
-                    return tid, thread, None
-                except ssl.SSLError as ssl_error:
-                    if attempt < max_retries:
-                        # Exponential backoff: 1s, 2s, 4s
-                        delay = 2**attempt
-                        logger.warning(
-                            f"[get_gmail_threads_content_batch] SSL error for thread {tid} on attempt {attempt + 1}: {ssl_error}. Retrying in {delay}s..."
-                        )
-                        await asyncio.sleep(delay)
-                    else:
-                        logger.error(
-                            f"[get_gmail_threads_content_batch] SSL error for thread {tid} on final attempt: {ssl_error}"
-                        )
-                        return tid, None, ssl_error
-                except Exception as e:
-                    if _is_retryable_error(e) and attempt < max_retries:
-                        delay = 2**attempt
-                        logger.warning(
-                            f"[get_gmail_threads_content_batch] Retryable error for thread {tid} on attempt {attempt + 1}: {e}. Retrying in {delay}s..."
-                        )
-                        await asyncio.sleep(delay)
-                    else:
-                        return tid, None, e
-
         batch_completed = False
 
         # Try to use batch API
@@ -3396,23 +3316,20 @@ async def get_gmail_threads_content_batch(
 
             # Process threads sequentially with small delays to prevent connection exhaustion
             for tid in chunk_ids:
-                tid_result, thread_data, error = await fetch_thread_with_retry(tid)
+                tid_result, thread_data, error = await _fetch_thread_with_retry(
+                    service,
+                    thread_id=tid,
+                    log_prefix="get_gmail_threads_content_batch",
+                )
                 results[tid_result] = {"data": thread_data, "error": error}
                 # Brief delay between requests to allow connection cleanup
                 await asyncio.sleep(GMAIL_REQUEST_DELAY)
 
-        # Re-fetch sub-requests that failed with retryable (transient) errors
-        # (e.g. 429 rate limit); retryable errors surface per-sub-request inside
-        # a successful batch response and are invisible to client-side retries.
+        # Sub-requests that failed with a transient error (e.g. 429 rate limit)
+        # inside an otherwise successful batch response: re-fetch only those IDs
+        # and merge. The sequential fallback has already exhausted its retries.
         retryable_ids = (
-            [
-                tid
-                for tid in chunk_ids
-                if results.get(tid, {}).get("error")
-                and _is_retryable_error(results[tid]["error"])
-            ]
-            if batch_completed
-            else []
+            _retryable_result_ids(results, chunk_ids) if batch_completed else []
         )
         if retryable_ids:
             logger.warning(
@@ -3421,7 +3338,11 @@ async def get_gmail_threads_content_batch(
             )
             await asyncio.sleep(GMAIL_RATE_LIMIT_BACKOFF)
             for tid in retryable_ids:
-                tid_result, thread_data, error = await fetch_thread_with_retry(tid)
+                tid_result, thread_data, error = await _fetch_thread_with_retry(
+                    service,
+                    thread_id=tid,
+                    log_prefix="get_gmail_threads_content_batch",
+                )
                 results[tid_result] = {"data": thread_data, "error": error}
                 await asyncio.sleep(GMAIL_REQUEST_DELAY)
 

--- a/tests/gmail/test_gmail_batch_retry.py
+++ b/tests/gmail/test_gmail_batch_retry.py
@@ -1,0 +1,240 @@
+"""Tests for retryable-error handling in Gmail batch fetches (429 / 5xx / quota).
+
+Covers:
+- `_is_retryable_error` classification.
+- The batch redo loop: sub-requests that fail with a retryable error are
+  re-fetched (only the failed IDs), and the results are merged so the final
+  output contains every requested message.
+"""
+
+import os
+import ssl
+import sys
+from unittest.mock import Mock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gmail.gmail_tools import (
+    _is_retryable_error,
+    get_gmail_messages_content_batch,
+    get_gmail_threads_content_batch,
+)
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+class _FakeResp:
+    """Minimal stand-in for an httplib2 Response (status + reason)."""
+
+    def __init__(self, status: int):
+        self.status = status
+        self.reason = "fake"
+
+
+class TestIsRetryableError:
+    def test_429_is_retryable(self):
+        assert _is_retryable_error(HttpError(_FakeResp(429), b"{}"))
+
+    def test_5xx_is_retryable(self):
+        assert _is_retryable_error(HttpError(_FakeResp(502), b"{}"))
+        assert _is_retryable_error(HttpError(_FakeResp(503), b"{}"))
+
+    def test_ssl_error_is_retryable(self):
+        assert _is_retryable_error(ssl.SSLError("handshake failed"))
+
+    def test_404_is_not_retryable(self):
+        assert not _is_retryable_error(HttpError(_FakeResp(404), b"{}"))
+
+    def test_403_rate_limit_marker_is_retryable(self):
+        body = b'{"error":{"errors":[{"reason":"userRateLimitExceeded"}]}}'
+        assert _is_retryable_error(HttpError(_FakeResp(403), body))
+
+    def test_403_plain_denied_is_not_retryable(self):
+        body = b'{"error":{"errors":[{"reason":"forbidden"}]}}'
+        assert not _is_retryable_error(HttpError(_FakeResp(403), body))
+
+    def test_non_http_errors_are_not_retryable(self):
+        assert not _is_retryable_error(ValueError("boom"))
+        assert not _is_retryable_error(RuntimeError("boom"))
+
+
+class _FakeBatch:
+    """Batch that invokes each request's execute() and calls back per request."""
+
+    def __init__(self, callback):
+        self._callback = callback
+        self._requests = []
+
+    def add(self, request, request_id):
+        self._requests.append((request_id, request))
+
+    def execute(self):
+        for request_id, request in self._requests:
+            try:
+                response = request.execute()
+                self._callback(request_id, response, None)
+            except Exception as exc:
+                self._callback(request_id, None, exc)
+
+
+def _headers(subject="Example subject"):
+    return [
+        {"name": "Subject", "value": subject},
+        {"name": "From", "value": "sender@example.com"},
+        {"name": "To", "value": "recipient@example.com"},
+        {"name": "Message-ID", "value": "<msg@example.com>"},
+        {"name": "Date", "value": "Fri, 28 Mar 2026 10:00:00 -0400"},
+    ]
+
+
+def _message_response(message_id, text="body"):
+    return {
+        "id": message_id,
+        "payload": {
+            "headers": _headers(f"Subject {message_id}"),
+            "mimeType": "text/plain",
+            "body": {"data": _b64(text)},
+        },
+    }
+
+
+def _thread_response(thread_id, message_id):
+    return {
+        "id": thread_id,
+        "messages": [
+            {
+                "id": message_id,
+                "payload": {
+                    "headers": _headers(f"Subject {thread_id}"),
+                    "mimeType": "text/plain",
+                    "body": {"data": _b64("thread body")},
+                },
+            }
+        ],
+    }
+
+
+def _b64(text):
+    import base64
+
+    return base64.urlsafe_b64encode(text.encode()).decode()
+
+
+@pytest.mark.asyncio
+async def test_batch_refetches_only_rate_limited_sub_requests(monkeypatch):
+    """A 429 sub-request is re-fetched; successful IDs are fetched exactly once."""
+    # Track every message_get call per ID.
+    calls = {"msg-1": 0, "msg-2": 0}
+
+    def message_get(**kwargs):
+        mid = kwargs["id"]
+        calls[mid] += 1
+        request = Mock()
+        # msg-2 fails with 429 on its FIRST call only; retries succeed.
+        if mid == "msg-2" and calls[mid] == 1:
+            request.execute.side_effect = HttpError(_FakeResp(429), b"{}")
+        else:
+            request.execute.return_value = _message_response(mid)
+        return request
+
+    service = Mock()
+    service.users().messages().get.side_effect = message_get
+    service.new_batch_http_request.side_effect = lambda callback: _FakeBatch(callback)
+
+    # Keep the redo backoff near-zero so the test runs fast.
+    monkeypatch.setattr("gmail.gmail_tools.GMAIL_RATE_LIMIT_BACKOFF", 0)
+
+    result = await _unwrap(get_gmail_messages_content_batch)(
+        service=service,
+        message_ids=["msg-1", "msg-2"],
+        user_google_email="user@example.com",
+    )
+
+    # No error stub remains and both messages are present.
+    assert "⚠️" not in result
+    assert "Subject msg-1" in result
+    assert "Subject msg-2" in result
+
+    # Retry contract: msg-1 (success) fetched once; msg-2 (429) fetched twice
+    # (initial + redo). Successful IDs must NOT be re-fetched.
+    assert calls == {"msg-1": 1, "msg-2": 2}
+
+
+@pytest.mark.asyncio
+async def test_batch_does_not_refetch_non_retryable_errors(monkeypatch):
+    """A non-retryable error (404) is NOT re-fetched and stays as an error stub."""
+    calls = {"msg-1": 0, "missing": 0}
+
+    def message_get(**kwargs):
+        mid = kwargs["id"]
+        calls[mid] += 1
+        request = Mock()
+        if mid == "missing":
+            request.execute.side_effect = HttpError(_FakeResp(404), b"{}")
+        else:
+            request.execute.return_value = _message_response(mid)
+        return request
+
+    service = Mock()
+    service.users().messages().get.side_effect = message_get
+    service.new_batch_http_request.side_effect = lambda callback: _FakeBatch(callback)
+    monkeypatch.setattr("gmail.gmail_tools.GMAIL_RATE_LIMIT_BACKOFF", 0)
+
+    result = await _unwrap(get_gmail_messages_content_batch)(
+        service=service,
+        message_ids=["msg-1", "missing"],
+        user_google_email="user@example.com",
+    )
+
+    assert "Subject msg-1" in result
+    assert "⚠️ Message missing" in result
+
+    # Retry contract: the 404 message is fetched exactly once (no re-fetch).
+    assert calls == {"msg-1": 1, "missing": 1}
+
+
+@pytest.mark.asyncio
+async def test_thread_batch_refetches_rate_limited_thread(monkeypatch):
+    """Regression: a 429 on one thread sub-request (batch succeeds) is re-fetched.
+
+    The redo loop references fetch_thread_with_retry even when batch.execute()
+    succeeds, so that helper must be defined outside the batch-exception
+    handler (previously it was nested in `except`, causing UnboundLocalError).
+    """
+    calls = {"thread-1": 0, "thread-2": 0}
+
+    def thread_get(**kwargs):
+        tid = kwargs["id"]
+        calls[tid] += 1
+        request = Mock()
+        # thread-2 fails with 429 on its FIRST call only; retries succeed.
+        if tid == "thread-2" and calls[tid] == 1:
+            request.execute.side_effect = HttpError(_FakeResp(429), b"{}")
+        else:
+            request.execute.return_value = _thread_response(tid, f"msg-{tid}")
+        return request
+
+    service = Mock()
+    service.users().threads().get.side_effect = thread_get
+    service.new_batch_http_request.side_effect = lambda callback: _FakeBatch(callback)
+    monkeypatch.setattr("gmail.gmail_tools.GMAIL_RATE_LIMIT_BACKOFF", 0)
+
+    result = await _unwrap(get_gmail_threads_content_batch)(
+        service=service,
+        thread_ids=["thread-1", "thread-2"],
+        user_google_email="user@example.com",
+    )
+
+    assert "⚠️" not in result
+    assert "Subject thread-1" in result
+    assert "Subject thread-2" in result
+    assert calls == {"thread-1": 1, "thread-2": 2}

--- a/tests/gmail/test_gmail_batch_retry.py
+++ b/tests/gmail/test_gmail_batch_retry.py
@@ -18,6 +18,7 @@ from googleapiclient.errors import HttpError
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from gmail.gmail_tools import (
+    _fetch_message_with_retry,
     _is_retryable_error,
     get_gmail_messages_content_batch,
     get_gmail_threads_content_batch,
@@ -238,3 +239,114 @@ async def test_thread_batch_refetches_rate_limited_thread(monkeypatch):
     assert "Subject thread-1" in result
     assert "Subject thread-2" in result
     assert calls == {"thread-1": 1, "thread-2": 2}
+
+
+@pytest.mark.asyncio
+async def test_message_retry_uses_three_backoffs(monkeypatch):
+    """Three retries use the documented 1s/2s/4s exponential backoff."""
+    attempts = 0
+    sleeps = []
+
+    def message_get(**kwargs):
+        request = Mock()
+
+        def execute():
+            nonlocal attempts
+            attempts += 1
+            if attempts <= 3:
+                raise HttpError(_FakeResp(429), b"{}")
+            return _message_response(kwargs["id"])
+
+        request.execute.side_effect = execute
+        return request
+
+    async def record_sleep(delay):
+        sleeps.append(delay)
+
+    service = Mock()
+    service.users().messages().get.side_effect = message_get
+    monkeypatch.setattr("gmail.gmail_tools.asyncio.sleep", record_sleep)
+
+    _, message, error = await _fetch_message_with_retry(
+        service,
+        message_id="msg-1",
+        message_format="full",
+        log_prefix="test",
+    )
+
+    assert error is None
+    assert message["id"] == "msg-1"
+    assert attempts == 4
+    assert sleeps == [1, 2, 4]
+
+
+@pytest.mark.asyncio
+async def test_message_batch_failure_does_not_restart_exhausted_retries(monkeypatch):
+    """A global batch failure gets one sequential retry cycle, not two."""
+    attempts = 0
+
+    def message_get(**kwargs):
+        request = Mock()
+
+        def execute():
+            nonlocal attempts
+            attempts += 1
+            raise HttpError(_FakeResp(429), b"{}")
+
+        request.execute.side_effect = execute
+        return request
+
+    async def no_sleep(_delay):
+        return None
+
+    batch = Mock()
+    batch.execute.side_effect = RuntimeError("batch transport failed")
+    service = Mock()
+    service.users().messages().get.side_effect = message_get
+    service.new_batch_http_request.return_value = batch
+    monkeypatch.setattr("gmail.gmail_tools.asyncio.sleep", no_sleep)
+
+    result = await _unwrap(get_gmail_messages_content_batch)(
+        service=service,
+        message_ids=["msg-1"],
+        user_google_email="user@example.com",
+    )
+
+    assert "⚠️ Message msg-1" in result
+    assert attempts == 4
+
+
+@pytest.mark.asyncio
+async def test_thread_batch_failure_does_not_restart_exhausted_retries(monkeypatch):
+    """Thread fallback also gets only one sequential retry cycle."""
+    attempts = 0
+
+    def thread_get(**_kwargs):
+        request = Mock()
+
+        def execute():
+            nonlocal attempts
+            attempts += 1
+            raise HttpError(_FakeResp(429), b"{}")
+
+        request.execute.side_effect = execute
+        return request
+
+    async def no_sleep(_delay):
+        return None
+
+    batch = Mock()
+    batch.execute.side_effect = RuntimeError("batch transport failed")
+    service = Mock()
+    service.users().threads().get.side_effect = thread_get
+    service.new_batch_http_request.return_value = batch
+    monkeypatch.setattr("gmail.gmail_tools.asyncio.sleep", no_sleep)
+
+    result = await _unwrap(get_gmail_threads_content_batch)(
+        service=service,
+        thread_ids=["thread-1"],
+        user_google_email="user@example.com",
+    )
+
+    assert "⚠️ Thread thread-1" in result
+    assert attempts == 4

--- a/tests/gmail/test_gmail_batch_retry.py
+++ b/tests/gmail/test_gmail_batch_retry.py
@@ -17,9 +17,9 @@ from googleapiclient.errors import HttpError
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
+from gmail.gmail_helpers import _is_retryable_error
 from gmail.gmail_tools import (
     _fetch_message_with_retry,
-    _is_retryable_error,
     get_gmail_messages_content_batch,
     get_gmail_threads_content_batch,
 )
@@ -207,9 +207,9 @@ async def test_batch_does_not_refetch_non_retryable_errors(monkeypatch):
 async def test_thread_batch_refetches_rate_limited_thread(monkeypatch):
     """Regression: a 429 on one thread sub-request (batch succeeds) is re-fetched.
 
-    The redo loop references fetch_thread_with_retry even when batch.execute()
-    succeeds, so that helper must be defined outside the batch-exception
-    handler (previously it was nested in `except`, causing UnboundLocalError).
+    The redo loop runs even when batch.execute() succeeds, so the per-thread
+    fetch helper must live outside the batch-exception handler (previously it
+    was nested in `except`, causing UnboundLocalError).
     """
     calls = {"thread-1": 0, "thread-2": 0}
 
@@ -265,7 +265,7 @@ async def test_message_retry_uses_three_backoffs(monkeypatch):
 
     service = Mock()
     service.users().messages().get.side_effect = message_get
-    monkeypatch.setattr("gmail.gmail_tools.asyncio.sleep", record_sleep)
+    monkeypatch.setattr("asyncio.sleep", record_sleep)
 
     _, message, error = await _fetch_message_with_retry(
         service,
@@ -304,7 +304,7 @@ async def test_message_batch_failure_does_not_restart_exhausted_retries(monkeypa
     service = Mock()
     service.users().messages().get.side_effect = message_get
     service.new_batch_http_request.return_value = batch
-    monkeypatch.setattr("gmail.gmail_tools.asyncio.sleep", no_sleep)
+    monkeypatch.setattr("asyncio.sleep", no_sleep)
 
     result = await _unwrap(get_gmail_messages_content_batch)(
         service=service,
@@ -340,7 +340,7 @@ async def test_thread_batch_failure_does_not_restart_exhausted_retries(monkeypat
     service = Mock()
     service.users().threads().get.side_effect = thread_get
     service.new_batch_http_request.return_value = batch
-    monkeypatch.setattr("gmail.gmail_tools.asyncio.sleep", no_sleep)
+    monkeypatch.setattr("asyncio.sleep", no_sleep)
 
     result = await _unwrap(get_gmail_threads_content_batch)(
         service=service,


### PR DESCRIPTION
## Description

Fixes #1009 — `get_gmail_messages_content_batch` / `get_gmail_threads_content_batch`
silently lose messages when Gmail rate-limits individual sub-requests.

**The problem:** batch fetches only retried `ssl.SSLError`. HTTP 429 (rate limit) / 5xx
sub-request failures surfaced as `⚠️ Message <id>: <HttpError 429 ...>` stubs *inside a
successful batch response* — invisible to any client-side retry-on-error logic, so
partial fetches were quietly dropped under quota pressure (e.g. two back-to-back
25-message batches trip the per-user rate limit).

**The fix:**
- New `_is_retryable_error()`: retryable = SSL error, HTTP 429 / 5xx, or a
  quota/rate-limit marker in the body (reuses `_http_error_status` +
  `_is_quota_or_rate_limit_error` from `gmail_helpers`).
- `_fetch_message_with_retry` now retries retryable errors with 1s/2s/4s backoff
  (was SSL-only).
- After each batch chunk, collect sub-requests that failed with retryable errors,
  sleep a short backoff, then re-fetch **only those IDs** and merge — mirroring the
  existing 401 redo-loop pattern in `googleapiclient`.
- Reads are idempotent, so this retry is safe (deliberately NOT applied to sends;
  see #997).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
      (`tests/gmail/test_gmail_batch_retry.py`, 7 cases: 429/5xx retryable, 404 not,
      403 quota-marker retryable vs plain-forbidden not, non-HTTP not)
- [x] New and existing unit tests pass locally with my changes (`169 passed`)
- [x] I have tested this change manually
- [x] ruff clean

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

Quota context (researched from official docs): `messages.get` = 20 quota units, and
batch sub-requests count individually (n per batch). A 25-message batch ≈ 500 units.
The per-user sustained budget is ~100 units/sec (new model) or 250/sec (legacy), so
back-to-back 25-batches exceed it quickly; the exponential backoff added here makes
occasional 429s degrade gracefully rather than dropping messages. The concurrent-
request limit ("Too many concurrent requests for user") is shared across all clients
accessing a mailbox and is the variant I observed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gmail message and thread retrieval reliability during temporary service errors, rate limits, quota limits, and SSL issues.
  * Automatically retries eligible failures and selectively re-fetches unsuccessful batch requests.
  * Preserved clear handling for non-retryable errors, such as missing resources and ordinary permission failures.

* **Tests**
  * Added coverage for retryable and non-retryable Gmail API error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->