### PR TITLE
feat(auth): expose OAuthProxy token expiry knobs as env vars

### DIFF
--- a/.env.oauth21
+++ b/.env.oauth21
@@ -16,6 +16,28 @@ OAUTH2_ENABLE_DEBUG=false
 OAUTH2_ENABLE_LEGACY_AUTH=true
 
 # ---------------------------------------------------------------------------
+# FastMCP OAuth Proxy Token Lifetime Tuning (OAuth 2.1, optional)
+#
+# These settings mitigate client refresh-token races by making client-facing
+# access-token refreshes less frequent and refreshing Google's upstream access
+# token shortly before expiry. They do not add a grace period to FastMCP's
+# one-time-use client refresh tokens.
+#
+# Leave both unset to preserve FastMCP's defaults. Invalid or out-of-range values
+# are ignored with a warning.
+#
+# Refresh Google's upstream access token early. Allowed range: 0-300 seconds.
+# A small value such as 30-120 seconds is recommended; values near Google's
+# access-token lifetime would otherwise cause a refresh on every request.
+# WORKSPACE_MCP_OAUTH_PROXY_TOKEN_EXPIRY_THRESHOLD_SECONDS=60
+#
+# Client-facing FastMCP access-token lifetime. Allowed range: 1-2592000 seconds
+# (30 days). A longer lifetime reduces client refreshes but also lengthens the
+# replay window if a FastMCP bearer token is stolen. 86400 (24 hours) is a
+# conservative starting point for clients that race hourly refreshes.
+# WORKSPACE_MCP_OAUTH_PROXY_ACCESS_TOKEN_EXPIRY_SECONDS=86400
+#
+# ---------------------------------------------------------------------------
 # FastMCP OAuth Proxy Storage Backends (OAuth 2.1)
 #
 # Storage backend for OAuth proxy state. Options: memory, disk, valkey

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ Everything you need to run this in production lives in two places. The [document
 
 The **[Advanced Deployment guide](https://workspacemcp.com/docs/deployment?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=deploy-advanced)** covers self-hosting specifics: reverse proxy setup with `WORKSPACE_EXTERNAL_URL` (including the nginx `Origin: null` consent workaround, the `WORKSPACE_MCP_ALLOW_NULL_ORIGIN_CONSENT` escape hatch, and the `Referrer-Policy` pitfall), origin validation and VS Code webview allowlisting, credential store backends (local directory or GCS with CMEK enforcement), and the **[complete environment variable reference](https://workspacemcp.com/docs/deployment?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=deploy-env-vars#environment-variables)**.
 
+Advanced OAuth 2.1 deployments affected by concurrent client token refreshes can tune FastMCP's early-refresh threshold and client-facing access-token lifetime. See [`.env.oauth21`](.env.oauth21) for the bounded settings, recommended values, and security tradeoffs. These settings reduce how often the race occurs; they do not add a grace period to FastMCP's one-time-use refresh-token rotation.
+
 ## Security Best Practices
 
 By default this server sends no data anywhere except Google's APIs, using your own OAuth client credentials - no usage reporting, analytics, license server, or SaaS dependency. MIT licensed with no CLA, no dual licensing, and no copyleft in the dependency chain. The full security posture - scope minimization, sensitive-path blocking, stateless mode - is documented at [workspacemcp.com](https://workspacemcp.com/privacy?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=security-privacy).

--- a/auth/oauth_proxy_config.py
+++ b/auth/oauth_proxy_config.py
@@ -1,0 +1,74 @@
+"""Environment-backed configuration for FastMCP's OAuth proxy."""
+
+import logging
+import os
+from typing import Optional
+
+
+logger = logging.getLogger(__name__)
+
+OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV = (
+    "WORKSPACE_MCP_OAUTH_PROXY_TOKEN_EXPIRY_THRESHOLD_SECONDS"
+)
+OAUTH_ACCESS_TOKEN_EXPIRY_ENV = "WORKSPACE_MCP_OAUTH_PROXY_ACCESS_TOKEN_EXPIRY_SECONDS"
+MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS = 5 * 60
+MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS = 30 * 24 * 60 * 60
+
+
+def _parse_expiry_seconds_env(
+    name: str, *, minimum: int, maximum: int
+) -> Optional[int]:
+    """Read a bounded integer of seconds from the environment."""
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return None
+    try:
+        seconds = int(raw)
+    except ValueError:
+        logger.warning("Ignoring %s: %r is not an integer", name, raw)
+        return None
+    if not minimum <= seconds <= maximum:
+        logger.warning(
+            "Ignoring %s: %d is outside the supported range %d-%d seconds",
+            name,
+            seconds,
+            minimum,
+            maximum,
+        )
+        return None
+    return seconds
+
+
+def get_oauth_proxy_expiry_kwargs() -> dict[str, int]:
+    """Return configured token-expiry keyword arguments for GoogleProvider.
+
+    Invalid or unset values are omitted so FastMCP retains ownership of its
+    defaults and future compatibility.
+    """
+    token_expiry_threshold_seconds = _parse_expiry_seconds_env(
+        OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV,
+        minimum=0,
+        maximum=MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS,
+    )
+    fastmcp_access_token_expiry_seconds = _parse_expiry_seconds_env(
+        OAUTH_ACCESS_TOKEN_EXPIRY_ENV,
+        minimum=1,
+        maximum=MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS,
+    )
+
+    expiry_kwargs: dict[str, int] = {}
+    if token_expiry_threshold_seconds is not None:
+        logger.info(
+            "OAuth 2.1: refreshing upstream tokens %ds before expiry",
+            token_expiry_threshold_seconds,
+        )
+        expiry_kwargs["token_expiry_threshold_seconds"] = token_expiry_threshold_seconds
+    if fastmcp_access_token_expiry_seconds is not None:
+        logger.info(
+            "OAuth 2.1: issuing FastMCP access tokens with a %ds lifetime",
+            fastmcp_access_token_expiry_seconds,
+        )
+        expiry_kwargs["fastmcp_access_token_expiry_seconds"] = (
+            fastmcp_access_token_expiry_seconds
+        )
+    return expiry_kwargs

--- a/core/server.py
+++ b/core/server.py
@@ -74,6 +74,8 @@ _OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV = (
     "WORKSPACE_MCP_OAUTH_PROXY_TOKEN_EXPIRY_THRESHOLD_SECONDS"
 )
 _OAUTH_ACCESS_TOKEN_EXPIRY_ENV = "WORKSPACE_MCP_OAUTH_PROXY_ACCESS_TOKEN_EXPIRY_SECONDS"
+_MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS = 5 * 60
+_MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS = 30 * 24 * 60 * 60
 
 
 def _parse_bool_env(value: str) -> bool:
@@ -395,11 +397,14 @@ def _parse_allowed_redirect_uris(value: Optional[str]) -> Optional[List[str]]:
     return uris or None
 
 
-def _parse_expiry_seconds_env(name: str) -> Optional[int]:
-    """Read a non-negative integer of seconds from the environment.
+def _parse_expiry_seconds_env(
+    name: str, *, minimum: int, maximum: int
+) -> Optional[int]:
+    """Read a bounded integer of seconds from the environment.
 
-    Returns None when unset, empty, or unparseable, so the caller keeps
-    FastMCP's own default rather than failing startup on a typo.
+    Returns None when unset, empty, unparseable, or outside the supported range.
+    Callers omit the corresponding provider argument in that case so FastMCP
+    retains ownership of its default and future compatibility.
     """
     raw = os.getenv(name, "").strip()
     if not raw:
@@ -409,8 +414,14 @@ def _parse_expiry_seconds_env(name: str) -> Optional[int]:
     except ValueError:
         logger.warning("Ignoring %s: %r is not an integer", name, raw)
         return None
-    if seconds < 0:
-        logger.warning("Ignoring %s: %d is negative", name, seconds)
+    if not minimum <= seconds <= maximum:
+        logger.warning(
+            "Ignoring %s: %d is outside the supported range %d-%d seconds",
+            name,
+            seconds,
+            minimum,
+            maximum,
+        )
         return None
     return seconds
 
@@ -748,10 +759,14 @@ def configure_server_for_http():
                         allowed_client_redirect_uris,
                     )
                 token_expiry_threshold_seconds = _parse_expiry_seconds_env(
-                    _OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV
+                    _OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV,
+                    minimum=0,
+                    maximum=_MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS,
                 )
                 fastmcp_access_token_expiry_seconds = _parse_expiry_seconds_env(
-                    _OAUTH_ACCESS_TOKEN_EXPIRY_ENV
+                    _OAUTH_ACCESS_TOKEN_EXPIRY_ENV,
+                    minimum=1,
+                    maximum=_MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS,
                 )
                 if token_expiry_threshold_seconds is not None:
                     logger.info(
@@ -763,6 +778,15 @@ def configure_server_for_http():
                         "OAuth 2.1: issuing FastMCP access tokens with a %ds lifetime",
                         fastmcp_access_token_expiry_seconds,
                     )
+                expiry_kwargs: dict[str, int] = {}
+                if token_expiry_threshold_seconds is not None:
+                    expiry_kwargs["token_expiry_threshold_seconds"] = (
+                        token_expiry_threshold_seconds
+                    )
+                if fastmcp_access_token_expiry_seconds is not None:
+                    expiry_kwargs["fastmcp_access_token_expiry_seconds"] = (
+                        fastmcp_access_token_expiry_seconds
+                    )
                 provider = GoogleProvider(
                     client_id=config.client_id,
                     client_secret=config.client_secret,
@@ -773,12 +797,7 @@ def configure_server_for_http():
                     client_storage=client_storage,
                     jwt_signing_key=jwt_signing_key,
                     allowed_client_redirect_uris=allowed_client_redirect_uris,
-                    token_expiry_threshold_seconds=(
-                        token_expiry_threshold_seconds
-                        if token_expiry_threshold_seconds is not None
-                        else 0
-                    ),
-                    fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
+                    **expiry_kwargs,
                 )
                 if provider.client_registration_options is not None:
                     # Keep protocol-level auth limited to base identity scopes, but

--- a/core/server.py
+++ b/core/server.py
@@ -691,6 +691,8 @@ def configure_server_for_http():
                     jwt_signing_key_override, config.client_secret
                 )
 
+            expiry_kwargs = get_oauth_proxy_expiry_kwargs()
+
             # Check if external OAuth provider is configured
             if config.is_external_oauth21_provider():
                 # External OAuth mode: use custom provider that handles ya29.* access tokens
@@ -704,6 +706,7 @@ def configure_server_for_http():
                     required_scopes=provider_valid_scopes,
                     resource_server_url=config.get_oauth_base_url(),
                     jwt_signing_key=jwt_signing_key,
+                    **expiry_kwargs,
                 )
                 server.auth = provider
 
@@ -724,7 +727,6 @@ def configure_server_for_http():
                         "OAuth 2.1: restricting DCR client redirect URIs to allowlist: %s",
                         allowed_client_redirect_uris,
                     )
-                expiry_kwargs = get_oauth_proxy_expiry_kwargs()
                 provider = GoogleProvider(
                     client_id=config.client_id,
                     client_secret=config.client_secret,

--- a/core/server.py
+++ b/core/server.py
@@ -24,6 +24,7 @@ from auth.oauth_config import (
     get_oauth_config,
     is_trust_gateway_identity,
 )
+from auth.oauth_proxy_config import get_oauth_proxy_expiry_kwargs
 from auth.oauth_responses import (
     create_error_response,
     create_success_response,
@@ -70,12 +71,6 @@ _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 # header that received the request (a same-origin check).
 _DEFAULT_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443}
 _ALLOW_NULL_ORIGIN_CONSENT_ENV = "WORKSPACE_MCP_ALLOW_NULL_ORIGIN_CONSENT"
-_OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV = (
-    "WORKSPACE_MCP_OAUTH_PROXY_TOKEN_EXPIRY_THRESHOLD_SECONDS"
-)
-_OAUTH_ACCESS_TOKEN_EXPIRY_ENV = "WORKSPACE_MCP_OAUTH_PROXY_ACCESS_TOKEN_EXPIRY_SECONDS"
-_MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS = 5 * 60
-_MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS = 30 * 24 * 60 * 60
 
 
 def _parse_bool_env(value: str) -> bool:
@@ -395,35 +390,6 @@ def _parse_allowed_redirect_uris(value: Optional[str]) -> Optional[List[str]]:
         return None
     uris = [u.strip() for u in value.split(",") if u.strip()]
     return uris or None
-
-
-def _parse_expiry_seconds_env(
-    name: str, *, minimum: int, maximum: int
-) -> Optional[int]:
-    """Read a bounded integer of seconds from the environment.
-
-    Returns None when unset, empty, unparseable, or outside the supported range.
-    Callers omit the corresponding provider argument in that case so FastMCP
-    retains ownership of its default and future compatibility.
-    """
-    raw = os.getenv(name, "").strip()
-    if not raw:
-        return None
-    try:
-        seconds = int(raw)
-    except ValueError:
-        logger.warning("Ignoring %s: %r is not an integer", name, raw)
-        return None
-    if not minimum <= seconds <= maximum:
-        logger.warning(
-            "Ignoring %s: %d is outside the supported range %d-%d seconds",
-            name,
-            seconds,
-            minimum,
-            maximum,
-        )
-        return None
-    return seconds
 
 
 def set_transport_mode(mode: str):
@@ -758,35 +724,7 @@ def configure_server_for_http():
                         "OAuth 2.1: restricting DCR client redirect URIs to allowlist: %s",
                         allowed_client_redirect_uris,
                     )
-                token_expiry_threshold_seconds = _parse_expiry_seconds_env(
-                    _OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV,
-                    minimum=0,
-                    maximum=_MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS,
-                )
-                fastmcp_access_token_expiry_seconds = _parse_expiry_seconds_env(
-                    _OAUTH_ACCESS_TOKEN_EXPIRY_ENV,
-                    minimum=1,
-                    maximum=_MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS,
-                )
-                if token_expiry_threshold_seconds is not None:
-                    logger.info(
-                        "OAuth 2.1: refreshing upstream tokens %ds before expiry",
-                        token_expiry_threshold_seconds,
-                    )
-                if fastmcp_access_token_expiry_seconds is not None:
-                    logger.info(
-                        "OAuth 2.1: issuing FastMCP access tokens with a %ds lifetime",
-                        fastmcp_access_token_expiry_seconds,
-                    )
-                expiry_kwargs: dict[str, int] = {}
-                if token_expiry_threshold_seconds is not None:
-                    expiry_kwargs["token_expiry_threshold_seconds"] = (
-                        token_expiry_threshold_seconds
-                    )
-                if fastmcp_access_token_expiry_seconds is not None:
-                    expiry_kwargs["fastmcp_access_token_expiry_seconds"] = (
-                        fastmcp_access_token_expiry_seconds
-                    )
+                expiry_kwargs = get_oauth_proxy_expiry_kwargs()
                 provider = GoogleProvider(
                     client_id=config.client_id,
                     client_secret=config.client_secret,

--- a/core/server.py
+++ b/core/server.py
@@ -70,6 +70,10 @@ _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 # header that received the request (a same-origin check).
 _DEFAULT_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443}
 _ALLOW_NULL_ORIGIN_CONSENT_ENV = "WORKSPACE_MCP_ALLOW_NULL_ORIGIN_CONSENT"
+_OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV = (
+    "WORKSPACE_MCP_OAUTH_PROXY_TOKEN_EXPIRY_THRESHOLD_SECONDS"
+)
+_OAUTH_ACCESS_TOKEN_EXPIRY_ENV = "WORKSPACE_MCP_OAUTH_PROXY_ACCESS_TOKEN_EXPIRY_SECONDS"
 
 
 def _parse_bool_env(value: str) -> bool:
@@ -389,6 +393,26 @@ def _parse_allowed_redirect_uris(value: Optional[str]) -> Optional[List[str]]:
         return None
     uris = [u.strip() for u in value.split(",") if u.strip()]
     return uris or None
+
+
+def _parse_expiry_seconds_env(name: str) -> Optional[int]:
+    """Read a non-negative integer of seconds from the environment.
+
+    Returns None when unset, empty, or unparseable, so the caller keeps
+    FastMCP's own default rather than failing startup on a typo.
+    """
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return None
+    try:
+        seconds = int(raw)
+    except ValueError:
+        logger.warning("Ignoring %s: %r is not an integer", name, raw)
+        return None
+    if seconds < 0:
+        logger.warning("Ignoring %s: %d is negative", name, seconds)
+        return None
+    return seconds
 
 
 def set_transport_mode(mode: str):
@@ -723,6 +747,22 @@ def configure_server_for_http():
                         "OAuth 2.1: restricting DCR client redirect URIs to allowlist: %s",
                         allowed_client_redirect_uris,
                     )
+                token_expiry_threshold_seconds = _parse_expiry_seconds_env(
+                    _OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV
+                )
+                fastmcp_access_token_expiry_seconds = _parse_expiry_seconds_env(
+                    _OAUTH_ACCESS_TOKEN_EXPIRY_ENV
+                )
+                if token_expiry_threshold_seconds is not None:
+                    logger.info(
+                        "OAuth 2.1: refreshing upstream tokens %ds before expiry",
+                        token_expiry_threshold_seconds,
+                    )
+                if fastmcp_access_token_expiry_seconds is not None:
+                    logger.info(
+                        "OAuth 2.1: issuing FastMCP access tokens with a %ds lifetime",
+                        fastmcp_access_token_expiry_seconds,
+                    )
                 provider = GoogleProvider(
                     client_id=config.client_id,
                     client_secret=config.client_secret,
@@ -733,6 +773,12 @@ def configure_server_for_http():
                     client_storage=client_storage,
                     jwt_signing_key=jwt_signing_key,
                     allowed_client_redirect_uris=allowed_client_redirect_uris,
+                    token_expiry_threshold_seconds=(
+                        token_expiry_threshold_seconds
+                        if token_expiry_threshold_seconds is not None
+                        else 0
+                    ),
+                    fastmcp_access_token_expiry_seconds=fastmcp_access_token_expiry_seconds,
                 )
                 if provider.client_registration_options is not None:
                     # Keep protocol-level auth limited to base identity scopes, but

--- a/tests/auth/test_oauth_proxy_config.py
+++ b/tests/auth/test_oauth_proxy_config.py
@@ -1,0 +1,70 @@
+import pytest
+
+from auth.oauth_proxy_config import (
+    MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS,
+    MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS,
+    OAUTH_ACCESS_TOKEN_EXPIRY_ENV,
+    OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV,
+    get_oauth_proxy_expiry_kwargs,
+)
+
+
+def test_token_expiry_env_defaults_leave_fastmcp_behaviour_unchanged(monkeypatch):
+    monkeypatch.delenv(OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV, raising=False)
+    monkeypatch.delenv(OAUTH_ACCESS_TOKEN_EXPIRY_ENV, raising=False)
+
+    assert get_oauth_proxy_expiry_kwargs() == {}
+
+
+def test_token_expiry_env_is_forwarded_to_the_provider_kwargs(monkeypatch):
+    monkeypatch.setenv(OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV, "120")
+    monkeypatch.setenv(OAUTH_ACCESS_TOKEN_EXPIRY_ENV, "86400")
+
+    assert get_oauth_proxy_expiry_kwargs() == {
+        "token_expiry_threshold_seconds": 120,
+        "fastmcp_access_token_expiry_seconds": 86400,
+    }
+
+
+@pytest.mark.parametrize("value", ["not-a-number", "-1", "   "])
+def test_token_expiry_env_ignores_unusable_values(monkeypatch, value):
+    monkeypatch.setenv(OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV, value)
+    monkeypatch.setenv(OAUTH_ACCESS_TOKEN_EXPIRY_ENV, value)
+
+    assert get_oauth_proxy_expiry_kwargs() == {}
+
+
+def test_zero_is_valid_only_for_token_expiry_threshold(monkeypatch):
+    monkeypatch.setenv(OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV, "0")
+    monkeypatch.setenv(OAUTH_ACCESS_TOKEN_EXPIRY_ENV, "0")
+
+    assert get_oauth_proxy_expiry_kwargs() == {"token_expiry_threshold_seconds": 0}
+
+
+def test_token_expiry_env_rejects_values_above_safe_limits(monkeypatch):
+    monkeypatch.setenv(
+        OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV,
+        str(MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS + 1),
+    )
+    monkeypatch.setenv(
+        OAUTH_ACCESS_TOKEN_EXPIRY_ENV,
+        str(MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS + 1),
+    )
+
+    assert get_oauth_proxy_expiry_kwargs() == {}
+
+
+def test_token_expiry_env_accepts_safe_limit_boundaries(monkeypatch):
+    monkeypatch.setenv(
+        OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV,
+        str(MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS),
+    )
+    monkeypatch.setenv(
+        OAUTH_ACCESS_TOKEN_EXPIRY_ENV,
+        str(MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS),
+    )
+
+    assert get_oauth_proxy_expiry_kwargs() == {
+        "token_expiry_threshold_seconds": 300,
+        "fastmcp_access_token_expiry_seconds": 2_592_000,
+    }

--- a/tests/core/test_http_oauth_scope_config.py
+++ b/tests/core/test_http_oauth_scope_config.py
@@ -262,8 +262,8 @@ def test_token_expiry_env_defaults_leave_fastmcp_behaviour_unchanged(monkeypatch
 
     server_module.configure_server_for_http()
 
-    assert captured["token_expiry_threshold_seconds"] == 0
-    assert captured["fastmcp_access_token_expiry_seconds"] is None
+    assert "token_expiry_threshold_seconds" not in captured
+    assert "fastmcp_access_token_expiry_seconds" not in captured
 
 
 def test_token_expiry_env_is_forwarded_to_the_provider(monkeypatch):
@@ -285,5 +285,50 @@ def test_token_expiry_env_ignores_unusable_values(monkeypatch, value):
 
     server_module.configure_server_for_http()
 
+    assert "token_expiry_threshold_seconds" not in captured
+    assert "fastmcp_access_token_expiry_seconds" not in captured
+
+
+def test_zero_is_valid_only_for_token_expiry_threshold(monkeypatch):
+    monkeypatch.setenv(server_module._OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV, "0")
+    monkeypatch.setenv(server_module._OAUTH_ACCESS_TOKEN_EXPIRY_ENV, "0")
+    captured = _capture_provider_kwargs(monkeypatch)
+
+    server_module.configure_server_for_http()
+
     assert captured["token_expiry_threshold_seconds"] == 0
-    assert captured["fastmcp_access_token_expiry_seconds"] is None
+    assert "fastmcp_access_token_expiry_seconds" not in captured
+
+
+def test_token_expiry_env_rejects_values_above_safe_limits(monkeypatch):
+    monkeypatch.setenv(
+        server_module._OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV,
+        str(server_module._MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS + 1),
+    )
+    monkeypatch.setenv(
+        server_module._OAUTH_ACCESS_TOKEN_EXPIRY_ENV,
+        str(server_module._MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS + 1),
+    )
+    captured = _capture_provider_kwargs(monkeypatch)
+
+    server_module.configure_server_for_http()
+
+    assert "token_expiry_threshold_seconds" not in captured
+    assert "fastmcp_access_token_expiry_seconds" not in captured
+
+
+def test_token_expiry_env_accepts_safe_limit_boundaries(monkeypatch):
+    monkeypatch.setenv(
+        server_module._OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV,
+        str(server_module._MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS),
+    )
+    monkeypatch.setenv(
+        server_module._OAUTH_ACCESS_TOKEN_EXPIRY_ENV,
+        str(server_module._MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS),
+    )
+    captured = _capture_provider_kwargs(monkeypatch)
+
+    server_module.configure_server_for_http()
+
+    assert captured["token_expiry_threshold_seconds"] == 300
+    assert captured["fastmcp_access_token_expiry_seconds"] == 2_592_000

--- a/tests/core/test_http_oauth_scope_config.py
+++ b/tests/core/test_http_oauth_scope_config.py
@@ -221,3 +221,69 @@ def test_configure_server_for_http_passes_jwt_key_to_external_provider(monkeypat
         "jwt_signing_key must be a bytes object"
     )
     assert len(captured["jwt_signing_key"]) > 0, "jwt_signing_key must be non-empty"
+
+
+def _oauth21_config():
+    return SimpleNamespace(
+        is_oauth21_enabled=lambda: True,
+        is_configured=lambda: True,
+        is_public_client=lambda: False,
+        is_external_oauth21_provider=lambda: False,
+        client_id="client-id",
+        client_secret="client-secret",
+        get_oauth_base_url=lambda: "https://workspace-mcp.example.test",
+        redirect_path="/oauth2callback",
+    )
+
+
+def _capture_provider_kwargs(monkeypatch):
+    captured = {}
+
+    class FakeGoogleProvider:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.client_registration_options = None
+            self._default_scope_str = ""
+            self._cimd_manager = None
+
+    monkeypatch.setattr(server_module, "get_transport_mode", lambda: "streamable-http")
+    monkeypatch.setattr(server_module, "GoogleProvider", FakeGoogleProvider)
+    monkeypatch.setattr(server_module, "set_auth_provider", lambda provider: None)
+    monkeypatch.setattr(server_module, "_auth_provider", server_module._auth_provider)
+    monkeypatch.setattr(server_module.server, "auth", server_module.server.auth)
+    monkeypatch.setattr("auth.oauth_config.get_oauth_config", _oauth21_config)
+    return captured
+
+
+def test_token_expiry_env_defaults_leave_fastmcp_behaviour_unchanged(monkeypatch):
+    monkeypatch.delenv(server_module._OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV, raising=False)
+    monkeypatch.delenv(server_module._OAUTH_ACCESS_TOKEN_EXPIRY_ENV, raising=False)
+    captured = _capture_provider_kwargs(monkeypatch)
+
+    server_module.configure_server_for_http()
+
+    assert captured["token_expiry_threshold_seconds"] == 0
+    assert captured["fastmcp_access_token_expiry_seconds"] is None
+
+
+def test_token_expiry_env_is_forwarded_to_the_provider(monkeypatch):
+    monkeypatch.setenv(server_module._OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV, "120")
+    monkeypatch.setenv(server_module._OAUTH_ACCESS_TOKEN_EXPIRY_ENV, "86400")
+    captured = _capture_provider_kwargs(monkeypatch)
+
+    server_module.configure_server_for_http()
+
+    assert captured["token_expiry_threshold_seconds"] == 120
+    assert captured["fastmcp_access_token_expiry_seconds"] == 86400
+
+
+@pytest.mark.parametrize("value", ["not-a-number", "-1", "   "])
+def test_token_expiry_env_ignores_unusable_values(monkeypatch, value):
+    monkeypatch.setenv(server_module._OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV, value)
+    monkeypatch.setenv(server_module._OAUTH_ACCESS_TOKEN_EXPIRY_ENV, value)
+    captured = _capture_provider_kwargs(monkeypatch)
+
+    server_module.configure_server_for_http()
+
+    assert captured["token_expiry_threshold_seconds"] == 0
+    assert captured["fastmcp_access_token_expiry_seconds"] is None

--- a/tests/core/test_http_oauth_scope_config.py
+++ b/tests/core/test_http_oauth_scope_config.py
@@ -231,3 +231,52 @@ def test_configure_server_for_http_passes_jwt_key_to_external_provider(monkeypat
         "jwt_signing_key must be a bytes object"
     )
     assert len(captured["jwt_signing_key"]) > 0, "jwt_signing_key must be non-empty"
+
+
+def test_configure_server_for_http_passes_expiry_config_to_external_provider(
+    monkeypatch,
+):
+    captured = {}
+
+    class FakeExternalOAuthProvider:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setenv(
+        "FASTMCP_SERVER_AUTH_GOOGLE_JWT_SIGNING_KEY",
+        "this-is-a-long-enough-jwt-signing-key",
+    )
+    monkeypatch.setenv(
+        "WORKSPACE_MCP_OAUTH_PROXY_TOKEN_EXPIRY_THRESHOLD_SECONDS", "120"
+    )
+    monkeypatch.setenv("WORKSPACE_MCP_OAUTH_PROXY_ACCESS_TOKEN_EXPIRY_SECONDS", "86400")
+    monkeypatch.setattr(server_module, "get_transport_mode", lambda: "streamable-http")
+    monkeypatch.setattr(server_module, "set_auth_provider", lambda provider: None)
+    monkeypatch.setattr(server_module, "_auth_provider", server_module._auth_provider)
+    monkeypatch.setattr(server_module.server, "auth", server_module.server.auth)
+    monkeypatch.setattr(
+        server_module,
+        "get_current_scopes",
+        lambda: ["https://www.googleapis.com/auth/userinfo.email", "openid"],
+    )
+    monkeypatch.setattr(
+        "auth.external_oauth_provider.ExternalOAuthProvider",
+        FakeExternalOAuthProvider,
+    )
+    monkeypatch.setattr(
+        "auth.oauth_config.get_oauth_config",
+        lambda: SimpleNamespace(
+            is_oauth21_enabled=lambda: True,
+            is_configured=lambda: True,
+            is_external_oauth21_provider=lambda: True,
+            client_id="client-id",
+            client_secret=None,
+            get_oauth_base_url=lambda: "https://workspace-mcp.example.test",
+            redirect_path="/oauth2callback",
+        ),
+    )
+
+    server_module.configure_server_for_http()
+
+    assert captured["token_expiry_threshold_seconds"] == 120
+    assert captured["fastmcp_access_token_expiry_seconds"] == 86400

--- a/tests/core/test_http_oauth_scope_config.py
+++ b/tests/core/test_http_oauth_scope_config.py
@@ -75,6 +75,14 @@ def test_configure_server_for_http_uses_protocol_auth_required_scopes(monkeypatc
         ],
     )
     monkeypatch.setattr(server_module, "set_auth_provider", lambda provider: None)
+    monkeypatch.setattr(
+        server_module,
+        "get_oauth_proxy_expiry_kwargs",
+        lambda: {
+            "token_expiry_threshold_seconds": 120,
+            "fastmcp_access_token_expiry_seconds": 86400,
+        },
+    )
 
     # Capture and restore globals that configure_server_for_http() mutates directly
     monkeypatch.setattr(server_module, "_auth_provider", server_module._auth_provider)
@@ -98,6 +106,8 @@ def test_configure_server_for_http_uses_protocol_auth_required_scopes(monkeypatc
 
     assert captured["required_scopes"] == sorted(server_module.PROTOCOL_AUTH_SCOPES)
     assert captured["valid_scopes"] == sorted(server_module.get_current_scopes())
+    assert captured["token_expiry_threshold_seconds"] == 120
+    assert captured["fastmcp_access_token_expiry_seconds"] == 86400
     assert (
         server_module.server.auth.client_registration_options.default_scopes
         == sorted(server_module.get_current_scopes())
@@ -221,114 +231,3 @@ def test_configure_server_for_http_passes_jwt_key_to_external_provider(monkeypat
         "jwt_signing_key must be a bytes object"
     )
     assert len(captured["jwt_signing_key"]) > 0, "jwt_signing_key must be non-empty"
-
-
-def _oauth21_config():
-    return SimpleNamespace(
-        is_oauth21_enabled=lambda: True,
-        is_configured=lambda: True,
-        is_public_client=lambda: False,
-        is_external_oauth21_provider=lambda: False,
-        client_id="client-id",
-        client_secret="client-secret",
-        get_oauth_base_url=lambda: "https://workspace-mcp.example.test",
-        redirect_path="/oauth2callback",
-    )
-
-
-def _capture_provider_kwargs(monkeypatch):
-    captured = {}
-
-    class FakeGoogleProvider:
-        def __init__(self, **kwargs):
-            captured.update(kwargs)
-            self.client_registration_options = None
-            self._default_scope_str = ""
-            self._cimd_manager = None
-
-    monkeypatch.setattr(server_module, "get_transport_mode", lambda: "streamable-http")
-    monkeypatch.setattr(server_module, "GoogleProvider", FakeGoogleProvider)
-    monkeypatch.setattr(server_module, "set_auth_provider", lambda provider: None)
-    monkeypatch.setattr(server_module, "_auth_provider", server_module._auth_provider)
-    monkeypatch.setattr(server_module.server, "auth", server_module.server.auth)
-    monkeypatch.setattr("auth.oauth_config.get_oauth_config", _oauth21_config)
-    return captured
-
-
-def test_token_expiry_env_defaults_leave_fastmcp_behaviour_unchanged(monkeypatch):
-    monkeypatch.delenv(server_module._OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV, raising=False)
-    monkeypatch.delenv(server_module._OAUTH_ACCESS_TOKEN_EXPIRY_ENV, raising=False)
-    captured = _capture_provider_kwargs(monkeypatch)
-
-    server_module.configure_server_for_http()
-
-    assert "token_expiry_threshold_seconds" not in captured
-    assert "fastmcp_access_token_expiry_seconds" not in captured
-
-
-def test_token_expiry_env_is_forwarded_to_the_provider(monkeypatch):
-    monkeypatch.setenv(server_module._OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV, "120")
-    monkeypatch.setenv(server_module._OAUTH_ACCESS_TOKEN_EXPIRY_ENV, "86400")
-    captured = _capture_provider_kwargs(monkeypatch)
-
-    server_module.configure_server_for_http()
-
-    assert captured["token_expiry_threshold_seconds"] == 120
-    assert captured["fastmcp_access_token_expiry_seconds"] == 86400
-
-
-@pytest.mark.parametrize("value", ["not-a-number", "-1", "   "])
-def test_token_expiry_env_ignores_unusable_values(monkeypatch, value):
-    monkeypatch.setenv(server_module._OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV, value)
-    monkeypatch.setenv(server_module._OAUTH_ACCESS_TOKEN_EXPIRY_ENV, value)
-    captured = _capture_provider_kwargs(monkeypatch)
-
-    server_module.configure_server_for_http()
-
-    assert "token_expiry_threshold_seconds" not in captured
-    assert "fastmcp_access_token_expiry_seconds" not in captured
-
-
-def test_zero_is_valid_only_for_token_expiry_threshold(monkeypatch):
-    monkeypatch.setenv(server_module._OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV, "0")
-    monkeypatch.setenv(server_module._OAUTH_ACCESS_TOKEN_EXPIRY_ENV, "0")
-    captured = _capture_provider_kwargs(monkeypatch)
-
-    server_module.configure_server_for_http()
-
-    assert captured["token_expiry_threshold_seconds"] == 0
-    assert "fastmcp_access_token_expiry_seconds" not in captured
-
-
-def test_token_expiry_env_rejects_values_above_safe_limits(monkeypatch):
-    monkeypatch.setenv(
-        server_module._OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV,
-        str(server_module._MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS + 1),
-    )
-    monkeypatch.setenv(
-        server_module._OAUTH_ACCESS_TOKEN_EXPIRY_ENV,
-        str(server_module._MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS + 1),
-    )
-    captured = _capture_provider_kwargs(monkeypatch)
-
-    server_module.configure_server_for_http()
-
-    assert "token_expiry_threshold_seconds" not in captured
-    assert "fastmcp_access_token_expiry_seconds" not in captured
-
-
-def test_token_expiry_env_accepts_safe_limit_boundaries(monkeypatch):
-    monkeypatch.setenv(
-        server_module._OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV,
-        str(server_module._MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS),
-    )
-    monkeypatch.setenv(
-        server_module._OAUTH_ACCESS_TOKEN_EXPIRY_ENV,
-        str(server_module._MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS),
-    )
-    captured = _capture_provider_kwargs(monkeypatch)
-
-    server_module.configure_server_for_http()
-
-    assert captured["token_expiry_threshold_seconds"] == 300
-    assert captured["fastmcp_access_token_expiry_seconds"] == 2_592_000


### PR DESCRIPTION
## Description

FastMCP's `GoogleProvider` accepts `token_expiry_threshold_seconds` and `fastmcp_access_token_expiry_seconds`, but `configure_server_for_http()` passes neither, so a deployment cannot reach either without patching the server. This reads both from the environment and forwards them, following the `WORKSPACE_MCP_ALLOWED_CLIENT_REDIRECT_URIS` pattern a few lines above:

- `WORKSPACE_MCP_OAUTH_PROXY_TOKEN_EXPIRY_THRESHOLD_SECONDS`
- `WORKSPACE_MCP_OAUTH_PROXY_ACCESS_TOKEN_EXPIRY_SECONDS`

Unset, empty, non-integer and negative values keep FastMCP's own defaults (`0` and `None`), so existing deployments are unaffected.

Why they are worth reaching: `OAuthProxy` rotates its client-facing refresh token one-time-use with no grace window, so when two refreshes race on the same token the loser is rejected with `invalid_grant` and the user is pushed through a full re-authentication (PrefectHQ/fastmcp#4265, PrefectHQ/fastmcp#4901). Raising the FastMCP access-token lifetime above Google's hour makes refreshes rarer, and a non-zero threshold refreshes early rather than at the edge — both narrow the window. On our deployment this currently shows up as roughly 14 `Refresh token not found ... already rotated` warnings a day across independent clients.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Three cases covered: defaults preserved when unset, values forwarded when set, unusable values ignored.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional environment-based configuration for OAuth access-token lifetime and early refresh timing.
  * Settings now apply consistently across supported OAuth providers.
  * Valid values are applied automatically; leaving them unset preserves default behavior.
* **Bug Fixes**
  * Invalid, negative, empty, or out-of-range values are safely ignored.
  * Reduced concurrent token-refresh race frequency without adding a grace period to one-time-use refresh tokens.
* **Documentation**
  * Documented configuration options, supported ranges, defaults, and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->