### PR TITLE
fix(gmail): include Reply-To in message and thread header output

### DIFF
--- a/gmail/gmail_helpers.py
+++ b/gmail/gmail_helpers.py
@@ -34,6 +34,7 @@ GMAIL_METADATA_HEADERS = [
     "From",
     "To",
     "Cc",
+    "Reply-To",
     "Message-ID",
     "In-Reply-To",
     "References",

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -296,6 +296,7 @@ def _format_message_header_lines(
     """Format standard Gmail message headers for response output."""
     subject = headers.get("Subject", "(no subject)")
     sender = headers.get("From", "(unknown sender)")
+    reply_to = headers.get("Reply-To", "")
     to = headers.get("To", "")
     cc = headers.get("Cc", "")
     rfc822_msg_id = headers.get("Message-ID", "")
@@ -316,6 +317,8 @@ def _format_message_header_lines(
             f"Date: {headers.get('Date', '(unknown date)')}",
         ]
     )
+    if reply_to:
+        content_lines.append(f"Reply-To: {reply_to}")
 
     if rfc822_msg_id:
         content_lines.append(f"Message-ID: {rfc822_msg_id}")
@@ -3127,6 +3130,7 @@ def _format_thread_content(
         sender = headers.get("From", "(unknown sender)")
         date = headers.get("Date", "(unknown date)")
         subject = headers.get("Subject", "(no subject)")
+        reply_to = headers.get("Reply-To", "")
         to = headers.get("To", "")
         cc = headers.get("Cc", "")
         rfc822_message_id = headers.get("Message-ID", "")
@@ -3162,6 +3166,8 @@ def _format_thread_content(
                 f"Date: {date}",
             ]
         )
+        if reply_to:
+            content_lines.append(f"Reply-To: {reply_to}")
         content_lines.append(
             f"To: {to}" if "To" in headers else "To: [not present in Gmail response]"
         )

--- a/tests/gmail/test_get_gmail_thread_content_analysis.py
+++ b/tests/gmail/test_get_gmail_thread_content_analysis.py
@@ -39,6 +39,7 @@ def _fake_thread_response() -> dict:
                 "payload": {
                     "headers": [
                         {"name": "From", "value": "Alex <alex@alexreynolds.com>"},
+                        {"name": "Reply-To", "value": "alex-support@alexreynolds.com"},
                         {"name": "To", "value": "vendor@example.com"},
                         {"name": "Date", "value": "Mon, 14 Apr 2026 09:00:00 -0400"},
                         {"name": "Subject", "value": "Test thread"},
@@ -93,6 +94,7 @@ async def test_default_returns_string_unchanged_behavior():
     assert isinstance(result, str)
     assert "Thread ID: t1" in result
     assert "alex@alexreynolds.com" in result or "Alex" in result
+    assert "Reply-To: alex-support@alexreynolds.com" in result
     assert "To: vendor@example.com" in result
     assert "Cc: [not present in Gmail response]" in result
 

--- a/tests/gmail/test_reply_to_header.py
+++ b/tests/gmail/test_reply_to_header.py
@@ -1,0 +1,42 @@
+"""Regression test for the Reply-To header gap.
+
+get_gmail_message_content (and get_gmail_thread_content, covered separately in
+test_get_gmail_thread_content_analysis.py) silently dropped Reply-To: it was
+never in GMAIL_METADATA_HEADERS, so Gmail's metadataHeaders filter excluded it
+from the API response before this project's formatting code ever saw it.
+"""
+
+from __future__ import annotations
+
+from gmail.gmail_helpers import GMAIL_METADATA_HEADERS
+from gmail.gmail_tools import _format_message_header_lines
+
+
+def test_reply_to_in_metadata_headers_whitelist():
+    """Reply-To must be requested from the Gmail API or it never arrives."""
+    assert "Reply-To" in GMAIL_METADATA_HEADERS
+
+
+def test_format_message_header_lines_includes_reply_to_when_present():
+    headers = {
+        "Subject": "Test",
+        "From": "Alex <alex@example.com>",
+        "Reply-To": "alex-support@example.com",
+        "Date": "Mon, 14 Apr 2026 09:00:00 -0400",
+    }
+
+    lines = _format_message_header_lines(headers)
+
+    assert "Reply-To: alex-support@example.com" in lines
+
+
+def test_format_message_header_lines_omits_reply_to_when_absent():
+    headers = {
+        "Subject": "Test",
+        "From": "Alex <alex@example.com>",
+        "Date": "Mon, 14 Apr 2026 09:00:00 -0400",
+    }
+
+    lines = _format_message_header_lines(headers)
+
+    assert not any(line.startswith("Reply-To:") for line in lines)

--- a/tests/gmail/test_reply_to_header.py
+++ b/tests/gmail/test_reply_to_header.py
@@ -18,6 +18,7 @@ def test_reply_to_in_metadata_headers_whitelist():
 
 
 def test_format_message_header_lines_includes_reply_to_when_present():
+    """When Reply-To is in the headers dict, it must appear in the output."""
     headers = {
         "Subject": "Test",
         "From": "Alex <alex@example.com>",
@@ -31,6 +32,7 @@ def test_format_message_header_lines_includes_reply_to_when_present():
 
 
 def test_format_message_header_lines_omits_reply_to_when_absent():
+    """Without Reply-To in the headers dict, no Reply-To line is emitted."""
     headers = {
         "Subject": "Test",
         "From": "Alex <alex@example.com>",


### PR DESCRIPTION
## Description

`GMAIL_METADATA_HEADERS` (`gmail/gmail_helpers.py`) never included `Reply-To`, so it was excluded from the Gmail API's `metadataHeaders` filter before reaching any formatting code. `get_gmail_message_content`, `get_gmail_messages_content_batch`, `get_gmail_thread_content` and `get_gmail_threads_content_batch` all silently dropped it as a result.

Reply-To was already being fetched and used internally for reply-target resolution (the reply-header derivation helpers), it just was never surfaced to the caller reading a message.

Follows the explicit-presence convention already established for To/Cc by #970 — no output change when Reply-To is absent from a given message.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (`pytest tests/gmail/` — 213 passed)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gmail message and thread details now display the `Reply-To` header when available.
  * Gmail metadata collection now includes the `Reply-To` header for more complete email details.

* **Bug Fixes**
  * Improved handling of messages without a `Reply-To` header, ensuring empty values are omitted.

* **Tests**
  * Added coverage to verify `Reply-To` headers are included, formatted correctly, and excluded when absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #1043
