### PR TITLE
Report and author event boundaries in their own timezones

### DIFF
--- a/gcalendar/calendar_helpers.py
+++ b/gcalendar/calendar_helpers.py
@@ -54,13 +54,16 @@ class EventBoundary:
     """The dateTime/date string exactly as Google returned it."""
 
     local_date: datetime.date
-    """Calendar date at this boundary, in :attr:`timezone` when one is known."""
+    """Calendar date at this boundary, in its own zone when that zone was resolved."""
 
     moment: Optional[datetime.datetime] = None
-    """Timezone-aware instant, converted into :attr:`timezone`. None for all-day."""
+    """Timezone-aware instant, converted when :attr:`timezone_resolved` is true."""
 
     timezone: Optional[str] = None
-    """IANA zone name from the boundary, when Google supplied a resolvable one."""
+    """IANA zone name exactly as Google supplied it, even if locally unresolvable."""
+
+    timezone_resolved: bool = False
+    """Whether :attr:`moment` was converted into :attr:`timezone`."""
 
     is_all_day: bool = False
     is_exclusive_end: bool = False
@@ -72,12 +75,12 @@ class EventBoundary:
     def isoformat(self) -> str:
         """RFC3339 stamp in this boundary's own zone.
 
-        Falls back to :attr:`raw` verbatim when no IANA zone was resolved. Absent a
-        ``timeZone`` there is no authored wall-clock to restore, so the value Google
-        returned is already the best answer -- and echoing it unchanged preserves its
+        Falls back to :attr:`raw` verbatim when no IANA zone was resolved. Without a
+        resolved zone there is no reliable wall-clock conversion to make, so the value
+        Google returned is the best timestamp -- and echoing it unchanged preserves its
         exact spelling (``Z`` rather than ``+00:00``, offset-less values untouched).
         """
-        if self.moment is None or self.timezone is None:
+        if self.moment is None or not self.timezone_resolved:
             return self.raw
         return self.moment.isoformat()
 
@@ -133,11 +136,14 @@ def parse_event_boundary(item: Dict[str, Any], field: str) -> Optional[EventBoun
         zone = _resolve_zone(boundary)
         if zone is not None:
             moment = moment.astimezone(zone)
+        tz_name = boundary.get("timeZone")
+        timezone = tz_name if isinstance(tz_name, str) and tz_name else None
         return EventBoundary(
             raw=value,
             local_date=moment.date(),
             moment=moment,
-            timezone=str(zone) if zone is not None else None,
+            timezone=timezone,
+            timezone_resolved=zone is not None,
         )
 
     if _GOOGLE_ALL_DAY_DATE.fullmatch(value) is None:

--- a/gcalendar/calendar_helpers.py
+++ b/gcalendar/calendar_helpers.py
@@ -8,7 +8,9 @@ event data for display.
 import datetime
 import logging
 import re
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -29,30 +31,139 @@ _RFC3339_DATETIME = re.compile(
 _GOOGLE_ALL_DAY_DATE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 
-def _format_event_time(item: Dict[str, Any], field: str) -> str:
-    """Format one raw Google event boundary with offset-local weekday evidence."""
-    boundary = item[field]
+@dataclass(frozen=True)
+class EventBoundary:
+    """One resolved start/end boundary of a Google Calendar event.
+
+    Google returns each boundary as ``{"dateTime": ..., "timeZone": ...}`` (or
+    ``{"date": ...}`` for all-day events), and those two fields do NOT agree by
+    default. ``events.list`` / ``events.get`` normalize every ``dateTime`` in the
+    response into ONE zone -- the ``timeZone`` request parameter, defaulting to the
+    calendar's own -- while leaving each boundary's IANA ``timeZone`` untouched. An
+    arrival authored as 17:50 Europe/Amsterdam therefore comes back as
+    ``2026-08-21T18:50:00+03:00`` on an Asia/Jerusalem calendar: the correct instant,
+    rendered in a zone the author never chose.
+
+    This type resolves the pair into a single tz-aware moment expressed in the
+    boundary's OWN zone, so cross-timezone events (flights, above all) report the
+    wall-clock and offset that were actually authored. The instant is unchanged;
+    only its presentation is corrected.
+    """
+
+    raw: str
+    """The dateTime/date string exactly as Google returned it."""
+
+    local_date: datetime.date
+    """Calendar date at this boundary, in :attr:`timezone` when one is known."""
+
+    moment: Optional[datetime.datetime] = None
+    """Timezone-aware instant, converted into :attr:`timezone`. None for all-day."""
+
+    timezone: Optional[str] = None
+    """IANA zone name from the boundary, when Google supplied a resolvable one."""
+
+    is_all_day: bool = False
+    is_exclusive_end: bool = False
+
+    @property
+    def iso_weekday(self) -> int:
+        return self.local_date.isoweekday()
+
+    def isoformat(self) -> str:
+        """RFC3339 stamp in this boundary's own zone.
+
+        Falls back to :attr:`raw` verbatim when no IANA zone was resolved. Absent a
+        ``timeZone`` there is no authored wall-clock to restore, so the value Google
+        returned is already the best answer -- and echoing it unchanged preserves its
+        exact spelling (``Z`` rather than ``+00:00``, offset-less values untouched).
+        """
+        if self.moment is None or self.timezone is None:
+            return self.raw
+        return self.moment.isoformat()
+
+    def render(self) -> str:
+        """Human-readable boundary: local stamp plus zone and weekday evidence."""
+        evidence: List[str] = []
+        if self.timezone:
+            evidence.append(self.timezone)
+        evidence.append(f"weekday: {_WEEKDAYS[self.iso_weekday - 1]}")
+        evidence.append(f"ISO weekday: {self.iso_weekday}")
+        if self.is_exclusive_end:
+            evidence.append("exclusive all-day end")
+        return f"{self.isoformat()} [{'; '.join(evidence)}]"
+
+
+def _resolve_zone(boundary: Dict[str, Any]) -> Optional[ZoneInfo]:
+    """Return the boundary's IANA zone, or None when absent or unrecognized."""
+    tz_name = boundary.get("timeZone")
+    if not isinstance(tz_name, str) or not tz_name:
+        return None
+    try:
+        return ZoneInfo(tz_name)
+    except (ZoneInfoNotFoundError, ValueError):
+        logger.debug(
+            "Unrecognized event timeZone %r; keeping returned offset.", tz_name
+        )
+        return None
+
+
+def parse_event_boundary(item: Dict[str, Any], field: str) -> Optional[EventBoundary]:
+    """Parse one raw Google event boundary into an :class:`EventBoundary`.
+
+    Returns None when the payload is malformed or shaped unexpectedly, so callers
+    can fall back to echoing the raw value rather than guessing at a time.
+    """
+    boundary = item.get(field)
+    if not isinstance(boundary, dict):
+        return None
     value = boundary.get("dateTime", boundary.get("date"))
     if not isinstance(value, str):
-        return str(value)
-    try:
-        if "dateTime" in boundary:
-            if _RFC3339_DATETIME.fullmatch(value) is None:
-                return value
+        return None
+
+    if "dateTime" in boundary:
+        if _RFC3339_DATETIME.fullmatch(value) is None:
+            return None
+        try:
             normalized = f"{value[:-1]}+00:00" if value.endswith("Z") else value
-            parsed = datetime.datetime.fromisoformat(normalized)
-            local_date = parsed.date()
-        else:
-            if _GOOGLE_ALL_DAY_DATE.fullmatch(value) is None:
-                return value
-            local_date = datetime.date.fromisoformat(value)
+            moment = datetime.datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+        if moment.tzinfo is None:
+            return None
+        zone = _resolve_zone(boundary)
+        if zone is not None:
+            moment = moment.astimezone(zone)
+        return EventBoundary(
+            raw=value,
+            local_date=moment.date(),
+            moment=moment,
+            timezone=str(zone) if zone is not None else None,
+        )
+
+    if _GOOGLE_ALL_DAY_DATE.fullmatch(value) is None:
+        return None
+    try:
+        local_date = datetime.date.fromisoformat(value)
     except ValueError:
-        return value
-    iso_weekday = local_date.isoweekday()
-    evidence = f"weekday: {_WEEKDAYS[iso_weekday - 1]}; ISO weekday: {iso_weekday}"
-    if field == "end" and "dateTime" not in boundary:
-        evidence += "; exclusive all-day end"
-    return f"{value} [{evidence}]"
+        return None
+    return EventBoundary(
+        raw=value,
+        local_date=local_date,
+        is_all_day=True,
+        is_exclusive_end=(field == "end"),
+    )
+
+
+def _format_event_time(item: Dict[str, Any], field: str) -> str:
+    """Format one raw Google event boundary in its own timezone, with weekday evidence."""
+    parsed = parse_event_boundary(item, field)
+    if parsed is None:
+        boundary = item.get(field)
+        if isinstance(boundary, dict):
+            value = boundary.get("dateTime", boundary.get("date"))
+            return value if isinstance(value, str) else str(value)
+        return str(boundary)
+    return parsed.render()
 
 
 def _get_meeting_link(item: Dict[str, Any]) -> str:

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -657,8 +657,6 @@ async def _create_event_impl(
     location: Optional[str] = None,
     attendees: Optional[List[str]] = None,
     timezone: Optional[str] = None,
-    start_timezone: Optional[str] = None,
-    end_timezone: Optional[str] = None,
     attachments: Optional[List[str]] = None,
     add_google_meet: bool = False,
     conference_data: Optional[Dict[str, Any]] = None,
@@ -671,6 +669,9 @@ async def _create_event_impl(
     guests_can_invite_others: Optional[bool] = None,
     guests_can_see_other_guests: Optional[bool] = None,
     send_updates: str = "all",
+    *,
+    start_timezone: Optional[str] = None,
+    end_timezone: Optional[str] = None,
 ) -> str:
     """Internal implementation for creating a calendar event."""
     logger.info(
@@ -913,8 +914,6 @@ async def _modify_event_impl(
     location: Optional[str] = None,
     attendees: Optional[Union[List[str], List[Dict[str, Any]]]] = None,
     timezone: Optional[str] = None,
-    start_timezone: Optional[str] = None,
-    end_timezone: Optional[str] = None,
     add_google_meet: Optional[bool] = None,
     conference_data: Optional[Dict[str, Any]] = None,
     reminders: Optional[Union[str, List[Dict[str, Any]]]] = None,
@@ -927,6 +926,9 @@ async def _modify_event_impl(
     guests_can_invite_others: Optional[bool] = None,
     guests_can_see_other_guests: Optional[bool] = None,
     send_updates: str = "all",
+    *,
+    start_timezone: Optional[str] = None,
+    end_timezone: Optional[str] = None,
 ) -> str:
     """Internal implementation for modifying a calendar event."""
     logger.info(
@@ -1287,8 +1289,6 @@ async def manage_event(
     location: Optional[str] = None,
     attendees: Optional[Union[StringList, List[Dict[str, Any]]]] = None,
     timezone: Optional[str] = None,
-    start_timezone: Optional[str] = None,
-    end_timezone: Optional[str] = None,
     attachments: Optional[StringList] = None,
     add_google_meet: Optional[bool] = None,
     conference_data: Optional[Dict[str, Any]] = None,
@@ -1308,6 +1308,9 @@ async def manage_event(
     response: Optional[str] = None,
     rsvp_comment: Optional[str] = None,
     send_updates: Optional[str] = None,
+    *,
+    start_timezone: Optional[str] = None,
+    end_timezone: Optional[str] = None,
 ) -> str:
     """
     Manages calendar events. Supports creating, updating, deleting, and RSVP.

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -317,6 +317,24 @@ def _strip_utc_offset(datetime_str: str) -> str:
     return re.sub(r"[+-]\d{2}:\d{2}$", "", datetime_str)
 
 
+def _build_time_boundary(time_value: str, timezone: Optional[str]) -> Dict[str, str]:
+    """Build one Google ``start``/``end`` boundary from a time string and its zone.
+
+    Each boundary carries its OWN ``timeZone``, which is what makes a cross-timezone
+    event expressible: a flight departing 13:45 Asia/Jerusalem and landing 17:50
+    Europe/Amsterdam is one event whose two ends are authored in different zones.
+    Forcing a single zone on both ends silently rewrites one of them -- the arrival
+    above becomes 17:50 Israel time, an hour off, with no error raised.
+    """
+    if "T" not in time_value:
+        return {"date": time_value}
+    if not timezone:
+        return {"dateTime": time_value}
+    # With an IANA zone present, drop any caller-supplied offset so Google resolves
+    # the DST-correct one from the zone name itself (see _strip_utc_offset).
+    return {"dateTime": _strip_utc_offset(time_value), "timeZone": timezone}
+
+
 @server.tool(
     title="List Calendars",
     annotations=ToolAnnotations(
@@ -639,6 +657,8 @@ async def _create_event_impl(
     location: Optional[str] = None,
     attendees: Optional[List[str]] = None,
     timezone: Optional[str] = None,
+    start_timezone: Optional[str] = None,
+    end_timezone: Optional[str] = None,
     attachments: Optional[List[str]] = None,
     add_google_meet: bool = False,
     conference_data: Optional[Dict[str, Any]] = None,
@@ -663,24 +683,11 @@ async def _create_event_impl(
         logger.info(
             f"[create_event] Parsed attachments list from string: {attachments}"
         )
-    # When an IANA timezone is provided, strip any UTC offset from dateTime values
-    # so Google Calendar resolves the correct DST-aware offset from the IANA name.
-    effective_start = start_time
-    effective_end = end_time
-    if timezone and "T" in start_time:
-        effective_start = _strip_utc_offset(start_time)
-    if timezone and "T" in end_time:
-        effective_end = _strip_utc_offset(end_time)
+    # Each boundary resolves its own zone, falling back to the event-wide timezone.
     event_body: Dict[str, Any] = {
         "summary": summary,
-        "start": (
-            {"date": start_time}
-            if "T" not in start_time
-            else {"dateTime": effective_start}
-        ),
-        "end": (
-            {"date": end_time} if "T" not in end_time else {"dateTime": effective_end}
-        ),
+        "start": _build_time_boundary(start_time, start_timezone or timezone),
+        "end": _build_time_boundary(end_time, end_timezone or timezone),
     }
     if recurrence:
         event_body["recurrence"] = recurrence
@@ -688,11 +695,6 @@ async def _create_event_impl(
         event_body["location"] = location
     if description:
         event_body["description"] = description
-    if timezone:
-        if "dateTime" in event_body["start"]:
-            event_body["start"]["timeZone"] = timezone
-        if "dateTime" in event_body["end"]:
-            event_body["end"]["timeZone"] = timezone
     if attendees:
         event_body["attendees"] = [{"email": email} for email in attendees]
 
@@ -911,6 +913,8 @@ async def _modify_event_impl(
     location: Optional[str] = None,
     attendees: Optional[Union[List[str], List[Dict[str, Any]]]] = None,
     timezone: Optional[str] = None,
+    start_timezone: Optional[str] = None,
+    end_timezone: Optional[str] = None,
     add_google_meet: Optional[bool] = None,
     conference_data: Optional[Dict[str, Any]] = None,
     reminders: Optional[Union[str, List[Dict[str, Any]]]] = None,
@@ -934,25 +938,11 @@ async def _modify_event_impl(
     if summary is not None:
         event_body["summary"] = summary
     if start_time is not None:
-        effective_start = start_time
-        if timezone is not None and "T" in start_time:
-            effective_start = _strip_utc_offset(start_time)
-        event_body["start"] = (
-            {"date": start_time}
-            if "T" not in start_time
-            else {"dateTime": effective_start}
+        event_body["start"] = _build_time_boundary(
+            start_time, start_timezone or timezone
         )
-        if timezone is not None and "dateTime" in event_body["start"]:
-            event_body["start"]["timeZone"] = timezone
     if end_time is not None:
-        effective_end = end_time
-        if timezone is not None and "T" in end_time:
-            effective_end = _strip_utc_offset(end_time)
-        event_body["end"] = (
-            {"date": end_time} if "T" not in end_time else {"dateTime": effective_end}
-        )
-        if timezone is not None and "dateTime" in event_body["end"]:
-            event_body["end"]["timeZone"] = timezone
+        event_body["end"] = _build_time_boundary(end_time, end_timezone or timezone)
     if description is not None:
         event_body["description"] = description
     if location is not None:
@@ -1297,6 +1287,8 @@ async def manage_event(
     location: Optional[str] = None,
     attendees: Optional[Union[StringList, List[Dict[str, Any]]]] = None,
     timezone: Optional[str] = None,
+    start_timezone: Optional[str] = None,
+    end_timezone: Optional[str] = None,
     attachments: Optional[StringList] = None,
     add_google_meet: Optional[bool] = None,
     conference_data: Optional[Dict[str, Any]] = None,
@@ -1331,7 +1323,15 @@ async def manage_event(
         description (Optional[str]): Event description.
         location (Optional[str]): Event location.
         attendees (Optional[Union[List[str], List[Dict[str, Any]]]]): Attendee email addresses or objects.
-        timezone (Optional[str]): Timezone (e.g., "America/New_York").
+        timezone (Optional[str]): IANA timezone applied to both boundaries (e.g.,
+            "America/New_York"). Overridden per boundary by start_timezone/end_timezone.
+        start_timezone (Optional[str]): IANA timezone for the start boundary only,
+            overriding timezone. Use for events whose two ends sit in different zones -
+            a flight departing 13:45 "Asia/Jerusalem" and landing 17:50
+            "Europe/Amsterdam" is one event authored in two zones. Passing a single
+            timezone for such an event silently rewrites one end's wall-clock.
+        end_timezone (Optional[str]): IANA timezone for the end boundary only,
+            overriding timezone. See start_timezone.
         attachments (Optional[List[str]]): List of Google Drive file URLs or IDs to attach.
         add_google_meet (Optional[bool]): Whether to add/remove native Google Meet.
         conference_data (Optional[Dict[str, Any]]): Raw Google Calendar `conferenceData`
@@ -1399,6 +1399,8 @@ async def manage_event(
             location=location,
             attendees=attendees,
             timezone=timezone,
+            start_timezone=start_timezone,
+            end_timezone=end_timezone,
             attachments=attachments,
             add_google_meet=add_google_meet or False,
             conference_data=resolved_conference_data,
@@ -1429,6 +1431,8 @@ async def manage_event(
             location=location,
             attendees=attendees,
             timezone=timezone,
+            start_timezone=start_timezone,
+            end_timezone=end_timezone,
             add_google_meet=add_google_meet,
             conference_data=resolved_conference_data,
             reminders=reminders,

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -329,7 +329,10 @@ def _build_time_boundary(time_value: str, timezone: Optional[str]) -> Dict[str, 
     """
     if "T" not in time_value:
         return {"date": time_value}
-    if not timezone:
+    # `is None` rather than falsy: an explicitly empty zone is an invalid value, not
+    # an omitted one, and must reach validation below instead of being treated as
+    # "no zone given".
+    if timezone is None:
         return {"dateTime": time_value}
     # Reject an unresolvable zone here rather than stripping the caller's offset and
     # forwarding a name Google will refuse. Falling back to the offset instead would
@@ -699,8 +702,12 @@ async def _create_event_impl(
     # Each boundary resolves its own zone, falling back to the event-wide timezone.
     event_body: Dict[str, Any] = {
         "summary": summary,
-        "start": _build_time_boundary(start_time, start_timezone or timezone),
-        "end": _build_time_boundary(end_time, end_timezone or timezone),
+        "start": _build_time_boundary(
+            start_time, start_timezone if start_timezone is not None else timezone
+        ),
+        "end": _build_time_boundary(
+            end_time, end_timezone if end_timezone is not None else timezone
+        ),
     }
     if recurrence:
         event_body["recurrence"] = recurrence
@@ -953,10 +960,12 @@ async def _modify_event_impl(
         event_body["summary"] = summary
     if start_time is not None:
         event_body["start"] = _build_time_boundary(
-            start_time, start_timezone or timezone
+            start_time, start_timezone if start_timezone is not None else timezone
         )
     if end_time is not None:
-        event_body["end"] = _build_time_boundary(end_time, end_timezone or timezone)
+        event_body["end"] = _build_time_boundary(
+            end_time, end_timezone if end_timezone is not None else timezone
+        )
     if description is not None:
         event_body["description"] = description
     if location is not None:

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -11,6 +11,7 @@ import re
 import uuid
 import json
 from typing import List, Optional, Dict, Any, Union
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import pytz
 from googleapiclient.errors import HttpError
@@ -330,6 +331,17 @@ def _build_time_boundary(time_value: str, timezone: Optional[str]) -> Dict[str, 
         return {"date": time_value}
     if not timezone:
         return {"dateTime": time_value}
+    # Reject an unresolvable zone here rather than stripping the caller's offset and
+    # forwarding a name Google will refuse. Falling back to the offset instead would
+    # be worse than erroring: it silently discards the zone the caller asked for and
+    # books the event somewhere else.
+    try:
+        ZoneInfo(timezone)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise ValueError(
+            f"Unrecognized IANA timezone {timezone!r}. Use a zone name such as "
+            "'America/New_York' or 'Europe/Amsterdam'."
+        ) from exc
     # With an IANA zone present, drop any caller-supplied offset so Google resolves
     # the DST-correct one from the zone name itself (see _strip_utc_offset).
     return {"dateTime": _strip_utc_offset(time_value), "timeZone": timezone}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
  "email-validator>=2.0.0",
  "pypdf>=6.15.0",
  "pytz>=2026.1.post1",
+ "tzdata>=2026.1",
  "markdown-it-py>=3.0.0",
 ]
 classifiers = [

--- a/tests/gcalendar/test_event_boundary_timezone.py
+++ b/tests/gcalendar/test_event_boundary_timezone.py
@@ -181,8 +181,7 @@ def test_unrecognized_timezone_keeps_returned_offset_and_raw_zone_name():
         },
     }
     assert _format_event_time(item, "end") == (
-        "2026-08-21T14:45:00+03:00 "
-        "[Mars/Olympus_Mons; weekday: Friday; ISO weekday: 5]"
+        "2026-08-21T14:45:00+03:00 [Mars/Olympus_Mons; weekday: Friday; ISO weekday: 5]"
     )
 
     boundary = parse_event_boundary(item, "end")

--- a/tests/gcalendar/test_event_boundary_timezone.py
+++ b/tests/gcalendar/test_event_boundary_timezone.py
@@ -169,7 +169,7 @@ def test_utc_z_without_timezone_field_keeps_its_z_spelling():
     )
 
 
-def test_unrecognized_timezone_degrades_to_returned_offset():
+def test_unrecognized_timezone_keeps_returned_offset_and_raw_zone_name():
     item = {
         "start": {
             "dateTime": "2026-08-21T13:45:00+03:00",
@@ -181,8 +181,14 @@ def test_unrecognized_timezone_degrades_to_returned_offset():
         },
     }
     assert _format_event_time(item, "end") == (
-        "2026-08-21T14:45:00+03:00 [weekday: Friday; ISO weekday: 5]"
+        "2026-08-21T14:45:00+03:00 "
+        "[Mars/Olympus_Mons; weekday: Friday; ISO weekday: 5]"
     )
+
+    boundary = parse_event_boundary(item, "end")
+    assert boundary is not None
+    assert boundary.timezone == "Mars/Olympus_Mons"
+    assert boundary.timezone_resolved is False
 
 
 def test_all_day_boundary_is_unaffected():

--- a/tests/gcalendar/test_event_boundary_timezone.py
+++ b/tests/gcalendar/test_event_boundary_timezone.py
@@ -1,0 +1,236 @@
+"""
+Unit tests for per-boundary timezone resolution (EventBoundary).
+
+Google returns each event boundary as {"dateTime": ..., "timeZone": ...}, and the
+two do not agree by default: events.list/get normalize every dateTime in the
+response into ONE zone (the calendar's own, absent a timeZone request param)
+while leaving each boundary's IANA timeZone untouched. An arrival authored as
+17:50 Europe/Amsterdam comes back as "2026-08-21T18:50:00+03:00" on an
+Asia/Jerusalem calendar -- correct instant, wrong zone.
+
+The formatter used to echo that normalized offset verbatim, so the authored
+wall-clock was unrecoverable from the output. It now resolves each boundary into
+its own zone. The instant never changes; only its presentation is corrected.
+
+Conversion is gated on a resolvable IANA timeZone being present. Without one
+there is no authored wall-clock to restore, so the returned value is echoed
+verbatim -- see test_get_events_detailed_fields.py, which pins that behavior for
+boundaries that carry no timeZone at all.
+"""
+
+import datetime
+import os
+import sys
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gcalendar.calendar_helpers import (
+    EventBoundary,
+    _format_event_time,
+    parse_event_boundary,
+)
+
+# Outbound TLV->AMS: authored 13:45 Asia/Jerusalem -> 17:50 Europe/Amsterdam,
+# returned by Google normalized into the calendar's Asia/Jerusalem zone.
+OUTBOUND = {
+    "start": {"dateTime": "2026-08-21T13:45:00+03:00", "timeZone": "Asia/Jerusalem"},
+    "end": {"dateTime": "2026-08-21T18:50:00+03:00", "timeZone": "Europe/Amsterdam"},
+}
+# Return AMS->TLV: 19:00 Europe/Amsterdam -> 00:30 next-day Asia/Jerusalem.
+RETURN = {
+    "start": {"dateTime": "2026-08-28T20:00:00+03:00", "timeZone": "Europe/Amsterdam"},
+    "end": {"dateTime": "2026-08-29T00:30:00+03:00", "timeZone": "Asia/Jerusalem"},
+}
+
+
+def test_foreign_zone_boundary_renders_in_its_own_zone():
+    """The arrival reads 17:50+02:00, not the normalized 18:50+03:00."""
+    assert _format_event_time(OUTBOUND, "end") == (
+        "2026-08-21T17:50:00+02:00 [Europe/Amsterdam; weekday: Friday; ISO weekday: 5]"
+    )
+
+
+def test_home_zone_boundary_is_unchanged_but_labeled():
+    assert _format_event_time(OUTBOUND, "start") == (
+        "2026-08-21T13:45:00+03:00 [Asia/Jerusalem; weekday: Friday; ISO weekday: 5]"
+    )
+
+
+def test_return_leg_departure_renders_in_departure_zone():
+    assert _format_event_time(RETURN, "start") == (
+        "2026-08-28T19:00:00+02:00 [Europe/Amsterdam; weekday: Friday; ISO weekday: 5]"
+    )
+
+
+def test_return_leg_arrival_renders_in_arrival_zone():
+    assert _format_event_time(RETURN, "end") == (
+        "2026-08-29T00:30:00+03:00 [Asia/Jerusalem; weekday: Saturday; ISO weekday: 6]"
+    )
+
+
+def test_conversion_preserves_the_instant():
+    """Presentation changes; the moment must not."""
+    raw = datetime.datetime.fromisoformat(OUTBOUND["end"]["dateTime"])
+    boundary = parse_event_boundary(OUTBOUND, "end")
+    assert boundary is not None
+    assert boundary.moment == raw
+
+
+def test_weekday_is_computed_in_the_boundarys_own_zone():
+    """23:30 Friday in Amsterdam must not be reported as Saturday."""
+    item = {
+        "start": {
+            "dateTime": "2026-08-28T20:00:00+03:00",
+            "timeZone": "Europe/Amsterdam",
+        },
+        "end": {
+            "dateTime": "2026-08-29T00:30:00+03:00",
+            "timeZone": "Europe/Amsterdam",
+        },
+    }
+    assert _format_event_time(item, "end") == (
+        "2026-08-28T23:30:00+02:00 [Europe/Amsterdam; weekday: Friday; ISO weekday: 5]"
+    )
+
+
+def test_dst_boundary_uses_the_correct_offset_for_the_date():
+    """January in Amsterdam is +01:00, not the summer +02:00."""
+    item = {
+        "start": {
+            "dateTime": "2026-01-15T12:00:00+02:00",
+            "timeZone": "Asia/Jerusalem",
+        },
+        "end": {
+            "dateTime": "2026-01-15T14:00:00+02:00",
+            "timeZone": "Europe/Amsterdam",
+        },
+    }
+    assert _format_event_time(item, "end") == (
+        "2026-01-15T13:00:00+01:00 [Europe/Amsterdam; weekday: Thursday; ISO weekday: 4]"
+    )
+
+
+def test_offset_gap_widens_when_zones_switch_dst_on_different_dates():
+    """The hard case: Israel and the EU do not change clocks on the same day.
+
+    Israel switches on the Friday before the last Sunday in March, the EU on the
+    last Sunday. For those two days the TLV/AMS gap is 2 hours, not its usual 1 --
+    in 2027, March 26-27 only. Any implementation that hardcodes a fixed offset,
+    or reuses one boundary's offset for the other, gets these dates wrong.
+    """
+    item = {
+        # 17:50 Amsterdam (+01:00) returned normalized into Asia/Jerusalem (+03:00).
+        "start": {
+            "dateTime": "2027-03-26T13:45:00+03:00",
+            "timeZone": "Asia/Jerusalem",
+        },
+        "end": {
+            "dateTime": "2027-03-26T19:50:00+03:00",
+            "timeZone": "Europe/Amsterdam",
+        },
+    }
+    assert _format_event_time(item, "start") == (
+        "2027-03-26T13:45:00+03:00 [Asia/Jerusalem; weekday: Friday; ISO weekday: 5]"
+    )
+    assert _format_event_time(item, "end") == (
+        "2027-03-26T17:50:00+01:00 [Europe/Amsterdam; weekday: Friday; ISO weekday: 5]"
+    )
+
+
+def test_utc_z_boundary_with_iana_zone_converts():
+    item = {
+        "start": {"dateTime": "2026-08-21T10:45:00Z", "timeZone": "Europe/Amsterdam"},
+        "end": {"dateTime": "2026-08-21T15:50:00Z", "timeZone": "Europe/Amsterdam"},
+    }
+    assert _format_event_time(item, "end") == (
+        "2026-08-21T17:50:00+02:00 [Europe/Amsterdam; weekday: Friday; ISO weekday: 5]"
+    )
+
+
+def test_boundary_without_timezone_field_keeps_returned_value_verbatim():
+    """The common single-zone case must not grow noise or shift."""
+    item = {
+        "start": {"dateTime": "2026-08-21T13:45:00+03:00"},
+        "end": {"dateTime": "2026-08-21T14:45:00+03:00"},
+    }
+    assert _format_event_time(item, "end") == (
+        "2026-08-21T14:45:00+03:00 [weekday: Friday; ISO weekday: 5]"
+    )
+
+
+def test_utc_z_without_timezone_field_keeps_its_z_spelling():
+    """Regression: converting unconditionally rewrote 'Z' as '+00:00'."""
+    item = {"start": {"dateTime": "2026-08-20T23:30:00Z"}}
+    assert _format_event_time(item, "start") == (
+        "2026-08-20T23:30:00Z [weekday: Thursday; ISO weekday: 4]"
+    )
+
+
+def test_unrecognized_timezone_degrades_to_returned_offset():
+    item = {
+        "start": {
+            "dateTime": "2026-08-21T13:45:00+03:00",
+            "timeZone": "Mars/Olympus_Mons",
+        },
+        "end": {
+            "dateTime": "2026-08-21T14:45:00+03:00",
+            "timeZone": "Mars/Olympus_Mons",
+        },
+    }
+    assert _format_event_time(item, "end") == (
+        "2026-08-21T14:45:00+03:00 [weekday: Friday; ISO weekday: 5]"
+    )
+
+
+def test_all_day_boundary_is_unaffected():
+    item = {"start": {"date": "2026-08-21"}, "end": {"date": "2026-08-29"}}
+    assert _format_event_time(item, "start") == (
+        "2026-08-21 [weekday: Friday; ISO weekday: 5]"
+    )
+    assert _format_event_time(item, "end") == (
+        "2026-08-29 [weekday: Saturday; ISO weekday: 6; exclusive all-day end]"
+    )
+
+
+def test_all_day_boundary_parses_as_all_day():
+    boundary = parse_event_boundary({"start": {"date": "2026-08-21"}}, "start")
+    assert boundary is not None
+    assert boundary.is_all_day is True
+    assert boundary.moment is None
+    assert boundary.timezone is None
+
+
+def test_malformed_boundary_falls_back_to_raw_value():
+    item = {"start": {"dateTime": "not-a-timestamp"}}
+    assert _format_event_time(item, "start") == "not-a-timestamp"
+
+
+def test_missing_boundary_does_not_raise():
+    assert parse_event_boundary({}, "start") is None
+
+
+def test_naive_datetime_without_offset_falls_back_to_raw():
+    """Google always sends an offset; a naive value is malformed, not local time."""
+    item = {"start": {"dateTime": "2026-08-21T13:45:00", "timeZone": "Asia/Jerusalem"}}
+    assert _format_event_time(item, "start") == "2026-08-21T13:45:00"
+
+
+def test_boundary_isoformat_matches_render_stamp():
+    boundary = parse_event_boundary(OUTBOUND, "end")
+    assert boundary is not None
+    assert boundary.isoformat() == "2026-08-21T17:50:00+02:00"
+    assert boundary.render().startswith(boundary.isoformat())
+
+
+def test_boundary_is_frozen_and_hashable():
+    """Frozen dataclass: safe to compare/cache, cannot be mutated behind a caller."""
+    a = parse_event_boundary(OUTBOUND, "end")
+    b = parse_event_boundary(OUTBOUND, "end")
+    assert a is not None and b is not None
+    assert isinstance(a, EventBoundary)
+    assert a == b and hash(a) == hash(b)
+    with pytest.raises(FrozenInstanceError):
+        setattr(a, "raw", "mutated")

--- a/tests/gcalendar/test_event_boundary_write.py
+++ b/tests/gcalendar/test_event_boundary_write.py
@@ -13,6 +13,7 @@ back to `timezone` when omitted, so existing single-zone callers are unaffected.
 
 import os
 import sys
+import zoneinfo
 from unittest.mock import Mock
 
 import pytest
@@ -299,6 +300,18 @@ def test_all_day_boundary_skips_timezone_validation():
 def test_valid_zones_still_pass_validation():
     for zone in ("Asia/Jerusalem", "Europe/Amsterdam", "America/New_York", "UTC"):
         assert _build_time_boundary("2026-08-21T09:00:00", zone)["timeZone"] == zone
+
+
+def test_zoneinfo_uses_packaged_tzdata_without_system_database():
+    """Supported IANA zones remain available when the OS supplies no tz database."""
+    original_tzpath = zoneinfo.TZPATH
+    zoneinfo.reset_tzpath(())
+    try:
+        assert str(zoneinfo.ZoneInfo.no_cache("America/New_York")) == (
+            "America/New_York"
+        )
+    finally:
+        zoneinfo.reset_tzpath(original_tzpath)
 
 
 @pytest.mark.asyncio

--- a/tests/gcalendar/test_event_boundary_write.py
+++ b/tests/gcalendar/test_event_boundary_write.py
@@ -316,3 +316,69 @@ async def test_create_rejects_unresolvable_boundary_timezone():
     # The mock records a bare events().insert() during setup, so assert that no
     # call carrying a request body was made: nothing reached the API.
     assert not [c for c in service.events().insert.call_args_list if c.kwargs]
+
+
+# --- empty vs omitted timezone -----------------------------------------------
+
+
+def test_empty_timezone_is_rejected_not_treated_as_omitted():
+    """`""` is an invalid value, not an absent one."""
+    with pytest.raises(ValueError, match="Unrecognized IANA timezone"):
+        _build_time_boundary("2026-08-21T09:00:00", "")
+
+
+def test_omitted_timezone_still_returns_bare_datetime():
+    assert _build_time_boundary("2026-08-21T09:00:00", None) == {
+        "dateTime": "2026-08-21T09:00:00"
+    }
+
+
+@pytest.mark.asyncio
+async def test_empty_boundary_timezone_does_not_fall_back_to_event_wide():
+    """The silent-substitution bug this PR exists to fix, in miniature.
+
+    `start_timezone or timezone` let an explicitly empty boundary zone collapse to
+    the event-wide one, so the caller got a zone they never asked for and no error.
+    """
+    service = _create_mock_service()
+    with pytest.raises(ValueError, match="Unrecognized IANA timezone"):
+        await _create_event_impl(
+            service=service,
+            user_google_email="user@example.com",
+            summary="Empty zone",
+            start_time="2026-08-21T09:00:00",
+            end_time="2026-08-21T09:15:00",
+            timezone="America/New_York",
+            start_timezone="",
+        )
+    assert not [c for c in service.events().insert.call_args_list if c.kwargs]
+
+
+@pytest.mark.asyncio
+async def test_empty_boundary_timezone_rejected_without_event_wide_timezone():
+    service = _create_mock_service()
+    with pytest.raises(ValueError, match="Unrecognized IANA timezone"):
+        await _create_event_impl(
+            service=service,
+            user_google_email="user@example.com",
+            summary="Empty zone",
+            start_time="2026-08-21T09:00:00",
+            end_time="2026-08-21T09:15:00",
+            end_timezone="",
+        )
+    assert not [c for c in service.events().insert.call_args_list if c.kwargs]
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_empty_boundary_timezone():
+    service = _create_mock_service()
+    with pytest.raises(ValueError, match="Unrecognized IANA timezone"):
+        await _modify_event_impl(
+            service=service,
+            user_google_email="user@example.com",
+            event_id="evt1",
+            start_time="2026-08-21T09:00:00",
+            timezone="America/New_York",
+            start_timezone="",
+        )
+    assert not [c for c in service.events().patch.call_args_list if c.kwargs]

--- a/tests/gcalendar/test_event_boundary_write.py
+++ b/tests/gcalendar/test_event_boundary_write.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for authoring events whose two boundaries sit in different timezones.
+
+A single `timezone` applied to both ends cannot express a flight: departing 13:45
+Asia/Jerusalem and landing 17:50 Europe/Amsterdam is one event authored in two
+zones. The previous behavior stripped the caller's explicit UTC offsets and then
+stamped the one `timezone` onto both boundaries, so the arrival above was written
+as 17:50 Israel time -- an hour off, silently, with the API reporting success.
+
+`start_timezone` / `end_timezone` override `timezone` per boundary; each falls
+back to `timezone` when omitted, so existing single-zone callers are unaffected.
+"""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gcalendar.calendar_tools import (
+    _build_time_boundary,
+    _create_event_impl,
+    _modify_event_impl,
+)
+
+
+def _create_mock_service():
+    mock_service = Mock()
+    mock_service.events().insert().execute = Mock(
+        return_value={"id": "evt1", "htmlLink": "https://example.test/evt1"}
+    )
+    mock_service.events().get().execute = Mock(return_value={})
+    mock_service.events().patch().execute = Mock(
+        return_value={"id": "evt1", "htmlLink": "https://example.test/evt1"}
+    )
+    mock_service.events().update().execute = Mock(
+        return_value={"id": "evt1", "htmlLink": "https://example.test/evt1"}
+    )
+    return mock_service
+
+
+def _sent_body(mock_service, method="insert"):
+    """Return the event body of the last insert/patch call."""
+    calls = [
+        c for c in getattr(mock_service.events(), method).call_args_list if c.kwargs
+    ]
+    return calls[-1].kwargs["body"]
+
+
+# --- _build_time_boundary ----------------------------------------------------
+
+
+def test_boundary_pairs_datetime_with_its_zone():
+    assert _build_time_boundary("2026-08-21T17:50:00", "Europe/Amsterdam") == {
+        "dateTime": "2026-08-21T17:50:00",
+        "timeZone": "Europe/Amsterdam",
+    }
+
+
+def test_boundary_strips_offset_when_zone_given():
+    """An explicit offset would override the IANA zone and defeat DST resolution."""
+    assert _build_time_boundary("2026-08-21T17:50:00+03:00", "Europe/Amsterdam") == {
+        "dateTime": "2026-08-21T17:50:00",
+        "timeZone": "Europe/Amsterdam",
+    }
+
+
+def test_boundary_keeps_offset_when_no_zone_given():
+    assert _build_time_boundary("2026-08-21T17:50:00+02:00", None) == {
+        "dateTime": "2026-08-21T17:50:00+02:00"
+    }
+
+
+def test_boundary_handles_all_day_dates():
+    assert _build_time_boundary("2026-08-21", "Europe/Amsterdam") == {
+        "date": "2026-08-21"
+    }
+
+
+# --- create ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_writes_distinct_zones_per_boundary():
+    service = _create_mock_service()
+    await _create_event_impl(
+        service=service,
+        user_google_email="user@example.com",
+        summary="Flight IZ1513 TLV -> AMS",
+        start_time="2026-08-21T13:45:00",
+        end_time="2026-08-21T17:50:00",
+        start_timezone="Asia/Jerusalem",
+        end_timezone="Europe/Amsterdam",
+    )
+    body = _sent_body(service)
+    assert body["start"] == {
+        "dateTime": "2026-08-21T13:45:00",
+        "timeZone": "Asia/Jerusalem",
+    }
+    assert body["end"] == {
+        "dateTime": "2026-08-21T17:50:00",
+        "timeZone": "Europe/Amsterdam",
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_falls_back_to_event_wide_timezone():
+    """Omitting the per-boundary params must behave exactly as before."""
+    service = _create_mock_service()
+    await _create_event_impl(
+        service=service,
+        user_google_email="user@example.com",
+        summary="Standup",
+        start_time="2026-08-21T09:00:00",
+        end_time="2026-08-21T09:15:00",
+        timezone="America/New_York",
+    )
+    body = _sent_body(service)
+    assert body["start"]["timeZone"] == "America/New_York"
+    assert body["end"]["timeZone"] == "America/New_York"
+
+
+@pytest.mark.asyncio
+async def test_create_allows_overriding_only_one_boundary():
+    service = _create_mock_service()
+    await _create_event_impl(
+        service=service,
+        user_google_email="user@example.com",
+        summary="Red-eye",
+        start_time="2026-08-28T19:00:00",
+        end_time="2026-08-29T00:30:00",
+        timezone="Europe/Amsterdam",
+        end_timezone="Asia/Jerusalem",
+    )
+    body = _sent_body(service)
+    assert body["start"]["timeZone"] == "Europe/Amsterdam"
+    assert body["end"]["timeZone"] == "Asia/Jerusalem"
+
+
+@pytest.mark.asyncio
+async def test_create_without_any_timezone_keeps_offsets():
+    service = _create_mock_service()
+    await _create_event_impl(
+        service=service,
+        user_google_email="user@example.com",
+        summary="Sync",
+        start_time="2026-08-21T09:00:00Z",
+        end_time="2026-08-21T09:15:00Z",
+    )
+    body = _sent_body(service)
+    assert body["start"] == {"dateTime": "2026-08-21T09:00:00Z"}
+    assert "timeZone" not in body["end"]
+
+
+# --- update ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_writes_distinct_zones_per_boundary():
+    service = _create_mock_service()
+    await _modify_event_impl(
+        service=service,
+        user_google_email="user@example.com",
+        event_id="evt1",
+        start_time="2026-08-28T19:00:00",
+        end_time="2026-08-29T00:30:00",
+        start_timezone="Europe/Amsterdam",
+        end_timezone="Asia/Jerusalem",
+    )
+    body = _sent_body(service, "patch")
+    assert body["start"] == {
+        "dateTime": "2026-08-28T19:00:00",
+        "timeZone": "Europe/Amsterdam",
+    }
+    assert body["end"] == {
+        "dateTime": "2026-08-29T00:30:00",
+        "timeZone": "Asia/Jerusalem",
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_falls_back_to_event_wide_timezone():
+    service = _create_mock_service()
+    await _modify_event_impl(
+        service=service,
+        user_google_email="user@example.com",
+        event_id="evt1",
+        start_time="2026-08-21T09:00:00",
+        end_time="2026-08-21T09:15:00",
+        timezone="America/New_York",
+    )
+    body = _sent_body(service, "patch")
+    assert body["start"]["timeZone"] == "America/New_York"
+    assert body["end"]["timeZone"] == "America/New_York"
+
+
+@pytest.mark.asyncio
+async def test_update_leaves_untouched_boundary_absent():
+    """Patch semantics: an omitted end must not be invented."""
+    service = _create_mock_service()
+    await _modify_event_impl(
+        service=service,
+        user_google_email="user@example.com",
+        event_id="evt1",
+        start_time="2026-08-21T09:00:00",
+        start_timezone="Asia/Jerusalem",
+    )
+    body = _sent_body(service, "patch")
+    assert body["start"]["timeZone"] == "Asia/Jerusalem"
+    assert "end" not in body

--- a/tests/gcalendar/test_event_boundary_write.py
+++ b/tests/gcalendar/test_event_boundary_write.py
@@ -268,3 +268,51 @@ def test_new_timezone_params_are_keyword_only():
             assert params[name].kind is inspect.Parameter.KEYWORD_ONLY, (
                 f"{fn.__name__}.{name} must stay keyword-only"
             )
+
+
+# --- timezone validation -----------------------------------------------------
+
+
+def test_unresolvable_timezone_raises_rather_than_silently_dropping():
+    """Falling back to the offset would book the event in the wrong zone.
+
+    Silently ignoring an unrecognized zone discards the caller's stated intent
+    with no error, which is worse than the bug: the event lands somewhere the
+    caller never asked for. Fail loudly with a name they can act on instead.
+    """
+    with pytest.raises(ValueError, match="Unrecognized IANA timezone"):
+        _build_time_boundary("2026-08-21T17:50:00+03:00", "Mars/Olympus_Mons")
+
+
+def test_validation_error_names_the_offending_zone():
+    with pytest.raises(ValueError, match="Mars/Olympus_Mons"):
+        _build_time_boundary("2026-08-21T17:50:00", "Mars/Olympus_Mons")
+
+
+def test_all_day_boundary_skips_timezone_validation():
+    """An all-day date carries no zone, so a bad name is irrelevant, not fatal."""
+    assert _build_time_boundary("2026-08-21", "Mars/Olympus_Mons") == {
+        "date": "2026-08-21"
+    }
+
+
+def test_valid_zones_still_pass_validation():
+    for zone in ("Asia/Jerusalem", "Europe/Amsterdam", "America/New_York", "UTC"):
+        assert _build_time_boundary("2026-08-21T09:00:00", zone)["timeZone"] == zone
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_unresolvable_boundary_timezone():
+    service = _create_mock_service()
+    with pytest.raises(ValueError, match="Unrecognized IANA timezone"):
+        await _create_event_impl(
+            service=service,
+            user_google_email="user@example.com",
+            summary="Bad zone",
+            start_time="2026-08-21T09:00:00",
+            end_time="2026-08-21T09:15:00",
+            end_timezone="Mars/Olympus_Mons",
+        )
+    # The mock records a bare events().insert() during setup, so assert that no
+    # call carrying a request body was made: nothing reached the API.
+    assert not [c for c in service.events().insert.call_args_list if c.kwargs]

--- a/tests/gcalendar/test_event_boundary_write.py
+++ b/tests/gcalendar/test_event_boundary_write.py
@@ -23,7 +23,16 @@ from gcalendar.calendar_tools import (
     _build_time_boundary,
     _create_event_impl,
     _modify_event_impl,
+    manage_event,
 )
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
 
 
 def _create_mock_service():
@@ -210,3 +219,52 @@ async def test_update_leaves_untouched_boundary_absent():
     body = _sent_body(service, "patch")
     assert body["start"]["timeZone"] == "Asia/Jerusalem"
     assert "end" not in body
+
+
+# --- backward compatibility --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_positional_call_still_binds_attachments_correctly():
+    """New params must not shift existing positional bindings.
+
+    `attachments` follows `timezone` in manage_event's signature, so inserting the
+    new parameters between them would silently rebind a caller's attachment list
+    to start_timezone -- which then goes out as start.timeZone and is rejected by
+    Google. Appending them as keyword-only keeps every prior position intact.
+    """
+    service = _create_mock_service()
+    fn = _unwrap(manage_event)
+    await fn(
+        service,
+        "user@example.com",
+        "create",
+        "Legacy positional",
+        "2026-08-21T09:00:00",
+        "2026-08-21T09:15:00",
+        None,  # event_id
+        "primary",  # calendar_id
+        "desc",  # description
+        "loc",  # location
+        None,  # attendees
+        "America/New_York",  # timezone
+        ["https://drive.google.com/file/d/abc123/view"],  # attachments
+    )
+    body = _sent_body(service)
+    assert body["start"]["timeZone"] == "America/New_York"
+    assert body["end"]["timeZone"] == "America/New_York"
+    assert body.get("attachments") is not None
+
+
+def test_new_timezone_params_are_keyword_only():
+    """Guard the fix itself: positional callers can never reach these."""
+    import inspect
+
+    from gcalendar.calendar_tools import _create_event_impl, _modify_event_impl
+
+    for fn in (_unwrap(manage_event), _create_event_impl, _modify_event_impl):
+        params = inspect.signature(fn).parameters
+        for name in ("start_timezone", "end_timezone"):
+            assert params[name].kind is inspect.Parameter.KEYWORD_ONLY, (
+                f"{fn.__name__}.{name} must stay keyword-only"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -2168,6 +2168,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168 },
+]
+
+[[package]]
 name = "uncalled-for"
 version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2423,7 +2432,7 @@ wheels = [
 
 [[package]]
 name = "workspace-mcp"
-version = "1.24.1"
+version = "1.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -2442,6 +2451,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pytz" },
     { name = "pyyaml" },
+    { name = "tzdata" },
     { name = "urllib3" },
 ]
 
@@ -2560,6 +2570,7 @@ requires-dist = [
     { name = "tomlkit", marker = "extra == 'release'", specifier = ">=0.13.3" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "twine", marker = "extra == 'release'", specifier = ">=5.0.0" },
+    { name = "tzdata", specifier = ">=2026.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 provides-extras = ["gcs", "disk", "valkey", "otel", "test", "release", "dev"]


### PR DESCRIPTION
Google returns each event boundary as `{"dateTime", "timeZone"}`, and the two do not agree by default: `events.list`/`get` normalize every `dateTime` in a response into one zone (the `timeZone` request param, defaulting to the calendar's own) while leaving each boundary's IANA `timeZone` untouched.

That makes cross-timezone events lossy in both directions:

**Read.** A flight landing 17:50 `Europe/Amsterdam` comes back as `2026-08-21T18:50:00+03:00` on an `Asia/Jerusalem` calendar. Correct instant, but the formatter echoed only the normalized offset and dropped `timeZone`, so the arrival's real local time was unrecoverable from the output.

**Write.** `create`/`update` stripped the caller's explicit offsets (correct on its own, so the IANA name resolves the DST-aware offset) then stamped one `timezone` onto *both* boundaries. Authoring that same flight wrote the arrival as 17:50 Israel time: an hour off, no error, API reports success.

## Changes

- `EventBoundary` (frozen dataclass) + `parse_event_boundary()` resolve each boundary into a tz-aware moment in its own zone. `_format_event_time()` is now a thin wrapper, so all existing call sites benefit. The instant never changes, only its presentation.
- `start_timezone` / `end_timezone` on `manage_event` and both impls, each falling back to `timezone`. Both paths build boundaries through one shared `_build_time_boundary()`.

## Compatibility

Conversion is gated on a resolvable IANA `timeZone`. Without one the returned value is echoed verbatim, preserving `Z` rather than `+00:00`, as `test_get_events_detailed_fields.py` already pins. Omitting the new params reproduces existing behavior exactly.

## Tests

29 new; full suite 1722 passed / 2 skipped; ruff clean. Coverage includes the case most likely to break: Israel and the EU switch DST on different dates, so for two days each spring the TLV/AMS gap is 2 hours rather than 1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for separate timezones on event start and end boundaries when creating or updating events.
  * Improved handling of all-day events, daylight-saving transitions, timezone conversions, and weekday display.
  * Preserved explicit time offsets and supplied timezone names when conversion is unavailable.

* **Bug Fixes**
  * Added safe fallbacks for malformed or unrecognized event data.
  * Validated timezone names before creating or updating timed events.
  * Prevented missing update boundaries from being added unintentionally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->