### PR TITLE
fix(attachments): expire stored files by mtime so a restart stops orphaning them

### DIFF
--- a/core/attachment_storage.py
+++ b/core/attachment_storage.py
@@ -198,14 +198,12 @@ class AttachmentStorage:
         file_path = STORAGE_DIR / save_name
 
         try:
+            # Publish with a fresh mtime so a concurrent sweep cannot expire it.
+            os.utime(src_path, None)
             # shutil.move degrades to a streamed copy across filesystems, so it
             # stays memory-safe when the temp dir is on another mount.
             shutil.move(str(src_path), str(file_path))
             os.chmod(file_path, 0o600)
-            # A move can preserve the source timestamp. Expiry is keyed to the
-            # time the file enters attachment storage, not when the source was
-            # originally created or last written.
-            os.utime(file_path, None)
             size = file_path.stat().st_size
             logger.info(
                 f"Saved attachment file_id={file_id} filename={filename or save_name} "
@@ -318,18 +316,7 @@ class AttachmentStorage:
             del self._metadata[file_id]
 
     def sweep_expired(self) -> int:
-        """
-        Remove stored files older than the expiration window, using mtime only.
-
-        ``self._metadata`` is the only other record of when a file expires, and
-        it starts empty in a new process. Anything written before a restart is
-        therefore unreachable by the metadata-driven cleanup and would stay on
-        disk forever. Dating files by mtime keeps expiry working across restarts,
-        and also covers files that are simply never requested again.
-
-        Returns:
-            Number of files removed
-        """
+        """Remove files older than the expiration window based on mtime."""
         cutoff = time.time() - self.expiration_seconds
         swept: set[str] = set()
 
@@ -345,13 +332,10 @@ class AttachmentStorage:
                         continue
                     path.unlink()
                 except OSError as e:
-                    # One locked or unreadable entry must not abandon the rest.
                     logger.warning(f"Failed to remove expired attachment {path}: {e}")
                     continue
                 swept.add(str(path))
         except OSError as e:
-            # Cleanup is best-effort and must never make attachment storage
-            # unavailable when the directory cannot be enumerated.
             logger.warning(f"Failed to scan attachment storage {STORAGE_DIR}: {e}")
 
         if swept:
@@ -383,8 +367,6 @@ class AttachmentStorage:
         for file_id in expired_ids:
             self._cleanup_file(file_id)
 
-        # Files this process never recorded (written before a restart, or left
-        # behind by a failed save) are only reachable through the disk sweep.
         return len(expired_ids) + self.sweep_expired()
 
 
@@ -397,9 +379,6 @@ def get_attachment_storage() -> AttachmentStorage:
     global _attachment_storage
     if _attachment_storage is None:
         _attachment_storage = AttachmentStorage()
-    # Sweep on every acquisition so a previous process's still-fresh files are
-    # reconsidered once they cross the expiration boundary. Callers acquire the
-    # singleton once per attachment operation, so no background task is needed.
     _attachment_storage.sweep_expired()
     return _attachment_storage
 

--- a/core/attachment_storage.py
+++ b/core/attachment_storage.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import shutil
+import time
 import unicodedata
 import uuid
 from pathlib import Path
@@ -312,6 +313,50 @@ class AttachmentStorage:
                 logger.warning(f"Failed to delete attachment file {file_path}: {e}")
             del self._metadata[file_id]
 
+    def sweep_expired(self) -> int:
+        """
+        Remove stored files older than the expiration window, using mtime only.
+
+        ``self._metadata`` is the only other record of when a file expires, and
+        it starts empty in a new process. Anything written before a restart is
+        therefore unreachable by the metadata-driven cleanup and would stay on
+        disk forever. Dating files by mtime keeps expiry working across restarts,
+        and also covers files that are simply never requested again.
+
+        Returns:
+            Number of files removed
+        """
+        if not STORAGE_DIR.exists():
+            return 0
+
+        cutoff = time.time() - self.expiration_seconds
+        swept: set[str] = set()
+
+        for path in STORAGE_DIR.iterdir():
+            try:
+                if not path.is_file():
+                    continue
+                if path.stat().st_mtime >= cutoff:
+                    continue
+                path.unlink()
+            except OSError as e:
+                # One locked or unreadable entry must not abandon the rest.
+                logger.warning(f"Failed to remove expired attachment {path}: {e}")
+                continue
+            swept.add(str(path))
+
+        if swept:
+            stale_ids = [
+                file_id
+                for file_id, metadata in self._metadata.items()
+                if metadata["file_path"] in swept
+            ]
+            for file_id in stale_ids:
+                del self._metadata[file_id]
+            logger.info(f"Swept {len(swept)} expired attachment(s) from {STORAGE_DIR}")
+
+        return len(swept)
+
     def cleanup_expired(self) -> int:
         """
         Clean up expired attachments.
@@ -329,7 +374,9 @@ class AttachmentStorage:
         for file_id in expired_ids:
             self._cleanup_file(file_id)
 
-        return len(expired_ids)
+        # Files this process never recorded (written before a restart, or left
+        # behind by a failed save) are only reachable through the disk sweep.
+        return len(expired_ids) + self.sweep_expired()
 
 
 # Global instance
@@ -341,6 +388,9 @@ def get_attachment_storage() -> AttachmentStorage:
     global _attachment_storage
     if _attachment_storage is None:
         _attachment_storage = AttachmentStorage()
+        # First use in a process is the only opportunity to reclaim whatever the
+        # previous one left behind, since _metadata starts empty.
+        _attachment_storage.sweep_expired()
     return _attachment_storage
 
 

--- a/core/attachment_storage.py
+++ b/core/attachment_storage.py
@@ -202,6 +202,10 @@ class AttachmentStorage:
             # stays memory-safe when the temp dir is on another mount.
             shutil.move(str(src_path), str(file_path))
             os.chmod(file_path, 0o600)
+            # A move can preserve the source timestamp. Expiry is keyed to the
+            # time the file enters attachment storage, not when the source was
+            # originally created or last written.
+            os.utime(file_path, None)
             size = file_path.stat().st_size
             logger.info(
                 f"Saved attachment file_id={file_id} filename={filename or save_name} "
@@ -326,24 +330,29 @@ class AttachmentStorage:
         Returns:
             Number of files removed
         """
-        if not STORAGE_DIR.exists():
-            return 0
-
         cutoff = time.time() - self.expiration_seconds
         swept: set[str] = set()
 
-        for path in STORAGE_DIR.iterdir():
-            try:
-                if not path.is_file():
+        try:
+            if not STORAGE_DIR.exists():
+                return 0
+
+            for path in STORAGE_DIR.iterdir():
+                try:
+                    if not path.is_file():
+                        continue
+                    if path.stat().st_mtime >= cutoff:
+                        continue
+                    path.unlink()
+                except OSError as e:
+                    # One locked or unreadable entry must not abandon the rest.
+                    logger.warning(f"Failed to remove expired attachment {path}: {e}")
                     continue
-                if path.stat().st_mtime >= cutoff:
-                    continue
-                path.unlink()
-            except OSError as e:
-                # One locked or unreadable entry must not abandon the rest.
-                logger.warning(f"Failed to remove expired attachment {path}: {e}")
-                continue
-            swept.add(str(path))
+                swept.add(str(path))
+        except OSError as e:
+            # Cleanup is best-effort and must never make attachment storage
+            # unavailable when the directory cannot be enumerated.
+            logger.warning(f"Failed to scan attachment storage {STORAGE_DIR}: {e}")
 
         if swept:
             stale_ids = [
@@ -388,9 +397,10 @@ def get_attachment_storage() -> AttachmentStorage:
     global _attachment_storage
     if _attachment_storage is None:
         _attachment_storage = AttachmentStorage()
-        # First use in a process is the only opportunity to reclaim whatever the
-        # previous one left behind, since _metadata starts empty.
-        _attachment_storage.sweep_expired()
+    # Sweep on every acquisition so a previous process's still-fresh files are
+    # reconsidered once they cross the expiration boundary. Callers acquire the
+    # singleton once per attachment operation, so no background task is needed.
+    _attachment_storage.sweep_expired()
     return _attachment_storage
 
 

--- a/tests/core/test_attachment_storage.py
+++ b/tests/core/test_attachment_storage.py
@@ -113,6 +113,17 @@ class TestSaveAttachmentFromPath:
         assert Path(saved.path).read_bytes() == b"payload"
         assert not src.exists()
 
+    def test_resets_source_mtime_when_moving_into_storage(self, storage, tmp_path):
+        src = self._source(tmp_path)
+        past = time.time() - 7200
+        os.utime(src, (past, past))
+
+        saved = storage.save_attachment_from_path(str(src), filename="clip.mp4")
+
+        assert Path(saved.path).stat().st_mtime > past
+        assert storage.sweep_expired() == 0
+        assert Path(saved.path).exists()
+
     def test_stored_file_is_owner_only(self, storage, tmp_path):
         src = self._source(tmp_path)
 
@@ -149,7 +160,7 @@ class TestSaveAttachmentFromPath:
 
         assert Path(saved.path).name == f"{saved.file_id}.pdf"
 
-    @pytest.mark.parametrize("failure_point", ("chmod", "record"))
+    @pytest.mark.parametrize("failure_point", ("chmod", "utime", "record"))
     def test_removes_partially_saved_file_when_finalizing_fails(
         self, storage, tmp_path, monkeypatch, failure_point
     ):
@@ -159,6 +170,8 @@ class TestSaveAttachmentFromPath:
         error = OSError("nope")
         if failure_point == "chmod":
             monkeypatch.setattr(attachment_storage.os, "chmod", Mock(side_effect=error))
+        elif failure_point == "utime":
+            monkeypatch.setattr(attachment_storage.os, "utime", Mock(side_effect=error))
         else:
             monkeypatch.setattr(storage, "_record", Mock(side_effect=error))
 
@@ -251,8 +264,8 @@ class TestSweepExpired:
         assert storage.sweep_expired() == 1
 
 
-class TestGetAttachmentStorageSweepsOnCreate:
-    """A restart is the only chance to reclaim what the previous process left."""
+class TestGetAttachmentStorageSweeps:
+    """Singleton access reclaims files left by previous processes."""
 
     def test_singleton_creation_sweeps_orphans(self, tmp_path, monkeypatch):
         monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path / "attachments")
@@ -266,3 +279,52 @@ class TestGetAttachmentStorageSweepsOnCreate:
         attachment_storage.get_attachment_storage()
 
         assert not stale.exists()
+
+    def test_later_access_reconsiders_files_kept_on_first_sweep(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path / "attachments")
+        monkeypatch.setattr(attachment_storage, "_attachment_storage", None)
+        attachment_storage._ensure_storage_dir()
+        orphan = attachment_storage.STORAGE_DIR / "previous-process.bin"
+        orphan.write_bytes(b"payload")
+
+        first = attachment_storage.get_attachment_storage()
+        assert orphan.exists()
+
+        past = time.time() - 7200
+        os.utime(orphan, (past, past))
+        second = attachment_storage.get_attachment_storage()
+
+        assert first is second
+        assert not orphan.exists()
+
+    def test_scan_failure_is_best_effort_and_retried(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path / "attachments")
+        monkeypatch.setattr(attachment_storage, "_attachment_storage", None)
+        attachment_storage._ensure_storage_dir()
+        stale = attachment_storage.STORAGE_DIR / "stale.bin"
+        stale.write_bytes(b"payload")
+        past = time.time() - 7200
+        os.utime(stale, (past, past))
+
+        real_iterdir = Path.iterdir
+        calls = {"n": 0}
+
+        def flaky_iterdir(self):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("permission denied")
+            return real_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", flaky_iterdir)
+
+        first = attachment_storage.get_attachment_storage()
+        assert stale.exists()
+        second = attachment_storage.get_attachment_storage()
+
+        assert first is second
+        assert not stale.exists()
+        assert "Failed to scan attachment storage" in caplog.text

--- a/tests/core/test_attachment_storage.py
+++ b/tests/core/test_attachment_storage.py
@@ -113,7 +113,7 @@ class TestSaveAttachmentFromPath:
         assert Path(saved.path).read_bytes() == b"payload"
         assert not src.exists()
 
-    def test_resets_source_mtime_when_moving_into_storage(self, storage, tmp_path):
+    def test_refreshes_source_mtime_before_moving_into_storage(self, storage, tmp_path):
         src = self._source(tmp_path)
         past = time.time() - 7200
         os.utime(src, (past, past))
@@ -183,7 +183,7 @@ class TestSaveAttachmentFromPath:
 
 
 class TestSweepExpired:
-    """Expiry has to survive a restart, so it must be derivable from disk alone."""
+    """Tests for mtime-based expiry."""
 
     @pytest.fixture
     def storage(self, tmp_path, monkeypatch):
@@ -192,8 +192,7 @@ class TestSweepExpired:
 
     @staticmethod
     def _orphan(name="orphan.bin", age_seconds=0):
-        """Write a file straight into storage with no metadata entry, as a
-        previous process would have left behind."""
+        """Write a file without a metadata entry."""
         attachment_storage._ensure_storage_dir()
         path = attachment_storage.STORAGE_DIR / name
         path.write_bytes(b"payload")
@@ -203,8 +202,6 @@ class TestSweepExpired:
         return path
 
     def test_removes_orphaned_file_past_expiration(self, storage):
-        # The restart case: the file outlived the process that recorded it, so
-        # _metadata knows nothing about it and only mtime can date it.
         stale = self._orphan("stale.bin", age_seconds=7200)
 
         removed = storage.sweep_expired()
@@ -221,8 +218,6 @@ class TestSweepExpired:
         assert fresh.exists()
 
     def test_drops_metadata_for_files_it_sweeps(self, storage):
-        # A swept file must not leave a dangling metadata entry pointing at a
-        # path that no longer exists.
         saved = storage.save_attachment(
             base64.urlsafe_b64encode(b"payload").decode(), filename="doc.pdf"
         )
@@ -243,7 +238,6 @@ class TestSweepExpired:
         assert nested.is_dir()
 
     def test_missing_storage_dir_is_not_an_error(self, storage):
-        # Nothing has been saved yet, so the directory may not exist.
         assert storage.sweep_expired() == 0
 
     def test_one_unremovable_file_does_not_abort_the_sweep(self, storage, monkeypatch):
@@ -260,12 +254,11 @@ class TestSweepExpired:
 
         monkeypatch.setattr(Path, "unlink", flaky_unlink)
 
-        # The second file still gets reclaimed even though the first failed.
         assert storage.sweep_expired() == 1
 
 
 class TestGetAttachmentStorageSweeps:
-    """Singleton access reclaims files left by previous processes."""
+    """Tests for sweeping on singleton access."""
 
     def test_singleton_creation_sweeps_orphans(self, tmp_path, monkeypatch):
         monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path / "attachments")

--- a/tests/core/test_attachment_storage.py
+++ b/tests/core/test_attachment_storage.py
@@ -1,7 +1,9 @@
 """Tests for filename handling and storage in core.attachment_storage."""
 
 import base64
+import os
 import stat
+import time
 import unicodedata
 from pathlib import Path
 from unittest.mock import Mock
@@ -165,3 +167,102 @@ class TestSaveAttachmentFromPath:
 
         assert exc_info.value is error
         assert list(attachment_storage.STORAGE_DIR.iterdir()) == []
+
+
+class TestSweepExpired:
+    """Expiry has to survive a restart, so it must be derivable from disk alone."""
+
+    @pytest.fixture
+    def storage(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path / "attachments")
+        return AttachmentStorage(expiration_seconds=3600)
+
+    @staticmethod
+    def _orphan(name="orphan.bin", age_seconds=0):
+        """Write a file straight into storage with no metadata entry, as a
+        previous process would have left behind."""
+        attachment_storage._ensure_storage_dir()
+        path = attachment_storage.STORAGE_DIR / name
+        path.write_bytes(b"payload")
+        if age_seconds:
+            past = time.time() - age_seconds
+            os.utime(path, (past, past))
+        return path
+
+    def test_removes_orphaned_file_past_expiration(self, storage):
+        # The restart case: the file outlived the process that recorded it, so
+        # _metadata knows nothing about it and only mtime can date it.
+        stale = self._orphan("stale.bin", age_seconds=7200)
+
+        removed = storage.sweep_expired()
+
+        assert removed == 1
+        assert not stale.exists()
+
+    def test_keeps_orphaned_file_inside_expiration_window(self, storage):
+        fresh = self._orphan("fresh.bin", age_seconds=60)
+
+        removed = storage.sweep_expired()
+
+        assert removed == 0
+        assert fresh.exists()
+
+    def test_drops_metadata_for_files_it_sweeps(self, storage):
+        # A swept file must not leave a dangling metadata entry pointing at a
+        # path that no longer exists.
+        saved = storage.save_attachment(
+            base64.urlsafe_b64encode(b"payload").decode(), filename="doc.pdf"
+        )
+        past = time.time() - 7200
+        os.utime(saved.path, (past, past))
+
+        assert storage.sweep_expired() == 1
+        assert saved.file_id not in storage._metadata
+
+    def test_leaves_directories_alone(self, storage):
+        attachment_storage._ensure_storage_dir()
+        nested = attachment_storage.STORAGE_DIR / "nested"
+        nested.mkdir()
+        past = time.time() - 7200
+        os.utime(nested, (past, past))
+
+        assert storage.sweep_expired() == 0
+        assert nested.is_dir()
+
+    def test_missing_storage_dir_is_not_an_error(self, storage):
+        # Nothing has been saved yet, so the directory may not exist.
+        assert storage.sweep_expired() == 0
+
+    def test_one_unremovable_file_does_not_abort_the_sweep(self, storage, monkeypatch):
+        self._orphan("first.bin", age_seconds=7200)
+        self._orphan("second.bin", age_seconds=7200)
+        real_unlink = Path.unlink
+        calls = {"n": 0}
+
+        def flaky_unlink(self, *a, **kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("permission denied")
+            return real_unlink(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "unlink", flaky_unlink)
+
+        # The second file still gets reclaimed even though the first failed.
+        assert storage.sweep_expired() == 1
+
+
+class TestGetAttachmentStorageSweepsOnCreate:
+    """A restart is the only chance to reclaim what the previous process left."""
+
+    def test_singleton_creation_sweeps_orphans(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(attachment_storage, "STORAGE_DIR", tmp_path / "attachments")
+        monkeypatch.setattr(attachment_storage, "_attachment_storage", None)
+        attachment_storage._ensure_storage_dir()
+        stale = attachment_storage.STORAGE_DIR / "left-by-previous-process.bin"
+        stale.write_bytes(b"payload")
+        past = time.time() - 7200
+        os.utime(stale, (past, past))
+
+        attachment_storage.get_attachment_storage()
+
+        assert not stale.exists()

--- a/tests/gdrive/test_drive_download_streaming.py
+++ b/tests/gdrive/test_drive_download_streaming.py
@@ -196,9 +196,7 @@ async def test_worker_save_survives_concurrent_attachment_route_sweep(
         assert move_completed
 
         try:
-            racing_response = await serve_attachment(
-                _attachment_request(attachment_id)
-            )
+            racing_response = await serve_attachment(_attachment_request(attachment_id))
         finally:
             resume_save.set()
         result = await download

--- a/tests/gdrive/test_drive_download_streaming.py
+++ b/tests/gdrive/test_drive_download_streaming.py
@@ -160,6 +160,8 @@ async def test_worker_save_survives_concurrent_attachment_route_sweep(
 
     monkeypatch.setattr(attachment_storage, "STORAGE_DIR", storage_dir)
     monkeypatch.setattr(attachment_storage, "_attachment_storage", None)
+    attachment_id = "00000000-0000-0000-0000-000000000001"
+    monkeypatch.setattr(attachment_storage.uuid, "uuid4", lambda: attachment_id)
     monkeypatch.setattr("gdrive.drive_tools._download_file_to_temp", stale_download)
     storage = attachment_storage.get_attachment_storage()
 
@@ -195,7 +197,7 @@ async def test_worker_save_survives_concurrent_attachment_route_sweep(
 
         try:
             racing_response = await serve_attachment(
-                _attachment_request("save-in-progress")
+                _attachment_request(attachment_id)
             )
         finally:
             resume_save.set()
@@ -206,11 +208,10 @@ async def test_worker_save_survives_concurrent_attachment_route_sweep(
     assert "Saved to:" in result
     assert not source.exists()
 
-    [file_id] = storage._metadata
-    saved_path = Path(storage._metadata[file_id]["file_path"])
+    saved_path = Path(storage._metadata[attachment_id]["file_path"])
     assert saved_path.read_bytes() == b"video-bytes"
     assert isinstance(
-        await serve_attachment(_attachment_request(file_id)), FileResponse
+        await serve_attachment(_attachment_request(attachment_id)), FileResponse
     )
 
 

--- a/tests/gdrive/test_drive_download_streaming.py
+++ b/tests/gdrive/test_drive_download_streaming.py
@@ -6,14 +6,21 @@ streaming contract: the download handle is a real file, the temp file is always
 cleaned up, and nothing base64-encodes the payload on the way to storage.
 """
 
+import asyncio
 import io
+import os
+import time
 from pathlib import Path
+from threading import Event
 from unittest.mock import Mock, patch
 
 import pytest
+from starlette.requests import Request
+from starlette.responses import FileResponse, JSONResponse
 
 import core.attachment_storage as attachment_storage
 from core.attachment_storage import AttachmentStorage
+from core.server import serve_attachment
 from gdrive.drive_tools import _download_file_to_temp, get_drive_file_download_url
 
 
@@ -22,6 +29,18 @@ def _unwrap(tool):
     while hasattr(fn, "__wrapped__"):
         fn = fn.__wrapped__
     return fn
+
+
+def _attachment_request(file_id):
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": f"/attachments/{file_id}",
+        "headers": [],
+        "query_string": b"",
+        "path_params": {"file_id": file_id},
+    }
+    return Request(scope)
 
 
 class _FakeDownloader:
@@ -124,6 +143,75 @@ async def test_download_url_moves_payload_into_storage(mock_resolve, storage):
     assert "11 bytes" in result
     # The temp file was moved, not copied, so nothing is left behind.
     assert not Path(_FakeDownloader.handles[0].name).exists()
+
+
+@pytest.mark.asyncio
+async def test_worker_save_survives_concurrent_attachment_route_sweep(
+    mock_resolve, tmp_path, monkeypatch
+):
+    storage_dir = tmp_path / "attachments"
+    source = tmp_path / "stale-download.tmp"
+    source.write_bytes(b"video-bytes")
+    past = time.time() - 7200
+    os.utime(source, (past, past))
+
+    async def stale_download(*_args, **_kwargs):
+        return source
+
+    monkeypatch.setattr(attachment_storage, "STORAGE_DIR", storage_dir)
+    monkeypatch.setattr(attachment_storage, "_attachment_storage", None)
+    monkeypatch.setattr("gdrive.drive_tools._download_file_to_temp", stale_download)
+    storage = attachment_storage.get_attachment_storage()
+
+    moved = Event()
+    resume_save = Event()
+    real_move = attachment_storage.shutil.move
+
+    def pause_after_move(src, dst):
+        result = real_move(src, dst)
+        moved.set()
+        if not resume_save.wait(timeout=5):
+            raise TimeoutError("attachment route did not run")
+        return result
+
+    monkeypatch.setattr(attachment_storage.shutil, "move", pause_after_move)
+
+    with (
+        patch("gdrive.drive_tools.is_stateless_mode", return_value=False),
+        patch("gdrive.drive_tools.get_transport_mode", return_value="stdio"),
+    ):
+        download = asyncio.create_task(
+            _unwrap(get_drive_file_download_url)(
+                service=Mock(),
+                user_google_email="user@example.com",
+                file_id="file123",
+            )
+        )
+        move_completed = await asyncio.to_thread(moved.wait, 5)
+        if not move_completed:
+            resume_save.set()
+            await download
+        assert move_completed
+
+        try:
+            racing_response = await serve_attachment(
+                _attachment_request("save-in-progress")
+            )
+        finally:
+            resume_save.set()
+        result = await download
+
+    assert isinstance(racing_response, JSONResponse)
+    assert racing_response.status_code == 404
+    assert "Saved to:" in result
+    assert not source.exists()
+
+    [file_id] = storage._metadata
+    saved_path = Path(storage._metadata[file_id]["file_path"])
+    assert saved_path.read_bytes() == b"video-bytes"
+    assert isinstance(
+        await serve_attachment(_attachment_request(file_id)), FileResponse
+    )
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -2423,7 +2423,7 @@ wheels = [
 
 [[package]]
 name = "workspace-mcp"
-version = "1.24.0"
+version = "1.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
#995 closed. `AttachmentStorage` tells the user a downloaded file expires after an hour, but the only record of that expiry is the in-process `_metadata` dict. Nothing on disk says when a file should go away, and nothing sweeps the directory. So on restart `_metadata` starts empty and every file the previous process wrote becomes unreachable by the cleanup logic. The reporter ended up with 74 files and 41 GB sitting there, the oldest about a month old.

While I was in there I noticed `cleanup_expired()` isn't called from anywhere in the codebase. Even if it were, it only walks `_metadata`, so it has the same blind spot.

Made three changes:

- `sweep_expired()` dates files by mtime instead of the in-memory dict, so expiry survives a restart. It skips directories, and one locked or unreadable file doesn't abandon the rest of the sweep.
- `get_attachment_storage()` sweeps when it first creates the singleton. First use in a process is the only chance to reclaim what the previous one left behind.
- `cleanup_expired()` sweeps disk as well now, so files it never recorded are actually reachable.

Flagging: `get_attachment_storage()` is imported inside functions in `core/server.py` and `auth/oauth_callback_server.py`, so the sweep runs on the first attachment request after a restart rather than at process start. That still clears the orphans. Happy to move it to startup if you'd prefer it there.

(Type of Change: Bug fix. Testing: tests added ✓, suite passes ✓, manual unchecked. Checklist all ✓ including allow-edits-from-maintainers.)

7 tests in `tests/core/test_attachment_storage.py`, covering the restart case (file on disk, empty metadata), files still inside the window being left alone, metadata getting dropped for swept files, directories being skipped, a missing storage directory, and one unremovable file not aborting the sweep.

All 7 fail on `main` before the change. Full suite goes from 1618 to 1625 passing, with the same 20 pre-existing `gcontacts` failures before and after. `ruff check` and `ruff format` are clean on the pinned 0.15.22.

I have not run this against a live server with real attachments, so the manual box above is unchecked. The tests drive the real `AttachmentStorage` rather than a stub.

Extra

The sweep is keyed on `expiration_seconds`, so it inherits whatever the instance is configured with and doesn't introduce a second timeout to keep in sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment expiration handling so files begin expiration tracking when stored.
  * Automatically removes expired files from disk, including files no longer tracked in metadata.
  * Added resilient cleanup for missing files, directories, and temporary storage errors.
  * Storage access now triggers an expiration sweep to keep attachments synchronized.
  * Prevented attachments from being available before downloads finish moving into storage.
  * Ensured completed downloads become retrievable with their contents preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->