### PR TITLE
fix(gmail): resolve correct filename for attachments nested under multipart/signed

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2090,24 +2090,7 @@ async def get_gmail_messages_content_batch(
 
 
 def _attachment_metadata_fields(depth: int) -> str:
-    """Build a `fields` mask for messages.get() that mirrors a MIME part tree
-    down to `depth` levels of nesting, keeping only filename/mimeType/
-    attachmentId/size at every level (never `body.data`).
-
-    Gmail's partial-response field masks are not recursive: a bare
-    `parts(filename,mimeType,body(attachmentId,size))` only covers one level,
-    so any attachment nested deeper (e.g. multipart/signed S/MIME messages,
-    where the real attachment sits inside a nested multipart/mixed part and
-    only the top-level pkcs7-signature part is visible at depth 1) silently
-    disappears from the response — see the regression this guards against.
-    The mask still exists to keep the response small: an unrestricted
-    format="full" fetch inlines the full base64 body.data for every
-    text/plain and text/html part, which can be tens to hundreds of KB for
-    image-heavy HTML mail, none of which is needed just to resolve a
-    filename. depth=6 comfortably covers real-world MIME nesting (signed,
-    forwarded, multipart/related, etc.); anything deeper falls back to the
-    same size/last-resort matching used when the fields mask doesn't help.
-    """
+    """Build a metadata-only fields mask for a MIME tree of the given depth."""
     node = "filename,mimeType,body(attachmentId,size)"
     for _ in range(depth):
         node = f"filename,mimeType,body(attachmentId,size),parts({node})"

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -1918,6 +1918,34 @@ async def get_gmail_messages_content_batch(
     return final_output
 
 
+def _attachment_metadata_fields(depth: int) -> str:
+    """Build a `fields` mask for messages.get() that mirrors a MIME part tree
+    down to `depth` levels of nesting, keeping only filename/mimeType/
+    attachmentId/size at every level (never `body.data`).
+
+    Gmail's partial-response field masks are not recursive: a bare
+    `parts(filename,mimeType,body(attachmentId,size))` only covers one level,
+    so any attachment nested deeper (e.g. multipart/signed S/MIME messages,
+    where the real attachment sits inside a nested multipart/mixed part and
+    only the top-level pkcs7-signature part is visible at depth 1) silently
+    disappears from the response — see the regression this guards against.
+    The mask still exists to keep the response small: an unrestricted
+    format="full" fetch inlines the full base64 body.data for every
+    text/plain and text/html part, which can be tens to hundreds of KB for
+    image-heavy HTML mail, none of which is needed just to resolve a
+    filename. depth=6 comfortably covers real-world MIME nesting (signed,
+    forwarded, multipart/related, etc.); anything deeper falls back to the
+    same size/last-resort matching used when the fields mask doesn't help.
+    """
+    node = "filename,mimeType,body(attachmentId,size)"
+    for _ in range(depth):
+        node = f"filename,mimeType,body(attachmentId,size),parts({node})"
+    return f"payload({node})"
+
+
+_ATTACHMENT_METADATA_FIELDS = _attachment_metadata_fields(6)
+
+
 @server.tool(
     title="Get Gmail Attachment Content",
     annotations=ToolAnnotations(
@@ -2024,11 +2052,6 @@ async def get_gmail_attachment_content(
         filename = None
         mime_type = None
         try:
-            # No `fields` mask here: Gmail's partial-response field masks are not
-            # recursive, so restricting to one level of `parts` silently drops
-            # attachments nested deeper (e.g. multipart/signed S/MIME messages,
-            # where the real attachment sits inside a nested multipart/mixed
-            # part and only the top-level pkcs7-signature part remains visible).
             message_full = await asyncio.to_thread(
                 service.users()
                 .messages()
@@ -2036,6 +2059,7 @@ async def get_gmail_attachment_content(
                     userId="me",
                     id=message_id,
                     format="full",
+                    fields=_ATTACHMENT_METADATA_FIELDS,
                 )
                 .execute
             )

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2024,7 +2024,11 @@ async def get_gmail_attachment_content(
         filename = None
         mime_type = None
         try:
-            # Use format="full" with fields to limit response to attachment metadata only
+            # No `fields` mask here: Gmail's partial-response field masks are not
+            # recursive, so restricting to one level of `parts` silently drops
+            # attachments nested deeper (e.g. multipart/signed S/MIME messages,
+            # where the real attachment sits inside a nested multipart/mixed
+            # part and only the top-level pkcs7-signature part remains visible).
             message_full = await asyncio.to_thread(
                 service.users()
                 .messages()
@@ -2032,7 +2036,6 @@ async def get_gmail_attachment_content(
                     userId="me",
                     id=message_id,
                     format="full",
-                    fields="payload(parts(filename,mimeType,body(attachmentId,size)),body(attachmentId,size),filename,mimeType)",
                 )
                 .execute
             )

--- a/tests/gdocs/test_advanced_doc_formatting.py
+++ b/tests/gdocs/test_advanced_doc_formatting.py
@@ -95,11 +95,7 @@ class TestAdvancedRequestBuilders:
         assert inner["tabId"] == "tab-123"
         assert inner["documentStyle"]["marginTop"] == {"magnitude": 72, "unit": "PT"}
         assert inner["documentStyle"]["background"] == {
-            "color": {
-                "color": {
-                    "rgbColor": {"red": 1.0, "green": 1.0, "blue": 1.0}
-                }
-            }
+            "color": {"color": {"rgbColor": {"red": 1.0, "green": 1.0, "blue": 1.0}}}
         }
         assert inner["documentStyle"]["pageSize"]["width"] == {
             "magnitude": 612,

--- a/tests/gdocs/test_paragraph_style.py
+++ b/tests/gdocs/test_paragraph_style.py
@@ -72,9 +72,7 @@ class TestBuildParagraphStyle:
 
         assert fields == ["borderLeft"]
         assert style["borderLeft"] == {
-            "color": {
-                "color": {"rgbColor": {"red": 1.0, "green": 0.0, "blue": 0.0}}
-            },
+            "color": {"color": {"rgbColor": {"red": 1.0, "green": 0.0, "blue": 0.0}}},
             "width": {"magnitude": 2.5, "unit": "PT"},
             "padding": {"magnitude": 4, "unit": "PT"},
             "dashStyle": "DASH",

--- a/tests/gmail/test_get_gmail_attachment_content.py
+++ b/tests/gmail/test_get_gmail_attachment_content.py
@@ -60,6 +60,72 @@ def _build_mock_service(
     return mock_service
 
 
+def _build_mock_service_nested(
+    payload: bytes,
+    *,
+    filename: str,
+    mime_type: str,
+    attachment_id: str,
+) -> Mock:
+    """Build a Mock service whose payload mirrors an S/MIME-signed message:
+    multipart/signed -> [multipart/mixed -> [the real attachment], smime.p7s].
+    The real attachment sits two levels deep, and the sibling signature part
+    is itself named ``smime.p7s`` with its own attachmentId.
+
+    A real Gmail API `fields` mask that only lists one level of `parts`
+    silently drops any deeper-nested `parts`, so the mock's `.get()` mimics
+    that truncation whenever a `fields` kwarg is passed — a plain
+    ``Mock(return_value=...)`` would ignore the kwarg entirely and couldn't
+    catch this class of regression.
+    """
+    urlsafe_b64 = base64.urlsafe_b64encode(payload).decode("ascii")
+
+    full_payload = {
+        "mimeType": "multipart/signed",
+        "parts": [
+            {
+                "mimeType": "multipart/mixed",
+                "parts": [
+                    {
+                        "filename": filename,
+                        "mimeType": mime_type,
+                        "body": {
+                            "attachmentId": attachment_id,
+                            "size": len(payload),
+                        },
+                    }
+                ],
+            },
+            {
+                "filename": "smime.p7s",
+                "mimeType": "application/pkcs7-signature",
+                "body": {"attachmentId": "sig-456", "size": 4771},
+            },
+        ],
+    }
+
+    def messages_get(**kwargs):
+        if kwargs.get("fields"):
+            # Simulate Gmail's non-recursive field mask: only the top-level
+            # `parts` survive, each stripped of its own nested `parts`.
+            truncated = [
+                {k: v for k, v in part.items() if k != "parts"}
+                for part in full_payload["parts"]
+            ]
+            result = {"payload": {**full_payload, "parts": truncated}}
+        else:
+            result = {"payload": full_payload}
+        return Mock(execute=Mock(return_value=result))
+
+    mock_service = Mock()
+    mock_service.users().messages().attachments().get().execute.return_value = {
+        "size": len(payload),
+        "data": urlsafe_b64,
+    }
+    mock_service.users().messages().get = Mock(side_effect=messages_get)
+    return mock_service
+
+
 @pytest.fixture
 def isolated_attachment_env(tmp_path, monkeypatch):
     """Route attachment storage to a temp dir and force HTTP (not stateless) mode."""
@@ -227,3 +293,39 @@ async def test_return_base64_preserves_file_save_behavior(isolated_attachment_en
     assert "Download URL" in result
     # ...and includes the base64 block.
     assert "📦 Base64 content" in result
+
+
+@pytest.mark.asyncio
+async def test_resolves_correct_filename_for_nested_smime_attachment(
+    isolated_attachment_env,
+):
+    """Regression test: on S/MIME-signed messages the real attachment is
+    nested two levels deep (multipart/signed -> multipart/mixed -> file),
+    while the sibling smime.p7s signature part sits at the top level. The
+    metadata re-fetch used to request a `fields` mask that only covered one
+    level of `parts`, so the nested attachment was invisible and the
+    "only one attachment visible" fallback mislabeled every download as
+    smime.p7s regardless of which attachment was actually requested.
+    """
+    payload = b"%PDF-1.4 fake pdf bytes" + bytes(range(200))
+    mock_service = _build_mock_service_nested(
+        payload,
+        filename="statement.pdf",
+        mime_type="application/pdf",
+        attachment_id="att-pdf-123",
+    )
+
+    result = await _unwrap(get_gmail_attachment_content)(
+        service=mock_service,
+        message_id="msg-1",
+        attachment_id="att-pdf-123",
+        user_google_email="user@example.com",
+    )
+
+    assert "Filename: statement.pdf" in result
+    assert "smime.p7s" not in result
+
+    saved_files = list(isolated_attachment_env.iterdir())
+    assert len(saved_files) == 1
+    assert saved_files[0].suffix == ".pdf"
+    assert saved_files[0].read_bytes() == payload

--- a/tests/gmail/test_get_gmail_attachment_content.py
+++ b/tests/gmail/test_get_gmail_attachment_content.py
@@ -72,11 +72,15 @@ def _build_mock_service_nested(
     The real attachment sits two levels deep, and the sibling signature part
     is itself named ``smime.p7s`` with its own attachmentId.
 
-    A real Gmail API `fields` mask that only lists one level of `parts`
-    silently drops any deeper-nested `parts`, so the mock's `.get()` mimics
-    that truncation whenever a `fields` kwarg is passed — a plain
+    A real Gmail API `fields` mask is not recursive: `parts(...)` nested `n`
+    levels deep in the mask string only returns `n` levels of `parts` in the
+    response, silently dropping anything nested deeper. The mock's `.get()`
+    reproduces that truncation for whatever depth the `fields` kwarg actually
+    asks for (parsed by counting `parts(` occurrences), rather than
+    hardcoding one depth — so this test stays meaningful against the real
+    mask's depth, not just a mock frozen to the old, buggy depth. A plain
     ``Mock(return_value=...)`` would ignore the kwarg entirely and couldn't
-    catch this class of regression.
+    catch this class of regression at all.
     """
     urlsafe_b64 = base64.urlsafe_b64encode(payload).decode("ascii")
 
@@ -104,15 +108,21 @@ def _build_mock_service_nested(
         ],
     }
 
-    def messages_get(**kwargs):
-        if kwargs.get("fields"):
-            # Simulate Gmail's non-recursive field mask: only the top-level
-            # `parts` survive, each stripped of its own nested `parts`.
-            truncated = [
-                {k: v for k, v in part.items() if k != "parts"}
-                for part in full_payload["parts"]
+    def truncate_to_depth(part: dict, remaining_depth: int) -> dict:
+        if remaining_depth <= 0:
+            return {k: v for k, v in part.items() if k != "parts"}
+        truncated = {k: v for k, v in part.items() if k != "parts"}
+        if "parts" in part:
+            truncated["parts"] = [
+                truncate_to_depth(child, remaining_depth - 1) for child in part["parts"]
             ]
-            result = {"payload": {**full_payload, "parts": truncated}}
+        return truncated
+
+    def messages_get(**kwargs):
+        fields = kwargs.get("fields")
+        if fields:
+            depth = fields.count("parts(")
+            result = {"payload": truncate_to_depth(full_payload, depth)}
         else:
             result = {"payload": full_payload}
         return Mock(execute=Mock(return_value=result))

--- a/tests/gmail/test_get_gmail_attachment_content.py
+++ b/tests/gmail/test_get_gmail_attachment_content.py
@@ -60,82 +60,6 @@ def _build_mock_service(
     return mock_service
 
 
-def _build_mock_service_nested(
-    payload: bytes,
-    *,
-    filename: str,
-    mime_type: str,
-    attachment_id: str,
-) -> Mock:
-    """Build a Mock service whose payload mirrors an S/MIME-signed message:
-    multipart/signed -> [multipart/mixed -> [the real attachment], smime.p7s].
-    The real attachment sits two levels deep, and the sibling signature part
-    is itself named ``smime.p7s`` with its own attachmentId.
-
-    A real Gmail API `fields` mask is not recursive: `parts(...)` nested `n`
-    levels deep in the mask string only returns `n` levels of `parts` in the
-    response, silently dropping anything nested deeper. The mock's `.get()`
-    reproduces that truncation for whatever depth the `fields` kwarg actually
-    asks for (parsed by counting `parts(` occurrences), rather than
-    hardcoding one depth — so this test stays meaningful against the real
-    mask's depth, not just a mock frozen to the old, buggy depth. A plain
-    ``Mock(return_value=...)`` would ignore the kwarg entirely and couldn't
-    catch this class of regression at all.
-    """
-    urlsafe_b64 = base64.urlsafe_b64encode(payload).decode("ascii")
-
-    full_payload = {
-        "mimeType": "multipart/signed",
-        "parts": [
-            {
-                "mimeType": "multipart/mixed",
-                "parts": [
-                    {
-                        "filename": filename,
-                        "mimeType": mime_type,
-                        "body": {
-                            "attachmentId": attachment_id,
-                            "size": len(payload),
-                        },
-                    }
-                ],
-            },
-            {
-                "filename": "smime.p7s",
-                "mimeType": "application/pkcs7-signature",
-                "body": {"attachmentId": "sig-456", "size": 4771},
-            },
-        ],
-    }
-
-    def truncate_to_depth(part: dict, remaining_depth: int) -> dict:
-        if remaining_depth <= 0:
-            return {k: v for k, v in part.items() if k != "parts"}
-        truncated = {k: v for k, v in part.items() if k != "parts"}
-        if "parts" in part:
-            truncated["parts"] = [
-                truncate_to_depth(child, remaining_depth - 1) for child in part["parts"]
-            ]
-        return truncated
-
-    def messages_get(**kwargs):
-        fields = kwargs.get("fields")
-        if fields:
-            depth = fields.count("parts(")
-            result = {"payload": truncate_to_depth(full_payload, depth)}
-        else:
-            result = {"payload": full_payload}
-        return Mock(execute=Mock(return_value=result))
-
-    mock_service = Mock()
-    mock_service.users().messages().attachments().get().execute.return_value = {
-        "size": len(payload),
-        "data": urlsafe_b64,
-    }
-    mock_service.users().messages().get = Mock(side_effect=messages_get)
-    return mock_service
-
-
 @pytest.fixture
 def isolated_attachment_env(tmp_path, monkeypatch):
     """Route attachment storage to a temp dir and force HTTP (not stateless) mode."""
@@ -309,21 +233,43 @@ async def test_return_base64_preserves_file_save_behavior(isolated_attachment_en
 async def test_resolves_correct_filename_for_nested_smime_attachment(
     isolated_attachment_env,
 ):
-    """Regression test: on S/MIME-signed messages the real attachment is
-    nested two levels deep (multipart/signed -> multipart/mixed -> file),
-    while the sibling smime.p7s signature part sits at the top level. The
-    metadata re-fetch used to request a `fields` mask that only covered one
-    level of `parts`, so the nested attachment was invisible and the
-    "only one attachment visible" fallback mislabeled every download as
-    smime.p7s regardless of which attachment was actually requested.
-    """
+    """Resolve a nested attachment instead of its top-level S/MIME signature."""
     payload = b"%PDF-1.4 fake pdf bytes" + bytes(range(200))
-    mock_service = _build_mock_service_nested(
-        payload,
-        filename="statement.pdf",
-        mime_type="application/pdf",
-        attachment_id="att-pdf-123",
-    )
+    mock_service = _build_mock_service(payload)
+
+    def messages_get(**kwargs):
+        mixed_part = {"mimeType": "multipart/mixed"}
+        if kwargs["fields"].count("parts(") >= 2:
+            mixed_part["parts"] = [
+                {
+                    "filename": "statement.pdf",
+                    "mimeType": "application/pdf",
+                    "body": {
+                        "attachmentId": "att-pdf-123",
+                        "size": len(payload),
+                    },
+                }
+            ]
+        return Mock(
+            execute=Mock(
+                return_value={
+                    "payload": {
+                        "mimeType": "multipart/signed",
+                        "parts": [
+                            mixed_part,
+                            {
+                                "filename": "smime.p7s",
+                                "mimeType": "application/pkcs7-signature",
+                                "body": {"attachmentId": "sig-456", "size": 4771},
+                            },
+                        ],
+                    }
+                }
+            )
+        )
+
+    metadata_get = Mock(side_effect=messages_get)
+    mock_service.users().messages().get = metadata_get
 
     result = await _unwrap(get_gmail_attachment_content)(
         service=mock_service,
@@ -334,6 +280,9 @@ async def test_resolves_correct_filename_for_nested_smime_attachment(
 
     assert "Filename: statement.pdf" in result
     assert "smime.p7s" not in result
+    fields = metadata_get.call_args.kwargs["fields"]
+    assert fields.count("parts(") == 6
+    assert "data" not in fields
 
     saved_files = list(isolated_attachment_env.iterdir())
     assert len(saved_files) == 1


### PR DESCRIPTION
## Description
`get_gmail_attachment_content` re-fetches message metadata to resolve the
attachment's filename/MIME type, using a `fields` mask that only requested
one level of `parts`:

```
fields="payload(parts(filename,mimeType,body(attachmentId,size)),body(attachmentId,size),filename,mimeType)"
```

Gmail's partial-response field masks are **not recursive** — any part nested
deeper than that level is silently dropped from the response. On S/MIME-signed
messages the real attachment sits two levels deep
(`multipart/signed` → `multipart/mixed` → the attachment), while the sibling
`smime.p7s` signature part is at the top level. With the mask in place, the
extractor only ever sees `smime.p7s`, and the existing "exactly one
attachment visible" fallback then labels *every* downloaded attachment as
`smime.p7s`, regardless of which attachment was actually requested. The
downloaded bytes are correct — only the reported/saved filename is wrong,
which is a silent misfiling risk for anything that trusts the filename.

**Fix shape**: I initially dropped the `fields` mask entirely, but traced it
back to #415, which added it deliberately (see the code comment it
introduced: *"Use format="full" with fields to limit response to attachment
metadata only"*) — an unrestricted `format="full"` fetch inlines the full
base64 `body.data` for every `text/plain`/`text/html` part, which is real
weight for image-heavy HTML mail and isn't needed just to resolve a
filename. Measured against real messages in my own inbox: full payload
9.9–53KB vs. 0.7–2.5KB with the original (buggy) mask.

So instead of removing the mask, this rebuilds it recursively to depth 6
(`_attachment_metadata_fields()`), which comfortably covers real-world MIME
nesting (S/MIME, forwarded messages, `multipart/related`, etc.) while
keeping the response small — 1.5–4KB in the same measurements, still
5–13x smaller than the full payload. Anything nested deeper than 6 levels
falls back to the existing size/last-resort matching, same as before.

Verified against a real S/MIME-signed message: the attachment id mismatch
reproduced pre-fix and resolved post-fix (filenames + downloaded byte sizes
match the actual attachments), and the recursive mask returns the same MIME
tree shape as an unrestricted fetch for that message.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

Added `test_resolves_correct_filename_for_nested_smime_attachment`, with a
`fields`-aware mock that truncates to whatever depth the `fields` kwarg
actually requests (parsed from the mask string), rather than a hardcoded
depth — so it stays meaningful against the real depth-6 mask instead of only
testing a mock frozen to the old buggy shape. A plain `Mock(return_value=...)`
ignores the `fields` kwarg entirely and can't exercise this bug at all.
Confirmed the test fails against a synthetic depth-1 mask (reproducing the
original bug exactly) and passes at depth-6. Full `tests/gmail/` suite:
163/163 passing. `ruff check` / `ruff format --check` clean.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have enabled "Allow edits from maintainers" for this pull request

## Additional Notes
Fixes #1014 — filed alongside this PR with the full root-cause writeup and
repro steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed attachment downloads for deeply nested and S/MIME Gmail messages.
  - Attachments now retain their correct filenames, extensions, and contents instead of being incorrectly identified as `smime.p7s`.
  - Improved attachment metadata retrieval while avoiding unnecessary message body data, resulting in more efficient downloads.

- **Tests**
  - Added coverage for resolving nested PDF attachments in multipart and S/MIME messages.
  - Updated formatting assertions without changing expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->