### PR TITLE
feat(gdocs): support Google Docs suggested edits (suggest mode)

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -73,6 +73,7 @@ docs:
     - update_doc_headers_footers
     - batch_update_doc
     - manage_doc_suggestions
+    - list_doc_suggestions
     - inspect_doc_structure
     - create_table_with_data
     - debug_table_structure

--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -72,6 +72,7 @@ docs:
     - insert_doc_image
     - update_doc_headers_footers
     - batch_update_doc
+    - manage_doc_suggestions
     - inspect_doc_structure
     - create_table_with_data
     - debug_table_structure

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -1347,9 +1347,10 @@ async def batch_update_doc(
             Google Cloud project to be enrolled in the Workspace Developer
             Preview Program; otherwise the API call will fail. Not every
             operation type can be suggested - insert_doc_tab, delete_doc_tab,
-            update_doc_tab, create_named_range, delete_named_range, and
-            update_table_column_properties are rejected by the API in suggest
-            mode, as are the document_mode/use_even_page_header_footer/
+            update_doc_tab, create_named_range, delete_named_range,
+            update_table_column_properties, and create_header_footer are
+            rejected by the API in suggest mode, as are the
+            document_mode/use_even_page_header_footer/
             use_first_page_header_footer fields of update_document_style.
 
     Returns:
@@ -1410,6 +1411,11 @@ async def batch_update_doc(
                 (await _fetch_doc_suggestions(service, document_id)).keys()
             )
         except Exception:
+            logger.warning(
+                f"[batch_update_doc] Pre-batch suggestion fetch failed for "
+                f"{document_id}; skipping suggest_mode verification.",
+                exc_info=True,
+            )
             verify_enrollment = False
 
     # Use BatchOperationManager to handle the complex logic
@@ -1425,6 +1431,11 @@ async def batch_update_doc(
                 (await _fetch_doc_suggestions(service, document_id)).keys()
             )
         except Exception:
+            logger.warning(
+                f"[batch_update_doc] Post-batch suggestion fetch failed for "
+                f"{document_id}; enrollment verification inconclusive.",
+                exc_info=True,
+            )
             after_suggestion_ids = before_suggestion_ids  # inconclusive; don't flag
 
         if after_suggestion_ids - before_suggestion_ids:
@@ -1561,7 +1572,18 @@ def _collect_suggestions_from_elements(
     """
     Recursively walk document content elements collecting suggestion IDs
     (suggestedInsertionIds, suggestedDeletionIds, suggestedTextStyleChanges)
-    found on text runs, keyed by suggestion ID.
+    found on paragraph elements, keyed by suggestion ID.
+
+    Every ParagraphElement variant (textRun, autoText, pageBreak, columnBreak,
+    footnoteReference, horizontalRule, inlineObjectElement, person, richLink,
+    date) carries these fields the same way, so this walks every dict-valued
+    key on the element generically instead of special-casing textRun.
+
+    Known gaps (not covered here): suggestedParagraphStyleChanges/
+    suggestedBulletChanges at the paragraph level, and suggestion IDs on
+    tables/rows/cells themselves (only their text content is walked). These
+    would need dedicated handling to surface paragraph-style, bullet, and
+    table-structure suggestions in list_doc_suggestions.
     """
     if depth > 5:
         return
@@ -1570,32 +1592,35 @@ def _collect_suggestions_from_elements(
         paragraph = element.get("paragraph")
         if paragraph:
             for pe in paragraph.get("elements", []):
-                text_run = pe.get("textRun")
-                if not text_run:
-                    continue
-                content = text_run.get("content", "")
+                for sub in pe.values():
+                    if not isinstance(sub, dict):
+                        continue
+                    content = sub.get("content", "")
 
-                for sid in text_run.get("suggestedInsertionIds", []):
-                    entry = suggestions.setdefault(
-                        sid, {"types": set(), "text_preview": "", "tab_id": tab_id}
-                    )
-                    entry["types"].add("insertion")
-                    entry["text_preview"] += content
+                    for sid in sub.get("suggestedInsertionIds", []):
+                        entry = suggestions.setdefault(
+                            sid,
+                            {"types": set(), "text_preview": "", "tab_id": tab_id},
+                        )
+                        entry["types"].add("insertion")
+                        entry["text_preview"] += content
 
-                for sid in text_run.get("suggestedDeletionIds", []):
-                    entry = suggestions.setdefault(
-                        sid, {"types": set(), "text_preview": "", "tab_id": tab_id}
-                    )
-                    entry["types"].add("deletion")
-                    entry["text_preview"] += content
+                    for sid in sub.get("suggestedDeletionIds", []):
+                        entry = suggestions.setdefault(
+                            sid,
+                            {"types": set(), "text_preview": "", "tab_id": tab_id},
+                        )
+                        entry["types"].add("deletion")
+                        entry["text_preview"] += content
 
-                for sid in text_run.get("suggestedTextStyleChanges", {}):
-                    entry = suggestions.setdefault(
-                        sid, {"types": set(), "text_preview": "", "tab_id": tab_id}
-                    )
-                    entry["types"].add("style")
-                    if not entry["text_preview"]:
-                        entry["text_preview"] = content
+                    for sid in sub.get("suggestedTextStyleChanges", {}):
+                        entry = suggestions.setdefault(
+                            sid,
+                            {"types": set(), "text_preview": "", "tab_id": tab_id},
+                        )
+                        entry["types"].add("style")
+                        if not entry["text_preview"]:
+                            entry["text_preview"] = content
 
         table = element.get("table")
         if table:
@@ -1606,12 +1631,25 @@ def _collect_suggestions_from_elements(
                     )
 
 
+def _collect_suggestions_from_segment_map(
+    segment_map: dict[str, Any],
+    suggestions: dict[str, dict[str, Any]],
+    tab_id: Optional[str] = None,
+) -> None:
+    """Walk a headers/footers/footnotes map (id -> {"content": [...]})."""
+    for segment in segment_map.values():
+        _collect_suggestions_from_elements(
+            segment.get("content", []), suggestions, tab_id
+        )
+
+
 async def _fetch_doc_suggestions(
     service: Any, document_id: str
 ) -> dict[str, dict[str, Any]]:
     """
     Fetch a document with suggestionsViewMode=SUGGESTIONS_INLINE and return
-    every pending suggestion found, keyed by suggestion ID.
+    every pending suggestion found in the body, headers, footers, and
+    footnotes of the main document and every tab, keyed by suggestion ID.
     """
     doc_data = await asyncio.to_thread(
         service.documents()
@@ -1628,6 +1666,9 @@ async def _fetch_doc_suggestions(
     _collect_suggestions_from_elements(
         doc_data.get("body", {}).get("content", []), suggestions
     )
+    _collect_suggestions_from_segment_map(doc_data.get("headers", {}), suggestions)
+    _collect_suggestions_from_segment_map(doc_data.get("footers", {}), suggestions)
+    _collect_suggestions_from_segment_map(doc_data.get("footnotes", {}), suggestions)
 
     def walk_tabs(tab: dict[str, Any]) -> None:
         doc_tab = tab.get("documentTab")
@@ -1635,6 +1676,15 @@ async def _fetch_doc_suggestions(
             tab_id = tab.get("tabProperties", {}).get("tabId")
             _collect_suggestions_from_elements(
                 doc_tab.get("body", {}).get("content", []), suggestions, tab_id
+            )
+            _collect_suggestions_from_segment_map(
+                doc_tab.get("headers", {}), suggestions, tab_id
+            )
+            _collect_suggestions_from_segment_map(
+                doc_tab.get("footers", {}), suggestions, tab_id
+            )
+            _collect_suggestions_from_segment_map(
+                doc_tab.get("footnotes", {}), suggestions, tab_id
             )
         for child_tab in tab.get("childTabs", []):
             walk_tabs(child_tab)
@@ -1974,6 +2024,7 @@ _SUGGEST_MODE_UNSUPPORTED_OPERATION_TYPES = {
     "create_named_range": "CreateNamedRange",
     "delete_named_range": "DeleteNamedRange",
     "update_table_column_properties": "UpdateTableColumnProperties",
+    "create_header_footer": "CreateHeader/CreateFooter",
 }
 
 # update_document_style fields the API rejects as suggestions.

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -1431,29 +1431,35 @@ async def batch_update_doc(
                 (await _fetch_doc_suggestions(service, document_id)).keys()
             )
         except Exception:
+            # The batch itself already succeeded; a failure here only means
+            # verification is inconclusive, not that suggest_mode failed. Log
+            # and leave the enrollment cache untouched rather than risk
+            # flagging a working project as unenrolled off a transient read
+            # error.
             logger.warning(
                 f"[batch_update_doc] Post-batch suggestion fetch failed for "
                 f"{document_id}; enrollment verification inconclusive.",
                 exc_info=True,
             )
-            after_suggestion_ids = before_suggestion_ids  # inconclusive; don't flag
+            after_suggestion_ids = None
 
-        if after_suggestion_ids - before_suggestion_ids:
-            _SUGGEST_MODE_ENROLLED = True
-        else:
-            _SUGGEST_MODE_ENROLLED = False
-            return (
-                "Error: suggest_mode=true was requested, but verification shows "
-                f"the changes were applied directly to document {document_id} "
-                "instead of as pending suggestions. This Google Cloud project is "
-                "most likely not enrolled in the Workspace Developer Preview "
-                f"Program ({_DEVELOPER_PREVIEW_URL}), required for suggested "
-                "edits. Your changes ARE now live in the document (Google "
-                "silently ignored suggest_mode) - undo manually in the Docs UI "
-                "(Edit > Undo) if that's not what you wanted. suggest_mode and "
-                "manage_doc_suggestions are now disabled for the rest of this "
-                "server session; restart the server after enrolling to re-check."
-            )
+        if after_suggestion_ids is not None:
+            if after_suggestion_ids - before_suggestion_ids:
+                _SUGGEST_MODE_ENROLLED = True
+            else:
+                _SUGGEST_MODE_ENROLLED = False
+                return (
+                    "Error: suggest_mode=true was requested, but verification shows "
+                    f"the changes were applied directly to document {document_id} "
+                    "instead of as pending suggestions. This Google Cloud project is "
+                    "most likely not enrolled in the Workspace Developer Preview "
+                    f"Program ({_DEVELOPER_PREVIEW_URL}), required for suggested "
+                    "edits. Your changes ARE now live in the document (Google "
+                    "silently ignored suggest_mode) - undo manually in the Docs UI "
+                    "(Edit > Undo) if that's not what you wanted. suggest_mode and "
+                    "manage_doc_suggestions are now disabled for the rest of this "
+                    "server session; restart the server after enrolling to re-check."
+                )
 
     if success:
         link = f"https://docs.google.com/document/d/{document_id}/edit"

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -74,6 +74,42 @@ import json
 logger = logging.getLogger(__name__)
 HEADER_FOOTER_RUNTIME_CANARY = "docs-hf-canary-20260328b"
 
+# Google exposes no API to query Workspace Developer Preview Program
+# enrollment. Suggested edits (suggest_mode) and suggestion-thread management
+# (manage_doc_suggestions) are Preview-only, so the only way to know whether
+# the caller's Cloud project is enrolled is to actually try it and check the
+# result. This cache holds that outcome for the life of the process:
+#   None  - not yet verified
+#   True  - a suggest_mode call was confirmed to produce a real suggestion
+#   False - a suggest_mode call silently applied as a direct edit (or a
+#           suggestion-thread call failed), meaning the project is almost
+#           certainly not enrolled; suggestion features are disabled for the
+#           rest of this process.
+_SUGGEST_MODE_ENROLLED: Optional[bool] = None
+
+# Operation types that leave a suggestedInsertionIds/suggestedDeletionIds/
+# suggestedTextStyleChanges marker on a text run, so a before/after diff can
+# actually detect whether suggest_mode took effect.
+_SUGGEST_MODE_VERIFIABLE_OP_TYPES = {
+    "insert_text",
+    "delete_text",
+    "replace_text",
+    "format_text",
+    "find_replace",
+}
+
+_DEVELOPER_PREVIEW_URL = "https://developers.google.com/workspace/preview"
+
+_SUGGEST_MODE_NOT_ENROLLED_ERROR = (
+    "Suggestion features are disabled for this server process: an earlier call "
+    "showed that suggested edits were applied directly to the document instead "
+    "of as pending suggestions, which means this Google Cloud project is most "
+    f"likely not enrolled in the Workspace Developer Preview Program ({_DEVELOPER_PREVIEW_URL}), "
+    "required for suggest_mode and manage_doc_suggestions. Enroll there, then "
+    "restart this server to re-check. In the meantime, call batch_update_doc "
+    "with suggest_mode=false to apply changes directly."
+)
+
 
 @server.tool(
     title="Search Docs",
@@ -1319,6 +1355,8 @@ async def batch_update_doc(
     Returns:
         str: Confirmation message with batch results and document length for chaining
     """
+    global _SUGGEST_MODE_ENROLLED
+
     normalized_operations = [
         operation.model_dump(exclude_none=True)
         if hasattr(operation, "model_dump")
@@ -1343,9 +1381,36 @@ async def batch_update_doc(
         return f"Error: {error_msg}"
 
     if suggest_mode:
+        if _SUGGEST_MODE_ENROLLED is False:
+            return f"Error: {_SUGGEST_MODE_NOT_ENROLLED_ERROR}"
+
         unsupported_error = _validate_suggest_mode_operations(normalized_operations)
         if unsupported_error:
             return f"Error: {unsupported_error}"
+
+    # Google exposes no capability-check API for Developer Preview enrollment,
+    # and an unenrolled project may silently ignore writeControl.writeMode and
+    # apply changes directly instead of erroring. So the first time suggest_mode
+    # is used in this process, verify it actually produced a suggestion by
+    # diffing suggestion IDs before/after. Only meaningful for op types that
+    # leave a suggestedInsertionIds/suggestedDeletionIds/suggestedTextStyleChanges
+    # marker on a text run; skipped (and trusted) for structural-only batches.
+    verify_enrollment = (
+        suggest_mode
+        and _SUGGEST_MODE_ENROLLED is not True
+        and any(
+            op.get("type") in _SUGGEST_MODE_VERIFIABLE_OP_TYPES
+            for op in normalized_operations
+        )
+    )
+    before_suggestion_ids: set[str] = set()
+    if verify_enrollment:
+        try:
+            before_suggestion_ids = set(
+                (await _fetch_doc_suggestions(service, document_id)).keys()
+            )
+        except Exception:
+            verify_enrollment = False
 
     # Use BatchOperationManager to handle the complex logic
     batch_manager = BatchOperationManager(service)
@@ -1353,6 +1418,31 @@ async def batch_update_doc(
     success, message, metadata = await batch_manager.execute_batch_operations(
         document_id, normalized_operations, suggest_mode=suggest_mode
     )
+
+    if success and verify_enrollment:
+        try:
+            after_suggestion_ids = set(
+                (await _fetch_doc_suggestions(service, document_id)).keys()
+            )
+        except Exception:
+            after_suggestion_ids = before_suggestion_ids  # inconclusive; don't flag
+
+        if after_suggestion_ids - before_suggestion_ids:
+            _SUGGEST_MODE_ENROLLED = True
+        else:
+            _SUGGEST_MODE_ENROLLED = False
+            return (
+                "Error: suggest_mode=true was requested, but verification shows "
+                f"the changes were applied directly to document {document_id} "
+                "instead of as pending suggestions. This Google Cloud project is "
+                "most likely not enrolled in the Workspace Developer Preview "
+                f"Program ({_DEVELOPER_PREVIEW_URL}), required for suggested "
+                "edits. Your changes ARE now live in the document (Google "
+                "silently ignored suggest_mode) - undo manually in the Docs UI "
+                "(Edit > Undo) if that's not what you wanted. suggest_mode and "
+                "manage_doc_suggestions are now disabled for the rest of this "
+                "server session; restart the server after enrolling to re-check."
+            )
 
     if success:
         link = f"https://docs.google.com/document/d/{document_id}/edit"
@@ -1417,6 +1507,11 @@ async def manage_doc_suggestions(
     Returns:
         str: Confirmation message including how many suggestions were processed
     """
+    global _SUGGEST_MODE_ENROLLED
+
+    if _SUGGEST_MODE_ENROLLED is False:
+        return f"Error: {_SUGGEST_MODE_NOT_ENROLLED_ERROR}"
+
     if not suggestion_ids:
         return "Error: suggestion_ids cannot be empty"
 
@@ -1443,6 +1538,10 @@ async def manage_doc_suggestions(
         .batchUpdate(documentId=document_id, body={"requests": requests})
         .execute
     )
+
+    # A successful accept/reject/delete is itself confirmation the Preview
+    # feature works for this project.
+    _SUGGEST_MODE_ENROLLED = True
 
     comment_state = result.get("commentUpdateState")
     link = f"https://docs.google.com/document/d/{document_id}/edit"
@@ -1507,6 +1606,45 @@ def _collect_suggestions_from_elements(
                     )
 
 
+async def _fetch_doc_suggestions(
+    service: Any, document_id: str
+) -> dict[str, dict[str, Any]]:
+    """
+    Fetch a document with suggestionsViewMode=SUGGESTIONS_INLINE and return
+    every pending suggestion found, keyed by suggestion ID.
+    """
+    doc_data = await asyncio.to_thread(
+        service.documents()
+        .get(
+            documentId=document_id,
+            includeTabsContent=True,
+            suggestionsViewMode="SUGGESTIONS_INLINE",
+        )
+        .execute
+    )
+
+    suggestions: dict[str, dict[str, Any]] = {}
+
+    _collect_suggestions_from_elements(
+        doc_data.get("body", {}).get("content", []), suggestions
+    )
+
+    def walk_tabs(tab: dict[str, Any]) -> None:
+        doc_tab = tab.get("documentTab")
+        if doc_tab:
+            tab_id = tab.get("tabProperties", {}).get("tabId")
+            _collect_suggestions_from_elements(
+                doc_tab.get("body", {}).get("content", []), suggestions, tab_id
+            )
+        for child_tab in tab.get("childTabs", []):
+            walk_tabs(child_tab)
+
+    for tab in doc_data.get("tabs", []):
+        walk_tabs(tab)
+
+    return suggestions
+
+
 @server.tool(
     title="List Doc Suggestions",
     annotations=ToolAnnotations(
@@ -1543,34 +1681,7 @@ async def list_doc_suggestions(
         str: One line per suggestion thread ("suggestion_id | types | text
              preview"), or a message if there are no pending suggestions.
     """
-    doc_data = await asyncio.to_thread(
-        service.documents()
-        .get(
-            documentId=document_id,
-            includeTabsContent=True,
-            suggestionsViewMode="SUGGESTIONS_INLINE",
-        )
-        .execute
-    )
-
-    suggestions: dict[str, dict[str, Any]] = {}
-
-    _collect_suggestions_from_elements(
-        doc_data.get("body", {}).get("content", []), suggestions
-    )
-
-    def walk_tabs(tab: dict[str, Any]) -> None:
-        doc_tab = tab.get("documentTab")
-        if doc_tab:
-            tab_id = tab.get("tabProperties", {}).get("tabId")
-            _collect_suggestions_from_elements(
-                doc_tab.get("body", {}).get("content", []), suggestions, tab_id
-            )
-        for child_tab in tab.get("childTabs", []):
-            walk_tabs(child_tab)
-
-    for tab in doc_data.get("tabs", []):
-        walk_tabs(tab)
+    suggestions = await _fetch_doc_suggestions(service, document_id)
 
     link = f"https://docs.google.com/document/d/{document_id}/edit"
 

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -1401,10 +1401,9 @@ async def manage_doc_suggestions(
     Requires the requesting Google Cloud project to be enrolled in the
     Workspace Developer Preview Program; otherwise the API call will fail.
 
-    To find suggestion_ids, call get_doc_content or inspect_doc_structure with
-    suggestions_view_mode="SUGGESTIONS_INLINE" and look for the
-    suggestedInsertionIds / suggestedDeletionIds fields on text runs - each ID
-    identifies a suggestion thread (e.g. "suggest.vcti8ewm4mww").
+    To find suggestion_ids, call list_doc_suggestions first - it returns each
+    pending suggestion thread's ID (e.g. "suggest.vcti8ewm4mww") along with a
+    text preview.
 
     Args:
         user_google_email: User's Google email address
@@ -1452,6 +1451,143 @@ async def manage_doc_suggestions(
         f"in document {document_id} (comment_update_state: {comment_state}). "
         f"Link: {link}"
     )
+
+
+def _collect_suggestions_from_elements(
+    elements: list[dict[str, Any]],
+    suggestions: dict[str, dict[str, Any]],
+    tab_id: Optional[str] = None,
+    depth: int = 0,
+) -> None:
+    """
+    Recursively walk document content elements collecting suggestion IDs
+    (suggestedInsertionIds, suggestedDeletionIds, suggestedTextStyleChanges)
+    found on text runs, keyed by suggestion ID.
+    """
+    if depth > 5:
+        return
+
+    for element in elements:
+        paragraph = element.get("paragraph")
+        if paragraph:
+            for pe in paragraph.get("elements", []):
+                text_run = pe.get("textRun")
+                if not text_run:
+                    continue
+                content = text_run.get("content", "")
+
+                for sid in text_run.get("suggestedInsertionIds", []):
+                    entry = suggestions.setdefault(
+                        sid, {"types": set(), "text_preview": "", "tab_id": tab_id}
+                    )
+                    entry["types"].add("insertion")
+                    entry["text_preview"] += content
+
+                for sid in text_run.get("suggestedDeletionIds", []):
+                    entry = suggestions.setdefault(
+                        sid, {"types": set(), "text_preview": "", "tab_id": tab_id}
+                    )
+                    entry["types"].add("deletion")
+                    entry["text_preview"] += content
+
+                for sid in text_run.get("suggestedTextStyleChanges", {}):
+                    entry = suggestions.setdefault(
+                        sid, {"types": set(), "text_preview": "", "tab_id": tab_id}
+                    )
+                    entry["types"].add("style")
+                    if not entry["text_preview"]:
+                        entry["text_preview"] = content
+
+        table = element.get("table")
+        if table:
+            for row in table.get("tableRows", []):
+                for cell in row.get("tableCells", []):
+                    _collect_suggestions_from_elements(
+                        cell.get("content", []), suggestions, tab_id, depth + 1
+                    )
+
+
+@server.tool(
+    title="List Doc Suggestions",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("list_doc_suggestions", is_read_only=True, service_type="docs")
+@require_google_service("docs", "docs_read")
+async def list_doc_suggestions(
+    service: Any,
+    user_google_email: str,
+    document_id: str,
+) -> str:
+    """
+    Lists pending suggestion threads in a Google Doc, with the suggestion_id
+    values needed to call manage_doc_suggestions (accept/reject/delete).
+
+    Fetches the document with suggestionsViewMode=SUGGESTIONS_INLINE and
+    extracts every suggestion ID found on text runs (suggestedInsertionIds,
+    suggestedDeletionIds, suggestedTextStyleChanges), grouped by ID with a
+    text preview and whether it's an insertion, deletion, and/or style change.
+
+    Note: the Docs API does not expose the author or timestamp of a
+    suggestion - only its ID, type, and affected text are available here.
+
+    Args:
+        user_google_email: User's Google email address
+        document_id: ID of the document to inspect
+
+    Returns:
+        str: One line per suggestion thread ("suggestion_id | types | text
+             preview"), or a message if there are no pending suggestions.
+    """
+    doc_data = await asyncio.to_thread(
+        service.documents()
+        .get(
+            documentId=document_id,
+            includeTabsContent=True,
+            suggestionsViewMode="SUGGESTIONS_INLINE",
+        )
+        .execute
+    )
+
+    suggestions: dict[str, dict[str, Any]] = {}
+
+    _collect_suggestions_from_elements(
+        doc_data.get("body", {}).get("content", []), suggestions
+    )
+
+    def walk_tabs(tab: dict[str, Any]) -> None:
+        doc_tab = tab.get("documentTab")
+        if doc_tab:
+            tab_id = tab.get("tabProperties", {}).get("tabId")
+            _collect_suggestions_from_elements(
+                doc_tab.get("body", {}).get("content", []), suggestions, tab_id
+            )
+        for child_tab in tab.get("childTabs", []):
+            walk_tabs(child_tab)
+
+    for tab in doc_data.get("tabs", []):
+        walk_tabs(tab)
+
+    link = f"https://docs.google.com/document/d/{document_id}/edit"
+
+    if not suggestions:
+        return f"No pending suggestions found in document {document_id}. Link: {link}"
+
+    lines = [f"Pending suggestions in document {document_id}:"]
+    for sid, info in suggestions.items():
+        types = "+".join(sorted(info["types"]))
+        preview = info["text_preview"].replace("\n", "\\n")
+        if len(preview) > 80:
+            preview = preview[:80] + "..."
+        tab_info = f" (tab: {info['tab_id']})" if info["tab_id"] else ""
+        lines.append(f'  {sid} | {types}{tab_info} | "{preview}"')
+
+    lines.append(f"Link: {link}")
+    return "\n".join(lines)
 
 
 @server.tool(

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -1076,6 +1076,7 @@ async def batch_update_doc(
     user_google_email: str,
     document_id: str,
     operations: BatchDocOperations,
+    suggest_mode: bool = False,
 ) -> str:
     """
     Executes multiple low-level document operations in a single atomic batch update.
@@ -1292,6 +1293,29 @@ async def batch_update_doc(
             {"type": "update_document_style", "margin_top": 72, "margin_bottom": 72}
         ]
 
+    Example - Propose changes as suggestions instead of direct edits:
+        suggest_mode=true with:
+        [{"type": "find_replace", "find_text": "teh", "replace_text": "the"}]
+        The edit lands as a pending suggestion (as if made in "Suggesting" mode
+        in the Docs UI) rather than being applied directly. Use manage_doc_suggestions
+        to accept, reject, or delete it afterwards.
+
+    Args:
+        user_google_email: User's Google email address
+        document_id: ID of the document to update
+        operations: List of operation dicts. Each operation MUST have a 'type' field.
+                    All operations accept an optional 'tab_id' to target a specific tab.
+        suggest_mode: If true, apply every operation in this batch as a suggested
+            edit (pending approval) instead of a direct edit, equivalent to
+            enabling "Suggesting" mode in the Docs UI. Requires the requesting
+            Google Cloud project to be enrolled in the Workspace Developer
+            Preview Program; otherwise the API call will fail. Not every
+            operation type can be suggested - insert_doc_tab, delete_doc_tab,
+            update_doc_tab, create_named_range, delete_named_range, and
+            update_table_column_properties are rejected by the API in suggest
+            mode, as are the document_mode/use_even_page_header_footer/
+            use_first_page_header_footer fields of update_document_style.
+
     Returns:
         str: Confirmation message with batch results and document length for chaining
     """
@@ -1303,7 +1327,8 @@ async def batch_update_doc(
     ]
 
     logger.debug(
-        f"[batch_update_doc] Doc={document_id}, operations={len(normalized_operations)}"
+        f"[batch_update_doc] Doc={document_id}, operations={len(normalized_operations)}, "
+        f"suggest_mode={suggest_mode}"
     )
 
     # Input validation
@@ -1317,11 +1342,16 @@ async def batch_update_doc(
     if not is_valid:
         return f"Error: {error_msg}"
 
+    if suggest_mode:
+        unsupported_error = _validate_suggest_mode_operations(normalized_operations)
+        if unsupported_error:
+            return f"Error: {unsupported_error}"
+
     # Use BatchOperationManager to handle the complex logic
     batch_manager = BatchOperationManager(service)
 
     success, message, metadata = await batch_manager.execute_batch_operations(
-        document_id, normalized_operations
+        document_id, normalized_operations, suggest_mode=suggest_mode
     )
 
     if success:
@@ -1329,14 +1359,99 @@ async def batch_update_doc(
         replies_count = metadata.get("replies_count", 0)
         doc_length = metadata.get("document_length")
         length_info = f" Document length: {doc_length}." if doc_length else ""
+        suggest_info = ""
+        if suggest_mode:
+            comment_state = metadata.get("comment_update_state")
+            suggest_info = (
+                f" Applied as suggested edits (comment_update_state: {comment_state})."
+            )
         return (
             f"{message} on document {document_id}. "
-            f"API replies: {replies_count}.{length_info} "
+            f"API replies: {replies_count}.{length_info}{suggest_info} "
             f"To apply formatting, call inspect_doc_structure to get exact text positions. "
             f"Link: {link}"
         )
     else:
         return f"Error: {message}"
+
+
+@server.tool(
+    title="Manage Doc Suggestions",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("manage_doc_suggestions", service_type="docs")
+@require_google_service("docs", "docs_write")
+async def manage_doc_suggestions(
+    service: Any,
+    user_google_email: str,
+    document_id: str,
+    action: Literal["accept", "reject", "delete"],
+    suggestion_ids: List[str],
+) -> str:
+    """
+    Accepts, rejects, or deletes pending suggestion threads on a Google Doc
+    (the suggested edits produced by "Suggesting" mode in the Docs UI, or by
+    calling batch_update_doc with suggest_mode=true).
+
+    Requires the requesting Google Cloud project to be enrolled in the
+    Workspace Developer Preview Program; otherwise the API call will fail.
+
+    To find suggestion_ids, call get_doc_content or inspect_doc_structure with
+    suggestions_view_mode="SUGGESTIONS_INLINE" and look for the
+    suggestedInsertionIds / suggestedDeletionIds fields on text runs - each ID
+    identifies a suggestion thread (e.g. "suggest.vcti8ewm4mww").
+
+    Args:
+        user_google_email: User's Google email address
+        document_id: ID of the document containing the suggestions
+        action: "accept" applies the suggestion (requires edit access),
+            "reject" discards it (requires edit access or being its author),
+            "delete" removes the suggestion thread entirely (requires being
+            its author)
+        suggestion_ids: One or more suggestion thread IDs to act on
+
+    Returns:
+        str: Confirmation message including how many suggestions were processed
+    """
+    if not suggestion_ids:
+        return "Error: suggestion_ids cannot be empty"
+
+    request_key = {
+        "accept": "acceptSuggestion",
+        "reject": "rejectSuggestion",
+        "delete": "deleteSuggestion",
+    }.get(action)
+    if not request_key:
+        return f"Error: action must be one of 'accept', 'reject', 'delete', got '{action}'"
+
+    requests = [
+        {request_key: {"suggestionId": suggestion_id}}
+        for suggestion_id in suggestion_ids
+    ]
+
+    logger.debug(
+        f"[manage_doc_suggestions] Doc={document_id}, action={action}, "
+        f"suggestion_ids={suggestion_ids}"
+    )
+
+    result = await asyncio.to_thread(
+        service.documents()
+        .batchUpdate(documentId=document_id, body={"requests": requests})
+        .execute
+    )
+
+    comment_state = result.get("commentUpdateState")
+    link = f"https://docs.google.com/document/d/{document_id}/edit"
+    return (
+        f"Successfully requested '{action}' on {len(suggestion_ids)} suggestion(s) "
+        f"in document {document_id} (comment_update_state: {comment_state}). "
+        f"Link: {link}"
+    )
 
 
 @server.tool(
@@ -1600,6 +1715,62 @@ async def inspect_doc_structure(
 
     link = f"https://docs.google.com/document/d/{document_id}/edit"
     return f"Document structure analysis for {document_id}:\n\n{json.dumps(result, indent=2)}\n\nLink: {link}"
+
+
+# Operation types this codebase exposes that the Docs API rejects when
+# WriteControl.writeMode is SUGGEST (see "Unsupported requests in suggest
+# mode" at https://developers.google.com/workspace/docs/api/how-tos/suggestions).
+_SUGGEST_MODE_UNSUPPORTED_OPERATION_TYPES = {
+    "insert_doc_tab": "AddDocumentTab",
+    "delete_doc_tab": "DeleteTab",
+    "update_doc_tab": "UpdateDocumentTabProperties",
+    "create_named_range": "CreateNamedRange",
+    "delete_named_range": "DeleteNamedRange",
+    "update_table_column_properties": "UpdateTableColumnProperties",
+}
+
+# update_document_style fields the API rejects as suggestions.
+_SUGGEST_MODE_UNSUPPORTED_DOCUMENT_STYLE_FIELDS = {
+    "document_mode",
+    "use_even_page_header_footer",
+    "use_first_page_header_footer",
+}
+
+
+def _validate_suggest_mode_operations(
+    operations: list[dict[str, Any]],
+) -> Optional[str]:
+    """
+    Reject operations client-side that the Docs API is known to refuse when
+    executed with WriteControl.writeMode = SUGGEST, so callers get an
+    actionable error instead of an opaque API failure.
+    """
+    problems: list[str] = []
+    for i, op in enumerate(operations):
+        op_type = op.get("type")
+        api_name = _SUGGEST_MODE_UNSUPPORTED_OPERATION_TYPES.get(op_type)
+        if api_name:
+            problems.append(
+                f"operation {i} ('{op_type}') maps to {api_name}, which suggest mode does not support"
+            )
+        elif op_type == "update_document_style":
+            bad_fields = sorted(
+                _SUGGEST_MODE_UNSUPPORTED_DOCUMENT_STYLE_FIELDS & set(op.keys())
+            )
+            if bad_fields:
+                problems.append(
+                    f"operation {i} ('update_document_style') sets {bad_fields}, "
+                    "which cannot be suggested"
+                )
+
+    if not problems:
+        return None
+
+    return (
+        "suggest_mode=true but this batch includes operations the Docs API cannot "
+        "apply as suggestions: " + "; ".join(problems) + ". Remove them or run this "
+        "batch with suggest_mode=false."
+    )
 
 
 def _rewrite_modify_doc_text_http_error(

--- a/gdocs/managers/batch_operation_manager.py
+++ b/gdocs/managers/batch_operation_manager.py
@@ -68,7 +68,10 @@ class BatchOperationManager:
         self.validation_manager = ValidationManager()
 
     async def execute_batch_operations(
-        self, document_id: str, operations: list[dict[str, Any]]
+        self,
+        document_id: str,
+        operations: list[dict[str, Any]],
+        suggest_mode: bool = False,
     ) -> tuple[bool, str, dict[str, Any]]:
         """
         Execute multiple document operations in a single atomic batch.
@@ -78,6 +81,8 @@ class BatchOperationManager:
         Args:
             document_id: ID of the document to update
             operations: List of operation dictionaries
+            suggest_mode: If True, apply all requests as suggested edits
+                (WriteControl.writeMode = SUGGEST) instead of direct edits.
 
         Returns:
             Tuple of (success, message, metadata)
@@ -108,7 +113,9 @@ class BatchOperationManager:
                 return False, "No valid requests could be built from operations", {}
 
             # Execute the batch
-            result = await self._execute_batch_requests(document_id, requests)
+            result = await self._execute_batch_requests(
+                document_id, requests, suggest_mode=suggest_mode
+            )
 
             # Process results
             metadata = {
@@ -117,6 +124,8 @@ class BatchOperationManager:
                 "replies_count": len(result.get("replies", [])),
                 "operation_summary": operation_descriptions[:5],  # First 5 operations
             }
+            if suggest_mode:
+                metadata["comment_update_state"] = result.get("commentUpdateState")
 
             # Fetch document length after batch for downstream chaining
             try:
@@ -899,7 +908,10 @@ class BatchOperationManager:
         return request, description
 
     async def _execute_batch_requests(
-        self, document_id: str, requests: list[dict[str, Any]]
+        self,
+        document_id: str,
+        requests: list[dict[str, Any]],
+        suggest_mode: bool = False,
     ) -> dict[str, Any]:
         """
         Execute the batch requests against the Google Docs API.
@@ -907,13 +919,19 @@ class BatchOperationManager:
         Args:
             document_id: Document ID
             requests: List of API requests
+            suggest_mode: If True, apply the requests as suggested edits rather
+                than direct edits.
 
         Returns:
             API response
         """
+        body: dict[str, Any] = {"requests": requests}
+        if suggest_mode:
+            body["writeControl"] = {"writeMode": "SUGGEST"}
+
         return await asyncio.to_thread(
             self.service.documents()
-            .batchUpdate(documentId=document_id, body={"requests": requests})
+            .batchUpdate(documentId=document_id, body=body)
             .execute
         )
 

--- a/tests/gdocs/golden/docs_tool_schemas.json
+++ b/tests/gdocs/golden/docs_tool_schemas.json
@@ -2445,6 +2445,11 @@
         },
         "type": "array",
         "description": "List of operation dicts. Each operation MUST have a 'type' field.\n        All operations accept an optional 'tab_id' to target a specific tab."
+      },
+      "suggest_mode": {
+        "default": false,
+        "type": "boolean",
+        "description": "If true, apply every operation in this batch as a suggested\nedit (pending approval) instead of a direct edit, equivalent to\nenabling \"Suggesting\" mode in the Docs UI. Requires the requesting\nGoogle Cloud project to be enrolled in the Workspace Developer\nPreview Program; otherwise the API call will fail. Not every\noperation type can be suggested - insert_doc_tab, delete_doc_tab,\nupdate_doc_tab, create_named_range, delete_named_range, and\nupdate_table_column_properties are rejected by the API in suggest\nmode, as are the document_mode/use_even_page_header_footer/\nuse_first_page_header_footer fields of update_document_style."
       }
     },
     "required": [

--- a/tests/gdocs/golden/docs_tool_schemas.json
+++ b/tests/gdocs/golden/docs_tool_schemas.json
@@ -2449,7 +2449,7 @@
       "suggest_mode": {
         "default": false,
         "type": "boolean",
-        "description": "If true, apply every operation in this batch as a suggested\nedit (pending approval) instead of a direct edit, equivalent to\nenabling \"Suggesting\" mode in the Docs UI. Requires the requesting\nGoogle Cloud project to be enrolled in the Workspace Developer\nPreview Program; otherwise the API call will fail. Not every\noperation type can be suggested - insert_doc_tab, delete_doc_tab,\nupdate_doc_tab, create_named_range, delete_named_range, and\nupdate_table_column_properties are rejected by the API in suggest\nmode, as are the document_mode/use_even_page_header_footer/\nuse_first_page_header_footer fields of update_document_style."
+        "description": "If true, apply every operation in this batch as a suggested\nedit (pending approval) instead of a direct edit, equivalent to\nenabling \"Suggesting\" mode in the Docs UI. Requires the requesting\nGoogle Cloud project to be enrolled in the Workspace Developer\nPreview Program; otherwise the API call will fail. Not every\noperation type can be suggested - insert_doc_tab, delete_doc_tab,\nupdate_doc_tab, create_named_range, delete_named_range,\nupdate_table_column_properties, and create_header_footer are\nrejected by the API in suggest mode, as are the\ndocument_mode/use_even_page_header_footer/\nuse_first_page_header_footer fields of update_document_style."
       }
     },
     "required": [

--- a/tests/gdocs/test_suggest_mode_enrollment.py
+++ b/tests/gdocs/test_suggest_mode_enrollment.py
@@ -48,10 +48,55 @@ WITH_SUGGESTION_DOC = {
     "tabs": [],
 }
 
+NO_SUGGESTIONS_DOC_WITH_HEADER = {
+    "body": {"content": [{"paragraph": {"elements": [{"textRun": {"content": "Hello\n"}}]}}]},
+    "headers": {
+        "header1": {
+            "content": [
+                {"paragraph": {"elements": [{"textRun": {"content": "Header text\n"}}]}}
+            ]
+        }
+    },
+    "tabs": [],
+}
+
+WITH_HEADER_SUGGESTION_DOC = {
+    "body": {"content": [{"paragraph": {"elements": [{"textRun": {"content": "Hello\n"}}]}}]},
+    "headers": {
+        "header1": {
+            "content": [
+                {
+                    "paragraph": {
+                        "elements": [
+                            {"textRun": {"content": "Header text\n"}},
+                            {
+                                "textRun": {
+                                    "content": "Suggested header addition\n",
+                                    "suggestedInsertionIds": ["suggest.header1"],
+                                }
+                            },
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "tabs": [],
+}
+
 DOC_LENGTH_STUB = {"body": {"content": [{"endIndex": 100}]}}
 
 INSERT_TEXT_OPERATIONS = [
     {"type": "insert_text", "end_of_segment": True, "text": "New sentence\n"}
+]
+
+HEADER_INSERT_OPERATIONS = [
+    {
+        "type": "insert_text",
+        "end_of_segment": True,
+        "text": "Suggested header addition\n",
+        "segment_id": "header1",
+    }
 ]
 
 
@@ -93,6 +138,9 @@ class TestSuggestModeEnrollmentVerification:
         assert "Error" not in result
         assert "Applied as suggested edits" in result
         assert docs_tools._SUGGEST_MODE_ENROLLED is True
+
+        body = service.documents.return_value.batchUpdate.call_args.kwargs["body"]
+        assert body["writeControl"] == {"writeMode": "SUGGEST"}
 
     @pytest.mark.asyncio
     async def test_suggest_mode_flagged_when_no_new_suggestion_appears(self):
@@ -181,3 +229,47 @@ class TestSuggestModeEnrollmentVerification:
 
         assert "Error" not in result
         assert docs_tools._SUGGEST_MODE_ENROLLED is None
+
+        body = service.documents.return_value.batchUpdate.call_args.kwargs["body"]
+        assert "writeControl" not in body
+
+    @pytest.mark.asyncio
+    async def test_header_suggestion_is_detected_by_verifier(self):
+        """Regression test: a suggestion inside a header must not be missed
+        by the enrollment verifier. Previously _fetch_doc_suggestions only
+        walked body/tabs, so a real suggestion placed in a header would look
+        identical before/after and falsely disable suggest_mode for the rest
+        of the process."""
+        service = _make_service(
+            [
+                NO_SUGGESTIONS_DOC_WITH_HEADER,
+                DOC_LENGTH_STUB,
+                WITH_HEADER_SUGGESTION_DOC,
+            ]
+        )
+
+        result = await _unwrap(docs_tools.batch_update_doc)(
+            service=service,
+            user_google_email="user@example.com",
+            document_id="a" * 25,
+            operations=HEADER_INSERT_OPERATIONS,
+            suggest_mode=True,
+        )
+
+        assert "Error" not in result
+        assert docs_tools._SUGGEST_MODE_ENROLLED is True
+
+
+class TestValidateSuggestModeOperations:
+    def test_create_header_footer_rejected(self):
+        error = docs_tools._validate_suggest_mode_operations(
+            [{"type": "create_header_footer", "section_type": "header"}]
+        )
+        assert error is not None
+        assert "CreateHeader/CreateFooter" in error
+
+    def test_plain_insert_text_allowed(self):
+        error = docs_tools._validate_suggest_mode_operations(
+            [{"type": "insert_text", "end_of_segment": True, "text": "hi\n"}]
+        )
+        assert error is None

--- a/tests/gdocs/test_suggest_mode_enrollment.py
+++ b/tests/gdocs/test_suggest_mode_enrollment.py
@@ -122,6 +122,28 @@ def _make_service(get_side_effect):
 
 class TestSuggestModeEnrollmentVerification:
     @pytest.mark.asyncio
+    async def test_inconclusive_post_batch_fetch_does_not_flag_unenrolled(self):
+        """Regression test: a successful suggest-mode batch whose post-batch
+        verification fetch fails (transient error) must not be treated as
+        proof of non-enrollment. Only a real before/after diff should ever
+        set _SUGGEST_MODE_ENROLLED."""
+        service = _make_service(
+            [NO_SUGGESTIONS_DOC, DOC_LENGTH_STUB, RuntimeError("transient read error")]
+        )
+
+        result = await _unwrap(docs_tools.batch_update_doc)(
+            service=service,
+            user_google_email="user@example.com",
+            document_id="a" * 25,
+            operations=INSERT_TEXT_OPERATIONS,
+            suggest_mode=True,
+        )
+
+        assert "Error" not in result
+        assert "Applied as suggested edits" in result
+        assert docs_tools._SUGGEST_MODE_ENROLLED is None
+
+    @pytest.mark.asyncio
     async def test_suggest_mode_confirmed_when_suggestion_appears(self):
         service = _make_service(
             [NO_SUGGESTIONS_DOC, DOC_LENGTH_STUB, WITH_SUGGESTION_DOC]

--- a/tests/gdocs/test_suggest_mode_enrollment.py
+++ b/tests/gdocs/test_suggest_mode_enrollment.py
@@ -1,0 +1,183 @@
+"""
+Tests for the suggest_mode Developer Preview enrollment self-check.
+
+Google exposes no API to query Workspace Developer Preview Program
+enrollment, and an unenrolled project may silently ignore
+writeControl.writeMode and apply changes directly instead of erroring. These
+tests verify batch_update_doc detects that silent fallthrough by diffing
+suggestion IDs before/after, caches the result, and gates suggest_mode /
+manage_doc_suggestions for the rest of the process once a failure is seen.
+"""
+
+import pytest
+from unittest.mock import Mock
+
+from gdocs import docs_tools
+
+
+def _unwrap(tool):
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+NO_SUGGESTIONS_DOC = {
+    "body": {"content": [{"paragraph": {"elements": [{"textRun": {"content": "Hello\n"}}]}}]},
+    "tabs": [],
+}
+
+WITH_SUGGESTION_DOC = {
+    "body": {
+        "content": [
+            {
+                "paragraph": {
+                    "elements": [
+                        {"textRun": {"content": "Hello\n"}},
+                        {
+                            "textRun": {
+                                "content": "New sentence\n",
+                                "suggestedInsertionIds": ["suggest.abc123"],
+                            }
+                        },
+                    ]
+                }
+            }
+        ]
+    },
+    "tabs": [],
+}
+
+DOC_LENGTH_STUB = {"body": {"content": [{"endIndex": 100}]}}
+
+INSERT_TEXT_OPERATIONS = [
+    {"type": "insert_text", "end_of_segment": True, "text": "New sentence\n"}
+]
+
+
+@pytest.fixture(autouse=True)
+def _reset_enrollment_cache():
+    """Isolate the process-wide enrollment cache between tests."""
+    docs_tools._SUGGEST_MODE_ENROLLED = None
+    yield
+    docs_tools._SUGGEST_MODE_ENROLLED = None
+
+
+def _make_service(get_side_effect):
+    service = Mock()
+    service.documents.return_value.get.return_value.execute = Mock(
+        side_effect=get_side_effect
+    )
+    service.documents.return_value.batchUpdate.return_value.execute.return_value = {
+        "replies": [{}],
+        "commentUpdateState": "ALL_SAVED",
+    }
+    return service
+
+
+class TestSuggestModeEnrollmentVerification:
+    @pytest.mark.asyncio
+    async def test_suggest_mode_confirmed_when_suggestion_appears(self):
+        service = _make_service(
+            [NO_SUGGESTIONS_DOC, DOC_LENGTH_STUB, WITH_SUGGESTION_DOC]
+        )
+
+        result = await _unwrap(docs_tools.batch_update_doc)(
+            service=service,
+            user_google_email="user@example.com",
+            document_id="a" * 25,
+            operations=INSERT_TEXT_OPERATIONS,
+            suggest_mode=True,
+        )
+
+        assert "Error" not in result
+        assert "Applied as suggested edits" in result
+        assert docs_tools._SUGGEST_MODE_ENROLLED is True
+
+    @pytest.mark.asyncio
+    async def test_suggest_mode_flagged_when_no_new_suggestion_appears(self):
+        # Same document before and after: the API silently applied the edit
+        # directly instead of creating a suggestion.
+        service = _make_service(
+            [NO_SUGGESTIONS_DOC, DOC_LENGTH_STUB, NO_SUGGESTIONS_DOC]
+        )
+
+        result = await _unwrap(docs_tools.batch_update_doc)(
+            service=service,
+            user_google_email="user@example.com",
+            document_id="a" * 25,
+            operations=INSERT_TEXT_OPERATIONS,
+            suggest_mode=True,
+        )
+
+        assert "Error" in result
+        assert "not enrolled" in result or "Developer Preview" in result
+        assert docs_tools._SUGGEST_MODE_ENROLLED is False
+
+    @pytest.mark.asyncio
+    async def test_subsequent_suggest_mode_call_short_circuits_without_api_call(self):
+        docs_tools._SUGGEST_MODE_ENROLLED = False
+        service = _make_service([])  # any get() call would raise StopIteration
+
+        result = await _unwrap(docs_tools.batch_update_doc)(
+            service=service,
+            user_google_email="user@example.com",
+            document_id="a" * 25,
+            operations=INSERT_TEXT_OPERATIONS,
+            suggest_mode=True,
+        )
+
+        assert "Error" in result
+        assert "Developer Preview" in result
+        service.documents.return_value.batchUpdate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_doc_suggestions_short_circuits_when_not_enrolled(self):
+        docs_tools._SUGGEST_MODE_ENROLLED = False
+        service = Mock()
+
+        result = await _unwrap(docs_tools.manage_doc_suggestions)(
+            service=service,
+            user_google_email="user@example.com",
+            document_id="a" * 25,
+            action="accept",
+            suggestion_ids=["suggest.abc123"],
+        )
+
+        assert "Error" in result
+        assert "Developer Preview" in result
+        service.documents.return_value.batchUpdate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_manage_doc_suggestions_success_marks_enrolled(self):
+        service = Mock()
+        service.documents.return_value.batchUpdate.return_value.execute.return_value = {
+            "commentUpdateState": "ALL_SAVED"
+        }
+
+        result = await _unwrap(docs_tools.manage_doc_suggestions)(
+            service=service,
+            user_google_email="user@example.com",
+            document_id="a" * 25,
+            action="accept",
+            suggestion_ids=["suggest.abc123"],
+        )
+
+        assert "Successfully" in result
+        assert docs_tools._SUGGEST_MODE_ENROLLED is True
+
+    @pytest.mark.asyncio
+    async def test_direct_edit_batch_not_verified(self):
+        """suggest_mode=false should never touch the verification machinery."""
+        service = _make_service([DOC_LENGTH_STUB])
+
+        result = await _unwrap(docs_tools.batch_update_doc)(
+            service=service,
+            user_google_email="user@example.com",
+            document_id="a" * 25,
+            operations=INSERT_TEXT_OPERATIONS,
+            suggest_mode=False,
+        )
+
+        assert "Error" not in result
+        assert docs_tools._SUGGEST_MODE_ENROLLED is None


### PR DESCRIPTION
## Summary
- `batch_update_doc` gains a `suggest_mode` flag that applies the whole batch as pending suggestions (`WriteControl.writeMode = SUGGEST`) instead of direct edits, with client-side validation for the operation types the API rejects in suggest mode.
- New `list_doc_suggestions` tool: reads a document with `suggestionsViewMode=SUGGESTIONS_INLINE` and returns every pending suggestion's ID, type (insertion/deletion/style), and a text preview.
- New `manage_doc_suggestions` tool: accepts, rejects, or deletes suggestion threads by ID (`AcceptSuggestionRequest`/`RejectSuggestionRequest`/`DeleteSuggestionRequest`).
- **Enrollment self-check**: suggest mode and comment/suggestion-thread management are part of the Workspace Developer Preview Program, which has no API to query enrollment status — worse, an unenrolled project may silently ignore `writeControl.writeMode` and apply "suggested" edits directly instead of erroring. `batch_update_doc` detects this on first use by diffing suggestion IDs before/after a suggest-mode call, caches the result for the process, and refuses further suggest-mode/`manage_doc_suggestions` calls immediately (no API call) once a silent fallthrough is detected — with an error pointing at enrollment and a warning that the triggering change is already live.

Reference: [Work with comments and suggestions](https://developers.google.com/workspace/docs/api/how-tos/suggestions)

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run pytest` (full suite, 1698 passed / 2 skipped)
- [x] New `tests/gdocs/test_suggest_mode_enrollment.py` covers the enrollment gate, including the silent-fallthrough (not-enrolled) path via mocks, since that can't be observed live without an unenrolled account
- [x] Live end-to-end verification against a real Google Doc with an enrolled test project: created suggestions via `suggest_mode=true`, listed them via `list_doc_suggestions`, accepted one (merged into doc) and rejected another (discarded, doc reverted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for applying document edits as suggested changes.
  * Added tools to view, accept, reject, and delete pending document suggestions.
  * Added suggestion status reporting across document sections, including headers, footers, tables, and tabs.
* **Bug Fixes**
  * Prevented unsupported operations and fields from being used in suggestion mode.
  * Added enrollment checks before applying suggested edits.
  * Improved handling when enrollment status cannot be confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->