### PR TITLE
fix: OAuth2.1 Secretless public client mode 

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,16 +187,17 @@ uvx workspace-mcp --tools gmail drive calendar
 </td>
 <td valign="top" width="50%">
 
-**Secretless / Public OAuth 2.1 (PKCE)**
+**OAuth 2.1 (PKCE)**
 
 ```bash
-# 1. Credentials
+# 1. Credentials - MCP clients connect with PKCE and no
+#    secret, but Google still requires one server-side
 export MCP_ENABLE_OAUTH21=true
 export GOOGLE_OAUTH_CLIENT_ID="..."
+export GOOGLE_OAUTH_CLIENT_SECRET="..."
 export WORKSPACE_MCP_PORT=8000
 export GOOGLE_OAUTH_REDIRECT_URI="http://localhost:${WORKSPACE_MCP_PORT}/oauth2callback"
 export OAUTHLIB_INSECURE_TRANSPORT=1
-export FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY="$(openssl rand -hex 32)"
 
 # 2. Launch - OAuth 2.1 requires HTTP transport
 uvx workspace-mcp --transport streamable-http --tool-tier core

--- a/core/server.py
+++ b/core/server.py
@@ -427,6 +427,18 @@ def configure_server_for_http():
                 "protocol authentication can be configured."
             )
 
+        if not config.client_secret and not config.is_external_oauth21_provider():
+            # MCP clients stay secretless, but this server performs the Google code
+            # exchange itself and Google requires a secret for it. Fail here instead
+            # of at the last step of the user's browser flow.
+            raise RuntimeError(
+                "OAuth 2.1 requires GOOGLE_OAUTH_CLIENT_SECRET: Google rejects the "
+                "authorization code exchange without a client secret (invalid_request: "
+                "client_secret is missing), even for public clients using PKCE. Set "
+                "GOOGLE_OAUTH_CLIENT_SECRET, or set EXTERNAL_OAUTH21_PROVIDER=true if "
+                "another identity provider performs the code exchange."
+            )
+
         def validate_and_derive_jwt_key(
             jwt_signing_key_override: str | None, client_secret: str | None
         ) -> bytes:

--- a/tests/core/test_http_oauth_scope_config.py
+++ b/tests/core/test_http_oauth_scope_config.py
@@ -140,7 +140,7 @@ def test_configure_server_for_http_rejects_google_provider_without_client_secret
         server_module.configure_server_for_http()
 
 
-def test_configure_server_for_http_rejects_public_client_without_jwt_key(
+def test_configure_server_for_http_rejects_external_provider_without_jwt_key(
     monkeypatch,
 ):
     monkeypatch.delenv("FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY", raising=False)

--- a/tests/core/test_http_oauth_scope_config.py
+++ b/tests/core/test_http_oauth_scope_config.py
@@ -109,36 +109,19 @@ def test_configure_server_for_http_uses_protocol_auth_required_scopes(monkeypatc
     )
 
 
-def test_configure_server_for_http_supports_public_client_with_jwt_key(monkeypatch):
-    captured = {}
-
-    class FakeGoogleProvider:
-        def __init__(self, **kwargs):
-            captured.update(kwargs)
-            self.client_registration_options = SimpleNamespace(
-                valid_scopes=kwargs.get("valid_scopes"),
-                default_scopes=None,
-            )
-
+def test_configure_server_for_http_rejects_google_provider_without_client_secret(
+    monkeypatch,
+):
+    """Google rejects the code exchange without a secret, so startup must fail first."""
     monkeypatch.setenv(
         "FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY",
         "this-is-a-long-enough-jwt-signing-key",
     )
     monkeypatch.setattr(server_module, "get_transport_mode", lambda: "streamable-http")
-    monkeypatch.setattr(server_module, "GoogleProvider", FakeGoogleProvider)
-    monkeypatch.setattr(
-        server_module,
-        "get_current_scopes",
-        lambda: [
-            "https://www.googleapis.com/auth/userinfo.profile",
-            "https://www.googleapis.com/auth/userinfo.email",
-            "openid",
-        ],
-    )
+    monkeypatch.setattr(server_module, "GoogleProvider", object)
     monkeypatch.setattr(server_module, "set_auth_provider", lambda provider: None)
     monkeypatch.setattr(server_module, "_auth_provider", server_module._auth_provider)
     monkeypatch.setattr(server_module.server, "auth", server_module.server.auth)
-
     monkeypatch.setattr(
         "auth.oauth_config.get_oauth_config",
         lambda: SimpleNamespace(
@@ -153,11 +136,8 @@ def test_configure_server_for_http_supports_public_client_with_jwt_key(monkeypat
         ),
     )
 
-    server_module.configure_server_for_http()
-
-    assert captured["client_id"] == "public-client-id"
-    assert captured["client_secret"] is None
-    assert captured["jwt_signing_key"]
+    with pytest.raises(RuntimeError, match="requires GOOGLE_OAUTH_CLIENT_SECRET"):
+        server_module.configure_server_for_http()
 
 
 def test_configure_server_for_http_rejects_public_client_without_jwt_key(
@@ -175,7 +155,7 @@ def test_configure_server_for_http_rejects_public_client_without_jwt_key(
             is_oauth21_enabled=lambda: True,
             is_configured=lambda: True,
             is_public_client=lambda: True,
-            is_external_oauth21_provider=lambda: False,
+            is_external_oauth21_provider=lambda: True,
             client_id="public-client-id",
             client_secret=None,
             get_oauth_base_url=lambda: "https://workspace-mcp.example.test",


### PR DESCRIPTION
Closes: #1008 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth 2.1 startup now clearly reports a configuration error when a Google client secret is missing.
  * External OAuth 2.1 providers can continue using PKCE without a client secret.
  * Improved guidance in the startup error explains the required configuration and Google’s secret requirement.

* **Documentation**
  * Updated the OAuth 2.1 quick-start guidance to distinguish PKCE client behavior from Google’s server-side secret requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->