### PR TITLE
fix(utils): distinguish an unreadable Office file from an empty one

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -439,9 +439,15 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
                 except OfficeXmlExtractionError:
                     raise
                 except KeyError:
-                    # The member simply is not in the archive. That is ABSENT, not
-                    # damaged: a readable file with nothing to extract yields None,
-                    # which is the distinction this whole change exists to keep.
+                    # ABSENT is not DAMAGED, and the difference is the contract:
+                    # this function returns None for a readable file with no
+                    # extractable text, and raises only when the file cannot be
+                    # read. A member that is simply not in the archive is the
+                    # former.
+                    #
+                    # Do NOT merge this into the generic handler below. That one
+                    # raises, so folding these together would report every archive
+                    # lacking an optional member as corrupt.
                     logger.info(
                         f"Member '{member}' not present in {mime_type} file; skipping."
                     )

--- a/core/utils.py
+++ b/core/utils.py
@@ -352,7 +352,13 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
                         "No sharedStrings.xml found in Excel file (this is optional)."
                     )
                 except ET.ParseError as e:
+                    # Absent sharedStrings is optional (KeyError above). MALFORMED
+                    # is not: every t="s" cell resolves through it, so continuing
+                    # would silently produce wrong cell text.
                     logger.error(f"Error parsing sharedStrings.xml: {e}")
+                    raise OfficeXmlExtractionError(
+                        f"sharedStrings.xml is not parseable XML: {e}"
+                    ) from e
                 except (
                     Exception
                 ) as e:  # Catch any other unexpected error during sharedStrings parsing
@@ -420,15 +426,35 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
                         )  # Join texts from one member with spaces
 
                 except ET.ParseError as e:
+                    # A member that will not parse means we cannot report this
+                    # file's text. Swallowing it here and returning None below
+                    # would present a damaged document as an empty one.
                     logger.warning(
                         f"Could not parse XML in member '{member}' for {mime_type} file: {e}"
                     )
+                    raise OfficeXmlExtractionError(
+                        f"member '{member}' is not parseable XML "
+                        f"(mime_type: {mime_type}): {e}"
+                    ) from e
+                except OfficeXmlExtractionError:
+                    raise
+                except KeyError:
+                    # The member simply is not in the archive. That is ABSENT, not
+                    # damaged: a readable file with nothing to extract yields None,
+                    # which is the distinction this whole change exists to keep.
+                    logger.info(
+                        f"Member '{member}' not present in {mime_type} file; skipping."
+                    )
+                    continue
                 except Exception as e:
                     logger.error(
                         f"Error processing member '{member}' for {mime_type}: {e}",
                         exc_info=True,
                     )
-                    # continue processing other members
+                    raise OfficeXmlExtractionError(
+                        f"could not read member '{member}' "
+                        f"(mime_type: {mime_type}): {e}"
+                    ) from e
 
             if not pieces:  # If no text was extracted at all
                 return None

--- a/core/utils.py
+++ b/core/utils.py
@@ -284,11 +284,29 @@ def check_credentials_directory_permissions(credentials_dir: str = None) -> None
     )
 
 
+class OfficeXmlExtractionError(Exception):
+    """Raised when an Office file cannot be READ.
+
+    Distinct from a valid file that simply contains no text. Callers that cannot
+    tell those apart end up reporting a damaged document as an empty or
+    unsupported one, which sends the reader looking in the wrong place.
+    """
+
+
 def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
     """
     Very light-weight XML scraper for Word, Excel, PowerPoint files.
-    Returns plain-text if something readable is found, else None.
     Uses zipfile + defusedxml.ElementTree.
+
+    Returns:
+        The extracted text, or None if the file is readable but holds no text.
+
+    Raises:
+        OfficeXmlExtractionError: the file could not be read at all — not a ZIP,
+            or its XML will not parse. This is deliberately NOT folded into the
+            None return: "damaged" and "empty" call for different responses from
+            a caller, and conflating them reports a corrupt document as an
+            unsupported or empty one.
     """
     shared_strings: List[str] = []
     ns_excel_main = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
@@ -419,19 +437,30 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
             text = "\n\n".join(pieces).strip()
             return text or None  # Ensure None is returned if text is empty after strip
 
-    except zipfile.BadZipFile:
+    except zipfile.BadZipFile as e:
         logger.warning(f"File is not a valid ZIP archive (mime_type: {mime_type}).")
-        return None
+        raise OfficeXmlExtractionError(
+            f"not a valid Office file (mime_type: {mime_type}): {e}"
+        ) from e
     except (
         ET.ParseError
     ) as e:  # Catch parsing errors at the top level if zipfile itself is XML-like
         logger.error(f"XML parsing error at a high level for {mime_type}: {e}")
-        return None
+        raise OfficeXmlExtractionError(
+            f"Office file XML could not be parsed (mime_type: {mime_type}): {e}"
+        ) from e
+    except OfficeXmlExtractionError:
+        raise
     except Exception as e:
+        # An unexpected failure is still a failure to READ the file, not evidence
+        # that it holds no text. Surface it rather than letting it masquerade as
+        # an empty document.
         logger.error(
             f"Failed to extract office XML text for {mime_type}: {e}", exc_info=True
         )
-        return None
+        raise OfficeXmlExtractionError(
+            f"could not extract text from Office file (mime_type: {mime_type}): {e}"
+        ) from e
 
 
 IMAGE_MIME_TYPES = {

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -22,6 +22,7 @@ from mcp.types import ToolAnnotations
 from auth.service_decorator import require_google_service, require_multiple_services
 from core.utils import (
     GOOGLE_API_WRITE_RETRIES,
+    OfficeXmlExtractionError,
     extract_office_xml_text,
     handle_http_errors,
     UserInputError,
@@ -311,9 +312,20 @@ async def get_doc_content(
 
         file_content_bytes = fh.getvalue()
 
-        office_text = extract_office_xml_text(file_content_bytes, mime_type)
+        office_text = None
+        unreadable = None
+        try:
+            office_text = extract_office_xml_text(file_content_bytes, mime_type)
+        except OfficeXmlExtractionError as e:
+            # A damaged file must not be reported as an unsupported encoding.
+            unreadable = (
+                f"[Could not read '{mime_type}' file - it appears damaged or is "
+                f"not a valid Office document: {e}]"
+            )
         if office_text:
             body_text = office_text
+        elif unreadable:
+            body_text = unreadable
         else:
             try:
                 body_text = file_content_bytes.decode("utf-8")

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -29,6 +29,7 @@ from core.utils import (
     GOOGLE_API_WRITE_RETRIES,
     IMAGE_MIME_TYPES,
     encode_image_content,
+    OfficeXmlExtractionError,
     extract_office_xml_text,
     extract_pdf_text,
     handle_http_errors,
@@ -387,11 +388,24 @@ async def get_drive_file_content(
 
     if mime_type in office_mime_types:
         # Offload Office XML extraction to a thread to avoid blocking the event loop
-        office_text = await asyncio.to_thread(
-            extract_office_xml_text, file_content_bytes, mime_type
-        )
+        office_text = None
+        unreadable = None
+        try:
+            office_text = await asyncio.to_thread(
+                extract_office_xml_text, file_content_bytes, mime_type
+            )
+        except OfficeXmlExtractionError as e:
+            # Say the file is damaged. Falling through to the binary branch would
+            # report a corrupt document as "unsupported text encoding", sending
+            # the reader after the wrong problem.
+            unreadable = (
+                f"[Could not read '{mime_type}' file - it appears damaged or is "
+                f"not a valid Office document: {e}]"
+            )
         if office_text:
             body_text = office_text
+        elif unreadable:
+            body_text = unreadable
         else:
             # Fallback: try UTF-8; otherwise flag binary
             try:

--- a/tests/core/test_office_extraction_errors.py
+++ b/tests/core/test_office_extraction_errors.py
@@ -1,0 +1,80 @@
+"""Tests that extract_office_xml_text distinguishes UNREADABLE from EMPTY.
+
+Both used to return None, so a caller could not tell "this file is damaged"
+from "this file contains no text". The two call for different responses, and
+conflating them reports a corrupt document as an unsupported or empty one —
+which sends the reader after the wrong problem.
+"""
+
+import io
+import zipfile
+
+import pytest
+
+from core.utils import OfficeXmlExtractionError, extract_office_xml_text
+
+W_NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
+DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+
+def _docx(document_xml: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("word/document.xml", document_xml)
+    return buf.getvalue()
+
+
+def _valid(body: str) -> bytes:
+    return _docx(
+        f'<?xml version="1.0"?><w:document {W_NS}><w:body>{body}</w:body></w:document>'
+    )
+
+
+class TestUnreadableRaises:
+    def test_not_a_zip_raises(self):
+        with pytest.raises(OfficeXmlExtractionError):
+            extract_office_xml_text(b"this is not a zip at all", DOCX_MIME)
+
+    def test_truncated_zip_raises(self):
+        good = _valid("<w:p><w:r><w:t>hello</w:t></w:r></w:p>")
+        with pytest.raises(OfficeXmlExtractionError):
+            extract_office_xml_text(good[: len(good) // 2], DOCX_MIME)
+
+    def test_empty_bytes_raises(self):
+        with pytest.raises(OfficeXmlExtractionError):
+            extract_office_xml_text(b"", DOCX_MIME)
+
+    def test_message_names_the_mime_type(self):
+        """The report should say what it failed to read."""
+        with pytest.raises(OfficeXmlExtractionError) as excinfo:
+            extract_office_xml_text(b"not a zip", DOCX_MIME)
+        assert DOCX_MIME in str(excinfo.value)
+
+    def test_original_cause_is_chained(self):
+        """`raise ... from e` keeps the underlying error for debugging."""
+        with pytest.raises(OfficeXmlExtractionError) as excinfo:
+            extract_office_xml_text(b"not a zip", DOCX_MIME)
+        assert excinfo.value.__cause__ is not None
+
+
+class TestReadableButEmptyStillReturnsNone:
+    def test_document_with_no_text_returns_none(self):
+        """A valid file holding no text is NOT an error — the old contract."""
+        assert extract_office_xml_text(_valid("<w:p/>"), DOCX_MIME) is None
+
+    def test_whitespace_only_text_returns_none(self):
+        body = '<w:p><w:r><w:t xml:space="preserve">   </w:t></w:r></w:p>'
+        assert extract_office_xml_text(_valid(body), DOCX_MIME) is None
+
+    def test_zip_without_the_expected_member_returns_none(self):
+        """Readable ZIP, nothing to extract from — still empty, not damaged."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("unrelated.txt", "hello")
+        assert extract_office_xml_text(buf.getvalue(), DOCX_MIME) is None
+
+
+class TestSuccessPathUnchanged:
+    def test_normal_document_still_extracts(self):
+        blob = _valid("<w:p><w:r><w:t>hello world</w:t></w:r></w:p>")
+        assert extract_office_xml_text(blob, DOCX_MIME) == "hello world"

--- a/tests/core/test_office_extraction_errors.py
+++ b/tests/core/test_office_extraction_errors.py
@@ -15,6 +15,7 @@ from core.utils import OfficeXmlExtractionError, extract_office_xml_text
 
 W_NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
 DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 
 def _docx(document_xml: str) -> bytes:
@@ -55,6 +56,53 @@ class TestUnreadableRaises:
         with pytest.raises(OfficeXmlExtractionError) as excinfo:
             extract_office_xml_text(b"not a zip", DOCX_MIME)
         assert excinfo.value.__cause__ is not None
+
+
+class TestMemberLevelFailuresAlsoRaise:
+    """A per-member failure is still a failure to READ the file.
+
+    Suppressing it and falling through to "no pieces -> None" presents a damaged
+    document as an empty one, which is the exact conflation this change removes.
+    """
+
+    def test_malformed_document_xml_raises(self):
+        blob = _docx('<?xml version="1.0"?><w:document><unclosed>')
+        with pytest.raises(OfficeXmlExtractionError):
+            extract_office_xml_text(blob, DOCX_MIME)
+
+    def test_malformed_member_names_the_member(self):
+        blob = _docx('<?xml version="1.0"?><w:document><unclosed>')
+        with pytest.raises(OfficeXmlExtractionError) as excinfo:
+            extract_office_xml_text(blob, DOCX_MIME)
+        assert "word/document.xml" in str(excinfo.value)
+
+    def test_malformed_shared_strings_raises(self):
+        """Absent sharedStrings is optional; MALFORMED is not -- every t="s"
+        cell resolves through it, so continuing yields wrong cell text."""
+        ns = 'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(
+                "xl/worksheets/sheet1.xml",
+                f'<?xml version="1.0"?><worksheet {ns}><sheetData></sheetData>'
+                "</worksheet>",
+            )
+            zf.writestr("xl/sharedStrings.xml", '<?xml version="1.0"?><sst><unclosed>')
+        with pytest.raises(OfficeXmlExtractionError):
+            extract_office_xml_text(buf.getvalue(), XLSX_MIME)
+
+    def test_absent_shared_strings_is_not_an_error(self):
+        """The optional-member path must stay optional."""
+        ns = 'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(
+                "xl/worksheets/sheet1.xml",
+                f'<?xml version="1.0"?><worksheet {ns}><sheetData><row>'
+                '<c r="A1" t="str"><v>alpha</v></c>'
+                "</row></sheetData></worksheet>",
+            )
+        assert extract_office_xml_text(buf.getvalue(), XLSX_MIME) == "alpha"
 
 
 class TestReadableButEmptyStillReturnsNone:


### PR DESCRIPTION
## Description

`extract_office_xml_text` returns `None` both when a file **cannot be read** and when it is read fine but **holds no text**. Callers cannot act on that distinction because it is not available to them.

Both call sites treat `None` as "no text" and fall through to a UTF-8 decode, so a corrupt `.docx` is reported to the user as:

```
[Binary or unsupported text encoding for mimeType '...' - N bytes]
```

That reads as *"this is a binary file"*, not *"this file is damaged"* — sending the reader after a format question instead of a data-integrity one. Upload pipelines do produce corrupt Office files, and classifying them as unsupported hides the real failure.

### Changes

- Add `OfficeXmlExtractionError`, raised when the file is not a valid ZIP, when its XML will not parse, or on an unexpected failure inside extraction. The original exception is chained with `raise ... from e`.
- **Keep `None` for the readable-but-empty case**, so that part of the contract is unchanged.
- Update both call sites to report the file as damaged instead of falling through to the binary branch.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Marked breaking deliberately: a function that previously never raised now can. See Additional Notes — I am happy to make it additive instead.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

`tests/core/test_office_extraction_errors.py`, 9 tests: unreadable inputs raise (not-a-zip, truncated, empty bytes), the message names the mime type, the cause is chained, and readable-but-empty still returns `None` — including a valid ZIP with no `word/document.xml`, and a document whose only text is whitespace.

```
uv run --extra test python -m pytest tests   ->  1785 passed, 2 skipped
uvx ruff check <changed files>               ->  clean
uvx ruff format --check <changed files>      ->  clean
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

**A trade-off I would rather surface than hide.** This changes the contract of a function that previously never raised. Both in-repo callers are updated and `core.utils` is not a documented public API, but an external importer relying on `None` would be affected.

If you would prefer it non-breaking, the same distinction can be made additively — an opt-in `raise_on_error: bool = False` parameter, default preserving today's behaviour exactly. Say the word and I will rework it; I chose the exception because it makes the failure impossible to ignore by accident, which is the property that was missing.

**On code organisation:** the caller changes are in `gdrive/drive_tools.py` and `gdocs/docs_tools.py`, which CONTRIBUTING flags as a common revision reason. I modified the existing inline fallback in place rather than adding new logic there, to keep the diff minimal. If you would rather this extraction-and-fallback block moved into `drive_helpers.py` / a docs helper, I am glad to do that — it looked like a larger refactor than a bug fix should carry unannounced.

Independent of #1059; the two can be merged in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of damaged or invalid Office documents.
  * Document retrieval now reports a specific unreadable-file message instead of a misleading encoding or unsupported-format error.
  * Readable Office documents without text continue to be handled correctly.

* **Tests**
  * Added coverage for invalid, empty, and successfully readable Office documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->