### PR TITLE
fix(gmail): correct label array schema

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -13,7 +13,7 @@ import mimetypes
 import html
 from html.parser import HTMLParser
 from pathlib import Path
-from typing import Annotated, Optional, List, Dict, Literal, Any
+from typing import Annotated, Optional, List, Dict, Literal, Any, Union
 from urllib.parse import unquote, urlparse, urlunsplit
 
 from email.message import EmailMessage
@@ -24,6 +24,7 @@ import httpx
 from mcp.types import ToolAnnotations
 
 from pydantic import Field
+from pydantic.json_schema import SkipJsonSchema
 
 from auth.oauth_config import is_stateless_mode
 from auth.service_decorator import require_google_service
@@ -81,6 +82,12 @@ GMAIL_SEARCH_HEADER_BATCH_SIZE = 10
 GMAIL_REQUEST_DELAY = 0.1
 GMAIL_RATE_LIMIT_BACKOFF = 2.0
 HTML_BODY_TRUNCATE_LIMIT = 20000
+
+# Keep ``None`` valid at runtime without publishing it as an ``anyOf`` branch.
+# Cowork needs a top-level array schema, while Moonshot rejects the previous
+# parent-level array override alongside a nullable ``anyOf``.
+_OptionalLabelIdList = Union[StringList, SkipJsonSchema[None]]
+
 LOW_VALUE_TEXT_PLACEHOLDERS = (
     "your client does not support html",
     "view this email in your browser",
@@ -3777,8 +3784,8 @@ async def modify_gmail_message_labels(
     service,
     user_google_email: str,
     message_id: str,
-    add_label_ids: Optional[StringList] = None,
-    remove_label_ids: Optional[StringList] = None,
+    add_label_ids: _OptionalLabelIdList = None,
+    remove_label_ids: _OptionalLabelIdList = None,
 ) -> str:
     """
     Adds or removes labels from a Gmail message.
@@ -3953,8 +3960,8 @@ async def batch_modify_gmail_message_labels(
     service,
     user_google_email: str,
     message_ids: StringList,
-    add_label_ids: Optional[StringList] = None,
-    remove_label_ids: Optional[StringList] = None,
+    add_label_ids: _OptionalLabelIdList = None,
+    remove_label_ids: _OptionalLabelIdList = None,
     verify: bool = True,
 ) -> str:
     """

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -3765,14 +3765,8 @@ async def modify_gmail_message_labels(
     service,
     user_google_email: str,
     message_id: str,
-    add_label_ids: Annotated[
-        Optional[StringList],
-        Field(json_schema_extra={"type": "array", "items": {"type": "string"}}),
-    ] = None,
-    remove_label_ids: Annotated[
-        Optional[StringList],
-        Field(json_schema_extra={"type": "array", "items": {"type": "string"}}),
-    ] = None,
+    add_label_ids: Optional[StringList] = None,
+    remove_label_ids: Optional[StringList] = None,
 ) -> str:
     """
     Adds or removes labels from a Gmail message.
@@ -3947,14 +3941,8 @@ async def batch_modify_gmail_message_labels(
     service,
     user_google_email: str,
     message_ids: StringList,
-    add_label_ids: Annotated[
-        Optional[StringList],
-        Field(json_schema_extra={"type": "array", "items": {"type": "string"}}),
-    ] = None,
-    remove_label_ids: Annotated[
-        Optional[StringList],
-        Field(json_schema_extra={"type": "array", "items": {"type": "string"}}),
-    ] = None,
+    add_label_ids: Optional[StringList] = None,
+    remove_label_ids: Optional[StringList] = None,
     verify: bool = True,
 ) -> str:
     """

--- a/tests/gmail/test_modify_gmail_message_labels_schema.py
+++ b/tests/gmail/test_modify_gmail_message_labels_schema.py
@@ -1,29 +1,46 @@
+import inspect
+
 import gmail.gmail_tools  # noqa: F401
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
 from core.server import server
 from core.tool_registry import get_tool_components
 
 
-def _assert_optional_string_list_schema(field_schema):
-    assert "type" not in field_schema
-    assert "items" not in field_schema
-    assert field_schema["anyOf"] == [
-        {"type": "array", "items": {"type": "string"}},
-        {"type": "null"},
-    ]
+def _assert_label_id_list_schema(field_schema):
+    assert field_schema["type"] == "array"
+    assert field_schema["items"] == {"type": "string"}
+    assert "anyOf" not in field_schema
     assert field_schema["default"] is None
 
 
-def test_modify_gmail_message_labels_optional_arrays_publish_array_type():
-    components = get_tool_components(server)
-    schema = components["modify_gmail_message_labels"].parameters["properties"]
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool_name",
+    ["modify_gmail_message_labels", "batch_modify_gmail_message_labels"],
+)
+async def test_gmail_label_lists_publish_top_level_array_schema(tool_name):
+    tools = {tool.name: tool for tool in await server.list_tools()}
+    schema = tools[tool_name].parameters["properties"]
 
     for field_name in ("add_label_ids", "remove_label_ids"):
-        _assert_optional_string_list_schema(schema[field_name])
+        _assert_label_id_list_schema(schema[field_name])
 
 
-def test_batch_modify_gmail_message_labels_optional_arrays_publish_array_type():
-    components = get_tool_components(server)
-    schema = components["batch_modify_gmail_message_labels"].parameters["properties"]
+@pytest.mark.parametrize(
+    "tool_name",
+    ["modify_gmail_message_labels", "batch_modify_gmail_message_labels"],
+)
+def test_gmail_label_lists_accept_runtime_compatibility_inputs(tool_name):
+    tool = get_tool_components(server)[tool_name]
 
     for field_name in ("add_label_ids", "remove_label_ids"):
-        _assert_optional_string_list_schema(schema[field_name])
+        annotation = inspect.signature(tool.fn).parameters[field_name].annotation
+        adapter = TypeAdapter(annotation)
+
+        assert adapter.validate_python(["Label_57"]) == ["Label_57"]
+        assert adapter.validate_python('["Label_57"]') == ["Label_57"]
+        assert adapter.validate_python(None) is None
+        with pytest.raises(ValidationError):
+            adapter.validate_python("Label_57")

--- a/tests/gmail/test_modify_gmail_message_labels_schema.py
+++ b/tests/gmail/test_modify_gmail_message_labels_schema.py
@@ -1,6 +1,16 @@
+import gmail.gmail_tools  # noqa: F401
 from core.server import server
 from core.tool_registry import get_tool_components
-import gmail.gmail_tools  # noqa: F401
+
+
+def _assert_optional_string_list_schema(field_schema):
+    assert "type" not in field_schema
+    assert "items" not in field_schema
+    assert field_schema["anyOf"] == [
+        {"type": "array", "items": {"type": "string"}},
+        {"type": "null"},
+    ]
+    assert field_schema["default"] is None
 
 
 def test_modify_gmail_message_labels_optional_arrays_publish_array_type():
@@ -8,10 +18,7 @@ def test_modify_gmail_message_labels_optional_arrays_publish_array_type():
     schema = components["modify_gmail_message_labels"].parameters["properties"]
 
     for field_name in ("add_label_ids", "remove_label_ids"):
-        field_schema = schema[field_name]
-        assert field_schema["type"] == "array"
-        assert field_schema["items"] == {"type": "string"}
-        assert field_schema["default"] is None
+        _assert_optional_string_list_schema(schema[field_name])
 
 
 def test_batch_modify_gmail_message_labels_optional_arrays_publish_array_type():
@@ -19,7 +26,4 @@ def test_batch_modify_gmail_message_labels_optional_arrays_publish_array_type():
     schema = components["batch_modify_gmail_message_labels"].parameters["properties"]
 
     for field_name in ("add_label_ids", "remove_label_ids"):
-        field_schema = schema[field_name]
-        assert field_schema["type"] == "array"
-        assert field_schema["items"] == {"type": "string"}
-        assert field_schema["default"] is None
+        _assert_optional_string_list_schema(schema[field_name])


### PR DESCRIPTION
## Description
Remove redundant parent-level JSON Schema overrides from the Gmail message label tools so Optional[StringList] publishes a standards-compliant anyOf array/null schema.

Closes #979

## Testing
- Focused Gmail tests: 11 passed
- Full Gmail suite: 232 passed
- Full pytest: 1776 passed, 2 skipped
- Focused regression test Ruff check/format: passed

Repository-wide Ruff still reports pre-existing baseline violations outside this focused change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the published schema for Gmail label update options.
  * Label additions and removals are now correctly represented as optional lists of strings, including support for empty values.
  * Improved automatic reply targeting and email header handling for Gmail replies.

* **Documentation**
  * Updated reply guidance and examples to reflect automatic header derivation.

* **Tests**
  * Added coverage for label schemas, supported input formats, empty values, and invalid plain-string inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->