### PR TITLE
fix(calendar): include deterministic weekdays in event times

### DIFF
--- a/gcalendar/calendar_helpers.py
+++ b/gcalendar/calendar_helpers.py
@@ -5,10 +5,43 @@ This module provides utility functions for formatting Google Calendar
 event data for display.
 """
 
+import datetime
 import logging
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+_WEEKDAYS = (
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+)
+
+
+def _format_event_time(item: Dict[str, Any], field: str) -> str:
+    """Format one raw Google event boundary with offset-local weekday evidence."""
+    boundary = item[field]
+    value = boundary.get("dateTime", boundary.get("date"))
+    if not isinstance(value, str):
+        return str(value)
+    try:
+        if "T" in value:
+            local_date = datetime.datetime.fromisoformat(
+                value.replace("Z", "+00:00")
+            ).date()
+        else:
+            local_date = datetime.date.fromisoformat(value)
+    except ValueError:
+        return value
+    iso_weekday = local_date.isoweekday()
+    evidence = f"weekday: {_WEEKDAYS[iso_weekday - 1]}; ISO weekday: {iso_weekday}"
+    if field == "end" and "date" in boundary and "dateTime" not in boundary:
+        evidence += "; exclusive all-day end"
+    return f"{value} [{evidence}]"
 
 
 def _get_meeting_link(item: Dict[str, Any]) -> str:

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -20,6 +20,7 @@ from auth.service_decorator import require_google_service
 from core.utils import handle_http_errors, StringList
 from gcalendar.calendar_helpers import (
     _format_event_detail_lines,
+    _format_event_time,
     _get_meeting_link,
 )
 
@@ -467,8 +468,8 @@ async def get_events(
     if event_id and detailed:
         item = items[0]
         summary = item.get("summary", "No Title")
-        start = item["start"].get("dateTime", item["start"].get("date"))
-        end = item["end"].get("dateTime", item["end"].get("date"))
+        start = _format_event_time(item, "start")
+        end = _format_event_time(item, "end")
         link = item.get("htmlLink", "No Link")
 
         event_details = (
@@ -490,8 +491,8 @@ async def get_events(
     event_details_list = []
     for item in items:
         summary = item.get("summary", "No Title")
-        start_time = item["start"].get("dateTime", item["start"].get("date"))
-        end_time = item["end"].get("dateTime", item["end"].get("date"))
+        start_time = _format_event_time(item, "start")
+        end_time = _format_event_time(item, "end")
         link = item.get("htmlLink", "No Link")
         item_event_id = item.get("id", "No ID")
 

--- a/tests/gcalendar/test_get_events_detailed_fields.py
+++ b/tests/gcalendar/test_get_events_detailed_fields.py
@@ -59,9 +59,35 @@ async def _single_detail(item):
     )
 
 
+async def _ranged_basic(item):
+    """Basic output via the time_min/time_max branch."""
+    return await _unwrap(get_events)(
+        service=_mock_service([item]),
+        user_google_email="user@example.com",
+        time_min="2026-04-06T00:00:00Z",
+        time_max="2026-04-07T00:00:00Z",
+        detailed=False,
+    )
+
+
+async def _single_basic(item):
+    """Basic output via the event_id branch."""
+    return await _unwrap(get_events)(
+        service=_mock_service([item]),
+        user_google_email="user@example.com",
+        event_id=item["id"],
+        detailed=False,
+    )
+
+
 # Every test runs through both formatters. Their disagreement was the bug.
 both_branches = pytest.mark.parametrize(
     "detail", [_ranged_detail, _single_detail], ids=["ranged", "single"]
+)
+all_get_paths = pytest.mark.parametrize(
+    "read",
+    [_ranged_basic, _single_basic, _ranged_detail, _single_detail],
+    ids=["ranged-basic", "single-basic", "ranged-detailed", "single-detailed"],
 )
 
 RECURRING_INSTANCE = {
@@ -188,3 +214,65 @@ async def test_basic_ranged_output_is_unchanged():
 
     assert "Color ID" not in result
     assert "Recurring Event ID" not in result
+
+
+@pytest.mark.asyncio
+@all_get_paths
+@pytest.mark.parametrize(
+    "item,start_evidence,end_evidence",
+    [
+        (
+            {
+                **ORDINARY_MEETING,
+                "start": {"dateTime": "2026-08-20T17:15:00+02:00"},
+                "end": {"dateTime": "2026-08-20T18:00:00+02:00"},
+            },
+            "2026-08-20T17:15:00+02:00 [weekday: Thursday; ISO weekday: 4]",
+            "2026-08-20T18:00:00+02:00 [weekday: Thursday; ISO weekday: 4]",
+        ),
+        (
+            {
+                **ORDINARY_MEETING,
+                "start": {"dateTime": "2026-08-20T00:15:00+14:00"},
+                "end": {"dateTime": "2026-08-19T23:45:00-10:00"},
+            },
+            "2026-08-20T00:15:00+14:00 [weekday: Thursday; ISO weekday: 4]",
+            "2026-08-19T23:45:00-10:00 [weekday: Wednesday; ISO weekday: 3]",
+        ),
+        (
+            {
+                **ORDINARY_MEETING,
+                "start": {"dateTime": "2026-03-29T01:30:00+01:00"},
+                "end": {"dateTime": "2026-03-29T03:30:00+02:00"},
+            },
+            "2026-03-29T01:30:00+01:00 [weekday: Sunday; ISO weekday: 7]",
+            "2026-03-29T03:30:00+02:00 [weekday: Sunday; ISO weekday: 7]",
+        ),
+        (
+            {
+                **ORDINARY_MEETING,
+                "start": {"dateTime": "2026-08-20T23:30:00Z"},
+                "end": {"dateTime": "2026-08-21T00:30:00Z"},
+            },
+            "2026-08-20T23:30:00Z [weekday: Thursday; ISO weekday: 4]",
+            "2026-08-21T00:30:00Z [weekday: Friday; ISO weekday: 5]",
+        ),
+        (
+            {
+                **ALL_FIELDS_INSTANCE,
+                "start": {"date": "2026-08-20"},
+                "end": {"date": "2026-08-22"},
+            },
+            "2026-08-20 [weekday: Thursday; ISO weekday: 4]",
+            "2026-08-22 [weekday: Saturday; ISO weekday: 6; exclusive all-day end]",
+        ),
+    ],
+    ids=["timed", "offset-crossing", "dst-offsets", "z", "all-day"],
+)
+async def test_get_events_always_retains_raw_times_with_deterministic_weekdays(
+    read, item, start_evidence, end_evidence
+):
+    result = await read(item)
+
+    assert f"Starts: {start_evidence}" in result
+    assert f"Ends: {end_evidence}" in result


### PR DESCRIPTION
## Summary

- retain each raw Google Calendar start/end value and append the weekday derived from that value's own RFC 3339 offset or all-day date
- include both the English weekday and ISO weekday number across single/ranged and basic/detailed `get_events` output paths
- explicitly label Google all-day end dates as exclusive
- keep malformed values unchanged instead of guessing or using the server timezone

## Why

Calendar timestamps can cross UTC and local date boundaries. Supplying deterministic offset-local weekday evidence prevents consumers from deriving the wrong weekday from server time or an implicit timezone.

Example: `2026-08-20T17:15:00+02:00` is emitted as Thursday / ISO weekday 4 while retaining the raw timestamp.

## Tests

Focused parametrized coverage exercises all four `get_events` formatting paths for:

- timed explicit-offset values
- `Z` timestamps
- offset-local date crossings
- DST-relevant `+01:00` / `+02:00` values
- all-day dates with exclusive end labeling
- single-event and ranged-query parity

The contribution is provider-generic and contains no Aiden-specific code.