### PR TITLE
docs(drive): clarify file_name extension drives source-format detection

### DIFF
--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -1380,7 +1380,7 @@ async def import_to_google_doc(
 
     Args:
         user_google_email (str): The user's Google email address. Required.
-        file_name (str): The name for the new Google Doc (extension will be ignored).
+        file_name (str): The name for the new Google Doc. The extension is stripped from the title, but when 'content' is provided without 'source_format', the extension still drives source-format auto-detection (e.g. end file_name in '.md' so Markdown content, including tables, is not misdetected as plain text).
         content (Optional[str]): Text content for text-based formats. Use only for short snippets or content already in memory.
         file_path (Optional[str]): Local file path or file:// URL for any supported format (MD, TXT, HTML, DOCX, ODT, RTF). Appropriate for larger files than content, but file_path may still load the file into memory or perform non-streaming reads. Avoid very large files that could exceed memory or time limits; use streaming/chunked uploads or an alternative API for huge files.
         file_url (Optional[str]): Remote URL to fetch the file from (http/https).
@@ -1516,7 +1516,7 @@ async def import_to_google_sheets(
 
     Args:
         user_google_email (str): The user's Google email address. Required.
-        file_name (str): The name for the new Google Sheets spreadsheet (extension will be ignored).
+        file_name (str): The name for the new Google Sheets spreadsheet. The extension is stripped from the title, but when 'content' is provided without 'source_format', the extension still drives source-format auto-detection (e.g. end file_name in '.csv' so CSV content is not misdetected).
         content (Optional[str]): Text content for text-based formats (CSV, TSV). Use only for short snippets or content already in memory.
         file_path (Optional[str]): Local file path or file:// URL for any supported format (XLSX, XLS, ODS, CSV, TSV). Appropriate for larger files than content, but file_path may still load the file into memory or perform non-streaming reads. Avoid very large files that could exceed memory or time limits; use streaming/chunked uploads or an alternative API for huge files.
         file_url (Optional[str]): Remote URL to fetch the spreadsheet from (http/https).

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -1380,7 +1380,7 @@ async def import_to_google_doc(
 
     Args:
         user_google_email (str): The user's Google email address. Required.
-        file_name (str): The name for the new Google Doc. The extension is stripped from the title, but when 'content' is provided without 'source_format', the extension still drives source-format auto-detection (e.g. end file_name in '.md' so Markdown content, including tables, is not misdetected as plain text).
+        file_name (str): The name for the new Google Doc. The extension is stripped from the title, but when 'content' is provided without 'source_format', the extension still drives source-format auto-detection (e.g. end file_name with '.md' so Markdown content, including tables, is not misdetected as plain text).
         content (Optional[str]): Text content for text-based formats. Use only for short snippets or content already in memory.
         file_path (Optional[str]): Local file path or file:// URL for any supported format (MD, TXT, HTML, DOCX, ODT, RTF). Appropriate for larger files than content, but file_path may still load the file into memory or perform non-streaming reads. Avoid very large files that could exceed memory or time limits; use streaming/chunked uploads or an alternative API for huge files.
         file_url (Optional[str]): Remote URL to fetch the file from (http/https).
@@ -1516,7 +1516,7 @@ async def import_to_google_sheets(
 
     Args:
         user_google_email (str): The user's Google email address. Required.
-        file_name (str): The name for the new Google Sheets spreadsheet. The extension is stripped from the title, but when 'content' is provided without 'source_format', the extension still drives source-format auto-detection (e.g. end file_name in '.csv' so CSV content is not misdetected).
+        file_name (str): The name for the new Google Sheets spreadsheet. The extension is stripped from the title, but when 'content' is provided without 'source_format', the extension still drives source-format auto-detection (e.g. end file_name with '.csv' so CSV content is not misdetected).
         content (Optional[str]): Text content for text-based formats (CSV, TSV). Use only for short snippets or content already in memory.
         file_path (Optional[str]): Local file path or file:// URL for any supported format (XLSX, XLS, ODS, CSV, TSV). Appropriate for larger files than content, but file_path may still load the file into memory or perform non-streaming reads. Avoid very large files that could exceed memory or time limits; use streaming/chunked uploads or an alternative API for huge files.
         file_url (Optional[str]): Remote URL to fetch the spreadsheet from (http/https).


### PR DESCRIPTION
## Description

`import_to_google_doc` and `import_to_google_sheets` both document `file_name` as *"The name for the new Google Doc/Sheets spreadsheet (extension will be ignored)"*. That's true for the resulting title (`Path(file_name).stem`), but not for the whole pipeline: when `content` is passed without an explicit `source_format`, `_resolve_import_media` in `gdrive/drive_helpers.py` falls back to `file_name`'s extension for source-format detection (`_detect_source_format`, keyed on `Path(file_name).suffix.lower()`).

Without a recognized extension on `file_name`, detection falls through to a content heuristic (`content.startswith("#")`, backtick fences, `**`), and failing that, `text/plain`. Concretely: `import_to_google_doc(file_name="My Doc", content="| a | b |\n|---|---|\n...")` (a Markdown table) can silently import as literal text instead of a converted Doc, because `file_name` has no `.md` suffix and the heuristic doesn't fire on table syntax.

This PR only touches the docstrings — it clarifies that the extension is dropped from the title but still drives auto-detection when `content` is used, and tells the caller to keep a `.md`/`.csv` suffix on `file_name` in that case. `import_to_google_slides` doesn't take `content` (only `file_path`/`file_url`, which use their own path for detection), so its docstring is accurate as-is and untouched.

## Type of Change
- [x] Documentation update

## Testing
Docstring-only change, no behavior change. N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected the wording in Google Docs and Google Sheets import examples to clarify how filenames are specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->