### PR TITLE
fix(gmail): default replies to latest eligible thread message

### DIFF
--- a/gmail/gmail_helpers.py
+++ b/gmail/gmail_helpers.py
@@ -213,7 +213,10 @@ def _derive_reply_headers(
     references: Optional[str],
     target: Optional[Mapping[str, Any]] = None,
 ) -> tuple[Optional[str], Optional[str]]:
-    """Fill reply headers, defaulting to the latest thread message."""
+    """Fill reply headers, defaulting to the latest automatically eligible message.
+
+    Automatic targets are non-draft, non-trash messages with an RFC Message-ID.
+    """
     derived_in_reply_to = in_reply_to
     derived_references = references
 

--- a/gmail/gmail_helpers.py
+++ b/gmail/gmail_helpers.py
@@ -199,37 +199,46 @@ def _parse_date_header(
 
 
 def _parse_message_id_chain(header_value: Optional[str]) -> list[str]:
-    """Extract Message-IDs from a reply header value."""
+    """Extract RFC Message-IDs from a reply header value."""
     if not header_value:
         return []
 
     message_ids = re.findall(r"<[^>]+>", header_value)
-    if message_ids:
-        return message_ids
-
-    return header_value.split()
+    return message_ids or header_value.split()
 
 
 def _derive_reply_headers(
     thread_message_ids: list[str],
     in_reply_to: Optional[str],
     references: Optional[str],
+    target: Optional[Mapping[str, Any]] = None,
 ) -> tuple[Optional[str], Optional[str]]:
-    """Fill missing reply headers while preserving caller intent."""
+    """Fill reply headers, defaulting to the latest thread message."""
     derived_in_reply_to = in_reply_to
     derived_references = references
 
-    if not thread_message_ids:
+    if not thread_message_ids and not target:
         return derived_in_reply_to, derived_references
 
+    target_message_id = target.get("message_id") if target else None
     if not derived_in_reply_to:
-        reference_chain = _parse_message_id_chain(derived_references)
-        derived_in_reply_to = (
-            reference_chain[-1] if reference_chain else thread_message_ids[-1]
-        )
+        # References describe ancestry; only In-Reply-To explicitly selects an
+        # older reply parent. Without one, rebuild both headers from the latest
+        # eligible message in the thread.
+        derived_in_reply_to = target_message_id or thread_message_ids[-1]
+        derived_references = None
 
     if not derived_references:
-        if derived_in_reply_to and derived_in_reply_to in thread_message_ids:
+        if target_message_id and derived_in_reply_to == target_message_id:
+            reference_chain = _parse_message_id_chain(target.get("references"))
+            if not reference_chain:
+                parent_ids = _parse_message_id_chain(target.get("in_reply_to"))
+                if len(parent_ids) == 1:
+                    reference_chain = parent_ids
+            if target_message_id not in reference_chain:
+                reference_chain.append(target_message_id)
+            derived_references = " ".join(reference_chain)
+        elif derived_in_reply_to and derived_in_reply_to in thread_message_ids:
             reply_index = thread_message_ids.index(derived_in_reply_to)
             derived_references = " ".join(thread_message_ids[: reply_index + 1])
         elif derived_in_reply_to:

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -2329,7 +2329,7 @@ async def send_gmail_message(
     thread_id: Annotated[
         Optional[str],
         Field(
-            description="Optional Gmail thread ID to reply within. When in_reply_to is omitted, replies to the latest non-draft, non-trash message.",
+            description="Optional Gmail thread ID to reply within. When in_reply_to is omitted, replies to the latest non-draft, non-trash message with an RFC Message-ID.",
         ),
     ] = None,
     in_reply_to: Annotated[
@@ -2403,7 +2403,8 @@ async def send_gmail_message(
             the email will be sent from the authenticated user's primary email address.
         user_google_email (str): The user's Google email address. Required for authentication.
         thread_id (Optional[str]): Optional Gmail thread ID to reply within. When
-            in_reply_to is omitted, replies to the latest non-draft, non-trash message.
+            in_reply_to is omitted, replies to the latest non-draft, non-trash message
+            with an RFC Message-ID.
         in_reply_to (Optional[str]): Optional RFC Message-ID to explicitly reply to
             a specific message. Omit to reply to the latest eligible message.
         references (Optional[str]): Optional RFC Message-ID ancestry chain. Normally
@@ -2839,7 +2840,7 @@ async def draft_gmail_message(
     thread_id: Annotated[
         Optional[str],
         Field(
-            description="Optional Gmail thread ID to reply within. When in_reply_to is omitted, replies to the latest non-draft, non-trash message.",
+            description="Optional Gmail thread ID to reply within. When in_reply_to is omitted, replies to the latest non-draft, non-trash message with an RFC Message-ID.",
         ),
     ] = None,
     in_reply_to: Annotated[
@@ -2892,7 +2893,8 @@ async def draft_gmail_message(
             usable Send-As entry, falling back to the authenticated user's email when Gmail
             returns no usable entry or settings access is not authorized.
         thread_id (Optional[str]): Optional Gmail thread ID to reply within. When
-            in_reply_to is omitted, replies to the latest non-draft, non-trash message.
+            in_reply_to is omitted, replies to the latest non-draft, non-trash message
+            with an RFC Message-ID.
         in_reply_to (Optional[str]): Optional RFC Message-ID to explicitly reply to
             a specific message. Omit to reply to the latest eligible message.
         references (Optional[str]): Optional RFC Message-ID ancestry chain. Normally

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -833,7 +833,17 @@ async def _fetch_thread_reply_context(
     include_bodies: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """Fetch reply metadata for a thread, optionally including message bodies."""
-    header_names = ["Message-ID", "Subject", "From", "Reply-To", "To", "Cc", "Date"]
+    header_names = [
+        "Message-ID",
+        "In-Reply-To",
+        "References",
+        "Subject",
+        "From",
+        "Reply-To",
+        "To",
+        "Cc",
+        "Date",
+    ]
 
     try:
         request_kwargs = {
@@ -855,15 +865,15 @@ async def _fetch_thread_reply_context(
         return None
 
     message_contexts = []
+    eligible_contexts = []
     for msg in messages:
-        # Skip trashed messages so auto-derived In-Reply-To never points at a
-        # message that Gmail's UI cannot render
-        if "TRASH" in msg.get("labelIds", []):
-            continue
+        labels = msg.get("labelIds", [])
         payload = msg.get("payload", {})
         headers = _extract_headers(payload, header_names)
         context = {
             "message_id": headers.get("Message-ID"),
+            "in_reply_to": headers.get("In-Reply-To"),
+            "references": headers.get("References"),
             "subject": headers.get("Subject", ""),
             "from": headers.get("From", ""),
             "reply_to": headers.get("Reply-To", ""),
@@ -876,6 +886,11 @@ async def _fetch_thread_reply_context(
             context["text_body"] = bodies.get("text", "")
             context["html_body"] = bodies.get("html", "")
         message_contexts.append(context)
+        # Automatic selection only considers actual sent or received messages.
+        # Keep every context above so an explicit In-Reply-To can still resolve
+        # to the exact message the caller selected.
+        if context["message_id"] and "DRAFT" not in labels and "TRASH" not in labels:
+            eligible_contexts.append(context)
 
     target = None
     if in_reply_to:
@@ -883,19 +898,13 @@ async def _fetch_thread_reply_context(
             if msg.get("message_id") == in_reply_to:
                 target = msg
                 break
-    if target is None and message_contexts:
-        # message_contexts can be empty even though the thread itself has
-        # messages, if every message in it is trashed (see the TRASH skip
-        # above) -- message_contexts[-1] would then raise IndexError.
-        # Leaving target as None is safe: callers already treat a missing
-        # target as "no reply context available" and degrade gracefully
-        # (e.g. draft_gmail_message falls back to an unthreaded draft).
-        target = message_contexts[-1]
+    elif eligible_contexts:
+        target = eligible_contexts[-1]
 
     return {
-        "messages": message_contexts,
+        "messages": eligible_contexts,
         "message_ids": [
-            msg["message_id"] for msg in message_contexts if msg.get("message_id")
+            msg["message_id"] for msg in eligible_contexts if msg.get("message_id")
         ],
         "target": target,
     }
@@ -2320,19 +2329,19 @@ async def send_gmail_message(
     thread_id: Annotated[
         Optional[str],
         Field(
-            description="Optional Gmail thread ID to reply within.",
+            description="Optional Gmail thread ID to reply within. When in_reply_to is omitted, replies to the latest non-draft, non-trash message.",
         ),
     ] = None,
     in_reply_to: Annotated[
         Optional[str],
         Field(
-            description="Optional RFC Message-ID of the message being replied to (e.g., '<message123@gmail.com>').",
+            description="Optional RFC Message-ID to explicitly reply to a specific message (e.g., '<message123@gmail.com>'). Omit to reply to the latest eligible message in thread_id.",
         ),
     ] = None,
     references: Annotated[
         Optional[str],
         Field(
-            description="Optional chain of Message-IDs for proper threading.",
+            description="Optional Message-ID ancestry chain. Normally omit when thread_id is provided; the server derives the chain through the selected reply target.",
         ),
     ] = None,
     attachments: Annotated[
@@ -2393,9 +2402,12 @@ async def send_gmail_message(
             configured in Gmail settings (Settings > Accounts > Send mail as). If not provided,
             the email will be sent from the authenticated user's primary email address.
         user_google_email (str): The user's Google email address. Required for authentication.
-        thread_id (Optional[str]): Optional Gmail thread ID to reply within. When provided, sends a reply.
-        in_reply_to (Optional[str]): Optional RFC Message-ID of the message being replied to (e.g., '<message123@gmail.com>').
-        references (Optional[str]): Optional chain of RFC Message-IDs for proper threading (e.g., '<msg1@gmail.com> <msg2@gmail.com>').
+        thread_id (Optional[str]): Optional Gmail thread ID to reply within. When
+            in_reply_to is omitted, replies to the latest non-draft, non-trash message.
+        in_reply_to (Optional[str]): Optional RFC Message-ID to explicitly reply to
+            a specific message. Omit to reply to the latest eligible message.
+        references (Optional[str]): Optional RFC Message-ID ancestry chain. Normally
+            omit when thread_id is provided; the chain is derived automatically.
         include_signature (bool): Whether to append Gmail signature HTML from send-as settings.
             When include_signature is true and Gmail signature retrieval fails for benign reasons
             (e.g., missing gmail.settings.basic scope), the send proceeds without a signature.
@@ -2472,9 +2484,7 @@ async def send_gmail_message(
             to="user@example.com",
             subject="Re: Meeting tomorrow",
             body="Thanks for the update!",
-            thread_id="thread_123",
-            in_reply_to="<message123@gmail.com>",
-            references="<original@gmail.com> <message123@gmail.com>"
+            thread_id="thread_123"
         )
 
         # Send a reply-all with the original quoted, deriving headers and
@@ -2566,14 +2576,15 @@ async def send_gmail_message(
             include_bodies=quote_original,
         )
 
+    target_reply = reply_context.get("target") if reply_context else None
     if thread_id and (not in_reply_to or not references):
         in_reply_to, references = _derive_reply_headers(
             reply_context.get("message_ids", []) if reply_context else [],
             in_reply_to,
             references,
+            target_reply,
         )
 
-    target_reply = reply_context.get("target") if reply_context else None
     if reply_all and target_reply:
         to, cc = _derive_reply_all_recipients(
             target_reply, {user_google_email, sender_email}, to, cc
@@ -2828,19 +2839,19 @@ async def draft_gmail_message(
     thread_id: Annotated[
         Optional[str],
         Field(
-            description="Optional Gmail thread ID to reply within.",
+            description="Optional Gmail thread ID to reply within. When in_reply_to is omitted, replies to the latest non-draft, non-trash message.",
         ),
     ] = None,
     in_reply_to: Annotated[
         Optional[str],
         Field(
-            description="Optional RFC Message-ID of the message being replied to (e.g., '<message123@gmail.com>').",
+            description="Optional RFC Message-ID to explicitly reply to a specific message (e.g., '<message123@gmail.com>'). Omit to reply to the latest eligible message in thread_id.",
         ),
     ] = None,
     references: Annotated[
         Optional[str],
         Field(
-            description="Optional chain of Message-IDs for proper threading.",
+            description="Optional Message-ID ancestry chain. Normally omit when thread_id is provided; the server derives the chain through the selected reply target.",
         ),
     ] = None,
     attachments: Annotated[
@@ -2880,9 +2891,12 @@ async def draft_gmail_message(
             the draft uses the account's default Send As address, then the primary or first
             usable Send-As entry, falling back to the authenticated user's email when Gmail
             returns no usable entry or settings access is not authorized.
-        thread_id (Optional[str]): Optional Gmail thread ID to reply within. When provided, creates a reply draft.
-        in_reply_to (Optional[str]): Optional RFC Message-ID of the message being replied to (e.g., '<message123@gmail.com>').
-        references (Optional[str]): Optional chain of RFC Message-IDs for proper threading (e.g., '<msg1@gmail.com> <msg2@gmail.com>').
+        thread_id (Optional[str]): Optional Gmail thread ID to reply within. When
+            in_reply_to is omitted, replies to the latest non-draft, non-trash message.
+        in_reply_to (Optional[str]): Optional RFC Message-ID to explicitly reply to
+            a specific message. Omit to reply to the latest eligible message.
+        references (Optional[str]): Optional RFC Message-ID ancestry chain. Normally
+            omit when thread_id is provided; the chain is derived automatically.
         attachments (List[Dict[str, str]]): Optional list of attachments. Each dict can contain:
             Option 1 - File path (auto-encodes):
               - 'path' (required): File path to attach
@@ -2941,9 +2955,7 @@ async def draft_gmail_message(
             subject="Re: Meeting tomorrow",
             body="Thanks for the update!",
             to="user@example.com",
-            thread_id="thread_123",
-            in_reply_to="<message123@gmail.com>",
-            references="<original@gmail.com> <message123@gmail.com>"
+            thread_id="thread_123"
         )
 
         # Create a reply draft in HTML
@@ -2952,9 +2964,7 @@ async def draft_gmail_message(
             body="<strong>Thanks for the update!</strong>",
             body_format="html",
             to="user@example.com",
-            thread_id="thread_123",
-            in_reply_to="<message123@gmail.com>",
-            references="<original@gmail.com> <message123@gmail.com>"
+            thread_id="thread_123"
         )
     """
     logger.info(
@@ -2987,15 +2997,15 @@ async def draft_gmail_message(
             include_bodies=quote_original,
         )
 
+    target_reply = reply_context.get("target") if reply_context else None
     if thread_id and (not in_reply_to or not references):
         thread_message_ids = (
             reply_context.get("message_ids", []) if reply_context else []
         )
         in_reply_to, references = _derive_reply_headers(
-            thread_message_ids, in_reply_to, references
+            thread_message_ids, in_reply_to, references, target_reply
         )
 
-    target_reply = reply_context.get("target") if reply_context else None
     if thread_id and not to and target_reply:
         to = target_reply.get("reply_to") or target_reply.get("from") or to
     if thread_id and not subject.strip() and target_reply:

--- a/skills/managing-google-workspace/SKILL.md
+++ b/skills/managing-google-workspace/SKILL.md
@@ -268,7 +268,7 @@ Parameters: `user_google_email` (string, optional), `service_name` (string, requ
 ### Reply to an email
 1. `search_gmail_messages` -- find the email
 2. `get_gmail_message_content` -- read it (get `message_id` and `thread_id`)
-3. `send_gmail_message` -- reply using `in_reply_to` and `thread_id`
+3. `send_gmail_message` -- reply using `thread_id`; omit reply headers to target the latest eligible message
 
 ### Find and share a file
 1. `search_drive_files` -- find the file

--- a/skills/managing-google-workspace/SKILL.md
+++ b/skills/managing-google-workspace/SKILL.md
@@ -268,7 +268,7 @@ Parameters: `user_google_email` (string, optional), `service_name` (string, requ
 ### Reply to an email
 1. `search_gmail_messages` -- find the email
 2. `get_gmail_message_content` -- read it (get `message_id` and `thread_id`)
-3. `send_gmail_message` -- reply using `thread_id`; omit reply headers to target the latest eligible message
+3. `send_gmail_message` -- reply using `thread_id`; omit reply headers to target the latest non-draft, non-trash message with an RFC `Message-ID`
 
 ### Find and share a file
 1. `search_drive_files` -- find the file

--- a/skills/managing-google-workspace/references/gmail.md
+++ b/skills/managing-google-workspace/references/gmail.md
@@ -83,7 +83,7 @@ Send an email. Supports new messages, replies, HTML, attachments, CC/BCC, and Se
 | bcc | string | no | | |
 | from_name | string | no | | Display name, e.g. "John Doe" |
 | from_email | string | no | | Send As alias (must be configured in Gmail settings) |
-| thread_id | string | no | | Thread ID for replies; defaults to its latest non-draft, non-trash message |
+| thread_id | string | no | | Thread ID for replies; defaults to its latest non-draft, non-trash message with an RFC `Message-ID` |
 | in_reply_to | string | no | | RFC Message-ID of a specific reply target; omit to reply to the latest eligible message |
 | references | string | no | | Optional Message-ID ancestry chain; normally derived from thread_id |
 | attachments | array | no | | See attachment format below |
@@ -106,7 +106,7 @@ Create a draft. Same capabilities as send but with additional signature/quoting 
 | bcc | string | no | | |
 | from_name | string | no | | Display name |
 | from_email | string | no | Gmail default | Send As alias; when omitted, resolves `isDefault`, then `isPrimary`, then the first Send-As entry, and finally the authenticated email if no usable entry is available |
-| thread_id | string | no | | For reply drafts; defaults to its latest non-draft, non-trash message |
+| thread_id | string | no | | For reply drafts; defaults to its latest non-draft, non-trash message with an RFC `Message-ID` |
 | in_reply_to | string | no | | RFC Message-ID of a specific reply target; omit for the latest eligible message |
 | references | string | no | | Optional Message-ID ancestry chain; normally derived from thread_id |
 | attachments | array | no | | Same format as send |
@@ -199,7 +199,7 @@ Create or delete a filter.
 
 ### Threading and Replies
 - Every search result returns both a `message_id` and a `thread_id`. Use the thread_id to read the full conversation.
-- For a normal reply, pass `thread_id` and omit `in_reply_to` and `references`. The server targets the latest non-draft, non-trash message and derives both RFC reply headers through it.
+- For a normal reply, pass `thread_id` and omit `in_reply_to` and `references`. The server targets the latest non-draft, non-trash message with an RFC `Message-ID` and derives both RFC reply headers through it.
 - Set `in_reply_to` only when deliberately replying to a specific older message. Use that message's RFC `Message-ID` header, not its Gmail API message ID; `references` can still be omitted and derived automatically.
 - Keep the subject consistent with the thread, normally prefixed with `Re: `.
 

--- a/skills/managing-google-workspace/references/gmail.md
+++ b/skills/managing-google-workspace/references/gmail.md
@@ -83,9 +83,9 @@ Send an email. Supports new messages, replies, HTML, attachments, CC/BCC, and Se
 | bcc | string | no | | |
 | from_name | string | no | | Display name, e.g. "John Doe" |
 | from_email | string | no | | Send As alias (must be configured in Gmail settings) |
-| thread_id | string | no | | Thread ID for replies |
-| in_reply_to | string | no | | RFC Message-ID being replied to, e.g. `<msg@gmail.com>` |
-| references | string | no | | Space-separated chain of Message-IDs for threading |
+| thread_id | string | no | | Thread ID for replies; defaults to its latest non-draft, non-trash message |
+| in_reply_to | string | no | | RFC Message-ID of a specific reply target; omit to reply to the latest eligible message |
+| references | string | no | | Optional Message-ID ancestry chain; normally derived from thread_id |
 | attachments | array | no | | See attachment format below |
 
 **Attachment format** (each item is an object):
@@ -106,9 +106,9 @@ Create a draft. Same capabilities as send but with additional signature/quoting 
 | bcc | string | no | | |
 | from_name | string | no | | Display name |
 | from_email | string | no | Gmail default | Send As alias; when omitted, resolves `isDefault`, then `isPrimary`, then the first Send-As entry, and finally the authenticated email if no usable entry is available |
-| thread_id | string | no | | For reply drafts |
-| in_reply_to | string | no | | RFC Message-ID |
-| references | string | no | | Message-ID chain |
+| thread_id | string | no | | For reply drafts; defaults to its latest non-draft, non-trash message |
+| in_reply_to | string | no | | RFC Message-ID of a specific reply target; omit for the latest eligible message |
+| references | string | no | | Optional Message-ID ancestry chain; normally derived from thread_id |
 | attachments | array | no | | Same format as send |
 | include_signature | boolean | no | true | Append Gmail signature if available |
 | quote_original | boolean | no | false | Include original message as quoted reply (requires thread_id) |
@@ -199,9 +199,9 @@ Create or delete a filter.
 
 ### Threading and Replies
 - Every search result returns both a `message_id` and a `thread_id`. Use the thread_id to read the full conversation.
-- To reply: pass `thread_id`, `in_reply_to` (the Message-ID header of the message you are replying to), and `references` (chain of all Message-IDs in the thread, space-separated). Prefix the subject with `Re:` followed by a space.
-- The `in_reply_to` and `references` values come from the `Message-ID` header returned by `get_gmail_message_content`.
-- The `in_reply_to` field in this MCP server is known to be unreliable. Always provide `thread_id` and `references` for threading -- those are the fields Gmail actually uses.
+- For a normal reply, pass `thread_id` and omit `in_reply_to` and `references`. The server targets the latest non-draft, non-trash message and derives both RFC reply headers through it.
+- Set `in_reply_to` only when deliberately replying to a specific older message. Use that message's RFC `Message-ID` header, not its Gmail API message ID; `references` can still be omitted and derived automatically.
+- Keep the subject consistent with the thread, normally prefixed with `Re: `.
 
 ### Pagination
 - `search_gmail_messages` returns a `next_page_token` when more results exist. Pass it as `page_token` in the next call.

--- a/tests/gmail/test_draft_gmail_message.py
+++ b/tests/gmail/test_draft_gmail_message.py
@@ -32,16 +32,20 @@ def _unwrap(tool):
 
 
 def _thread_response(*message_ids):
-    return {
-        "messages": [
-            {
-                "payload": {
-                    "headers": [{"name": "Message-ID", "value": message_id}],
-                }
-            }
-            for message_id in message_ids
-        ]
-    }
+    messages = []
+    ancestors = []
+    for message_id in message_ids:
+        headers = [{"name": "Message-ID", "value": message_id}]
+        if ancestors:
+            headers.extend(
+                [
+                    {"name": "In-Reply-To", "value": ancestors[-1]},
+                    {"name": "References", "value": " ".join(ancestors)},
+                ]
+            )
+        messages.append({"payload": {"headers": headers}})
+        ancestors.append(message_id)
+    return {"messages": messages}
 
 
 def _encode_part(text: str) -> str:
@@ -54,6 +58,8 @@ def _thread_message(
     subject: str = "Meeting tomorrow",
     from_value: str = "sender@example.com",
     reply_to: str | None = None,
+    in_reply_to: str | None = None,
+    references: str | None = None,
     to_value: str = "user@example.com",
     cc_value: str | None = None,
     date: str = "Fri, 28 Mar 2026 10:00:00 -0400",
@@ -69,6 +75,10 @@ def _thread_message(
     ]
     if reply_to:
         headers.append({"name": "Reply-To", "value": reply_to})
+    if in_reply_to:
+        headers.append({"name": "In-Reply-To", "value": in_reply_to})
+    if references:
+        headers.append({"name": "References", "value": references})
     if cc_value:
         headers.append({"name": "Cc", "value": cc_value})
 
@@ -922,6 +932,143 @@ async def test_draft_gmail_message_autofills_reply_headers_from_thread():
 
 
 @pytest.mark.asyncio
+async def test_draft_gmail_message_skips_existing_draft_as_default_reply_parent():
+    mock_service = _mock_gmail_service()
+    mock_service.users().drafts().create().execute.return_value = {"id": "draft_reply"}
+    thread_messages = [
+        _thread_message("<latest-sent@example.com>"),
+        _thread_message("<existing-draft@example.com>"),
+    ]
+    thread_messages[-1]["labelIds"] = ["DRAFT"]
+    mock_service.users().threads().get().execute.return_value = {
+        "messages": thread_messages
+    }
+
+    await _unwrap(draft_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        to="recipient@example.com",
+        subject="Meeting tomorrow",
+        body="Thanks for the update.",
+        thread_id="thread123",
+        include_signature=False,
+    )
+
+    create_kwargs = (
+        mock_service.users.return_value.drafts.return_value.create.call_args.kwargs
+    )
+    message_body = create_kwargs["body"]["message"]
+    parsed = _parse_raw_message(message_body["raw"])
+
+    assert parsed["In-Reply-To"] == "<latest-sent@example.com>"
+    assert parsed["References"] == "<latest-sent@example.com>"
+    assert message_body["threadId"] == "thread123"
+
+
+@pytest.mark.asyncio
+async def test_draft_gmail_message_skips_headerless_default_reply_parent():
+    mock_service = _mock_gmail_service()
+    mock_service.users().drafts().create().execute.return_value = {"id": "draft_reply"}
+    headerless_latest = _thread_message(
+        "<remove-me@example.com>",
+        from_value="Carol Example <carol@example.com>",
+    )
+    headerless_latest["payload"]["headers"] = [
+        header
+        for header in headerless_latest["payload"]["headers"]
+        if header["name"] != "Message-ID"
+    ]
+    mock_service.users().threads().get().execute.return_value = {
+        "messages": [
+            _thread_message(
+                "<latest-replyable@example.com>",
+                from_value="Alice Example <alice@example.com>",
+                reply_to="alice-replies@example.com",
+            ),
+            headerless_latest,
+        ]
+    }
+
+    await _unwrap(draft_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        subject="Meeting tomorrow",
+        body="Thanks for the update.",
+        thread_id="thread123",
+        include_signature=False,
+    )
+
+    create_kwargs = (
+        mock_service.users.return_value.drafts.return_value.create.call_args.kwargs
+    )
+    parsed = _parse_raw_message(create_kwargs["body"]["message"]["raw"])
+
+    assert parsed["To"] == "alice-replies@example.com"
+    assert parsed["In-Reply-To"] == "<latest-replyable@example.com>"
+    assert parsed["References"] == "<latest-replyable@example.com>"
+
+
+@pytest.mark.parametrize(
+    ("middle_labels", "latest_in_reply_to", "latest_references", "expected"),
+    [
+        (
+            [],
+            "<root@example.com>",
+            "<root@example.com>",
+            "<root@example.com> <latest@example.com>",
+        ),
+        (
+            ["TRASH"],
+            "<middle@example.com>",
+            "<root@example.com> <middle@example.com>",
+            "<root@example.com> <middle@example.com> <latest@example.com>",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_draft_gmail_message_uses_selected_parent_rfc_ancestry(
+    middle_labels, latest_in_reply_to, latest_references, expected
+):
+    mock_service = _mock_gmail_service()
+    mock_service.users().drafts().create().execute.return_value = {"id": "draft_reply"}
+    middle = _thread_message(
+        "<middle@example.com>",
+        in_reply_to="<root@example.com>",
+        references="<root@example.com>",
+    )
+    middle["labelIds"] = middle_labels
+    mock_service.users().threads().get().execute.return_value = {
+        "messages": [
+            _thread_message("<root@example.com>"),
+            middle,
+            _thread_message(
+                "<latest@example.com>",
+                in_reply_to=latest_in_reply_to,
+                references=latest_references,
+            ),
+        ]
+    }
+
+    await _unwrap(draft_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        to="recipient@example.com",
+        subject="Meeting tomorrow",
+        body="Thanks for the update.",
+        thread_id="thread123",
+        include_signature=False,
+    )
+
+    create_kwargs = (
+        mock_service.users.return_value.drafts.return_value.create.call_args.kwargs
+    )
+    parsed = _parse_raw_message(create_kwargs["body"]["message"]["raw"])
+
+    assert parsed["In-Reply-To"] == "<latest@example.com>"
+    assert parsed["References"] == expected
+
+
+@pytest.mark.asyncio
 async def test_draft_gmail_message_uses_explicit_in_reply_to_when_filling_references():
     mock_service = _mock_gmail_service()
     mock_service.users().drafts().create().execute.return_value = {"id": "draft_reply"}
@@ -954,7 +1101,52 @@ async def test_draft_gmail_message_uses_explicit_in_reply_to_when_filling_refere
 
 
 @pytest.mark.asyncio
-async def test_draft_gmail_message_uses_explicit_references_when_filling_in_reply_to():
+async def test_draft_gmail_message_uses_explicit_trashed_reply_target_context():
+    mock_service = _mock_gmail_service()
+    mock_service.users().drafts().create().execute.return_value = {"id": "draft_reply"}
+    trashed_target = _thread_message(
+        "<trashed-target@example.com>",
+        from_value="Bob Example <bob@example.com>",
+        reply_to="bob-replies@example.com",
+        in_reply_to="<root@example.com>",
+        references="<root@example.com>",
+    )
+    trashed_target["labelIds"] = ["TRASH"]
+    mock_service.users().threads().get().execute.return_value = {
+        "messages": [
+            _thread_message("<root@example.com>"),
+            trashed_target,
+            _thread_message(
+                "<latest@example.com>",
+                from_value="Carol Example <carol@example.com>",
+                in_reply_to="<root@example.com>",
+                references="<root@example.com>",
+            ),
+        ]
+    }
+
+    await _unwrap(draft_gmail_message)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        subject="Meeting tomorrow",
+        body="Replying to the selected older message.",
+        thread_id="thread123",
+        in_reply_to="<trashed-target@example.com>",
+        include_signature=False,
+    )
+
+    create_kwargs = (
+        mock_service.users.return_value.drafts.return_value.create.call_args.kwargs
+    )
+    parsed = _parse_raw_message(create_kwargs["body"]["message"]["raw"])
+
+    assert parsed["To"] == "bob-replies@example.com"
+    assert parsed["In-Reply-To"] == "<trashed-target@example.com>"
+    assert parsed["References"] == ("<root@example.com> <trashed-target@example.com>")
+
+
+@pytest.mark.asyncio
+async def test_draft_gmail_message_defaults_to_latest_when_only_references_are_given():
     mock_service = _mock_gmail_service()
     mock_service.users().drafts().create().execute.return_value = {"id": "draft_reply"}
     mock_service.users().threads().get().execute.return_value = _thread_response(
@@ -980,9 +1172,11 @@ async def test_draft_gmail_message_uses_explicit_references_when_filling_in_repl
     raw_message = create_kwargs["body"]["message"]["raw"]
     raw_text = base64.urlsafe_b64decode(raw_message).decode("utf-8", errors="ignore")
 
-    assert "In-Reply-To: <msg2@example.com>" in raw_text
-    assert "References: <msg1@example.com> <msg2@example.com>" in raw_text
-    assert "<msg3@example.com>" not in raw_text
+    assert "In-Reply-To: <msg3@example.com>" in raw_text
+    assert (
+        "References: <msg1@example.com> <msg2@example.com> <msg3@example.com>"
+        in raw_text
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Fix Gmail replies and reply drafts sometimes targeting an older message or an existing draft instead of the latest real message in a thread.

This change:

- Defaults replies to the latest non-`DRAFT`, non-`TRASH` message containing an RFC `Message-ID`.
- Derives `In-Reply-To` and `References` from the selected parent's actual RFC ancestry, including branched threads.
- Preserves an explicitly selected older reply target.
- Keeps recipients, quoted content, and reply headers aligned with the same target.
- Treats `References` as ancestry rather than an implicit reply-target selector.
- Updates tool descriptions and agent guidance so normal replies provide `thread_id` and omit low-level reply headers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] I have added tests that prove the fix is effective
- [x] New and existing unit tests pass locally
- [x] I have tested this change manually

Added coverage for:

- Existing drafts appearing after the latest real message.
- References-only calls defaulting to the latest reply target.
- Branched RFC ancestry.
- Trashed ancestors.
- Explicit older and trashed reply targets.
- Messages without an RFC `Message-ID`.

Full result: `1,782 passed, 2 skipped`.

Live Gmail validation on the Inyo account created two disposable reply drafts in the same existing thread, with the second created while the first draft was present. Both retained the expected thread, reply parent, and RFC ancestry. Nothing was sent, and both test drafts were deleted afterward.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have commented the non-obvious logic
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gmail replies and drafts now automatically target the latest eligible message in a thread.
  * Reply ancestry, including `In-Reply-To` and `References` headers, is derived automatically.
  * Specific older or trashed messages can still be selected explicitly.

* **Documentation**
  * Updated Gmail guidance and examples to reflect automatic reply targeting and threading.

* **Tests**
  * Expanded coverage for reply-parent selection, draft exclusion, missing headers, and preserved ancestry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->