### PR TITLE
enh: harden base64 handling for drive

### DIFF
--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -548,8 +548,9 @@ def _decode_base64_upload(
     expected_sha256: Optional[str] = None,
 ) -> bytes:
     """Decode and validate an inline binary upload before sending it to Drive."""
-    estimated_decoded_size = len(base64_content) * 3 // 4
-    if estimated_decoded_size > MAX_INLINE_BASE64_BYTES:
+    max_encoded_len = ((MAX_INLINE_BASE64_BYTES + 2) // 3) * 4
+    if len(base64_content) > max_encoded_len:
+        estimated_decoded_size = len(base64_content) * 3 // 4
         raise ValueError(
             f"[{tool_name}] Inline payload exceeds the "
             f"{MAX_INLINE_BASE64_BYTES // (1024 * 1024)} MB limit "

--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -6,9 +6,14 @@ remote content download, and import-time format conversion.
 """
 
 import asyncio
+import base64
+import binascii
+import hashlib
 import io
 import logging
 import re
+import zipfile
+import zlib
 from pathlib import Path
 from tempfile import SpooledTemporaryFile
 from typing import List, Dict, Any, Awaitable, BinaryIO, Callable, Optional, Tuple
@@ -498,6 +503,93 @@ DOWNLOAD_CHUNK_SIZE_BYTES = 256 * 1024  # 256 KB
 UPLOAD_CHUNK_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB (Google recommended minimum)
 MAX_DOWNLOAD_BYTES = 2 * 1024 * 1024 * 1024  # 2 GB safety limit for URL downloads
 
+# Office Open XML and OpenDocument payloads are ZIP containers. Drive accepts
+# malformed bytes at upload time and may only surface the corruption minutes later
+# when its Docs/Sheets/Slides importer opens the file, so validate inline payloads
+# before making a write request.
+ZIP_CONTAINER_REQUIRED_MEMBERS = {
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
+        "[Content_Types].xml",
+        "word/document.xml",
+    },
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
+        "[Content_Types].xml",
+        "xl/workbook.xml",
+    },
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": {
+        "[Content_Types].xml",
+        "ppt/presentation.xml",
+    },
+    "application/vnd.oasis.opendocument.text": {
+        "mimetype",
+        "META-INF/manifest.xml",
+    },
+    "application/vnd.oasis.opendocument.spreadsheet": {
+        "mimetype",
+        "META-INF/manifest.xml",
+    },
+    "application/vnd.oasis.opendocument.presentation": {
+        "mimetype",
+        "META-INF/manifest.xml",
+    },
+}
+
+
+def _decode_base64_upload(
+    base64_content: str,
+    *,
+    tool_name: str,
+    mime_type: str,
+    expected_sha256: Optional[str] = None,
+) -> bytes:
+    """Decode and validate an inline binary upload before sending it to Drive."""
+    try:
+        file_data = base64.b64decode(base64_content, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("'base64_content' must be valid standard base64.") from exc
+
+    if expected_sha256 is not None:
+        normalized_sha256 = expected_sha256.strip().lower()
+        if not re.fullmatch(r"[0-9a-f]{64}", normalized_sha256):
+            raise ValueError("'base64_sha256' must be a 64-character hexadecimal SHA-256.")
+        actual_sha256 = hashlib.sha256(file_data).hexdigest()
+        if actual_sha256 != normalized_sha256:
+            raise ValueError(
+                f"[{tool_name}] Inline binary payload failed its SHA-256 integrity check. "
+                "The base64 content was altered or truncated before reaching the server."
+            )
+
+    required_members = ZIP_CONTAINER_REQUIRED_MEMBERS.get(mime_type)
+    if required_members is not None:
+        try:
+            with zipfile.ZipFile(io.BytesIO(file_data)) as archive:
+                names = set(archive.namelist())
+                missing = required_members - names
+                if missing:
+                    raise ValueError(
+                        f"[{tool_name}] Inline {mime_type} payload is missing required "
+                        f"archive members: {', '.join(sorted(missing))}."
+                    )
+                corrupt_member = archive.testzip()
+                if corrupt_member is not None:
+                    raise ValueError(
+                        f"[{tool_name}] Inline {mime_type} payload contains a corrupt "
+                        f"archive member: {corrupt_member}."
+                    )
+        except ValueError:
+            raise
+        except (zipfile.BadZipFile, EOFError, RuntimeError, zlib.error) as exc:
+            raise ValueError(
+                f"[{tool_name}] Inline {mime_type} payload is not a valid, intact archive."
+            ) from exc
+
+    return file_data
+
+
+def _use_resumable_upload(size: int) -> bool:
+    """Use Drive's resumable protocol only when a simple upload is too large."""
+    return size > UPLOAD_CHUNK_SIZE_BYTES
+
 
 async def _stream_url_with_validation(
     url: str, write_chunk: Optional[Callable[[bytes], Awaitable[None]]] = None
@@ -637,13 +729,16 @@ async def _resolve_import_media(
     file_path: Optional[str],
     file_url: Optional[str],
     source_format: Optional[str],
+    base64_content: Optional[str] = None,
+    base64_sha256: Optional[str] = None,
     format_map: Optional[Dict[str, str]] = None,
     passthrough_mime_type: Optional[str] = None,
 ) -> Tuple[MediaIoBaseUpload, str, Optional[BinaryIO]]:
     """
     Resolve a content source into an upload ``MediaIoBaseUpload`` and source MIME type.
 
-    Exactly one of ``content``, ``file_path``, or ``file_url`` must be provided.
+    Exactly one of ``content``, ``file_path``, ``file_url``, or
+    ``base64_content`` must be provided.
     The source bytes are uploaded with their *source* MIME type so the Drive API can
     convert them into the destination Google Apps format. ``format_map`` is the
     extension → source MIME allowlist used for detection and validation.
@@ -655,13 +750,21 @@ async def _resolve_import_media(
     Returns ``(media, source_mime_type, closeable)``; when the source is a remote URL,
     ``closeable`` is the download stream the caller must close after upload (else None).
     """
-    source_count = sum(1 for x in (content, file_path, file_url) if x is not None)
+    source_count = sum(
+        1 for x in (content, file_path, file_url, base64_content) if x is not None
+    )
     if source_count == 0:
         raise ValueError(
-            "You must provide one of: 'content', 'file_path', or 'file_url'."
+            "You must provide one of: 'content', 'file_path', 'file_url', or "
+            "'base64_content'."
         )
     if source_count > 1:
-        raise ValueError("Provide only one of: 'content', 'file_path', or 'file_url'.")
+        raise ValueError(
+            "Provide only one of: 'content', 'file_path', 'file_url', or "
+            "'base64_content'."
+        )
+    if base64_sha256 is not None and base64_content is None:
+        raise ValueError("'base64_sha256' can only be used with 'base64_content'.")
 
     # Determine source MIME type from the explicit hint or auto-detection.
     if passthrough_mime_type:
@@ -694,6 +797,15 @@ async def _resolve_import_media(
             )
         file_data = content.encode("utf-8")
         logger.info(f"[{tool_name}] Using content: {len(file_data)} bytes")
+
+    elif base64_content is not None:
+        file_data = _decode_base64_upload(
+            base64_content,
+            tool_name=tool_name,
+            mime_type=source_mime_type,
+            expected_sha256=base64_sha256,
+        )
+        logger.info(f"[{tool_name}] Decoded inline binary content: {len(file_data)} bytes")
 
     elif file_path is not None:
         parsed_url = urlparse(file_path)
@@ -752,10 +864,21 @@ async def _resolve_import_media(
             f"{', '.join(ext.lstrip('.') for ext in sorted(format_map.keys()))}."
         )
 
+    upload_stream = (
+        remote_file_data if remote_file_data is not None else io.BytesIO(file_data)
+    )
+    if remote_file_data is not None:
+        current_position = remote_file_data.tell()
+        remote_file_data.seek(0, io.SEEK_END)
+        upload_size = remote_file_data.tell()
+        remote_file_data.seek(current_position)
+    else:
+        upload_size = len(file_data)
+
     media = MediaIoBaseUpload(
-        remote_file_data if remote_file_data is not None else io.BytesIO(file_data),
+        upload_stream,
         mimetype=source_mime_type,  # Source format drives Drive's auto-conversion
-        resumable=True,
+        resumable=_use_resumable_upload(upload_size),
         chunksize=UPLOAD_CHUNK_SIZE_BYTES,
     )
     return media, source_mime_type, remote_file_data

--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -600,7 +600,11 @@ def _decode_base64_upload(
                         f"({total_uncompressed // (1024 * 1024)} MB) exceeds the "
                         f"{MAX_ZIP_UNCOMPRESSED_BYTES // (1024 * 1024)} MB limit."
                     )
-                if len(file_data) > 0 and total_uncompressed // max(len(file_data), 1) > MAX_ZIP_COMPRESSION_RATIO:
+                if (
+                    len(file_data) > 0
+                    and total_uncompressed // max(len(file_data), 1)
+                    > MAX_ZIP_COMPRESSION_RATIO
+                ):
                     raise ValueError(
                         f"[{tool_name}] Inline {mime_type} archive compression ratio "
                         f"exceeds {MAX_ZIP_COMPRESSION_RATIO}x."

--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -503,6 +503,11 @@ DOWNLOAD_CHUNK_SIZE_BYTES = 256 * 1024  # 256 KB
 UPLOAD_CHUNK_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB (Google recommended minimum)
 MAX_DOWNLOAD_BYTES = 2 * 1024 * 1024 * 1024  # 2 GB safety limit for URL downloads
 
+MAX_INLINE_BASE64_BYTES = 100 * 1024 * 1024  # 100 MB decoded payload ceiling
+MAX_ZIP_MEMBER_COUNT = 10_000
+MAX_ZIP_UNCOMPRESSED_BYTES = 500 * 1024 * 1024  # 500 MB total uncompressed
+MAX_ZIP_COMPRESSION_RATIO = 100
+
 # Office Open XML and OpenDocument payloads are ZIP containers. Drive accepts
 # malformed bytes at upload time and may only surface the corruption minutes later
 # when its Docs/Sheets/Slides importer opens the file, so validate inline payloads
@@ -543,10 +548,27 @@ def _decode_base64_upload(
     expected_sha256: Optional[str] = None,
 ) -> bytes:
     """Decode and validate an inline binary upload before sending it to Drive."""
+    estimated_decoded_size = len(base64_content) * 3 // 4
+    if estimated_decoded_size > MAX_INLINE_BASE64_BYTES:
+        raise ValueError(
+            f"[{tool_name}] Inline payload exceeds the "
+            f"{MAX_INLINE_BASE64_BYTES // (1024 * 1024)} MB limit "
+            f"(estimated {estimated_decoded_size // (1024 * 1024)} MB). "
+            "Upload via 'fileUrl' instead."
+        )
+
     try:
         file_data = base64.b64decode(base64_content, validate=True)
     except (binascii.Error, ValueError) as exc:
         raise ValueError("'base64_content' must be valid standard base64.") from exc
+
+    if len(file_data) > MAX_INLINE_BASE64_BYTES:
+        raise ValueError(
+            f"[{tool_name}] Inline payload exceeds the "
+            f"{MAX_INLINE_BASE64_BYTES // (1024 * 1024)} MB limit "
+            f"({len(file_data) // (1024 * 1024)} MB). "
+            "Upload via 'fileUrl' instead."
+        )
 
     if expected_sha256 is not None:
         normalized_sha256 = expected_sha256.strip().lower()
@@ -563,6 +585,24 @@ def _decode_base64_upload(
     if required_members is not None:
         try:
             with zipfile.ZipFile(io.BytesIO(file_data)) as archive:
+                members = archive.infolist()
+                if len(members) > MAX_ZIP_MEMBER_COUNT:
+                    raise ValueError(
+                        f"[{tool_name}] Inline {mime_type} archive contains "
+                        f"{len(members)} members (limit {MAX_ZIP_MEMBER_COUNT})."
+                    )
+                total_uncompressed = sum(m.file_size for m in members)
+                if total_uncompressed > MAX_ZIP_UNCOMPRESSED_BYTES:
+                    raise ValueError(
+                        f"[{tool_name}] Inline {mime_type} archive uncompressed size "
+                        f"({total_uncompressed // (1024 * 1024)} MB) exceeds the "
+                        f"{MAX_ZIP_UNCOMPRESSED_BYTES // (1024 * 1024)} MB limit."
+                    )
+                if len(file_data) > 0 and total_uncompressed // max(len(file_data), 1) > MAX_ZIP_COMPRESSION_RATIO:
+                    raise ValueError(
+                        f"[{tool_name}] Inline {mime_type} archive compression ratio "
+                        f"exceeds {MAX_ZIP_COMPRESSION_RATIO}x."
+                    )
                 names = set(archive.namelist())
                 missing = required_members - names
                 if missing:

--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -601,7 +601,11 @@ def _decode_base64_upload(
                         f"({total_uncompressed // (1024 * 1024)} MB) exceeds the "
                         f"{MAX_ZIP_UNCOMPRESSED_BYTES // (1024 * 1024)} MB limit."
                     )
-                if len(file_data) > 0 and total_uncompressed // max(len(file_data), 1) > MAX_ZIP_COMPRESSION_RATIO:
+                if (
+                    len(file_data) > 0
+                    and total_uncompressed // max(len(file_data), 1)
+                    > MAX_ZIP_COMPRESSION_RATIO
+                ):
                     raise ValueError(
                         f"[{tool_name}] Inline {mime_type} archive compression ratio "
                         f"exceeds {MAX_ZIP_COMPRESSION_RATIO}x."

--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -551,7 +551,9 @@ def _decode_base64_upload(
     if expected_sha256 is not None:
         normalized_sha256 = expected_sha256.strip().lower()
         if not re.fullmatch(r"[0-9a-f]{64}", normalized_sha256):
-            raise ValueError("'base64_sha256' must be a 64-character hexadecimal SHA-256.")
+            raise ValueError(
+                "'base64_sha256' must be a 64-character hexadecimal SHA-256."
+            )
         actual_sha256 = hashlib.sha256(file_data).hexdigest()
         if actual_sha256 != normalized_sha256:
             raise ValueError(
@@ -805,7 +807,9 @@ async def _resolve_import_media(
             mime_type=source_mime_type,
             expected_sha256=base64_sha256,
         )
-        logger.info(f"[{tool_name}] Decoded inline binary content: {len(file_data)} bytes")
+        logger.info(
+            f"[{tool_name}] Decoded inline binary content: {len(file_data)} bytes"
+        )
 
     elif file_path is not None:
         parsed_url = urlparse(file_path)

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -1014,6 +1014,10 @@ async def create_drive_file(
     )
     logger.debug(f"[create_drive_file] File Name: {file_name}")
 
+    mime_type = mime_type.strip().lower()
+    if content_mime_type is not None:
+        content_mime_type = content_mime_type.strip().lower()
+
     has_existing_content_source = content is not None or bool(fileUrl)
     if (
         not has_existing_content_source

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -1046,6 +1046,17 @@ async def create_drive_file(
             "MIME types."
         )
 
+    if mime_type == FOLDER_MIME_TYPE:
+        if base64_content is not None or content is not None or bool(fileUrl):
+            raise ValueError(
+                "Folders cannot contain file content. Remove 'content', "
+                "'base64_content', and 'fileUrl' when creating a folder, "
+                "or use a different mime_type."
+            )
+        return await _create_drive_folder_impl(
+            service, user_google_email, file_name, folder_id
+        )
+
     file_data = None
     if base64_content is not None:
         file_data = _decode_base64_upload(
@@ -1053,12 +1064,6 @@ async def create_drive_file(
             tool_name="create_drive_file",
             mime_type=content_mime_type,
             expected_sha256=base64_sha256,
-        )
-
-    # Create folder (no content or media_body). Prefer create_drive_folder for new code.
-    if mime_type == FOLDER_MIME_TYPE:
-        return await _create_drive_folder_impl(
-            service, user_google_email, file_name, folder_id
         )
 
     resolved_folder_id = await resolve_folder_id(service, folder_id)

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -5,10 +5,9 @@ This module provides MCP tools for interacting with Google Drive API.
 """
 
 import asyncio
+import base64
 import logging
 import io
-import base64
-import binascii
 
 from typing import Optional, List, Dict, Any
 from tempfile import NamedTemporaryFile, SpooledTemporaryFile
@@ -48,8 +47,10 @@ from gdrive.drive_helpers import (
     GOOGLE_SLIDES_MIME_TYPE,
     SHORTCUT_MIME_TYPE,
     UPLOAD_CHUNK_SIZE_BYTES,
+    _decode_base64_upload,
     _resolve_import_media,
     _stream_url_with_validation,
+    _use_resumable_upload,
     build_drive_list_params,
     check_public_link_permission,
     list_all_permissions,
@@ -984,10 +985,13 @@ async def create_drive_file(
     fileUrl: Optional[str] = None,  # Now explicitly Optional
     base64_content: Optional[str] = None,
     content_mime_type: Optional[str] = None,
+    base64_sha256: Optional[str] = None,
 ) -> str:
     """
     Creates a new file in Google Drive, supporting creation within shared drives.
     Accepts direct text content, inline base64 bytes, or a fileUrl to fetch content from.
+    This stores the supplied bytes without converting them to Google Docs, Sheets, or
+    Slides. Use the matching import_to_google_* tool for Google-native conversion.
 
     Args:
         user_google_email (str): The user's Google email address. Required.
@@ -998,6 +1002,7 @@ async def create_drive_file(
         fileUrl (Optional[str]): If provided, fetches the file content from this URL. Supports file://, http://, and https:// protocols.
         base64_content (Optional[str]): Standard base64-encoded file bytes.
         content_mime_type (Optional[str]): MIME type for base64_content uploads.
+        base64_sha256 (Optional[str]): Expected SHA-256 of decoded base64_content. Recommended for binary payload integrity checks.
 
     Returns:
         str: Confirmation message of the successful file creation with file link.
@@ -1024,13 +1029,27 @@ async def create_drive_file(
         raise ValueError("'content_mime_type' can only be used with 'base64_content'.")
     if base64_content is not None and not content_mime_type:
         raise ValueError("'content_mime_type' is required when using 'base64_content'.")
+    if base64_sha256 is not None and base64_content is None:
+        raise ValueError("'base64_sha256' can only be used with 'base64_content'.")
+    if base64_content is not None and (
+        mime_type.startswith(GOOGLE_APPS_MIME_PREFIX)
+        or content_mime_type.startswith(GOOGLE_APPS_MIME_PREFIX)
+    ):
+        raise ValueError(
+            "Google-native files cannot be created from inline binary bytes with "
+            "create_drive_file. Use import_to_google_doc, import_to_google_sheets, "
+            "or import_to_google_slides so Drive receives separate source and target "
+            "MIME types."
+        )
 
     file_data = None
     if base64_content is not None:
-        try:
-            file_data = base64.b64decode(base64_content, validate=True)
-        except (binascii.Error, ValueError) as exc:
-            raise ValueError("'base64_content' must be valid standard base64.") from exc
+        file_data = _decode_base64_upload(
+            base64_content,
+            tool_name="create_drive_file",
+            mime_type=content_mime_type,
+            expected_sha256=base64_sha256,
+        )
 
     # Create folder (no content or media_body). Prefer create_drive_folder for new code.
     if mime_type == FOLDER_MIME_TYPE:
@@ -1051,7 +1070,7 @@ async def create_drive_file(
         media = MediaIoBaseUpload(
             io.BytesIO(file_data),
             mimetype=content_mime_type,
-            resumable=True,
+            resumable=_use_resumable_upload(len(file_data)),
             chunksize=UPLOAD_CHUNK_SIZE_BYTES,
         )
 
@@ -1277,6 +1296,8 @@ async def _import_with_conversion(
     file_url: Optional[str],
     source_format: Optional[str],
     folder_id: str,
+    base64_content: Optional[str],
+    base64_sha256: Optional[str],
 ) -> str:
     """
     Shared implementation for the import_to_google_* tools.
@@ -1306,6 +1327,8 @@ async def _import_with_conversion(
         file_path=file_path,
         file_url=file_url,
         source_format=source_format,
+        base64_content=base64_content,
+        base64_sha256=base64_sha256,
         format_map=format_map,
     )
 
@@ -1385,13 +1408,16 @@ async def import_to_google_doc(
     file_url: Optional[str] = None,
     source_format: Optional[str] = None,
     folder_id: str = "root",
+    base64_content: Optional[str] = None,
+    base64_sha256: Optional[str] = None,
 ) -> str:
     """
     Imports a file (Markdown, DOCX, TXT, HTML, RTF, ODT) into Google Docs format with automatic conversion.
 
     Google Drive automatically converts the source file to native Google Docs format,
     preserving formatting like headings, lists, bold, italic, etc.
-    For batch operations, prefer file_path for files on disk so callers do not need
+    Binary sources may be passed directly as base64_content. For batch operations,
+    prefer file_path for files on disk so callers do not need
     to load full file contents into their context.
 
     Args:
@@ -1403,6 +1429,8 @@ async def import_to_google_doc(
         source_format (Optional[str]): Source format hint ('md', 'markdown', 'docx', 'txt', 'html', 'rtf', 'odt').
                                        Auto-detected from file_name extension if not provided.
         folder_id (str): The ID of the parent folder. Defaults to 'root'.
+        base64_content (Optional[str]): Standard base64-encoded bytes for a binary source such as DOCX or ODT.
+        base64_sha256 (Optional[str]): Expected SHA-256 of decoded base64_content. Recommended for binary payload integrity checks.
 
     Returns:
         str: Confirmation message with the new Google Doc link.
@@ -1434,6 +1462,8 @@ async def import_to_google_doc(
         file_url=file_url,
         source_format=source_format,
         folder_id=folder_id,
+        base64_content=base64_content,
+        base64_sha256=base64_sha256,
     )
 
 
@@ -1456,13 +1486,16 @@ async def import_to_google_slides(
     file_url: Optional[str] = None,
     source_format: Optional[str] = None,
     folder_id: str = "root",
+    base64_content: Optional[str] = None,
+    base64_sha256: Optional[str] = None,
 ) -> str:
     """
     Imports a presentation (PPTX, PPT, ODP) into Google Slides format with automatic conversion.
 
     Google Drive automatically converts the source presentation to native Google Slides format,
     preserving slides, layouts, text, and images.
-    For batch operations, prefer file_path for files on disk so callers do not need
+    Binary sources may be passed directly as base64_content. For batch operations,
+    prefer file_path for files on disk so callers do not need
     to load full file contents into their context.
 
     Args:
@@ -1473,6 +1506,8 @@ async def import_to_google_slides(
         source_format (Optional[str]): Source format hint ('pptx', 'ppt', 'odp').
                                        Auto-detected from file_name extension if not provided.
         folder_id (str): The ID of the parent folder. Defaults to 'root'.
+        base64_content (Optional[str]): Standard base64-encoded bytes for a PPTX or ODP source.
+        base64_sha256 (Optional[str]): Expected SHA-256 of decoded base64_content. Recommended for binary payload integrity checks.
 
     Returns:
         str: Confirmation message with the new Google Slides link.
@@ -1498,6 +1533,8 @@ async def import_to_google_slides(
         file_url=file_url,
         source_format=source_format,
         folder_id=folder_id,
+        base64_content=base64_content,
+        base64_sha256=base64_sha256,
     )
 
 
@@ -1521,13 +1558,16 @@ async def import_to_google_sheets(
     file_url: Optional[str] = None,
     source_format: Optional[str] = None,
     folder_id: str = "root",
+    base64_content: Optional[str] = None,
+    base64_sha256: Optional[str] = None,
 ) -> str:
     """
     Imports a spreadsheet (XLSX, XLS, ODS, CSV, TSV) into Google Sheets format with automatic conversion.
 
     Google Drive automatically converts the source spreadsheet to native Google Sheets format,
     preserving rows, columns, sheets, and values.
-    For batch operations, prefer file_path for files on disk so callers do not need
+    Binary sources may be passed directly as base64_content. For batch operations,
+    prefer file_path for files on disk so callers do not need
     to load full file contents into their context.
 
     Args:
@@ -1539,6 +1579,8 @@ async def import_to_google_sheets(
         source_format (Optional[str]): Source format hint ('xlsx', 'xls', 'ods', 'csv', 'tsv').
                                        Auto-detected from file_name extension if not provided.
         folder_id (str): The ID of the parent folder. Defaults to 'root'.
+        base64_content (Optional[str]): Standard base64-encoded bytes for an XLSX, XLS, or ODS source.
+        base64_sha256 (Optional[str]): Expected SHA-256 of decoded base64_content. Recommended for binary payload integrity checks.
 
     Returns:
         str: Confirmation message with the new Google Sheets link.
@@ -1567,6 +1609,8 @@ async def import_to_google_sheets(
         file_url=file_url,
         source_format=source_format,
         folder_id=folder_id,
+        base64_content=base64_content,
+        base64_sha256=base64_sha256,
     )
 
 

--- a/skills/managing-google-workspace/references/drive.md
+++ b/skills/managing-google-workspace/references/drive.md
@@ -83,7 +83,9 @@ Default export formats for Google native files:
 ## Create & Modify
 
 ### create_drive_file
-Create a new file in Drive.
+Create a new file in Drive without converting it to a native Google format. For
+Office-to-Google conversion, use `import_to_google_doc`,
+`import_to_google_sheets`, or `import_to_google_slides`.
 
 | Parameter | Type | Required | Default | Notes |
 |-----------|------|----------|---------|-------|
@@ -93,6 +95,13 @@ Create a new file in Drive.
 | folder_id | string | no | root | Parent folder ID |
 | mime_type | string | no | text/plain | MIME type of the file |
 | fileUrl | string | no | | Fetch content from this URL (file://, http://, https://) |
+| base64_content | string | no | | Standard base64-encoded binary content |
+| content_mime_type | string | with base64_content | | Source MIME type; Google-native MIME types are rejected |
+| base64_sha256 | string | no | | Optional SHA-256 integrity check for decoded binary content |
+
+The import tools also accept `base64_content` and optional `base64_sha256` for
+binary Office/OpenDocument sources. ZIP-based formats are checked for required
+members and CRC/decompression errors before Drive is called.
 
 ### create_drive_folder
 Create a new folder.

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -8,11 +8,13 @@ and `file_type` filtering behaviors.
 
 import asyncio
 import base64
+import hashlib
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
 import io
 import sys
 import os
+import zipfile
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
@@ -43,6 +45,15 @@ def _unwrap(tool):
     while hasattr(fn, "__wrapped__"):
         fn = fn.__wrapped__
     return fn
+
+
+def _xlsx_bytes() -> bytes:
+    """Return a minimal structurally valid XLSX ZIP for upload tests."""
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("[Content_Types].xml", "<Types/>")
+        archive.writestr("xl/workbook.xml", "<workbook/>")
+    return output.getvalue()
 
 
 # ---------------------------------------------------------------------------
@@ -81,8 +92,69 @@ async def test_create_drive_file_uploads_base64_content(mock_resolve_folder):
     assert create_kwargs["supportsAllDrives"] is True
     media = create_kwargs["media_body"]
     assert media.mimetype() == "application/pdf"
+    assert media.resumable() is False
     assert media.getbytes(0, len(payload)) == payload
     assert "Successfully created file 'report.pdf'" in result
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+async def test_create_drive_file_validates_inline_xlsx_before_upload(
+    mock_resolve_folder,
+):
+    """Corrupt ZIP-based Office files fail before Drive creates an unusable item."""
+    mock_resolve_folder.return_value = "folder123"
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="valid, intact archive"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="broken.xlsx",
+            base64_content=base64.b64encode(b"PK-not-an-xlsx").decode("ascii"),
+            content_mime_type=(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        )
+
+    mock_resolve_folder.assert_not_called()
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_drive_file_rejects_google_native_inline_mime_type():
+    """Inline bytes need a source MIME type, not a Google-native target MIME type."""
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="import_to_google_sheets"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="Budget",
+            base64_content=base64.b64encode(_xlsx_bytes()).decode("ascii"),
+            content_mime_type="application/vnd.google-apps.spreadsheet",
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_drive_file_rejects_changed_inline_payload_by_sha256():
+    """An optional digest catches syntactically valid base64 that changed in transit."""
+    mock_service = Mock()
+    payload = b"original binary payload"
+
+    with pytest.raises(ValueError, match="SHA-256 integrity check"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="report.pdf",
+            base64_content=base64.b64encode(b"changed binary payload").decode("ascii"),
+            content_mime_type="application/pdf",
+            base64_sha256=hashlib.sha256(payload).hexdigest(),
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1823,6 +1895,62 @@ async def test_import_to_google_sheets_converts_csv_content(mock_resolve_folder)
     assert media.mimetype() == "text/csv"
     assert "Successfully imported" in result
     assert "Spreadsheet ID" in result
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+async def test_import_to_google_sheets_accepts_validated_inline_xlsx(
+    mock_resolve_folder,
+):
+    """The purpose-built import tool accepts binary XLSX content without a detour."""
+    payload = _xlsx_bytes()
+    mock_resolve_folder.return_value = "resolved_root"
+    mock_service = Mock()
+    mock_service.files().create().execute.return_value = {
+        "id": "sheet123",
+        "name": "Budget",
+        "webViewLink": "https://docs.google.com/spreadsheets/d/sheet123",
+        "mimeType": "application/vnd.google-apps.spreadsheet",
+    }
+
+    result = await _unwrap(import_to_google_sheets)(
+        service=mock_service,
+        user_google_email="user@example.com",
+        file_name="Budget.xlsx",
+        source_format="xlsx",
+        folder_id="root",
+        base64_content=base64.b64encode(payload).decode("ascii"),
+        base64_sha256=hashlib.sha256(payload).hexdigest(),
+    )
+
+    create_kwargs = mock_service.files.return_value.create.call_args.kwargs
+    assert create_kwargs["body"]["mimeType"] == (
+        "application/vnd.google-apps.spreadsheet"
+    )
+    media = create_kwargs["media_body"]
+    assert media.mimetype() == (
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    assert media.resumable() is False
+    assert media.getbytes(0, len(payload)) == payload
+    assert "Successfully imported" in result
+
+
+@pytest.mark.asyncio
+async def test_import_to_google_sheets_rejects_corrupt_inline_xlsx():
+    """Malformed XLSX content never reaches Drive's slow asynchronous importer."""
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="valid, intact archive"):
+        await _unwrap(import_to_google_sheets)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="Budget.xlsx",
+            source_format="xlsx",
+            base64_content=base64.b64encode(b"not an xlsx archive").decode("ascii"),
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -258,14 +258,16 @@ async def test_create_drive_file_rejects_oversized_base64_before_decode():
     mock_service = Mock()
 
     with patch("gdrive.drive_helpers.MAX_INLINE_BASE64_BYTES", patched_limit):
-        with pytest.raises(ValueError, match="limit"):
-            await _unwrap(create_drive_file)(
-                service=mock_service,
-                user_google_email="user@example.com",
-                file_name="huge.bin",
-                base64_content=oversized_b64,
-                content_mime_type="application/octet-stream",
-            )
+        with patch("gdrive.drive_helpers.base64.b64decode") as decode:
+            with pytest.raises(ValueError, match="limit"):
+                await _unwrap(create_drive_file)(
+                    service=mock_service,
+                    user_google_email="user@example.com",
+                    file_name="huge.bin",
+                    base64_content=oversized_b64,
+                    content_mime_type="application/octet-stream",
+                )
+        decode.assert_not_called()
 
     mock_service.files.return_value.create.return_value.execute.assert_not_called()
 

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -275,7 +275,9 @@ async def test_create_drive_file_rejects_oversized_base64_before_decode():
     "gdrive.drive_helpers.MAX_ZIP_MEMBER_COUNT",
     5,
 )
-async def test_create_drive_file_rejects_zip_excessive_member_count(mock_resolve_folder):
+async def test_create_drive_file_rejects_zip_excessive_member_count(
+    mock_resolve_folder,
+):
     """ZIP archives with too many members are rejected before testzip()."""
     mock_resolve_folder.return_value = "folder123"
     mock_service = Mock()

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -245,7 +245,196 @@ async def test_create_drive_file_rejects_empty_file_url():
 
 
 # ---------------------------------------------------------------------------
-# get_drive_file_permissions — owners
+# create_drive_file - inline base64 resource-limit enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_drive_file_rejects_oversized_base64_before_decode():
+    """Base64 input exceeding the inline-upload limit is rejected before decoding."""
+    from gdrive.drive_helpers import MAX_INLINE_BASE64_BYTES
+
+    oversized_b64 = "A" * (MAX_INLINE_BASE64_BYTES * 2)
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="limit"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="huge.bin",
+            base64_content=oversized_b64,
+            content_mime_type="application/octet-stream",
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+@patch(
+    "gdrive.drive_helpers.MAX_ZIP_MEMBER_COUNT",
+    5,
+)
+async def test_create_drive_file_rejects_zip_excessive_member_count(mock_resolve_folder):
+    """ZIP archives with too many members are rejected before testzip()."""
+    mock_resolve_folder.return_value = "folder123"
+    mock_service = Mock()
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("[Content_Types].xml", "<Types/>")
+        archive.writestr("xl/workbook.xml", "<workbook/>")
+        for i in range(6):
+            archive.writestr(f"xl/extra_{i}.xml", "x")
+
+    with pytest.raises(ValueError, match="members"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="big.xlsx",
+            base64_content=base64.b64encode(buf.getvalue()).decode("ascii"),
+            content_mime_type=(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+@patch(
+    "gdrive.drive_helpers.MAX_ZIP_UNCOMPRESSED_BYTES",
+    1024,
+)
+async def test_create_drive_file_rejects_zip_excessive_uncompressed_size(
+    mock_resolve_folder,
+):
+    """ZIP archives whose total uncompressed size exceeds the limit are rejected."""
+    mock_resolve_folder.return_value = "folder123"
+    mock_service = Mock()
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("[Content_Types].xml", "<Types/>")
+        archive.writestr("xl/workbook.xml", "<workbook/>")
+        archive.writestr("xl/bigsheet.xml", "x" * 2048)
+
+    with pytest.raises(ValueError, match="uncompressed size"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="huge.xlsx",
+            base64_content=base64.b64encode(buf.getvalue()).decode("ascii"),
+            content_mime_type=(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+@patch(
+    "gdrive.drive_helpers.MAX_ZIP_COMPRESSION_RATIO",
+    2,
+)
+async def test_create_drive_file_rejects_zip_bomb_compression_ratio(
+    mock_resolve_folder,
+):
+    """ZIP archives with suspiciously high compression ratios are rejected."""
+    mock_resolve_folder.return_value = "folder123"
+    mock_service = Mock()
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("[Content_Types].xml", "<Types/>")
+        archive.writestr("xl/workbook.xml", "<workbook/>")
+        archive.writestr("xl/pad.xml", "A" * 50_000)
+
+    with pytest.raises(ValueError, match="compression ratio"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="bomb.xlsx",
+            base64_content=base64.b64encode(buf.getvalue()).decode("ascii"),
+            content_mime_type=(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# create_drive_file - MIME type case normalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_drive_file_rejects_mixed_case_google_apps_mime():
+    """Mixed-case Google Apps MIME types are caught by normalization."""
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="import_to_google"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="Budget",
+            base64_content=base64.b64encode(_xlsx_bytes()).decode("ascii"),
+            content_mime_type="Application/VND.Google-Apps.Spreadsheet",
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+async def test_create_drive_file_normalizes_mixed_case_xlsx_mime_for_zip_validation(
+    mock_resolve_folder,
+):
+    """Mixed-case XLSX MIME types receive the same ZIP validation as lowercase."""
+    mock_resolve_folder.return_value = "folder123"
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="valid, intact archive"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="broken.xlsx",
+            base64_content=base64.b64encode(b"PK-not-an-xlsx").decode("ascii"),
+            content_mime_type=(
+                "Application/VND.Openxmlformats-Officedocument.Spreadsheetml.Sheet"
+            ),
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("gdrive.drive_tools.resolve_folder_id", new_callable=AsyncMock)
+async def test_create_drive_file_normalizes_mixed_case_odt_mime_for_zip_validation(
+    mock_resolve_folder,
+):
+    """Mixed-case OpenDocument MIME types receive ZIP validation."""
+    mock_resolve_folder.return_value = "folder123"
+    mock_service = Mock()
+
+    with pytest.raises(ValueError, match="valid, intact archive"):
+        await _unwrap(create_drive_file)(
+            service=mock_service,
+            user_google_email="user@example.com",
+            file_name="broken.odt",
+            base64_content=base64.b64encode(b"PK-not-an-odt").decode("ascii"),
+            content_mime_type="Application/VND.Oasis.Opendocument.Text",
+        )
+
+    mock_service.files.return_value.create.return_value.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_drive_file_permissions - owners
 # ---------------------------------------------------------------------------
 
 

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -276,7 +276,9 @@ async def test_create_drive_file_rejects_oversized_base64_before_decode():
     "gdrive.drive_helpers.MAX_ZIP_MEMBER_COUNT",
     5,
 )
-async def test_create_drive_file_rejects_zip_excessive_member_count(mock_resolve_folder):
+async def test_create_drive_file_rejects_zip_excessive_member_count(
+    mock_resolve_folder,
+):
     """ZIP archives with too many members are rejected before testzip()."""
     mock_resolve_folder.return_value = "folder123"
     mock_service = Mock()

--- a/tests/gdrive/test_drive_tools.py
+++ b/tests/gdrive/test_drive_tools.py
@@ -252,19 +252,20 @@ async def test_create_drive_file_rejects_empty_file_url():
 @pytest.mark.asyncio
 async def test_create_drive_file_rejects_oversized_base64_before_decode():
     """Base64 input exceeding the inline-upload limit is rejected before decoding."""
-    from gdrive.drive_helpers import MAX_INLINE_BASE64_BYTES
-
-    oversized_b64 = "A" * (MAX_INLINE_BASE64_BYTES * 2)
+    patched_limit = 6
+    max_encoded_len = ((patched_limit + 2) // 3) * 4
+    oversized_b64 = "A" * (max_encoded_len + 4)
     mock_service = Mock()
 
-    with pytest.raises(ValueError, match="limit"):
-        await _unwrap(create_drive_file)(
-            service=mock_service,
-            user_google_email="user@example.com",
-            file_name="huge.bin",
-            base64_content=oversized_b64,
-            content_mime_type="application/octet-stream",
-        )
+    with patch("gdrive.drive_helpers.MAX_INLINE_BASE64_BYTES", patched_limit):
+        with pytest.raises(ValueError, match="limit"):
+            await _unwrap(create_drive_file)(
+                service=mock_service,
+                user_google_email="user@example.com",
+                file_name="huge.bin",
+                base64_content=oversized_b64,
+                content_mime_type="application/octet-stream",
+            )
 
     mock_service.files.return_value.create.return_value.execute.assert_not_called()
 

--- a/uv.lock
+++ b/uv.lock
@@ -2432,7 +2432,7 @@ wheels = [
 
 [[package]]
 name = "workspace-mcp"
-version = "1.25.0"
+version = "1.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
Add any other context about the pull request here.

---

**⚠️ IMPORTANT:** This repository requires that you enable "Allow edits from maintainers" when creating your pull request. This allows maintainers to make small fixes and improvements directly to your branch, speeding up the review process.

To enable this setting:
1. When creating the PR, check the "Allow edits from maintainers" checkbox
2. If you've already created the PR, you can enable this in the PR sidebar under "Allow edits from maintainers"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for uploading inline base64-encoded files to Google Drive.
  * Added optional SHA-256 integrity verification for inline uploads.
  * Enabled validated base64 imports to Google Docs, Slides, and Sheets.
  * Optimized uploads by using resumable transfers only for larger files.

* **Bug Fixes**
  * Added Office/OpenDocument archive and resource-limit validation before upload or import.
  * Improved validation and error messages for unsupported or invalid upload sources.
  * Prevented direct inline uploads to Google-native file formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->