### PR TITLE
fix(utils): preserve Word text fidelity in extract_office_xml_text

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -407,29 +407,102 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
                         # Runs are not stripped individually either: under
                         # xml:space="preserve" the leading/trailing spaces of a run
                         # are the real spacing between words.
-                        paragraphs = []
-                        for para in xml_root.iter():
-                            if not para.tag.endswith("}p"):
+                        # Every text node belongs to exactly one LINE, and every
+                        # line is assembled by the same rule: concatenate its runs
+                        # with no separator, strip once.
+                        #
+                        # Word splits a single token across runs routinely (spell
+                        # check state, formatting, tracked changes, hyperlinks), so
+                        # stripping each run and joining with " " turns
+                        # "ProjectX2024" into "Project X2024" and a search for the
+                        # identifier finds nothing.
+                        #
+                        # A line is normally a paragraph (w:p / a:p). Paragraphs
+                        # NEST — a text box inside a body paragraph carries its own
+                        # w:p — so a node is assigned to its CLOSEST paragraph
+                        # ancestor, never to every ancestor. Text with no paragraph
+                        # ancestor at all still forms a line, owned by its nearest
+                        # non-run container, so it is neither dropped nor split.
+                        # ElementTree has no parent links, hence the parent map.
+                        parents = {
+                            child: parent
+                            for parent in xml_root.iter()
+                            for child in parent
+                        }
+
+                        def _line_owner(node):
+                            """Closest paragraph ancestor, else nearest non-run container."""
+                            cur = parents.get(node)
+                            while cur is not None:
+                                if cur.tag.endswith("}p"):
+                                    return cur
+                                if not cur.tag.endswith("}r"):
+                                    parent = parents.get(cur)
+                                    while parent is not None:
+                                        if parent.tag.endswith("}p"):
+                                            return parent
+                                        parent = parents.get(parent)
+                                    return cur
+                                cur = parents.get(cur)
+                            return None
+
+                        # Markup-compatibility: Word writes a text box TWICE —
+                        # once under mc:Choice for modern readers and once under
+                        # mc:Fallback (VML) for old ones. Both carry the same
+                        # text, so scraping the subtree blindly emits it twice and
+                        # the duplicate is indistinguishable from a genuinely
+                        # repeated paragraph. Per the spec a consumer takes the
+                        # first Choice it understands, else the Fallback; we cannot
+                        # evaluate the Requires attribute, so take the first Choice
+                        # when there is one and ignore the rest of the alternatives.
+                        skip = set()
+                        for alt in xml_root.iter():
+                            if not alt.tag.endswith("}AlternateContent"):
                                 continue
-                            runs = [
-                                t.text
-                                for t in para.iter()
-                                if t.tag.endswith("}t") and t.text
-                            ]
-                            if runs:
-                                line = "".join(runs).strip()
-                                if line:
-                                    paragraphs.append(line)
-                        if paragraphs:
-                            member_texts.extend(paragraphs)
-                        else:
-                            # Fall back to the flat scan for text carried outside
-                            # any paragraph element (some shapes and tables).
-                            for elem in xml_root.iter():
-                                if elem.tag.endswith("}t") and elem.text:
-                                    cleaned_text = elem.text.strip()
-                                    if cleaned_text:
-                                        member_texts.append(cleaned_text)
+                            children = list(alt)
+                            choices = [c for c in children if c.tag.endswith("}Choice")]
+                            ignored = (
+                                choices[1:]
+                                + [c for c in children if c.tag.endswith("}Fallback")]
+                                if choices
+                                else []
+                            )
+                            for branch in ignored:
+                                for node in branch.iter():
+                                    skip.add(id(node))
+
+                        lines = {}
+                        order = []
+                        for node in xml_root.iter():
+                            if id(node) in skip:
+                                continue
+                            tag = node.tag
+                            piece = None
+                            if tag.endswith("}t") and node.text:
+                                piece = node.text
+                            elif (
+                                tag.endswith("}tab")
+                                or tag.endswith("}br")
+                                or tag.endswith("}cr")
+                            ):
+                                # Only inside a run: w:tab under w:pPr/w:tabs is a tab
+                                # STOP definition, not a tab character.
+                                parent = parents.get(node)
+                                if parent is not None and parent.tag.endswith("}r"):
+                                    piece = "\t" if tag.endswith("}tab") else "\n"
+                            if piece is None:
+                                continue
+                            owner = _line_owner(node)
+                            key = id(owner) if owner is not None else id(node)
+                            if key not in lines:
+                                lines[key] = []
+                                order.append(key)  # first appearance = document order
+                            lines[key].append(piece)
+
+                        for key in order:
+                            line = "".join(lines[key]).strip()
+                            if line:
+                                member_texts.append(line)
 
                     if member_texts:
                         # Word/PowerPoint entries are one paragraph each, so join

--- a/core/utils.py
+++ b/core/utils.py
@@ -301,7 +301,17 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
                 mime_type
                 == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
             ):
+                # Body first, then headers/footers/footnotes/endnotes. Text that
+                # lives only in a header — confidentiality banners, running
+                # titles, document numbers — is otherwise invisible to callers.
                 targets = ["word/document.xml"]
+                targets += sorted(
+                    n
+                    for n in zf.namelist()
+                    if re.fullmatch(
+                        r"word/(header\d*|footer\d*|footnotes|endnotes)\.xml", n
+                    )
+                )
             elif (
                 mime_type
                 == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
@@ -384,22 +394,55 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
                             else:  # Direct value (number, boolean, inline string if not 's')
                                 member_texts.append(value_element.text)
                     else:  # Word or PowerPoint
-                        for elem in xml_root.iter():
-                            # For Word: <w:t> where w is "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
-                            # For PowerPoint: <a:t> where a is "http://schemas.openxmlformats.org/drawingml/2006/main"
-                            if (
-                                elem.tag.endswith("}t") and elem.text
-                            ):  # Check for any namespaced tag ending with 't'
-                                cleaned_text = elem.text.strip()
-                                if (
-                                    cleaned_text
-                                ):  # Add only if there's non-whitespace text
-                                    member_texts.append(cleaned_text)
+                        # Group runs by their containing paragraph (w:p / a:p) and
+                        # join the runs of one paragraph with NO separator.
+                        #
+                        # Word splits a single word across runs routinely — spell
+                        # check state, formatting, tracked changes. Stripping each
+                        # run and joining with " " turns "ProjectX2024" into
+                        # "ProjectX 2024", so a search for the identifier finds
+                        # nothing. That is a false negative indistinguishable from
+                        # the term genuinely being absent.
+                        #
+                        # Runs are not stripped individually either: under
+                        # xml:space="preserve" the leading/trailing spaces of a run
+                        # are the real spacing between words.
+                        paragraphs = []
+                        for para in xml_root.iter():
+                            if not para.tag.endswith("}p"):
+                                continue
+                            runs = [
+                                t.text
+                                for t in para.iter()
+                                if t.tag.endswith("}t") and t.text
+                            ]
+                            if runs:
+                                line = "".join(runs).strip()
+                                if line:
+                                    paragraphs.append(line)
+                        if paragraphs:
+                            member_texts.extend(paragraphs)
+                        else:
+                            # Fall back to the flat scan for text carried outside
+                            # any paragraph element (some shapes and tables).
+                            for elem in xml_root.iter():
+                                if elem.tag.endswith("}t") and elem.text:
+                                    cleaned_text = elem.text.strip()
+                                    if cleaned_text:
+                                        member_texts.append(cleaned_text)
 
                     if member_texts:
-                        pieces.append(
-                            " ".join(member_texts)
-                        )  # Join texts from one member with spaces
+                        # Word/PowerPoint entries are one paragraph each, so join
+                        # them with newlines: paragraph boundaries carry meaning,
+                        # and collapsing them runs headings into body text.
+                        # Spreadsheet entries stay space-joined as before.
+                        sep = (
+                            " "
+                            if mime_type
+                            == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                            else "\n"
+                        )
+                        pieces.append(sep.join(member_texts))
 
                 except ET.ParseError as e:
                     logger.warning(

--- a/tests/core/test_extract_office_xml_text.py
+++ b/tests/core/test_extract_office_xml_text.py
@@ -10,9 +10,15 @@ import zipfile
 
 from core.utils import extract_office_xml_text
 
-W_NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
+W_NS = (
+    'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" '
+    'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" '
+    'xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" '
+    'xmlns:v="urn:schemas-microsoft-com:vml"'
+)
 DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 
 
 def _docx(body: str, **members: str) -> bytes:
@@ -57,8 +63,41 @@ class TestRunsWithinAParagraph:
         assert extract_office_xml_text(_docx(body), DOCX_MIME) == "hello world"
 
     def test_leading_and_trailing_whitespace_of_a_paragraph_is_trimmed(self):
-        body = '<w:p><w:r><w:t xml:space="preserve">  padded  </w:t></w:r></w:p>'
-        assert extract_office_xml_text(_docx(body), DOCX_MIME) == "padded"
+        """Padded paragraph in the MIDDLE. A lone one is stripped by the final
+        whole-output strip, so the per-paragraph property would go untested."""
+        body = (
+            _p("First.")
+            + '<w:p><w:r><w:t xml:space="preserve">  padded  </w:t></w:r></w:p>'
+            + _p("Last.")
+        )
+        assert (
+            extract_office_xml_text(_docx(body), DOCX_MIME) == "First.\npadded\nLast."
+        )
+
+    def test_whitespace_only_paragraph_produces_no_blank_line(self):
+        body = (
+            _p("First.")
+            + '<w:p><w:r><w:t xml:space="preserve">   </w:t></w:r></w:p>'
+            + _p("Second.")
+        )
+        assert extract_office_xml_text(_docx(body), DOCX_MIME) == "First.\nSecond."
+
+    def test_runs_nested_in_a_hyperlink_still_join(self):
+        """w:hyperlink puts runs a level deeper; the ancestor walk must reach it."""
+        body = (
+            '<w:p><w:r><w:t xml:space="preserve">see </w:t></w:r>'
+            "<w:hyperlink><w:r><w:t>here</w:t></w:r></w:hyperlink>"
+            '<w:r><w:t xml:space="preserve"> now</w:t></w:r></w:p>'
+        )
+        assert extract_office_xml_text(_docx(body), DOCX_MIME) == "see here now"
+
+    def test_tracked_insertion_does_not_split_a_token(self):
+        """The flagship regression, reappearing through w:ins nesting."""
+        body = (
+            "<w:p><w:r><w:t>Project</w:t></w:r>"
+            "<w:ins><w:r><w:t>X2024</w:t></w:r></w:ins></w:p>"
+        )
+        assert extract_office_xml_text(_docx(body), DOCX_MIME) == "ProjectX2024"
 
 
 class TestParagraphBoundaries:
@@ -75,8 +114,7 @@ class TestHeadersFootersAndNotes:
     def test_header_text_is_included(self):
         blob = _docx(_p("body text"), header1=_hdr(_p("CONFIDENTIAL")))
         out = extract_office_xml_text(blob, DOCX_MIME)
-        assert "body text" in out
-        assert "CONFIDENTIAL" in out
+        assert out == "body text\n\nCONFIDENTIAL"
 
     def test_body_comes_before_header_text(self):
         blob = _docx(_p("body text"), header1=_hdr(_p("CONFIDENTIAL")))
@@ -104,12 +142,134 @@ class TestHeadersFootersAndNotes:
         assert "NOT DOCUMENT TEXT" not in extract_office_xml_text(blob, DOCX_MIME)
 
 
-class TestFallbackAndOtherFormats:
-    def test_text_outside_any_paragraph_is_still_found(self):
-        """Some shapes and tables carry w:t outside a w:p; do not lose them."""
-        blob = _docx("<w:tbl><w:r><w:t>orphan cell</w:t></w:r></w:tbl>")
-        assert "orphan cell" in extract_office_xml_text(blob, DOCX_MIME)
+class TestNestedParagraphs:
+    def test_text_box_inside_a_paragraph_is_not_emitted_twice(self):
+        """Paragraphs nest: a text box inside a w:p carries its own w:p.
 
+        Collecting with para.iter() attributes the inner text to BOTH the inner
+        and the outer paragraph, so it appears twice.
+        """
+        body = (
+            "<w:p><w:r><w:t>outer</w:t></w:r>"
+            "<w:txbxContent><w:p><w:r><w:t>INNER</w:t></w:r></w:p></w:txbxContent>"
+            "</w:p>"
+        )
+        out = extract_office_xml_text(_docx(body), DOCX_MIME)
+        assert out.count("INNER") == 1, out
+
+    def test_outer_and_inner_paragraph_text_are_both_present(self):
+        body = (
+            "<w:p><w:r><w:t>outer</w:t></w:r>"
+            "<w:txbxContent><w:p><w:r><w:t>INNER</w:t></w:r></w:p></w:txbxContent>"
+            "</w:p>"
+        )
+        out = extract_office_xml_text(_docx(body), DOCX_MIME)
+        assert "outer" in out
+        assert "INNER" in out
+
+
+class TestMarkupCompatibility:
+    """Word writes a text box TWICE: mc:Choice for modern readers, mc:Fallback
+    (VML) for old ones. Both carry the same text."""
+
+    _CHOICE = (
+        '<mc:Choice Requires="wps"><w:drawing><wps:txbx><w:txbxContent>'
+        "<w:p><w:r><w:t>BOXED</w:t></w:r></w:p>"
+        "</w:txbxContent></wps:txbx></w:drawing></mc:Choice>"
+    )
+    _FALLBACK = (
+        "<mc:Fallback><w:pict><v:textbox><w:txbxContent>"
+        "<w:p><w:r><w:t>BOXED</w:t></w:r></w:p>"
+        "</w:txbxContent></v:textbox></w:pict></mc:Fallback>"
+    )
+
+    def test_text_box_content_is_not_emitted_once_per_alternative(self):
+        body = (
+            "<w:p><w:r><w:t>before</w:t></w:r><w:r><mc:AlternateContent>"
+            + self._CHOICE
+            + self._FALLBACK
+            + "</mc:AlternateContent></w:r>"
+            "<w:r><w:t>after</w:t></w:r></w:p>"
+        )
+        out = extract_office_xml_text(_docx(body), DOCX_MIME)
+        assert out.count("BOXED") == 1, out
+
+    def test_fallback_only_content_is_still_extracted(self):
+        """No Choice to prefer, so the Fallback must NOT be skipped."""
+        body = (
+            "<w:p><w:r><mc:AlternateContent>"
+            + self._FALLBACK
+            + "</mc:AlternateContent></w:r></w:p>"
+        )
+        out = extract_office_xml_text(_docx(body), DOCX_MIME)
+        assert "BOXED" in out
+
+
+class TestTables:
+    def test_real_table_cells_are_separate_lines(self):
+        """A real table is w:tbl > w:tr > w:tc > w:p, i.e. the PARAGRAPH path."""
+        body = (
+            "<w:tbl><w:tr>"
+            "<w:tc><w:p><w:r><w:t>cell A</w:t></w:r></w:p></w:tc>"
+            "<w:tc><w:p><w:r><w:t>cell B</w:t></w:r></w:p></w:tc>"
+            "</w:tr></w:tbl>"
+        )
+        assert extract_office_xml_text(_docx(body), DOCX_MIME) == "cell A\ncell B"
+
+
+class TestTextOutsideAnyParagraph:
+    """Defensive path: text with no w:p ancestor, neither dropped nor mangled."""
+
+    def test_orphan_runs_join_like_a_paragraph(self):
+        blob = _docx(
+            _p("body text")
+            + "<w:tbl><w:r><w:t>Project</w:t></w:r><w:r><w:t>X2024</w:t></w:r></w:tbl>"
+        )
+        assert extract_office_xml_text(blob, DOCX_MIME) == "body text\nProjectX2024"
+
+    def test_orphan_text_keeps_its_document_position(self):
+        blob = _docx(
+            "<w:tbl><w:r><w:t>ORPHAN FIRST</w:t></w:r></w:tbl>" + _p("body text")
+        )
+        assert extract_office_xml_text(blob, DOCX_MIME) == "ORPHAN FIRST\nbody text"
+
+
+class TestTabsAndBreaks:
+    def test_tab_between_runs_is_a_tab_not_a_fused_token(self):
+        body = (
+            "<w:p><w:r><w:t>A</w:t></w:r><w:r><w:tab/></w:r>"
+            "<w:r><w:t>B</w:t></w:r></w:p>"
+        )
+        assert extract_office_xml_text(_docx(body), DOCX_MIME) == "A\tB"
+
+    def test_break_inside_a_run_becomes_a_newline(self):
+        body = "<w:p><w:r><w:t>A</w:t><w:br/><w:t>B</w:t></w:r></w:p>"
+        assert extract_office_xml_text(_docx(body), DOCX_MIME) == "A\nB"
+
+    def test_tab_stop_definitions_are_not_tab_characters(self):
+        """w:tab under w:pPr/w:tabs defines a stop; it is not content."""
+        body = (
+            "<w:p><w:pPr><w:tabs><w:tab w:val='left' w:pos='720'/></w:tabs></w:pPr>"
+            "<w:r><w:t>AB</w:t></w:r></w:p>"
+        )
+        assert extract_office_xml_text(_docx(body), DOCX_MIME) == "AB"
+
+
+class TestPowerPoint:
+    def test_slide_runs_join_without_a_space(self):
+        buf = io.BytesIO()
+        a_ns = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(
+                "ppt/slides/slide1.xml",
+                f'<?xml version="1.0"?><root {a_ns}>'
+                "<a:p><a:r><a:t>Slide</a:t></a:r><a:r><a:t>Title1</a:t></a:r></a:p>"
+                "</root>",
+            )
+        assert extract_office_xml_text(buf.getvalue(), PPTX_MIME) == "SlideTitle1"
+
+
+class TestFallbackAndOtherFormats:
     def test_corrupt_zip_returns_none(self):
         assert extract_office_xml_text(b"definitely not a zip", DOCX_MIME) is None
 
@@ -126,5 +286,7 @@ class TestFallbackAndOtherFormats:
                 "</row></sheetData></worksheet>",
             )
         out = extract_office_xml_text(buf.getvalue(), XLSX_MIME)
-        assert out is not None
-        assert "alpha" in out and "beta" in out
+        # Exact, not containment: containment would also pass if spreadsheet
+        # values became newline-joined or concatenated, which is the very thing
+        # this test exists to prevent.
+        assert out == "alpha beta"

--- a/tests/core/test_extract_office_xml_text.py
+++ b/tests/core/test_extract_office_xml_text.py
@@ -1,0 +1,130 @@
+"""Tests for extract_office_xml_text in core/utils.py.
+
+Focus is text FIDELITY for Word documents: the extracted string has to be the
+string a human reads, because callers search it. A search that silently misses
+is worse than no search — it produces a confident "not present" that is wrong.
+"""
+
+import io
+import zipfile
+
+from core.utils import extract_office_xml_text
+
+W_NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
+DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+
+def _docx(body: str, **members: str) -> bytes:
+    """Minimal .docx: a body, plus any extra word/*.xml members by name."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(
+            "word/document.xml",
+            f'<?xml version="1.0"?><w:document {W_NS}><w:body>{body}</w:body>'
+            "</w:document>",
+        )
+        for name, xml in members.items():
+            zf.writestr(f"word/{name}.xml", xml)
+    return buf.getvalue()
+
+
+def _hdr(body: str) -> str:
+    return f'<?xml version="1.0"?><w:hdr {W_NS}>{body}</w:hdr>'
+
+
+def _p(*runs: str) -> str:
+    inner = "".join(f"<w:r><w:t>{r}</w:t></w:r>" for r in runs)
+    return f"<w:p>{inner}</w:p>"
+
+
+class TestRunsWithinAParagraph:
+    def test_word_split_across_runs_is_not_broken_by_a_space(self):
+        """The regression this suite exists for.
+
+        Word splits a single word across runs constantly — spell-check state,
+        formatting, tracked changes. Joining runs with a space turns one token
+        into two, and every search for that token then fails.
+        """
+        blob = _docx(_p("Project", "X2024"))
+        assert extract_office_xml_text(blob, DOCX_MIME) == "ProjectX2024"
+
+    def test_xml_space_preserve_run_keeps_its_spacing(self):
+        body = (
+            '<w:p><w:r><w:t xml:space="preserve">hello </w:t></w:r>'
+            "<w:r><w:t>world</w:t></w:r></w:p>"
+        )
+        assert extract_office_xml_text(_docx(body), DOCX_MIME) == "hello world"
+
+    def test_leading_and_trailing_whitespace_of_a_paragraph_is_trimmed(self):
+        body = '<w:p><w:r><w:t xml:space="preserve">  padded  </w:t></w:r></w:p>'
+        assert extract_office_xml_text(_docx(body), DOCX_MIME) == "padded"
+
+
+class TestParagraphBoundaries:
+    def test_paragraphs_are_newline_separated(self):
+        blob = _docx(_p("First.") + _p("Second."))
+        assert extract_office_xml_text(blob, DOCX_MIME) == "First.\nSecond."
+
+    def test_empty_paragraphs_do_not_produce_blank_lines(self):
+        blob = _docx(_p("First.") + "<w:p/>" + _p("Second."))
+        assert extract_office_xml_text(blob, DOCX_MIME) == "First.\nSecond."
+
+
+class TestHeadersFootersAndNotes:
+    def test_header_text_is_included(self):
+        blob = _docx(_p("body text"), header1=_hdr(_p("CONFIDENTIAL")))
+        out = extract_office_xml_text(blob, DOCX_MIME)
+        assert "body text" in out
+        assert "CONFIDENTIAL" in out
+
+    def test_body_comes_before_header_text(self):
+        blob = _docx(_p("body text"), header1=_hdr(_p("CONFIDENTIAL")))
+        out = extract_office_xml_text(blob, DOCX_MIME)
+        assert out.index("body text") < out.index("CONFIDENTIAL")
+
+    def test_footer_and_footnotes_are_included(self):
+        blob = _docx(
+            _p("body"),
+            footer1=_hdr(_p("page footer")),
+            footnotes=f'<?xml version="1.0"?><w:footnotes {W_NS}>'
+            f"{_p('a footnote')}</w:footnotes>",
+        )
+        out = extract_office_xml_text(blob, DOCX_MIME)
+        assert "page footer" in out
+        assert "a footnote" in out
+
+    def test_unrelated_word_members_are_not_scraped(self):
+        """settings.xml and friends are configuration, not document text."""
+        blob = _docx(
+            _p("body"),
+            settings=f'<?xml version="1.0"?><w:settings {W_NS}>'
+            f"{_p('NOT DOCUMENT TEXT')}</w:settings>",
+        )
+        assert "NOT DOCUMENT TEXT" not in extract_office_xml_text(blob, DOCX_MIME)
+
+
+class TestFallbackAndOtherFormats:
+    def test_text_outside_any_paragraph_is_still_found(self):
+        """Some shapes and tables carry w:t outside a w:p; do not lose them."""
+        blob = _docx("<w:tbl><w:r><w:t>orphan cell</w:t></w:r></w:tbl>")
+        assert "orphan cell" in extract_office_xml_text(blob, DOCX_MIME)
+
+    def test_corrupt_zip_returns_none(self):
+        assert extract_office_xml_text(b"definitely not a zip", DOCX_MIME) is None
+
+    def test_spreadsheet_cells_remain_space_joined(self):
+        """Sheets have no paragraphs; this fix must not change their behaviour."""
+        buf = io.BytesIO()
+        ns = 'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(
+                "xl/worksheets/sheet1.xml",
+                f'<?xml version="1.0"?><worksheet {ns}><sheetData><row>'
+                '<c r="A1" t="str"><v>alpha</v></c>'
+                '<c r="B1" t="str"><v>beta</v></c>'
+                "</row></sheetData></worksheet>",
+            )
+        out = extract_office_xml_text(buf.getvalue(), XLSX_MIME)
+        assert out is not None
+        assert "alpha" in out and "beta" in out


### PR DESCRIPTION
## Description

`extract_office_xml_text` loses text fidelity for Word documents in three ways that share one symptom: **a search of the extracted text finds nothing, and the caller cannot tell that apart from the term genuinely being absent.**

**1. A word split across runs is joined with a space.** Word splits a single token across runs routinely — spell-check state, formatting, tracked changes. The current loop strips each run and joins with `" "`, so:

```xml
<w:p><w:r><w:t>Project</w:t></w:r><w:r><w:t>X2024</w:t></w:r></w:p>
```

extracts as `Project X2024`, and a search for `ProjectX2024` returns nothing.

**2. Paragraph boundaries are discarded** — every paragraph in a member is joined with `" "`, running headings into body text.

**3. Only `word/document.xml` is read** — text in a header, footer, footnote or endnote (confidentiality banners, running titles, document numbers) is invisible to every caller.

### Changes

- Group `w:t` runs by their containing `w:p`; join runs of one paragraph with **no separator**. Runs are no longer stripped individually — under `xml:space="preserve"` those spaces are the real spacing between words.
- Join paragraphs within a member with newlines. Spreadsheets keep space-joining; they have no paragraphs.
- Include `word/header*.xml`, `footer*.xml`, `footnotes.xml`, `endnotes.xml` after the body, matched exactly so `settings.xml` is not scraped.
- Keep a flat-scan fallback for `w:t` outside any paragraph (some shapes and tables), so nothing previously found is lost.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

`tests/core/test_extract_office_xml_text.py`, 12 tests.

**Six fail against the current implementation and pass after the change**: the split-token case, both paragraph-boundary cases, and the three header/footer/footnote cases. I verified this by reverting `core/utils.py` and re-running — a test that passes either way proves nothing.

The other six are regression guards that pass both before and after: `xml:space` spacing, paragraph trimming, orphan `w:t` outside a paragraph, `settings.xml` not being scraped, corrupt input still returning `None`, and **spreadsheet extraction unchanged**.

```
uv run --extra test python -m pytest tests   ->  1788 passed, 2 skipped
uvx ruff check <changed files>               ->  clean
uvx ruff format --check <changed files>      ->  clean
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

One behaviour change worth flagging: extracted Word text now contains newlines between paragraphs where it previously contained spaces. Anything matching against the old single-line shape would need adjusting — I did not find such a caller in-repo.

Changes are confined to `core/utils.py`; no logic was added to any `*_tools.py` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Word text extraction to include headers, footers, footnotes, and endnotes.
  * Preserved paragraph structure, run spacing, tabs, and line breaks in Word and PowerPoint content.
  * Added support for extracting text from tables, text boxes, and other structured office content.
  * Added fallback extraction when paragraph-based content is unavailable.

* **Bug Fixes**
  * Improved handling of duplicate markup, malformed office files, and corrupt archives.
  * Preserved existing spreadsheet cell text extraction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->