### PR TITLE
feat(auth): optional static endpoint token for legacy streamable-http, pinned to one account

### DIFF
--- a/auth/oauth_config.py
+++ b/auth/oauth_config.py
@@ -642,3 +642,20 @@ def is_trust_gateway_identity() -> bool:
 def is_service_account_enabled() -> bool:
     """Check if service account (domain-wide delegation) mode is enabled."""
     return get_oauth_config().is_service_account_enabled()
+
+
+def get_static_endpoint_token() -> Optional[str]:
+    """Return the shared secret gating the MCP endpoint, if one is configured.
+
+    This is deliberately independent of Google auth. It decides whether a caller
+    may talk to this server at all, never which Google account a request acts
+    as. Only meaningful outside OAuth 2.1 mode, where the HTTP transport has no
+    MCP-level auth provider of its own.
+    """
+    token = os.getenv("WORKSPACE_MCP_STATIC_TOKEN", "").strip()
+    return token or None
+
+
+def is_static_endpoint_token_enabled() -> bool:
+    """Check if a static endpoint token is configured."""
+    return get_static_endpoint_token() is not None

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -507,7 +507,7 @@ def _extract_oauth20_user_email(
     # would turn one credential into access to every credential in the store, so
     # the configured email wins over anything the caller passes.
     if is_static_endpoint_token_enabled():
-        pinned_email = _get_configured_user_google_email()
+        pinned_email = (_get_configured_user_google_email() or "").strip()
         if not pinned_email:
             raise Exception(
                 "WORKSPACE_MCP_STATIC_TOKEN requires USER_GOOGLE_EMAIL so requests "

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -28,6 +28,7 @@ from auth.oauth_config import (
     is_external_oauth21_provider,
     is_service_account_enabled,
     is_trust_gateway_identity,
+    is_static_endpoint_token_enabled,
 )
 from core.context import set_fastmcp_session_id
 from core.telemetry import record_authenticated_user
@@ -500,6 +501,26 @@ def _extract_oauth20_user_email(
     bound_args.apply_defaults()
 
     user_google_email = bound_args.arguments.get("user_google_email")
+
+    # A static endpoint token is a single shared secret, so every caller holding
+    # it is the same principal. Letting that principal name an arbitrary account
+    # would turn one credential into access to every credential in the store, so
+    # the configured email wins over anything the caller passes.
+    if is_static_endpoint_token_enabled():
+        pinned_email = _get_configured_user_google_email()
+        if not pinned_email:
+            raise Exception(
+                "WORKSPACE_MCP_STATIC_TOKEN requires USER_GOOGLE_EMAIL so requests "
+                "are bound to a single Google account."
+            )
+        if user_google_email and user_google_email != pinned_email:
+            logger.warning(
+                "Ignoring caller-supplied user_google_email; static endpoint token "
+                "pins requests to the configured account."
+            )
+        kwargs["user_google_email"] = pinned_email
+        return pinned_email
+
     if not user_google_email:
         # Fall back to USER_GOOGLE_EMAIL env var for single-user / self-hosted mode.
         # This allows callers (agents) to omit the parameter when a default is configured.

--- a/core/server.py
+++ b/core/server.py
@@ -23,6 +23,7 @@ from auth.oauth_config import (
     is_external_oauth21_provider,
     get_oauth_config,
     is_trust_gateway_identity,
+    get_static_endpoint_token,
 )
 from auth.oauth_responses import (
     create_error_response,
@@ -763,12 +764,33 @@ def configure_server_for_http():
             )
             raise
     else:
-        # Debug level: main.py surfaces the loopback default as a startup notice.
-        logger.debug(
-            "OAuth 2.0 legacy mode - streamable HTTP defaults to loopback unless "
-            "WORKSPACE_MCP_HOST is explicitly set."
-        )
-        server.auth = None
+        static_token = get_static_endpoint_token()
+        if static_token:
+            # A shared secret in front of the endpoint, for deployments that
+            # accept the documented risks of exposing legacy mode. It answers
+            # "may you talk to this server", never "whose Google account is
+            # this" - the principal is pinned separately in service_decorator.
+            from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+            server.auth = StaticTokenVerifier(
+                tokens={
+                    static_token: {
+                        "client_id": "workspace-mcp-static-token",
+                        "scopes": [],
+                    }
+                }
+            )
+            logger.info(
+                "Static endpoint token enabled - MCP requests require a matching "
+                "Authorization: Bearer header"
+            )
+        else:
+            # Debug level: main.py surfaces the loopback default as a startup notice.
+            logger.debug(
+                "OAuth 2.0 legacy mode - streamable HTTP defaults to loopback unless "
+                "WORKSPACE_MCP_HOST is explicitly set."
+            )
+            server.auth = None
         _auth_provider = None
         set_auth_provider(None)
         _ensure_legacy_callback_route()

--- a/main.py
+++ b/main.py
@@ -781,7 +781,8 @@ def main():
             )
             sys.exit(1)
 
-        if not os.getenv("USER_GOOGLE_EMAIL"):
+        pinned_email = os.getenv("USER_GOOGLE_EMAIL", "").strip()
+        if not pinned_email:
             ui.step(
                 "WORKSPACE_MCP_STATIC_TOKEN requires USER_GOOGLE_EMAIL", state="fail"
             )
@@ -791,7 +792,7 @@ def main():
 
         ui.step("Static endpoint token enabled")
         ui.detail("MCP requests must carry a matching Authorization: Bearer header")
-        ui.detail(f"requests are pinned to {os.getenv('USER_GOOGLE_EMAIL')}")
+        ui.detail(f"requests are pinned to {pinned_email}")
 
     # Set global single-user mode flag
     if args.single_user:

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ def _load_startup_dependencies():
         reload_oauth_config,
         is_stateless_mode,
         is_service_account_enabled,
+        is_static_endpoint_token_enabled,
     )
     from core.log_formatter import (
         EnhancedLogFormatter,
@@ -50,6 +51,7 @@ def _load_startup_dependencies():
         reload_oauth_config,
         is_stateless_mode,
         is_service_account_enabled,
+        is_static_endpoint_token_enabled,
         EnhancedLogFormatter,
         configure_file_logging,
         install_noisy_log_filters,
@@ -73,6 +75,7 @@ def _load_startup_dependencies():
     reload_oauth_config,
     is_stateless_mode,
     is_service_account_enabled,
+    is_static_endpoint_token_enabled,
     EnhancedLogFormatter,
     configure_file_logging,
     install_noisy_log_filters,
@@ -759,6 +762,36 @@ def main():
         )
 
     ui.section("Startup")
+
+    # A static endpoint token only takes effect in the legacy (non-OAuth-2.1)
+    # branch, where the server would otherwise run with no MCP-level auth. Under
+    # OAuth 2.1 the GoogleProvider owns protocol-level auth and would overwrite
+    # the verifier, so refuse the combination rather than ignoring the token.
+    if is_static_endpoint_token_enabled():
+        if os.getenv("MCP_ENABLE_OAUTH21", "false").lower() == "true":
+            ui.step(
+                "WORKSPACE_MCP_STATIC_TOKEN is incompatible with OAuth 2.1 mode",
+                state="fail",
+            )
+            ui.detail(
+                "OAuth 2.1 already gates the endpoint with per-user bearer tokens"
+            )
+            ui.detail(
+                "Choose one: WORKSPACE_MCP_STATIC_TOKEN OR MCP_ENABLE_OAUTH21=true"
+            )
+            sys.exit(1)
+
+        if not os.getenv("USER_GOOGLE_EMAIL"):
+            ui.step(
+                "WORKSPACE_MCP_STATIC_TOKEN requires USER_GOOGLE_EMAIL", state="fail"
+            )
+            ui.detail("The token is one shared secret, so it maps to one account")
+            ui.detail("Set USER_GOOGLE_EMAIL to the account requests should act as")
+            sys.exit(1)
+
+        ui.step("Static endpoint token enabled")
+        ui.detail("MCP requests must carry a matching Authorization: Bearer header")
+        ui.detail(f"requests are pinned to {os.getenv('USER_GOOGLE_EMAIL')}")
 
     # Set global single-user mode flag
     if args.single_user:

--- a/tests/auth/test_static_endpoint_token.py
+++ b/tests/auth/test_static_endpoint_token.py
@@ -9,6 +9,7 @@ from auth.oauth_config import (
     get_static_endpoint_token,
     is_static_endpoint_token_enabled,
 )
+from auth import service_decorator
 from auth.service_decorator import _extract_oauth20_user_email
 
 
@@ -16,6 +17,9 @@ from auth.service_decorator import _extract_oauth20_user_email
 def _clean_env(monkeypatch):
     monkeypatch.delenv("WORKSPACE_MCP_STATIC_TOKEN", raising=False)
     monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
+    # _ENV_USER_EMAIL snapshots the environment at import time, so clearing the
+    # variable is not enough to exercise the missing-email path.
+    monkeypatch.setattr(service_decorator, "_ENV_USER_EMAIL", None, raising=False)
 
 
 def test_static_endpoint_token_absent_by_default():
@@ -86,3 +90,19 @@ def test_without_a_static_token_the_caller_supplied_email_is_honoured(monkeypatc
 
     kwargs = {"user_google_email": "other@example.com"}
     assert _extract_oauth20_user_email((), kwargs, _sig()) == "other@example.com"
+
+
+def test_whitespace_only_pinned_email_is_rejected(monkeypatch):
+    """A blank USER_GOOGLE_EMAIL cannot identify an account, so it must not pin."""
+    monkeypatch.setenv("WORKSPACE_MCP_STATIC_TOKEN", "shared-secret")
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "   ")
+
+    with pytest.raises(Exception, match="USER_GOOGLE_EMAIL"):
+        _extract_oauth20_user_email((), {}, _sig())
+
+
+def test_pinned_email_is_stripped(monkeypatch):
+    monkeypatch.setenv("WORKSPACE_MCP_STATIC_TOKEN", "shared-secret")
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "  owner@example.com  ")
+
+    assert _extract_oauth20_user_email((), {}, _sig()) == "owner@example.com"

--- a/tests/auth/test_static_endpoint_token.py
+++ b/tests/auth/test_static_endpoint_token.py
@@ -1,0 +1,88 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from auth.oauth_config import (
+    get_static_endpoint_token,
+    is_static_endpoint_token_enabled,
+)
+from auth.service_decorator import _extract_oauth20_user_email
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("WORKSPACE_MCP_STATIC_TOKEN", raising=False)
+    monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
+
+
+def test_static_endpoint_token_absent_by_default():
+    assert get_static_endpoint_token() is None
+    assert is_static_endpoint_token_enabled() is False
+
+
+def test_static_endpoint_token_reads_env(monkeypatch):
+    monkeypatch.setenv("WORKSPACE_MCP_STATIC_TOKEN", "shared-secret")
+
+    assert get_static_endpoint_token() == "shared-secret"
+    assert is_static_endpoint_token_enabled() is True
+
+
+def test_static_endpoint_token_strips_surrounding_whitespace(monkeypatch):
+    monkeypatch.setenv("WORKSPACE_MCP_STATIC_TOKEN", "  shared-secret  ")
+
+    assert get_static_endpoint_token() == "shared-secret"
+
+
+def test_whitespace_only_token_is_not_treated_as_configured(monkeypatch):
+    """A blank value must not be mistaken for a configured secret."""
+    monkeypatch.setenv("WORKSPACE_MCP_STATIC_TOKEN", "   ")
+
+    assert get_static_endpoint_token() is None
+    assert is_static_endpoint_token_enabled() is False
+
+
+def _sig():
+    import inspect
+
+    def tool(user_google_email: str = None, query: str = None):
+        pass
+
+    return inspect.signature(tool)
+
+
+def test_caller_supplied_email_is_ignored_under_a_static_token(monkeypatch):
+    """The shared secret is one principal, so it must not select another account."""
+    monkeypatch.setenv("WORKSPACE_MCP_STATIC_TOKEN", "shared-secret")
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "owner@example.com")
+
+    kwargs = {"user_google_email": "victim@example.com", "query": "from:ceo"}
+    resolved = _extract_oauth20_user_email((), kwargs, _sig())
+
+    assert resolved == "owner@example.com"
+    assert kwargs["user_google_email"] == "owner@example.com"
+
+
+def test_omitted_email_resolves_to_the_pinned_account(monkeypatch):
+    monkeypatch.setenv("WORKSPACE_MCP_STATIC_TOKEN", "shared-secret")
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "owner@example.com")
+
+    kwargs = {}
+    assert _extract_oauth20_user_email((), kwargs, _sig()) == "owner@example.com"
+
+
+def test_static_token_without_configured_email_is_rejected(monkeypatch):
+    monkeypatch.setenv("WORKSPACE_MCP_STATIC_TOKEN", "shared-secret")
+
+    with pytest.raises(Exception, match="USER_GOOGLE_EMAIL"):
+        _extract_oauth20_user_email((), {"user_google_email": "a@example.com"}, _sig())
+
+
+def test_without_a_static_token_the_caller_supplied_email_is_honoured(monkeypatch):
+    """Unchanged behaviour for the existing loopback single-user path."""
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "owner@example.com")
+
+    kwargs = {"user_google_email": "other@example.com"}
+    assert _extract_oauth20_user_email((), kwargs, _sig()) == "other@example.com"

--- a/tests/core/test_http_oauth_scope_config.py
+++ b/tests/core/test_http_oauth_scope_config.py
@@ -221,3 +221,63 @@ def test_configure_server_for_http_passes_jwt_key_to_external_provider(monkeypat
         "jwt_signing_key must be a bytes object"
     )
     assert len(captured["jwt_signing_key"]) > 0, "jwt_signing_key must be non-empty"
+
+
+def _legacy_oauth_config():
+    return SimpleNamespace(is_oauth21_enabled=lambda: False, is_configured=lambda: True)
+
+
+def _stub_legacy_http(monkeypatch, calls):
+    monkeypatch.setattr(server_module, "get_transport_mode", lambda: "streamable-http")
+    monkeypatch.setattr(
+        server_module, "set_auth_provider", lambda provider: calls.append(provider)
+    )
+    monkeypatch.setattr(
+        server_module,
+        "_ensure_legacy_callback_route",
+        lambda: calls.append("callback"),
+    )
+    monkeypatch.setattr(server_module, "_auth_provider", object())
+    monkeypatch.setattr(server_module.server, "auth", object())
+    monkeypatch.setattr("auth.oauth_config.get_oauth_config", _legacy_oauth_config)
+
+
+def test_configure_server_for_http_installs_static_token_verifier(monkeypatch):
+    from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+    calls = []
+    _stub_legacy_http(monkeypatch, calls)
+    monkeypatch.setattr(server_module, "get_static_endpoint_token", lambda: "s3cret")
+
+    server_module.configure_server_for_http()
+
+    assert isinstance(server_module.server.auth, StaticTokenVerifier)
+    assert "s3cret" in server_module.server.auth.tokens
+    # Google identity is untouched: the token only gates the endpoint.
+    assert server_module._auth_provider is None
+    assert calls == [None, "callback"]
+
+
+@pytest.mark.asyncio
+async def test_static_token_verifier_accepts_only_the_configured_token(monkeypatch):
+    calls = []
+    _stub_legacy_http(monkeypatch, calls)
+    monkeypatch.setattr(server_module, "get_static_endpoint_token", lambda: "s3cret")
+
+    server_module.configure_server_for_http()
+    verifier = server_module.server.auth
+
+    assert await verifier.verify_token("wrong") is None
+    accepted = await verifier.verify_token("s3cret")
+    assert accepted is not None
+    assert accepted.token == "s3cret"
+
+
+def test_configure_server_for_http_without_static_token_leaves_auth_unset(monkeypatch):
+    calls = []
+    _stub_legacy_http(monkeypatch, calls)
+    monkeypatch.setattr(server_module, "get_static_endpoint_token", lambda: None)
+
+    server_module.configure_server_for_http()
+
+    assert server_module.server.auth is None


### PR DESCRIPTION
## Description

Fixes #1056.

Legacy streamable-http has no MCP-level auth provider, so `server.auth` is left unset, the bind host is clamped to `127.0.0.1`, and a startup warning fires when an operator overrides it. That warning has no remedy today: reaching the server from another machine means either OAuth 2.1, which sends every client through a browser handshake, or `TRUST_GATEWAY_IDENTITY`, which needs a proxy minting JWKS-verifiable assertions. Neither suits a single-account deployment driven by clients that can send a header but cannot complete an OAuth flow.

This adds an optional `WORKSPACE_MCP_STATIC_TOKEN`. When set, FastMCP's existing `StaticTokenVerifier` is installed in place of leaving `server.auth` unset, so requests without a matching `Authorization: Bearer` header are rejected at the protocol layer.

The token gates the endpoint only. Google identity still comes from the server's own stored credentials.

Because the token is a single shared secret, every caller holding it is the same principal, and letting that principal name an arbitrary account would turn one credential into access to every credential in the store. So `_extract_oauth20_user_email` pins requests to `USER_GOOGLE_EMAIL` whenever the token is enabled, ignores a caller-supplied `user_google_email`, and logs when the two differ. Startup fails if `USER_GOOGLE_EMAIL` is absent, so the pin cannot be silently missing. For deployments that enable the token, the account-selection behaviour described in #1001 no longer applies.

Two things are deliberately unchanged:

- **The `127.0.0.1` default and its warning.** Exposing legacy mode stays an explicit operator decision, exactly as set out in the resolution of #1001. This only makes that decision survivable.
- **Every existing auth path.** With no token set, the code takes the same branch it does today.

Setting the token together with `MCP_ENABLE_OAUTH21` fails at startup rather than being silently ignored, since the `GoogleProvider` owns protocol-level auth in that branch and would overwrite the verifier.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

11 tests added across `tests/auth/test_static_endpoint_token.py` and `tests/core/test_http_oauth_scope_config.py`, covering token parsing (including a whitespace-only value not counting as configured), verifier installation, that only the configured token verifies, the account pin, the missing-`USER_GOOGLE_EMAIL` rejection, and that behaviour is unchanged when no token is set. Full suite: 1787 passed, 2 skipped. `ruff check .` and `ruff format --check` are clean.

Manual testing against a container built from this branch:

| Request | Result |
| --- | --- |
| No `Authorization` header | 401 |
| Wrong token | 401 |
| Correct token | 200, session lists all registered tools |
| `/health` | 200, unchanged for container probes |
| #1001 reproduction, calling `search_gmail_messages` with another account in `user_google_email` | resolves to the pinned account, warning logged |
| `WORKSPACE_MCP_STATIC_TOKEN` + `MCP_ENABLE_OAUTH21=true` | exits non-zero at startup |
| `WORKSPACE_MCP_STATIC_TOKEN` with no `USER_GOOGLE_EMAIL` | exits non-zero at startup |
| No token set | starts and behaves as before |

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

Two things I would rather flag than assume:

The docs are not updated here, since deployment documentation lives on the site rather than in the repo. Happy to write whatever section you want, in whatever shape fits, once the direction is agreed.

I also considered hiding `user_google_email` from the tool schema under a static token, the way `_user_email_is_managed()` does for OAuth 2.1 and trusted-gateway mode. That is arguably tidier, since the parameter is ignored rather than absent, but it changes tool schemas and felt like a separate decision. Glad to fold it in if you would prefer that.

If the answer is that legacy mode should not be reachable at all and the gap is intentional, that is a fair call and no hard feelings. It seemed worth offering, given operators are exposing it either way.

## Model Used
Claude Opus 5, via Claude Code. It drafted the implementation, the tests and this description; I directed the design, ran the container testing, and reviewed everything before it went out.

---

🤖 Generated with Claude Code (Claude Opus 5)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional static bearer-token authentication for HTTP endpoints.
  * Requests can be secured with a configured token and associated account.
  * Static token mode restricts access to the configured account.

* **Bug Fixes**
  * Added validation for incompatible authentication settings.
  * Improved handling of missing, conflicting, or whitespace-only configuration.

* **Tests**
  * Added coverage for token parsing, authentication, account resolution, and invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->