### PR TITLE
fix(auth): three cross-account defects — a refused session rebind is not a failed operation

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -1140,7 +1140,18 @@ def get_credentials(
                     return None
 
                 if persist_succeeded or is_stateless_mode():
-                    # Also update OAuth21SessionStore
+                    # Also update OAuth21SessionStore.
+                    #
+                    # Do NOT bind this session to the refreshed user when the
+                    # session already belongs to somebody else — that is a
+                    # legitimate multi-account request (e.g. the personal
+                    # account's session asking for a second workspace account),
+                    # and the read path above has already flagged it via
+                    # skip_session_cache. Passing mcp_session_id here makes the
+                    # store attempt a rebind, which it correctly refuses with a
+                    # ValueError; that exception was then caught by the generic
+                    # handler below and reported as a REFRESH failure, throwing
+                    # away a token that had just refreshed successfully.
                     store = get_oauth21_session_store()
                     store.store_session(
                         user_email=user_google_email,
@@ -1151,12 +1162,18 @@ def get_credentials(
                         client_secret=credentials.client_secret,
                         scopes=credentials.scopes,
                         expiry=credentials.expiry,
-                        mcp_session_id=session_id,
+                        mcp_session_id=None if skip_session_cache else session_id,
                         issuer="https://accounts.google.com",  # Add issuer for Google tokens
                     )
 
-            if session_id and (persist_succeeded or is_stateless_mode()):
-                # Update session cache if it was the source or is active
+            if (
+                session_id
+                and not skip_session_cache
+                and (persist_succeeded or is_stateless_mode())
+            ):
+                # Update session cache if it was the source or is active.
+                # Skipped for a cross-account request so the cache keeps
+                # belonging to the session's own user.
                 save_credentials_to_session(session_id, credentials)
         except RefreshError as e:
             logger.warning(

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -796,14 +796,30 @@ async def handle_auth_callback(
 
             if session_id:
                 try:
-                    session_credentials = store.get_credentials_by_mcp_session(
-                        session_id
+                    # Only borrow a refresh token from the session when the
+                    # session actually belongs to the account that just
+                    # consented. On a cross-account callback (personal account's
+                    # session consenting for a second workspace account) this
+                    # would otherwise graft the FIRST user's refresh token onto
+                    # the SECOND user's credential.
+                    get_bound_user = getattr(store, "get_user_by_mcp_session", None)
+                    session_user = (
+                        get_bound_user(session_id) if get_bound_user else None
                     )
-                    if session_credentials and session_credentials.refresh_token:
-                        fallback_refresh_token = session_credentials.refresh_token
+                    if session_user and session_user != user_google_email:
                         logger.info(
-                            "OAuth callback response omitted refresh token; preserving existing refresh token from session store."
+                            "OAuth callback response omitted refresh token; session belongs to "
+                            f"{session_user}, not {user_google_email} — not borrowing its refresh token."
                         )
+                    else:
+                        session_credentials = store.get_credentials_by_mcp_session(
+                            session_id
+                        )
+                        if session_credentials and session_credentials.refresh_token:
+                            fallback_refresh_token = session_credentials.refresh_token
+                            logger.info(
+                                "OAuth callback response omitted refresh token; preserving existing refresh token from session store."
+                            )
                 except Exception as e:
                     logger.debug(
                         f"Could not check session store for existing refresh token: {e}"
@@ -856,22 +872,42 @@ async def handle_auth_callback(
                     "session state was not updated."
                 )
 
-        # Always save to OAuth21SessionStore for centralized management
-        store.store_session(
-            user_email=user_google_email,
-            access_token=credentials.token,
-            refresh_token=credentials.refresh_token,
-            token_uri=credentials.token_uri,
-            client_id=credentials.client_id,
-            client_secret=credentials.client_secret,
-            scopes=credentials.scopes,
-            expiry=credentials.expiry,
-            mcp_session_id=session_id,
-            issuer="https://accounts.google.com",  # Add issuer for Google tokens
-        )
+        # Always save to OAuth21SessionStore for centralized management.
+        #
+        # The store refuses to rebind an MCP session that already belongs to
+        # another user, and it is RIGHT to refuse — session bindings are
+        # deliberately immutable. But a refused rebind is not a failed
+        # authorization: by this point the credential is already written to the
+        # on-disk credential store AND keyed by user_email inside the session
+        # store, so everything the caller needs is persisted. Letting the
+        # ValueError escape turns a perfectly good consent into a 500 on
+        # /oauth2callback — the "re-auth appears to work, then doesn't" shape.
+        binding_refused = False
+        try:
+            store.store_session(
+                user_email=user_google_email,
+                access_token=credentials.token,
+                refresh_token=credentials.refresh_token,
+                token_uri=credentials.token_uri,
+                client_id=credentials.client_id,
+                client_secret=credentials.client_secret,
+                scopes=credentials.scopes,
+                expiry=credentials.expiry,
+                mcp_session_id=session_id,
+                issuer="https://accounts.google.com",  # Add issuer for Google tokens
+            )
+        except ValueError as e:
+            binding_refused = True
+            logger.info(
+                f"OAuth callback for {user_google_email}: MCP session {session_id} stays bound to its "
+                f"original user ({e}). Credentials were persisted to the credential store; "
+                "the session cache is left untouched."
+            )
 
-        # If session_id is provided, also save to session cache for compatibility
-        if session_id:
+        # If session_id is provided, also save to session cache for compatibility.
+        # Never when the binding was refused — that cache belongs to the session's
+        # own user and must not be overwritten with a second account's credential.
+        if session_id and not binding_refused:
             save_credentials_to_session(session_id, credentials)
 
         return user_google_email, credentials

--- a/tests/auth/test_google_auth_callback_cross_account.py
+++ b/tests/auth/test_google_auth_callback_cross_account.py
@@ -1,0 +1,129 @@
+"""Cross-account /oauth2callback regressions.
+
+Both cases are the same shape: an MCP session already bound to account A
+completes a consent flow for account B. The session store refuses to rebind the
+session — correctly, bindings are immutable — and the callback path must survive
+that refusal without (a) grafting A's refresh token onto B's credential or
+(b) turning a good consent into a 500.
+"""
+
+import pytest
+
+from auth.google_auth import handle_auth_callback
+
+from tests.auth.test_google_auth_callback_refresh_token import (
+    _DummyCredentialStore,
+    _DummyFlow,
+    _DummyOAuthStore,
+    _make_credentials,
+)
+
+
+class _RebindRefusingOAuthStore(_DummyOAuthStore):
+    """Session store that refuses to rebind a session already owned by someone else."""
+
+    def __init__(self, bound_user, **kwargs):
+        super().__init__(**kwargs)
+        self._bound_user = bound_user
+
+    def get_user_by_mcp_session(self, mcp_session_id):  # noqa: ARG002
+        return self._bound_user
+
+    def store_session(self, **kwargs):
+        super().store_session(**kwargs)
+        if kwargs.get("mcp_session_id") and self._bound_user != kwargs["user_email"]:
+            raise ValueError(
+                f"Session {kwargs['mcp_session_id']} is already bound to a different user"
+            )
+
+
+@pytest.mark.asyncio
+async def test_cross_account_callback_does_not_borrow_session_refresh_token(
+    monkeypatch,
+):
+    """A second account's consent must not inherit the first account's refresh token."""
+    callback_credentials = _make_credentials(refresh_token=None)
+    oauth_store = _RebindRefusingOAuthStore(
+        bound_user="first@personal.com",
+        session_credentials=_make_credentials(refresh_token="first-user-refresh-token"),
+    )
+    credential_store = _DummyCredentialStore(
+        existing_credentials=_make_credentials(
+            refresh_token="second-user-refresh-token"
+        )
+    )
+
+    monkeypatch.setattr(
+        "auth.google_auth.create_oauth_flow",
+        lambda **kwargs: _DummyFlow(callback_credentials),  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_oauth21_session_store", lambda: oauth_store
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_credential_store", lambda: credential_store
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_user_info",
+        lambda credentials: {"email": "second@work.org"},  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.save_credentials_to_session", lambda *args: None
+    )
+    monkeypatch.setattr("auth.google_auth.is_stateless_mode", lambda: False)
+
+    _email, credentials = await handle_auth_callback(
+        scopes=["scope.a"],
+        authorization_response="http://localhost/callback?state=abc123&code=code123",
+        redirect_uri="http://localhost/callback",
+        session_id="session-1",
+    )
+
+    assert credentials.refresh_token == "second-user-refresh-token"
+
+
+@pytest.mark.asyncio
+async def test_cross_account_callback_survives_refused_session_rebind(monkeypatch):
+    """A refused rebind is not a failed authorization — it must not 500 the callback."""
+    callback_credentials = _make_credentials(refresh_token="second-user-refresh-token")
+    oauth_store = _RebindRefusingOAuthStore(
+        bound_user="first@personal.com", session_credentials=None
+    )
+    credential_store = _DummyCredentialStore(existing_credentials=None)
+    session_cache_writes = []
+
+    monkeypatch.setattr(
+        "auth.google_auth.create_oauth_flow",
+        lambda **kwargs: _DummyFlow(callback_credentials),  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_oauth21_session_store", lambda: oauth_store
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_credential_store", lambda: credential_store
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_user_info",
+        lambda credentials: {"email": "second@work.org"},  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.save_credentials_to_session",
+        lambda *args: session_cache_writes.append(args),
+    )
+    monkeypatch.setattr("auth.google_auth.is_stateless_mode", lambda: False)
+
+    email, credentials = await handle_auth_callback(
+        scopes=["scope.a"],
+        authorization_response="http://localhost/callback?state=abc123&code=code123",
+        redirect_uri="http://localhost/callback",
+        session_id="session-1",
+    )
+
+    # The consent succeeded and the credential reached the on-disk store ...
+    assert email == "second@work.org"
+    assert credentials.refresh_token == "second-user-refresh-token"
+    assert (
+        credential_store.saved_credentials.refresh_token == "second-user-refresh-token"
+    )
+    # ... and the first user's session cache was left alone.
+    assert session_cache_writes == []


### PR DESCRIPTION
Three defects, one root cause: **`OAuth21SessionStore` correctly refuses to rebind an MCP session to a second user, and three call sites treat that refusal as a failure of the operation they were performing.** The result is that a second Google account is unreachable from a session bound to a first one — and, in the third case, that a wrong credential is written and success is returned.

This is a general multi-account defect, not a configuration problem. Anyone running a personal Google account alongside a workspace account can hit it.

---

## ① A refreshed credential is discarded when the session belongs to another user

`get_credentials()` has an asymmetry between two paths. The **read** path handles the cross-account case correctly — it notices the mismatch, sets `skip_session_cache = True`, logs `Session user X doesn't match requested Y; skipping session store`, and moves on. The **write-back-after-refresh** path ignores that flag and calls:

```python
store.store_session(..., mcp_session_id=session_id, ...)
```

The store raises `ValueError: Session <id> is already bound to a different user` — correctly; bindings are immutable. But the call sits inside a `try` whose generic `except Exception` returns `None`, so **a refused rebind is reported as a failed refresh**, and a credential that had just refreshed successfully *and been persisted to disk* is thrown away:

```
[get_credentials] Session user a@first.com doesn't match requested b@second.org; skipping session store
[get_credentials] Credentials not valid. Attempting refresh. User: 'b@second.org'
[get_credentials] Credentials refreshed successfully. User: 'b@second.org'      <-- token is fine
[CREDS] Stored credentials for b@second.org to .../credentials/b@second.org.json <-- and persisted
[ERROR] SECURITY: Attempt to rebind session <id> from a@first.com to b@second.org
[get_credentials] Error refreshing credentials: Session <id> is already bound to a different user.
[get_events] No valid credentials. Email: 'b@second.org'.
--> ACTION REQUIRED: Google Authentication Needed ...
```

**Fix:** pass `mcp_session_id=None` when `skip_session_cache` is set, so the refreshed credential persists to the on-disk credential store — already the correct home for multi-account use — without attempting a rebind. `save_credentials_to_session()` is guarded the same way, so account B's credential can never land in account A's session cache.

## ② A refused rebind returns HTTP 500 from the OAuth callback

`handle_auth_callback()` has the same unconditional `mcp_session_id=session_id`, with a worse presentation: the `ValueError` reaches the generic handler, so **a successful consent is reported to the browser as HTTP 500 on `/oauth2callback`**. In one real deployment this accounted for 4 of 8 HTTP 500s over a ten-week window.

By that point the credential has already been written to the on-disk store *and* keyed by `user_email` inside the session store, so nothing is actually missing — only the session→user mapping, which **should** not be rebound, failed. Caught, logged at INFO, and execution continues.

**This is the mechanism behind "re-authenticating fixes it, until it doesn't":** the consent that would repair the account is itself refused whenever the session already belongs to the other account.

## ③ Silent cross-account refresh-token grafting — the reason to merge

**This one does not throw, does not log an error, and returns success.**

When Google's callback omits a refresh token — **routine on re-consent, not an edge case** — the code falls back to the refresh token held by the MCP session, without checking whose session it is. On a cross-account callback that **grafts the first account's refresh token onto the second account's credential.**

Nothing fails at the moment of corruption. The symptom is a second account that mysteriously stops working later, with nothing in the logs pointing back at when it broke. ① and ② announce themselves; this one writes a wrong credential quietly.

**Fix:** guard the fallback on `get_user_by_mcp_session(session_id) == user_google_email`. The credential-store fallback below it is already keyed by email and correct. Accessed via `getattr` so a session store without the method degrades to the previous behaviour.

---

## Why this is hard to diagnose from outside

The failure presents as a token expiry, and **re-authenticating appears to fix it**: the consent flow returns a credential in a context not yet bound to the first account, so the very next call succeeds. Every call after that fails again, because the session has re-bound. That produces a loop of "re-auth works, then breaks within the day" that looks like a token-lifetime problem.

Two red herrings we chased, recorded so others don't:

- **A refresh-token lifetime problem.** Ruled out by the logs — the refresh *succeeds*.
- **A credential-persistence problem.** The on-disk credential file was being rewritten on every **failed** call, which looked exactly like persistence failing and was in fact proof that persistence worked. The evidence pointed 180° from what it appeared to say.

## Verification

Reproduced and confirmed on the sequence that used to fail:

1. Call a tool as **account A** — this binds the MCP session (the precondition for the bug).
2. Call the same tool as **account B** on that same session.

Before: the `ACTION REQUIRED` consent wall, every time. After: data returns normally. Verified against real Google Calendar `get_events` calls across two accounts in one session.

Tests: `tests/auth/test_google_auth_callback_cross_account.py` covers ② and ③ — both fail against `main` and pass here. Full auth suite: 133 passed.

The security guard itself is untouched throughout. The rebind is still refused; it is simply no longer mistaken for a failure of the surrounding operation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google authentication when switching between accounts.
  * Prevented credentials from being borrowed across accounts.
  * Preserved existing sessions when account rebinding is declined.
  * Ensured successful authorization is not blocked by session rebinding issues.
  * Prevented cross-account credentials from overwriting session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->