### PR TITLE
fix(gmail): stop reporting batch label changes that Gmail never made

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -3930,9 +3930,7 @@ async def _verify_batch_label_changes(
 
         for mid in chunk_ids:
             entry = results.get(mid)
-            if not entry or (
-                entry.get("data") is None and entry.get("error") is None
-            ):
+            if not entry or (entry.get("data") is None and entry.get("error") is None):
                 statuses[mid] = "unverified"
                 continue
             error = entry.get("error")

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -3856,8 +3856,8 @@ async def _verify_batch_label_changes(
 
     Returns a per-ID status: ``applied`` (end state matches the request),
     ``not_applied`` (message exists, labels do not match), ``unresolved``
-    (no such message — the ID was silently ignored), or ``unverified``
-    (the read-back itself failed, so nothing can be claimed either way).
+    (the ID does not currently resolve to a message), or ``unverified`` (the
+    read-back itself failed, so nothing can be claimed either way).
     """
     wanted = set(add_label_ids or ())
     unwanted = set(remove_label_ids or ())
@@ -3866,6 +3866,7 @@ async def _verify_batch_label_changes(
     for chunk_start in range(0, len(message_ids), GMAIL_BATCH_SIZE):
         chunk_ids = message_ids[chunk_start : chunk_start + GMAIL_BATCH_SIZE]
         results: Dict[str, Dict] = {}
+        batch_completed = False
 
         def _batch_callback(request_id, response, exception):
             results[request_id] = {"data": response, "error": exception}
@@ -3880,6 +3881,7 @@ async def _verify_batch_label_changes(
                     request_id=mid,
                 )
             await asyncio.to_thread(batch.execute)
+            batch_completed = True
         except Exception as batch_error:
             # Same fallback the read tools use: sequential reads with a small
             # delay, to avoid exhausting connections when the batch endpoint is
@@ -3902,8 +3904,37 @@ async def _verify_batch_label_changes(
                 results[mid_result] = {"data": data, "error": error}
                 await asyncio.sleep(GMAIL_REQUEST_DELAY)
 
+        retryable_ids = (
+            _retryable_result_ids(results, chunk_ids) if batch_completed else []
+        )
+        if retryable_ids:
+            logger.warning(
+                f"[batch_modify_gmail_message_labels] "
+                f"{len(retryable_ids)}/{len(chunk_ids)} verification reads failed "
+                f"with retryable errors; re-fetching: {retryable_ids}"
+            )
+            await asyncio.sleep(GMAIL_RATE_LIMIT_BACKOFF)
+            for mid in retryable_ids:
+                mid_result, data, error = await _fetch_with_retry(
+                    build_request=lambda mid=mid: (
+                        service.users()
+                        .messages()
+                        .get(userId="me", id=mid, format="minimal")
+                    ),
+                    item_id=mid,
+                    item_label="message",
+                    log_prefix="batch_modify_gmail_message_labels",
+                )
+                results[mid_result] = {"data": data, "error": error}
+                await asyncio.sleep(GMAIL_REQUEST_DELAY)
+
         for mid in chunk_ids:
-            entry = results.get(mid) or {}
+            entry = results.get(mid)
+            if not entry or (
+                entry.get("data") is None and entry.get("error") is None
+            ):
+                statuses[mid] = "unverified"
+                continue
             error = entry.get("error")
             if error is not None:
                 statuses[mid] = (
@@ -4016,9 +4047,9 @@ async def batch_modify_gmail_message_labels(
     if unresolved:
         lines.append(
             f"No such message ({len(unresolved)}): {_format_id_list(unresolved)}\n"
-            "  These IDs do not resolve to a message in this mailbox, so Gmail "
-            "ignored them. A common cause is passing a THREAD id where a MESSAGE "
-            "id is required."
+            "  These IDs do not currently resolve to messages in this mailbox, "
+            "so the requested change could not be verified. One possible cause "
+            "is passing a THREAD id where a MESSAGE id is required."
         )
     if not_applied:
         lines.append(

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -64,6 +64,7 @@ from gmail.gmail_helpers import (
     _derive_reply_all_recipients,
     _derive_reply_headers,
     _fetch_with_retry,
+    _http_error_status,
     _is_benign_signature_http_error,
     _retryable_result_ids,
     _signature_fetch_tool_error,
@@ -3832,6 +3833,93 @@ async def modify_gmail_message_labels(
     return f"Message labels updated successfully!\nMessage ID: {message_id}\n{'; '.join(actions)}"
 
 
+def _format_id_list(ids: List[str], limit: int = 10) -> str:
+    """Join IDs for a result message, truncating very long lists."""
+    shown = ", ".join(ids[:limit])
+    if len(ids) > limit:
+        shown += f", … (+{len(ids) - limit} more)"
+    return shown
+
+
+async def _verify_batch_label_changes(
+    service,
+    message_ids: List[str],
+    add_label_ids: Optional[List[str]],
+    remove_label_ids: Optional[List[str]],
+) -> Dict[str, str]:
+    """Read the messages back to see which requested label changes actually landed.
+
+    ``users.messages.batchModify`` answers ``204 No Content`` and silently
+    ignores IDs it does not recognise, so its own response cannot distinguish a
+    sweep that changed everything from one that changed nothing. This re-reads
+    each message with ``format="minimal"`` (``labelIds`` only) and classifies it.
+
+    Returns a per-ID status: ``applied`` (end state matches the request),
+    ``not_applied`` (message exists, labels do not match), ``unresolved``
+    (no such message — the ID was silently ignored), or ``unverified``
+    (the read-back itself failed, so nothing can be claimed either way).
+    """
+    wanted = set(add_label_ids or ())
+    unwanted = set(remove_label_ids or ())
+    statuses: Dict[str, str] = {}
+
+    for chunk_start in range(0, len(message_ids), GMAIL_BATCH_SIZE):
+        chunk_ids = message_ids[chunk_start : chunk_start + GMAIL_BATCH_SIZE]
+        results: Dict[str, Dict] = {}
+
+        def _batch_callback(request_id, response, exception):
+            results[request_id] = {"data": response, "error": exception}
+
+        try:
+            batch = service.new_batch_http_request(callback=_batch_callback)
+            for mid in chunk_ids:
+                batch.add(
+                    service.users()
+                    .messages()
+                    .get(userId="me", id=mid, format="minimal"),
+                    request_id=mid,
+                )
+            await asyncio.to_thread(batch.execute)
+        except Exception as batch_error:
+            # Same fallback the read tools use: sequential reads with a small
+            # delay, to avoid exhausting connections when the batch endpoint is
+            # unavailable.
+            logger.warning(
+                f"[batch_modify_gmail_message_labels] Verification batch failed, "
+                f"falling back to sequential reads: {batch_error}"
+            )
+            for mid in chunk_ids:
+                mid_result, data, error = await _fetch_with_retry(
+                    build_request=lambda mid=mid: (
+                        service.users()
+                        .messages()
+                        .get(userId="me", id=mid, format="minimal")
+                    ),
+                    item_id=mid,
+                    item_label="message",
+                    log_prefix="batch_modify_gmail_message_labels",
+                )
+                results[mid_result] = {"data": data, "error": error}
+                await asyncio.sleep(GMAIL_REQUEST_DELAY)
+
+        for mid in chunk_ids:
+            entry = results.get(mid) or {}
+            error = entry.get("error")
+            if error is not None:
+                statuses[mid] = (
+                    "unresolved" if _http_error_status(error) == 404 else "unverified"
+                )
+                continue
+            labels = set((entry.get("data") or {}).get("labelIds") or ())
+            statuses[mid] = (
+                "applied"
+                if wanted <= labels and not (unwanted & labels)
+                else "not_applied"
+            )
+
+    return statuses
+
+
 @server.tool(
     title="Batch Modify Gmail Message Labels",
     annotations=ToolAnnotations(
@@ -3855,18 +3943,27 @@ async def batch_modify_gmail_message_labels(
         Optional[StringList],
         Field(json_schema_extra={"type": "array", "items": {"type": "string"}}),
     ] = None,
+    verify: bool = True,
 ) -> str:
     """
     Adds or removes labels from multiple Gmail messages in a single batch request.
+
+    Takes MESSAGE ids, not thread ids. Gmail's batch endpoint returns no
+    per-message result and silently ignores ids it does not recognise, so by
+    default this reads the messages back afterwards and reports which ids
+    actually changed.
 
     Args:
         user_google_email (str): The user's Google email address. Required.
         message_ids (List[str]): A list of message IDs to modify.
         add_label_ids (Optional[List[str]]): List of label IDs to add to the messages.
         remove_label_ids (Optional[List[str]]): List of label IDs to remove from the messages.
+        verify (bool): Read the messages back and report per-id outcomes. Costs
+            one extra (batched) read per id. Set False for very large sweeps
+            where that cost matters and an unverified result is acceptable.
 
     Returns:
-        str: Confirmation message of the label changes applied to the messages.
+        str: Which label changes were applied, and which ids did not resolve.
     """
     logger.info(
         f"[batch_modify_gmail_message_labels] Invoked. Email: '{user_google_email}', Message IDs: '{message_ids}'"
@@ -3892,5 +3989,46 @@ async def batch_modify_gmail_message_labels(
         actions.append(f"Added labels: {', '.join(add_label_ids)}")
     if remove_label_ids:
         actions.append(f"Removed labels: {', '.join(remove_label_ids)}")
+    action_summary = "; ".join(actions)
 
-    return f"Labels updated for {len(message_ids)} messages: {'; '.join(actions)}"
+    total = len(message_ids)
+
+    if not verify:
+        return (
+            f"Requested label changes for {total} message ID(s): {action_summary}\n"
+            "NOT VERIFIED: Gmail's batchModify returns no per-message result and "
+            "silently ignores IDs it does not recognise, so this records what was "
+            "asked for, not what changed. Re-run with verify=True to confirm."
+        )
+
+    statuses = await _verify_batch_label_changes(
+        service, message_ids, add_label_ids, remove_label_ids
+    )
+    applied = [mid for mid in message_ids if statuses.get(mid) == "applied"]
+    not_applied = [mid for mid in message_ids if statuses.get(mid) == "not_applied"]
+    unresolved = [mid for mid in message_ids if statuses.get(mid) == "unresolved"]
+    unverified = [mid for mid in message_ids if statuses.get(mid) == "unverified"]
+
+    lines = [
+        f"Label changes for {total} message ID(s): {action_summary}",
+        f"Applied: {len(applied)}/{total}",
+    ]
+    if unresolved:
+        lines.append(
+            f"No such message ({len(unresolved)}): {_format_id_list(unresolved)}\n"
+            "  These IDs do not resolve to a message in this mailbox, so Gmail "
+            "ignored them. A common cause is passing a THREAD id where a MESSAGE "
+            "id is required."
+        )
+    if not_applied:
+        lines.append(
+            f"Unchanged ({len(not_applied)}): {_format_id_list(not_applied)}\n"
+            "  These messages exist but their labels do not match the request."
+        )
+    if unverified:
+        lines.append(
+            f"Could not verify ({len(unverified)}): {_format_id_list(unverified)}\n"
+            "  The read-back failed; the change may or may not have been applied."
+        )
+
+    return "\n".join(lines)

--- a/tests/gmail/test_batch_modify_label_verification.py
+++ b/tests/gmail/test_batch_modify_label_verification.py
@@ -104,6 +104,8 @@ async def test_unrecognised_id_is_not_reported_as_success():
     assert "No such message (1)" in result
     assert "thread-id" in result
     assert "THREAD id where a MESSAGE id is required" in result
+    assert "requested change could not be verified" in result
+    assert "Gmail ignored" not in result
     # The old wording must not come back.
     assert "Labels updated for 1 messages" not in result
 
@@ -147,6 +149,50 @@ async def test_read_back_failure_is_reported_as_unverified():
     assert "Applied: 0/1" in result
     assert "Could not verify (1): msg-1" in result
     assert "may or may not have been applied" in result
+
+
+@pytest.mark.asyncio
+async def test_missing_batch_result_is_not_applied_for_remove_only_request():
+    """No callback data cannot prove that an absent label was removed."""
+    service = _service({"msg-1": ["INBOX"]})
+
+    class _BatchWithoutCallbacks:
+        def add(self, request, request_id):
+            pass
+
+        def execute(self):
+            pass
+
+    service.new_batch_http_request.side_effect = lambda callback: _BatchWithoutCallbacks()
+
+    result = await _run(service, message_ids=["msg-1"], remove_label_ids=["UNREAD"])
+
+    assert "Applied: 0/1" in result
+    assert "Could not verify (1): msg-1" in result
+
+
+@pytest.mark.asyncio
+async def test_retryable_batch_read_is_retried_sequentially(monkeypatch):
+    monkeypatch.setattr("gmail.gmail_tools.GMAIL_RATE_LIMIT_BACKOFF", 0)
+    monkeypatch.setattr("gmail.gmail_tools.GMAIL_REQUEST_DELAY", 0)
+    outcomes = iter([HttpError(_FakeResp(429), b"{}"), ["TRASH"]])
+    service = _service({})
+
+    def message_get(**kwargs):
+        outcome = next(outcomes)
+        request = Mock()
+        if isinstance(outcome, Exception):
+            request.execute.side_effect = outcome
+        else:
+            request.execute.return_value = {"id": kwargs["id"], "labelIds": outcome}
+        return request
+
+    service.users().messages().get.side_effect = message_get
+
+    result = await _run(service, message_ids=["msg-1"], add_label_ids=["TRASH"])
+
+    assert "Applied: 1/1" in result
+    assert service.users().messages().get.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/gmail/test_batch_modify_label_verification.py
+++ b/tests/gmail/test_batch_modify_label_verification.py
@@ -1,0 +1,194 @@
+"""Tests for honest result reporting in `batch_modify_gmail_message_labels`.
+
+Gmail's `users.messages.batchModify` answers `204 No Content` and silently
+ignores IDs it does not recognise, so the call itself cannot distinguish a
+sweep that changed everything from one that changed nothing. The tool used to
+report `Labels updated for N messages` where N was simply `len(message_ids)` —
+a confident, indistinguishable success for wrong or stale IDs.
+
+These tests pin the corrected behaviour: the read-back classifies every ID, and
+nothing is claimed for IDs Gmail ignored.
+"""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gmail.gmail_tools import batch_modify_gmail_message_labels
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+class _FakeResp:
+    """Minimal stand-in for an httplib2 Response (status + reason)."""
+
+    def __init__(self, status: int):
+        self.status = status
+        self.reason = "fake"
+
+
+class _FakeBatch:
+    """Batch that invokes each request's execute() and calls back per request."""
+
+    def __init__(self, callback):
+        self._callback = callback
+        self._requests = []
+
+    def add(self, request, request_id):
+        self._requests.append((request_id, request))
+
+    def execute(self):
+        for request_id, request in self._requests:
+            try:
+                self._callback(request_id, request.execute(), None)
+            except Exception as exc:  # noqa: BLE001 - mirrors the batch callback contract
+                self._callback(request_id, None, exc)
+
+
+def _service(read_results, batch_available=True):
+    """Build a mock Gmail service.
+
+    `read_results` maps message ID -> either a `labelIds` list (success) or an
+    Exception to raise from the read-back.
+    """
+
+    def message_get(**kwargs):
+        outcome = read_results[kwargs["id"]]
+        request = Mock()
+        if isinstance(outcome, Exception):
+            request.execute.side_effect = outcome
+        else:
+            request.execute.return_value = {"id": kwargs["id"], "labelIds": outcome}
+        return request
+
+    service = Mock()
+    service.users().messages().get.side_effect = message_get
+    if batch_available:
+        service.new_batch_http_request.side_effect = lambda callback: _FakeBatch(
+            callback
+        )
+    else:
+        service.new_batch_http_request.side_effect = RuntimeError("batch unavailable")
+    return service
+
+
+async def _run(service, **kwargs):
+    return await _unwrap(batch_modify_gmail_message_labels)(
+        service=service, user_google_email="user@example.com", **kwargs
+    )
+
+
+@pytest.mark.asyncio
+async def test_unrecognised_id_is_not_reported_as_success():
+    """The regression: a thread ID where a message ID belongs.
+
+    Gmail ignores it and returns 204; the read-back 404s. The result must say
+    so instead of claiming the label was applied.
+    """
+    service = _service({"thread-id": HttpError(_FakeResp(404), b"{}")})
+
+    result = await _run(service, message_ids=["thread-id"], add_label_ids=["TRASH"])
+
+    assert "Applied: 0/1" in result
+    assert "No such message (1)" in result
+    assert "thread-id" in result
+    assert "THREAD id where a MESSAGE id is required" in result
+    # The old wording must not come back.
+    assert "Labels updated for 1 messages" not in result
+
+
+@pytest.mark.asyncio
+async def test_mixed_batch_counts_only_what_landed():
+    service = _service(
+        {
+            "msg-good": ["INBOX", "TRASH"],
+            "msg-gone": HttpError(_FakeResp(404), b"{}"),
+        }
+    )
+
+    result = await _run(
+        service, message_ids=["msg-good", "msg-gone"], add_label_ids=["TRASH"]
+    )
+
+    assert "Applied: 1/2" in result
+    assert "No such message (1): msg-gone" in result
+    assert "msg-good" not in result.split("No such message")[1]
+
+
+@pytest.mark.asyncio
+async def test_removal_that_did_not_take_is_reported_unchanged():
+    """The message exists, but the label we asked to remove is still on it."""
+    service = _service({"msg-1": ["INBOX", "UNREAD"]})
+
+    result = await _run(service, message_ids=["msg-1"], remove_label_ids=["UNREAD"])
+
+    assert "Applied: 0/1" in result
+    assert "Unchanged (1): msg-1" in result
+
+
+@pytest.mark.asyncio
+async def test_read_back_failure_is_reported_as_unverified():
+    """A 500 on the read-back is not a 404 — we cannot claim either outcome."""
+    service = _service({"msg-1": HttpError(_FakeResp(500), b"{}")})
+
+    result = await _run(service, message_ids=["msg-1"], add_label_ids=["TRASH"])
+
+    assert "Applied: 0/1" in result
+    assert "Could not verify (1): msg-1" in result
+    assert "may or may not have been applied" in result
+
+
+@pytest.mark.asyncio
+async def test_verify_false_makes_no_reads_and_says_so():
+    """Opting out must be explicit about what it did not check."""
+    service = _service({})
+
+    result = await _run(
+        service, message_ids=["msg-1", "msg-2"], add_label_ids=["TRASH"], verify=False
+    )
+
+    assert "Requested label changes for 2 message ID(s)" in result
+    assert "NOT VERIFIED" in result
+    service.users().messages().get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sequential_fallback_classifies_when_batch_is_unavailable(monkeypatch):
+    monkeypatch.setattr("gmail.gmail_tools.GMAIL_REQUEST_DELAY", 0)
+    service = _service(
+        {
+            "msg-good": ["TRASH"],
+            "msg-gone": HttpError(_FakeResp(404), b"{}"),
+        },
+        batch_available=False,
+    )
+
+    result = await _run(
+        service, message_ids=["msg-good", "msg-gone"], add_label_ids=["TRASH"]
+    )
+
+    assert "Applied: 1/2" in result
+    assert "No such message (1): msg-gone" in result
+
+
+@pytest.mark.asyncio
+async def test_batch_modify_is_still_called_once_with_all_ids():
+    """Verification is additive — it must not replace the batchModify call."""
+    service = _service({"msg-1": ["TRASH"], "msg-2": ["TRASH"]})
+
+    await _run(service, message_ids=["msg-1", "msg-2"], add_label_ids=["TRASH"])
+
+    service.users().messages().batchModify.assert_called_once_with(
+        userId="me", body={"ids": ["msg-1", "msg-2"], "addLabelIds": ["TRASH"]}
+    )

--- a/tests/gmail/test_batch_modify_label_verification.py
+++ b/tests/gmail/test_batch_modify_label_verification.py
@@ -163,7 +163,9 @@ async def test_missing_batch_result_is_not_applied_for_remove_only_request():
         def execute(self):
             pass
 
-    service.new_batch_http_request.side_effect = lambda callback: _BatchWithoutCallbacks()
+    service.new_batch_http_request.side_effect = lambda callback: (
+        _BatchWithoutCallbacks()
+    )
 
     result = await _run(service, message_ids=["msg-1"], remove_label_ids=["UNREAD"])
 


### PR DESCRIPTION
## The bug

`batch_modify_gmail_message_labels` returns `Labels updated for N messages` where **N is the length of the input list** — not a count of anything Gmail did. `users.messages.batchModify` answers `204 No Content` and **silently ignores IDs it does not recognise**, so a wrong or stale ID produces a confident success indistinguishable from a real one, on every retry, forever.

The easiest way to hit it: pass a **thread** ID where a **message** ID belongs (`draft_gmail_message` returns both; several tools return only thread IDs). Nothing is modified and the tool says it worked. Field report from our deployment: an agent called this three times on the same wrong ID, reported the target trashed each time, and it wasn't — a human caught it, not the tooling. For an agent caller a false success is worse than an error, because it suppresses the retry that would have fixed it. Blast radius is any bulk archive / mark-read / label sweep.

## The fix

After the `batchModify` call, read the messages back (`messages.get(format="minimal")`, batched with the same `new_batch_http_request` + sequential-fallback pattern the batch read tools use) and classify every ID:

- **Applied** — end state matches the request
- **Unchanged** — message exists, labels don't match
- **No such message** — the ID was silently ignored (reported by name, with a hint that a THREAD id may have been passed where a MESSAGE id is required)
- **Could not verify** — the read-back itself failed; no claim either way

```
Label changes for 2 message ID(s): Added labels: TRASH
Applied: 1/2
No such message (1): 1a025da58e17ce23
  These IDs do not resolve to a message in this mailbox, so Gmail ignored them. A common cause is passing a THREAD id where a MESSAGE id is required.
```

`verify=True` is the default — a destructive tool whose failure mode is a confident lie should be correct by default. `verify=False` opts out for very large sweeps and then says plainly that it recorded the request without verifying (`NOT VERIFIED: ...`), never claiming success.

## Tests

7 tests in `tests/gmail/test_batch_modify_label_verification.py`; 6 of them fail against the unpatched tool (the seventh pins that `batchModify` itself is still called once with all IDs — verification is additive, not a replacement). Covers: the thread-ID repro, mixed batches, removal-didn't-take, read-back failure → unverified, `verify=False` wording, and the sequential fallback when the batch endpoint is unavailable. Full suite passes.

Verified live against a deployed streamable-http instance: the exact thread-ID repro that motivated this now returns `Applied: 0/1` with the offending ID named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gmail label updates now verify whether requested changes were applied.
  * Results distinguish successfully updated, unchanged, missing, and unverifiable messages.
  * Invalid or stale IDs are no longer reported as successful updates.
  * Temporary verification failures are retried when possible.

* **New Features**
  * Added an option to skip verification when needed, with results clearly marked as unverified.
  * Verification results now provide clearer per-message outcome summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->