### PR TITLE
fix(gmail): prevent duplicate delivery after an ambiguous send

### DIFF
--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2643,7 +2643,7 @@ async def send_gmail_message(
     # Send the message
     sent_message = await asyncio.to_thread(
         service.users().messages().send(userId="me", body=send_body).execute,
-        num_retries=GOOGLE_API_WRITE_RETRIES,
+        num_retries=0,
     )
     message_id = sent_message.get("id")
 
@@ -2767,7 +2767,7 @@ async def _forward_gmail_message_impl(
     # Send the message
     sent_message = await asyncio.to_thread(
         service.users().messages().send(userId="me", body=send_body).execute,
-        num_retries=GOOGLE_API_WRITE_RETRIES,
+        num_retries=0,
     )
     sent_message_id = sent_message.get("id")
 

--- a/tests/gmail/test_draft_gmail_message.py
+++ b/tests/gmail/test_draft_gmail_message.py
@@ -1665,3 +1665,6 @@ async def test_send_gmail_message_does_not_fetch_thread_for_a_new_message():
     )
 
     assert mock_service.users.return_value.threads.return_value.get.call_count == 0
+    mock_service.users().messages().send.return_value.execute.assert_called_once_with(
+        num_retries=0
+    )

--- a/tests/gmail/test_forward_gmail_message.py
+++ b/tests/gmail/test_forward_gmail_message.py
@@ -160,6 +160,9 @@ async def test_forward_simple_text_email():
     assert "Email forwarded" in result
     assert "fwd001" in result
     mock_service.users().messages().send.assert_called()
+    mock_service.users().messages().send.return_value.execute.assert_called_once_with(
+        num_retries=0
+    )
 
     sent = get_sent_mime_message(mock_service)
     assert sent["Subject"] == "Fwd: Hello"


### PR DESCRIPTION
## Description

### Problem

Gmail's `messages.send` operation is non-idempotent. The existing `num_retries=3` setting could resend a message after an ambiguous transport or server response even when Gmail had already accepted the first request, resulting in duplicate delivery.

### Changes

- Disable googleapiclient retries for new-message and forward sends.
- Add regression assertions for both send paths.
- Preserve the existing retry behavior for draft creation and other write operations.

### User impact

An ambiguous Gmail send now returns its error to the caller instead of silently risking duplicate delivery. Successful sends are unchanged.

Fixes #997

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

## Verification

- `uv run pytest tests/gmail/test_draft_gmail_message.py tests/gmail/test_forward_gmail_message.py -q` — 64 passed.
- `uv run pytest -q` — 1,772 passed and 2 skipped; four pre-existing Windows-specific permission/home-path assertions failed outside the changed Gmail code.
- `uvx ruff@0.15.2 check` — passed.
- `uvx ruff@0.15.2 format --check` — 193 files already formatted.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

Draft creation remains retryable because it does not deliver a message to recipients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when sending and forwarding Gmail messages by preventing automatic write retries.
  * Ensured each send operation is executed only once, reducing the risk of duplicate messages.

* **Tests**
  * Added coverage verifying the updated send behavior for new and forwarded messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->