### PR TITLE
Add opt-in include_headers to search_gmail_messages

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -1493,9 +1493,15 @@ async def _fetch_search_result_headers(
                     )
                 headers_by_id[mid] = None
             else:
-                headers_by_id[mid] = _extract_headers(
-                    entry["data"].get("payload", {}), GMAIL_METADATA_HEADERS
-                )
+                try:
+                    headers_by_id[mid] = _extract_headers(
+                        entry["data"].get("payload") or {}, GMAIL_METADATA_HEADERS
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        f"[search_gmail_messages] Invalid metadata for message {mid}, will retry: {exc}"
+                    )
+                    headers_by_id[mid] = None
 
     # Retry failures one at a time. Batch failures are usually Gmail's
     # per-user concurrency limit (429), which sequential requests don't hit.
@@ -1513,9 +1519,14 @@ async def _fetch_search_result_headers(
                 log_prefix="search_gmail_messages",
             )
             if msg_data and not error:
-                headers_by_id[mid] = _extract_headers(
-                    msg_data.get("payload", {}), GMAIL_METADATA_HEADERS
-                )
+                try:
+                    headers_by_id[mid] = _extract_headers(
+                        msg_data.get("payload") or {}, GMAIL_METADATA_HEADERS
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        f"[search_gmail_messages] Invalid metadata for message {mid} after retry: {exc}"
+                    )
             else:
                 logger.warning(
                     f"[search_gmail_messages] Metadata fetch failed for message {mid} after retry: {error}"
@@ -1645,8 +1656,9 @@ async def search_gmail_messages(
         page_size (int): The maximum number of messages to return. Defaults to 10.
         page_token (Optional[str]): Token for retrieving the next page of results. Use the next_page_token from a previous response.
         include_headers (bool): If True, also fetch each message's metadata and include
-            Subject, From, and Date per result. Costs one extra batched metadata fetch
-            per page. Defaults to False (output unchanged from prior versions).
+            Subject, From, and Date per result. Costs one metadata get per result,
+            grouped into HTTP batches of up to 10, plus retries for transient failures.
+            Defaults to False (output unchanged from prior versions).
 
     Returns:
         str: LLM-friendly structured results with Message IDs, Thread IDs, and clickable Gmail web interface URLs for each found message.
@@ -1689,7 +1701,15 @@ async def search_gmail_messages(
             for msg in messages
             if msg and isinstance(msg, dict) and msg.get("id")
         ]
-        headers_by_id = await _fetch_search_result_headers(service, result_ids)
+        try:
+            headers_by_id = await _fetch_search_result_headers(service, result_ids)
+        except Exception as exc:
+            logger.exception(
+                "[search_gmail_messages] Header enrichment failed; "
+                "returning search results without headers: %s",
+                exc,
+            )
+            headers_by_id = dict.fromkeys(result_ids)
 
     formatted_output = _format_gmail_results_plain(
         messages, query, next_page_token, headers_by_id

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -69,6 +69,10 @@ from gmail.gmail_helpers import (
 logger = logging.getLogger(__name__)
 
 GMAIL_BATCH_SIZE = 25
+# Smaller chunks for search-result header fetches: the batch endpoint executes
+# every get in a chunk concurrently server-side, and chunks of 25 metadata gets
+# trip Gmail's per-user concurrency limit ("Too many concurrent requests").
+GMAIL_SEARCH_HEADER_BATCH_SIZE = 10
 GMAIL_REQUEST_DELAY = 0.1
 HTML_BODY_TRUNCATE_LIMIT = 20000
 LOW_VALUE_TEXT_PLACEHOLDERS = (
@@ -1430,8 +1434,101 @@ def _generate_gmail_web_url(item_id: str, account_index: int = 0) -> str:
     return f"https://mail.google.com/mail/u/{account_index}/#all/{item_id}"
 
 
+async def _fetch_search_result_headers(
+    service, message_ids: List[str]
+) -> Dict[str, Optional[Dict[str, str]]]:
+    """Fetch metadata headers for search result message IDs.
+
+    Uses the Gmail batch HTTP endpoint (one request per
+    GMAIL_SEARCH_HEADER_BATCH_SIZE chunk, with a delay between chunks),
+    falling back to sequential fetches with a delay if the batch API fails.
+    Messages that fail inside a batch (typically transient per-user
+    concurrency 429s) are retried sequentially afterwards. A message that
+    still cannot be fetched maps to None so the caller can degrade that row
+    instead of failing the whole search.
+    """
+    headers_by_id: Dict[str, Optional[Dict[str, str]]] = {}
+
+    for chunk_start in range(0, len(message_ids), GMAIL_SEARCH_HEADER_BATCH_SIZE):
+        if chunk_start:
+            await asyncio.sleep(GMAIL_REQUEST_DELAY)
+        chunk_ids = message_ids[
+            chunk_start : chunk_start + GMAIL_SEARCH_HEADER_BATCH_SIZE
+        ]
+        results: Dict[str, Dict] = {}
+
+        def _batch_callback(request_id, response, exception):
+            results[request_id] = {"data": response, "error": exception}
+
+        try:
+            batch = service.new_batch_http_request(callback=_batch_callback)
+            for mid in chunk_ids:
+                batch.add(
+                    _build_message_get_request(
+                        service, message_id=mid, message_format="metadata"
+                    ),
+                    request_id=mid,
+                )
+            await asyncio.to_thread(batch.execute)
+        except Exception as batch_error:
+            logger.warning(
+                f"[search_gmail_messages] Batch metadata fetch failed, falling back to sequential processing: {batch_error}"
+            )
+            for mid in chunk_ids:
+                mid_result, msg_data, error = await _fetch_message_with_retry(
+                    service,
+                    message_id=mid,
+                    message_format="metadata",
+                    log_prefix="search_gmail_messages",
+                )
+                results[mid_result] = {"data": msg_data, "error": error}
+                await asyncio.sleep(GMAIL_REQUEST_DELAY)
+
+        for mid in chunk_ids:
+            entry = results.get(mid, {"data": None, "error": "No result"})
+            if entry["error"] or not entry["data"]:
+                if entry["error"]:
+                    logger.debug(
+                        f"[search_gmail_messages] Metadata fetch failed for message {mid}, will retry: {entry['error']}"
+                    )
+                headers_by_id[mid] = None
+            else:
+                headers_by_id[mid] = _extract_headers(
+                    entry["data"].get("payload", {}), GMAIL_METADATA_HEADERS
+                )
+
+    # Retry failures one at a time. Batch failures are usually Gmail's
+    # per-user concurrency limit (429), which sequential requests don't hit.
+    failed_ids = [mid for mid in message_ids if headers_by_id.get(mid) is None]
+    if failed_ids:
+        logger.info(
+            f"[search_gmail_messages] Retrying {len(failed_ids)} failed metadata fetches sequentially"
+        )
+        for mid in failed_ids:
+            await asyncio.sleep(GMAIL_REQUEST_DELAY)
+            _, msg_data, error = await _fetch_message_with_retry(
+                service,
+                message_id=mid,
+                message_format="metadata",
+                log_prefix="search_gmail_messages",
+            )
+            if msg_data and not error:
+                headers_by_id[mid] = _extract_headers(
+                    msg_data.get("payload", {}), GMAIL_METADATA_HEADERS
+                )
+            else:
+                logger.warning(
+                    f"[search_gmail_messages] Metadata fetch failed for message {mid} after retry: {error}"
+                )
+
+    return headers_by_id
+
+
 def _format_gmail_results_plain(
-    messages: list, query: str, next_page_token: Optional[str] = None
+    messages: list,
+    query: str,
+    next_page_token: Optional[str] = None,
+    headers_by_id: Optional[Dict[str, Optional[Dict[str, str]]]] = None,
 ) -> str:
     """Format Gmail search results in clean, LLM-friendly plain text."""
     if not messages:
@@ -1475,9 +1572,23 @@ def _format_gmail_results_plain(
         else:
             thread_url = "N/A"
 
+        lines.append(f"  {i}. Message ID: {message_id}")
+
+        if headers_by_id is not None:
+            headers = headers_by_id.get(message_id)
+            if headers is None:
+                lines.append("     Headers: unavailable (metadata fetch failed)")
+            else:
+                lines.extend(
+                    [
+                        f"     Subject: {headers.get('Subject', '(no subject)')}",
+                        f"     From: {headers.get('From', '(unknown sender)')}",
+                        f"     Date: {headers.get('Date', '(unknown date)')}",
+                    ]
+                )
+
         lines.extend(
             [
-                f"  {i}. Message ID: {message_id}",
                 f"     Web Link: {message_url}",
                 f"     Thread ID: {thread_id}",
                 f"     Thread Link: {thread_url}",
@@ -1521,6 +1632,7 @@ async def search_gmail_messages(
     user_google_email: str,
     page_size: int = 10,
     page_token: Optional[str] = None,
+    include_headers: bool = False,
 ) -> str:
     """
     Searches messages in a user's Gmail account based on a query.
@@ -1532,9 +1644,13 @@ async def search_gmail_messages(
         user_google_email (str): The user's Google email address. Required.
         page_size (int): The maximum number of messages to return. Defaults to 10.
         page_token (Optional[str]): Token for retrieving the next page of results. Use the next_page_token from a previous response.
+        include_headers (bool): If True, also fetch each message's metadata and include
+            Subject, From, and Date per result. Costs one extra batched metadata fetch
+            per page. Defaults to False (output unchanged from prior versions).
 
     Returns:
         str: LLM-friendly structured results with Message IDs, Thread IDs, and clickable Gmail web interface URLs for each found message.
+        With include_headers=True, each result also includes Subject, From, and Date.
         Includes pagination token if more results are available.
     """
     logger.info(
@@ -1566,7 +1682,18 @@ async def search_gmail_messages(
     # Extract next page token for pagination
     next_page_token = response.get("nextPageToken")
 
-    formatted_output = _format_gmail_results_plain(messages, query, next_page_token)
+    headers_by_id: Optional[Dict[str, Optional[Dict[str, str]]]] = None
+    if include_headers and messages:
+        result_ids = [
+            msg["id"]
+            for msg in messages
+            if msg and isinstance(msg, dict) and msg.get("id")
+        ]
+        headers_by_id = await _fetch_search_result_headers(service, result_ids)
+
+    formatted_output = _format_gmail_results_plain(
+        messages, query, next_page_token, headers_by_id
+    )
 
     logger.info(f"[search_gmail_messages] Found {len(messages)} messages")
     if next_page_token:

--- a/tests/gmail/test_search_gmail_messages_headers.py
+++ b/tests/gmail/test_search_gmail_messages_headers.py
@@ -4,7 +4,11 @@ from unittest.mock import Mock
 
 import pytest
 
-from gmail.gmail_tools import search_gmail_messages
+from gmail.gmail_helpers import GMAIL_METADATA_HEADERS
+from gmail.gmail_tools import (
+    GMAIL_SEARCH_HEADER_BATCH_SIZE,
+    search_gmail_messages,
+)
 
 
 def _unwrap(tool):
@@ -37,6 +41,10 @@ class _FakeBatch:
         self._callback = callback
         self._requests = []
 
+    @property
+    def request_ids(self):
+        return [request_id for request_id, _ in self._requests]
+
     def add(self, request, request_id):
         self._requests.append((request_id, request))
 
@@ -53,6 +61,7 @@ def _build_service(*, list_response, message_responses=None, batch_factory=None)
     message_responses = message_responses or {}
 
     service = Mock()
+    batches = []
 
     def message_list(**kwargs):
         request = Mock()
@@ -68,12 +77,25 @@ def _build_service(*, list_response, message_responses=None, batch_factory=None)
             request.execute.return_value = response
         return request
 
+    def recording_batch_factory(callback):
+        batch = _FakeBatch(callback)
+        batches.append(batch)
+        return batch
+
     service.users().messages().list.side_effect = message_list
     service.users().messages().get.side_effect = message_get
-    if batch_factory is None:
-        batch_factory = lambda callback: _FakeBatch(callback)
-    service.new_batch_http_request.side_effect = batch_factory
+    service.new_batch_http_request.side_effect = batch_factory or recording_batch_factory
+    # Batches created during the call, in order, for batch-boundary assertions.
+    service.created_batches = batches
     return service
+
+
+def _get_call_kwargs(service):
+    """All kwargs passed to messages().get(), in call order."""
+    return [
+        call.kwargs
+        for call in service.users.return_value.messages.return_value.get.call_args_list
+    ]
 
 
 def _list_response(message_ids, next_page_token=None):
@@ -168,11 +190,60 @@ async def test_include_headers_returns_subject_sender_and_date():
     assert "Message ID: msg-1" in result
     assert "Thread ID: thread-msg-1" in result
 
-    formats = [
-        call.kwargs["format"]
-        for call in service.users.return_value.messages.return_value.get.call_args_list
+    get_calls = _get_call_kwargs(service)
+    assert [call["format"] for call in get_calls] == ["metadata", "metadata"]
+    # Every fetch must request the metadata header allowlist, which is what
+    # actually makes Subject/From/Date available on the response.
+    for call in get_calls:
+        assert call["metadataHeaders"] == GMAIL_METADATA_HEADERS
+        for required in ("Subject", "From", "Date"):
+            assert required in call["metadataHeaders"]
+
+
+def test_batch_size_stays_under_measured_429_threshold():
+    """Pin the chunk size itself, not just the splitting logic.
+
+    Measured live against a real account: chunks of 25 (the general
+    GMAIL_BATCH_SIZE) returned 429 "Too many concurrent requests for user"
+    for 9 of 50 metadata gets, because the batch endpoint runs every get in
+    a chunk concurrently server-side. Chunks of 10 returned 50/50 clean.
+    Raising this constant back toward 25 reintroduces that failure, so it is
+    asserted here rather than left to a comment.
+    """
+    assert 1 <= GMAIL_SEARCH_HEADER_BATCH_SIZE <= 10
+
+
+@pytest.mark.asyncio
+async def test_header_fetches_are_chunked_at_batch_size(monkeypatch):
+    """Chunking is what keeps us under Gmail's per-user concurrency limit.
+
+    Batches larger than GMAIL_SEARCH_HEADER_BATCH_SIZE reproducibly return
+    429 "Too many concurrent requests for user", so the split must hold.
+    """
+    import gmail.gmail_tools as gmail_tools
+
+    monkeypatch.setattr(gmail_tools, "GMAIL_REQUEST_DELAY", 0)
+
+    message_ids = [f"msg-{i}" for i in range(GMAIL_SEARCH_HEADER_BATCH_SIZE + 1)]
+    service = _build_service(
+        list_response=_list_response(message_ids),
+        message_responses={
+            (mid, "metadata"): _metadata_response(mid) for mid in message_ids
+        },
+    )
+
+    result = await _run_search(service, include_headers=True)
+
+    batch_sizes = [len(batch.request_ids) for batch in service.created_batches]
+    assert batch_sizes == [GMAIL_SEARCH_HEADER_BATCH_SIZE, 1]
+    # Chunk boundaries must not drop or duplicate any ID.
+    batched_ids = [
+        mid for batch in service.created_batches for mid in batch.request_ids
     ]
-    assert formats == ["metadata", "metadata"]
+    assert batched_ids == message_ids
+    assert len(_get_call_kwargs(service)) == len(message_ids)
+    assert "Headers: unavailable" not in result
+    assert result.count("Subject: Example subject") == len(message_ids)
 
 
 @pytest.mark.asyncio

--- a/tests/gmail/test_search_gmail_messages_headers.py
+++ b/tests/gmail/test_search_gmail_messages_headers.py
@@ -1,0 +1,285 @@
+"""Tests for search_gmail_messages header enrichment (include_headers flag)."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from gmail.gmail_tools import search_gmail_messages
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _headers(**overrides):
+    header_map = {
+        "Subject": "Example subject",
+        "From": "sender@example.com",
+        "Date": "Fri, 28 Mar 2026 10:00:00 -0400",
+    }
+    header_map.update(overrides)
+    return [{"name": name, "value": value} for name, value in header_map.items()]
+
+
+def _metadata_response(message_id: str, headers=None):
+    return {
+        "id": message_id,
+        "payload": {"headers": headers or _headers()},
+    }
+
+
+class _FakeBatch:
+    def __init__(self, callback):
+        self._callback = callback
+        self._requests = []
+
+    def add(self, request, request_id):
+        self._requests.append((request_id, request))
+
+    def execute(self):
+        for request_id, request in self._requests:
+            try:
+                response = request.execute()
+                self._callback(request_id, response, None)
+            except Exception as exc:
+                self._callback(request_id, None, exc)
+
+
+def _build_service(*, list_response, message_responses=None, batch_factory=None):
+    message_responses = message_responses or {}
+
+    service = Mock()
+
+    def message_list(**kwargs):
+        request = Mock()
+        request.execute.return_value = list_response
+        return request
+
+    def message_get(**kwargs):
+        request = Mock()
+        response = message_responses[(kwargs["id"], kwargs["format"])]
+        if isinstance(response, Exception):
+            request.execute.side_effect = response
+        else:
+            request.execute.return_value = response
+        return request
+
+    service.users().messages().list.side_effect = message_list
+    service.users().messages().get.side_effect = message_get
+    if batch_factory is None:
+        batch_factory = lambda callback: _FakeBatch(callback)
+    service.new_batch_http_request.side_effect = batch_factory
+    return service
+
+
+def _list_response(message_ids, next_page_token=None):
+    response = {
+        "messages": [
+            {"id": mid, "threadId": f"thread-{mid}"} for mid in message_ids
+        ]
+    }
+    if next_page_token:
+        response["nextPageToken"] = next_page_token
+    return response
+
+
+async def _run_search(service, **kwargs):
+    return await _unwrap(search_gmail_messages)(
+        service=service,
+        query="test query",
+        user_google_email="user@example.com",
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_output_is_unchanged():
+    """include_headers=False (the default) must produce today's exact format."""
+    service = _build_service(list_response=_list_response(["msg-1", "msg-2"]))
+
+    result = await _run_search(service)
+
+    expected = "\n".join(
+        [
+            "Found 2 messages matching 'test query':",
+            "",
+            "📧 MESSAGES:",
+            "  1. Message ID: msg-1",
+            "     Web Link: https://mail.google.com/mail/u/0/#all/msg-1",
+            "     Thread ID: thread-msg-1",
+            "     Thread Link: https://mail.google.com/mail/u/0/#all/thread-msg-1",
+            "",
+            "  2. Message ID: msg-2",
+            "     Web Link: https://mail.google.com/mail/u/0/#all/msg-2",
+            "     Thread ID: thread-msg-2",
+            "     Thread Link: https://mail.google.com/mail/u/0/#all/thread-msg-2",
+            "",
+            "💡 USAGE:",
+            "  • Pass the Message IDs **as a list** to get_gmail_messages_content_batch()",
+            "    e.g. get_gmail_messages_content_batch(message_ids=[...])",
+            "  • Pass the Thread IDs to get_gmail_thread_content() (single) or get_gmail_threads_content_batch() (batch)",
+        ]
+    )
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_default_makes_no_metadata_fetches():
+    service = _build_service(list_response=_list_response(["msg-1"]))
+
+    await _run_search(service)
+
+    assert service.users.return_value.messages.return_value.get.call_count == 0
+    assert service.new_batch_http_request.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_include_headers_returns_subject_sender_and_date():
+    service = _build_service(
+        list_response=_list_response(["msg-1", "msg-2"]),
+        message_responses={
+            ("msg-1", "metadata"): _metadata_response(
+                "msg-1", headers=_headers(Subject="First subject")
+            ),
+            ("msg-2", "metadata"): _metadata_response(
+                "msg-2",
+                headers=_headers(
+                    Subject="Second subject",
+                    From="other@example.com",
+                    Date="Sat, 29 Mar 2026 09:00:00 -0400",
+                ),
+            ),
+        },
+    )
+
+    result = await _run_search(service, include_headers=True)
+
+    assert "Subject: First subject" in result
+    assert "Subject: Second subject" in result
+    assert "From: sender@example.com" in result
+    assert "From: other@example.com" in result
+    assert "Date: Fri, 28 Mar 2026 10:00:00 -0400" in result
+    assert "Date: Sat, 29 Mar 2026 09:00:00 -0400" in result
+    # IDs and links are still present alongside the headers.
+    assert "Message ID: msg-1" in result
+    assert "Thread ID: thread-msg-1" in result
+
+    formats = [
+        call.kwargs["format"]
+        for call in service.users.return_value.messages.return_value.get.call_args_list
+    ]
+    assert formats == ["metadata", "metadata"]
+
+
+@pytest.mark.asyncio
+async def test_partial_metadata_failure_degrades_per_row(monkeypatch):
+    import gmail.gmail_tools as gmail_tools
+
+    monkeypatch.setattr(gmail_tools, "GMAIL_REQUEST_DELAY", 0)
+    service = _build_service(
+        list_response=_list_response(["msg-1", "msg-2"]),
+        message_responses={
+            ("msg-1", "metadata"): _metadata_response("msg-1"),
+            ("msg-2", "metadata"): Exception("boom"),
+        },
+    )
+
+    result = await _run_search(service, include_headers=True)
+
+    assert "Subject: Example subject" in result
+    assert "Headers: unavailable (metadata fetch failed)" in result
+    # The failing message's row survives with its IDs intact.
+    assert "Message ID: msg-2" in result
+    assert "Thread ID: thread-msg-2" in result
+
+
+@pytest.mark.asyncio
+async def test_transient_batch_failure_recovers_on_retry(monkeypatch):
+    """A 429 inside the batch is retried sequentially and recovers."""
+    import gmail.gmail_tools as gmail_tools
+
+    monkeypatch.setattr(gmail_tools, "GMAIL_REQUEST_DELAY", 0)
+
+    calls = {"count": 0}
+
+    def flaky_get(**kwargs):
+        request = Mock()
+        calls["count"] += 1
+        if calls["count"] == 1:
+            request.execute.side_effect = Exception(
+                "429 Too many concurrent requests for user."
+            )
+        else:
+            request.execute.return_value = _metadata_response("msg-1")
+        return request
+
+    service = _build_service(list_response=_list_response(["msg-1"]))
+    service.users().messages().get.side_effect = flaky_get
+
+    result = await _run_search(service, include_headers=True)
+
+    assert "Subject: Example subject" in result
+    assert "Headers: unavailable" not in result
+    assert calls["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_missing_headers_use_placeholders():
+    service = _build_service(
+        list_response=_list_response(["msg-1"]),
+        message_responses={
+            ("msg-1", "metadata"): {"id": "msg-1", "payload": {"headers": []}},
+        },
+    )
+
+    result = await _run_search(service, include_headers=True)
+
+    assert "Subject: (no subject)" in result
+    assert "From: (unknown sender)" in result
+    assert "Date: (unknown date)" in result
+
+
+@pytest.mark.asyncio
+async def test_pagination_preserved_with_include_headers():
+    service = _build_service(
+        list_response=_list_response(["msg-1"], next_page_token="tok-123"),
+        message_responses={
+            ("msg-1", "metadata"): _metadata_response("msg-1"),
+        },
+    )
+
+    result = await _run_search(service, include_headers=True, page_token="tok-000")
+
+    assert "page_token='tok-123'" in result
+    assert "Subject: Example subject" in result
+    list_kwargs = (
+        service.users.return_value.messages.return_value.list.call_args.kwargs
+    )
+    assert list_kwargs["pageToken"] == "tok-000"
+
+
+@pytest.mark.asyncio
+async def test_batch_failure_falls_back_to_sequential(monkeypatch):
+    import gmail.gmail_tools as gmail_tools
+
+    monkeypatch.setattr(gmail_tools, "GMAIL_REQUEST_DELAY", 0)
+
+    def _broken_batch(callback):
+        raise RuntimeError("batch endpoint unavailable")
+
+    service = _build_service(
+        list_response=_list_response(["msg-1"]),
+        message_responses={
+            ("msg-1", "metadata"): _metadata_response("msg-1"),
+        },
+        batch_factory=_broken_batch,
+    )
+
+    result = await _run_search(service, include_headers=True)
+
+    assert "Subject: Example subject" in result
+    assert "From: sender@example.com" in result

--- a/tests/gmail/test_search_gmail_messages_headers.py
+++ b/tests/gmail/test_search_gmail_messages_headers.py
@@ -84,7 +84,9 @@ def _build_service(*, list_response, message_responses=None, batch_factory=None)
 
     service.users().messages().list.side_effect = message_list
     service.users().messages().get.side_effect = message_get
-    service.new_batch_http_request.side_effect = batch_factory or recording_batch_factory
+    service.new_batch_http_request.side_effect = (
+        batch_factory or recording_batch_factory
+    )
     # Batches created during the call, in order, for batch-boundary assertions.
     service.created_batches = batches
     return service
@@ -100,9 +102,7 @@ def _get_call_kwargs(service):
 
 def _list_response(message_ids, next_page_token=None):
     response = {
-        "messages": [
-            {"id": mid, "threadId": f"thread-{mid}"} for mid in message_ids
-        ]
+        "messages": [{"id": mid, "threadId": f"thread-{mid}"} for mid in message_ids]
     }
     if next_page_token:
         response["nextPageToken"] = next_page_token
@@ -315,6 +315,43 @@ async def test_missing_headers_use_placeholders():
 
 
 @pytest.mark.asyncio
+async def test_malformed_metadata_degrades_per_row(monkeypatch):
+    import gmail.gmail_tools as gmail_tools
+
+    monkeypatch.setattr(gmail_tools, "GMAIL_REQUEST_DELAY", 0)
+    service = _build_service(
+        list_response=_list_response(["msg-1"]),
+        message_responses={
+            ("msg-1", "metadata"): {"id": "msg-1", "payload": None},
+        },
+    )
+
+    result = await _run_search(service, include_headers=True)
+
+    assert "Subject: (no subject)" in result
+    assert "From: (unknown sender)" in result
+    assert "Date: (unknown date)" in result
+    assert "Message ID: msg-1" in result
+
+
+@pytest.mark.asyncio
+async def test_unexpected_enrichment_failure_preserves_search_results(monkeypatch):
+    import gmail.gmail_tools as gmail_tools
+
+    async def fail_enrichment(service, message_ids):
+        raise RuntimeError("unexpected enrichment failure")
+
+    monkeypatch.setattr(gmail_tools, "_fetch_search_result_headers", fail_enrichment)
+    service = _build_service(list_response=_list_response(["msg-1"]))
+
+    result = await _run_search(service, include_headers=True)
+
+    assert "Headers: unavailable (metadata fetch failed)" in result
+    assert "Message ID: msg-1" in result
+    assert "Thread ID: thread-msg-1" in result
+
+
+@pytest.mark.asyncio
 async def test_pagination_preserved_with_include_headers():
     service = _build_service(
         list_response=_list_response(["msg-1"], next_page_token="tok-123"),
@@ -327,9 +364,7 @@ async def test_pagination_preserved_with_include_headers():
 
     assert "page_token='tok-123'" in result
     assert "Subject: Example subject" in result
-    list_kwargs = (
-        service.users.return_value.messages.return_value.list.call_args.kwargs
-    )
+    list_kwargs = service.users.return_value.messages.return_value.list.call_args.kwargs
     assert list_kwargs["pageToken"] == "tok-000"
 
 


### PR DESCRIPTION
## What this adds

`search_gmail_messages` returns only message IDs, thread IDs and web links. To see what any result actually is, the caller has to make a second content call. This PR adds an opt-in `include_headers: bool = False` parameter. When set, each result row also carries Subject, From and Date, fetched with `format="metadata"`.

Default behavior is byte-identical to today, proven by an exact-string test, so nothing that already calls this tool changes.

Example output with `include_headers=True`:

```
  1. Message ID: 19ff62ef39bdb48b
     Subject: Fwd: Alliance Shippers reefer containers, next steps
     From: Erik Holzhauer <erik.holzhauer@purplewave.com>
     Date: Wed, 12 Aug 2026 07:35:00 -0600
     Web Link: https://mail.google.com/mail/u/0/#all/19ff62ef39bdb48b
     Thread ID: ...
     Thread Link: ...
```

## Implementation

Reuses the existing fetch machinery rather than adding new: `_build_message_get_request(..., "metadata")`, `_fetch_message_with_retry`, `_extract_headers` and `GMAIL_METADATA_HEADERS`.

Headers are fetched through the Gmail batch HTTP endpoint. One finding worth flagging: chunks of 25 (the existing `GMAIL_BATCH_SIZE`) reproducibly trip Gmail's per-user concurrency limit on a 50-result page, returning 429 "Too many concurrent requests for user" for some gets, because the batch endpoint executes every get in a chunk concurrently server-side. This helper therefore uses chunks of 10 (`GMAIL_SEARCH_HEADER_BATCH_SIZE`) with `GMAIL_REQUEST_DELAY` between chunks, and retries any remaining failures sequentially, which clears transient concurrency 429s.

A message whose metadata still cannot be fetched degrades to a `Headers: unavailable` line for that row. The search itself never fails because of header enrichment.

## Testing

- 8 new tests in `tests/gmail/test_search_gmail_messages_headers.py`: exact byte-identical default output, zero extra API calls when off, headers when on, per-row degradation on partial failure, placeholder headers, pagination with the flag set, batch API fallback to sequential, and 429-then-retry recovery.
- Full `tests/gmail/` suite passes (170 tests on this branch).
- Verified live against a real account: two 50-result pages, 50/50 headers returned in under 2.3s, no 429s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gmail search results can optionally include each message’s subject, sender, and date.
  * Results remain unchanged by default unless header details are requested.
  * Unavailable message details are clearly indicated when metadata cannot be retrieved.

* **Bug Fixes**
  * Improved reliability of Gmail message-detail retrieval through batching, retries, and fallback handling.
  * Preserved pagination and search results when individual metadata requests fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->