### PR TITLE
fix(gappsscript): surface deployment version in list_deployments (#922)

### DIFF
--- a/gappsscript/apps_script_tools.py
+++ b/gappsscript/apps_script_tools.py
@@ -719,10 +719,24 @@ async def _list_deployments_impl(
 
     for i, deployment in enumerate(deployments, 1):
         deployment_id = deployment.get("deploymentId", "Unknown")
-        description = deployment.get("description", "No description")
+        # description and versionNumber live under deploymentConfig; fall back to
+        # any top-level description for forward/backward compatibility.
+        config = deployment.get("deploymentConfig", {})
+        description = (
+            config.get("description")
+            or deployment.get("description")
+            or "No description"
+        )
         update_time = deployment.get("updateTime", "Unknown")
+        # A HEAD deployment has no versionNumber — it always serves the latest
+        # saved content rather than a pinned version.
+        version_number = config.get("versionNumber")
+        version_label = (
+            str(version_number) if version_number is not None else "HEAD (latest)"
+        )
 
         output.append(f"{i}. {description} ({deployment_id})")
+        output.append(f"   Version: {version_label}")
         output.append(f"   Updated: {update_time}")
         output.append("")
 
@@ -747,7 +761,8 @@ async def list_deployments(
     script_id: str,
 ) -> str:
     """
-    Lists all deployments for a script project.
+    Lists all deployments for a script project, including the bound version
+    number of each deployment so callers can verify which version is served.
 
     Args:
         service: Injected Google API service client
@@ -755,7 +770,7 @@ async def list_deployments(
         script_id: The script project ID
 
     Returns:
-        str: Formatted string with deployment list
+        str: Formatted string with deployment list (id, description, version, updated time)
     """
     return await _list_deployments_impl(service, user_google_email, script_id)
 

--- a/tests/gappsscript/test_apps_script_tools.py
+++ b/tests/gappsscript/test_apps_script_tools.py
@@ -437,13 +437,18 @@ async def test_create_deployment():
 
 @pytest.mark.asyncio
 async def test_list_deployments():
-    """Test listing deployments"""
+    """Listing surfaces the bound version and description from deploymentConfig (issue #922)."""
     mock_service = Mock()
+    # The real API nests description and versionNumber under deploymentConfig.
     mock_response = {
         "deployments": [
             {
                 "deploymentId": "deploy123",
-                "description": "Production",
+                "deploymentConfig": {
+                    "scriptId": "test123",
+                    "versionNumber": 7,
+                    "description": "Production",
+                },
                 "updateTime": "2026-01-12T15:30:00Z",
             }
         ]
@@ -457,6 +462,32 @@ async def test_list_deployments():
 
     assert "Production" in result
     assert "deploy123" in result
+    # Version must be visible so callers can verify which version is served.
+    assert "Version: 7" in result
+
+
+@pytest.mark.asyncio
+async def test_list_deployments_head_deployment_has_no_version():
+    """A HEAD deployment (no versionNumber) is labelled rather than shown blank (issue #922)."""
+    mock_service = Mock()
+    mock_response = {
+        "deployments": [
+            {
+                "deploymentId": "head123",
+                "deploymentConfig": {"scriptId": "test123"},
+                "updateTime": "2026-01-12T15:30:00Z",
+            }
+        ]
+    }
+
+    mock_service.projects().deployments().list().execute.return_value = mock_response
+
+    result = await _list_deployments_impl(
+        service=mock_service, user_google_email="test@example.com", script_id="test123"
+    )
+
+    assert "head123" in result
+    assert "HEAD (latest)" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Fixes the remaining, still-open half of #922: `list_deployments` gave no way to verify **which version** a deployment actually serves.

Two problems in `_list_deployments_impl`:
1. **Version was never shown.** The bound `versionNumber` lives under `deploymentConfig` in the API response and was simply dropped by the formatter.
2. **Description read from the wrong place.** It read top-level `deployment["description"]`, but the API nests it under `deploymentConfig` — so real deployments displayed `No description`.

### Why this matters
The issue author maintains ~14 in-place Apps Script web apps and hit a case where three production dashboards silently served **stale code for over a day**, with *"no programmatic way to confirm which version a deployment is actually serving"* — because `list_deployments` exposed only `updateTime`, which advances on any rebind (successful or not). Surfacing the version makes deployment state verifiable from the API.

### Change
- Read `description` and `versionNumber` from `deploymentConfig` (falling back to any top-level `description` for compatibility).
- Print `Version: <n>` per deployment.
- HEAD deployments have no `versionNumber` (they always serve the latest saved content), so they're labelled `HEAD (latest)` rather than shown blank.

### Note on the rest of #922
The issue's primary bug — `manage_deployment(action="update")` sending a flat body instead of wrapping it in `deploymentConfig` — was **already fixed** in `f174989` (merged via #836). That PR referenced #836 but not #922, so #922 stayed open. This PR closes out the remaining ask.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

- Updated `test_list_deployments` to use a realistic API response (description + `versionNumber` nested under `deploymentConfig`) and assert `Version: 7` appears.
- Added `test_list_deployments_head_deployment_has_no_version` for the HEAD case (no `versionNumber` → `HEAD (latest)`).
- Full suite green locally: `1777 passed, 2 skipped`. `ruff check` + `ruff format --check` clean.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Output-formatting change only; no tool signature/schema changes, so no golden snapshots are affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Deployment listings now show version numbers and descriptions more consistently.
  * Unversioned HEAD deployments are clearly labeled as **HEAD (latest)**.
  * Descriptions are displayed using available deployment details, with fallback support.

* **Documentation**
  * Updated deployment-listing documentation to note that version information is included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->