### PR TITLE
Fix/calendar recurring series read

### DIFF
--- a/gcalendar/calendar_helpers.py
+++ b/gcalendar/calendar_helpers.py
@@ -6,6 +6,7 @@ event data for display.
 """
 
 import datetime
+import json
 import logging
 import re
 from dataclasses import dataclass
@@ -307,6 +308,13 @@ def _format_event_detail_lines(
     recurring_event_id = item.get("recurringEventId")
     if recurring_event_id:
         lines.append(f"{prefix}Recurring Event ID: {recurring_event_id}")
+
+    recurrence = item.get("recurrence")
+    if recurrence:
+        # Keep the individual RFC5545 lines lossless and machine-readable. A
+        # recurring master may carry RRULE plus RDATE/EXDATE entries whose
+        # commas and semicolons make a hand-joined string ambiguous.
+        lines.append(f"{prefix}Recurrence: {json.dumps(recurrence)}")
 
     # eventType and status are omitted at their API defaults, so an ordinary
     # one-off meeting stays as compact as it was before these fields existed.

--- a/gcalendar/calendar_helpers.py
+++ b/gcalendar/calendar_helpers.py
@@ -324,9 +324,8 @@ def _format_event_detail_lines(
         lines.append(f"{prefix}Recurring Event ID: {recurring_event_id}")
 
     original_start_time = item.get("originalStartTime")
-    if original_start_time:
-        # Keep the raw boundary lossless: its timeZone is material recurrence
-        # evidence and can differ from the offset Google used for dateTime.
+    is_exception = item.get("status") != "confirmed" or not item.get("start")
+    if original_start_time and is_exception:
         lines.append(f"{prefix}Original Start Time: {json.dumps(original_start_time)}")
 
     recurrence = item.get("recurrence")

--- a/gcalendar/calendar_helpers.py
+++ b/gcalendar/calendar_helpers.py
@@ -162,14 +162,28 @@ def parse_event_boundary(item: Dict[str, Any], field: str) -> Optional[EventBoun
 
 
 def _format_event_time(item: Dict[str, Any], field: str) -> str:
-    """Format one raw Google event boundary in its own timezone, with weekday evidence."""
-    parsed = parse_event_boundary(item, field)
+    """Format one event boundary, including sparse cancelled exceptions.
+
+    Google may return cancelled instances of an unexpanded recurring series as
+    tombstones with no ``start`` or ``end``. Their ``originalStartTime`` is the
+    occurrence they exclude, so use it as the start boundary instead of
+    failing or presenting an unexplained ``None``.
+    """
+    boundary_field = field
+    if (
+        not isinstance(item.get(field), dict)
+        and field == "start"
+        and item.get("status") == "cancelled"
+    ):
+        boundary_field = "originalStartTime"
+
+    parsed = parse_event_boundary(item, boundary_field)
     if parsed is None:
-        boundary = item.get(field)
+        boundary = item.get(boundary_field)
         if isinstance(boundary, dict):
             value = boundary.get("dateTime", boundary.get("date"))
-            return value if isinstance(value, str) else str(value)
-        return str(boundary)
+            return value if isinstance(value, str) else "Unavailable"
+        return "Unavailable"
     return parsed.render()
 
 
@@ -308,6 +322,12 @@ def _format_event_detail_lines(
     recurring_event_id = item.get("recurringEventId")
     if recurring_event_id:
         lines.append(f"{prefix}Recurring Event ID: {recurring_event_id}")
+
+    original_start_time = item.get("originalStartTime")
+    if original_start_time:
+        # Keep the raw boundary lossless: its timeZone is material recurrence
+        # evidence and can differ from the offset Google used for dateTime.
+        lines.append(f"{prefix}Original Start Time: {json.dumps(original_start_time)}")
 
     recurrence = item.get("recurrence")
     if recurrence:

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -424,7 +424,7 @@ async def get_events(
         user_google_email (str): The user's Google email address. Required.
         calendar_id (str): The ID of the calendar to query. Use 'primary' for the user's primary calendar. Defaults to 'primary'. Calendar IDs can be obtained using `list_calendars`.
         event_id (Optional[str]): The ID of a specific event to retrieve. If provided, retrieves only this event and ignores time filtering parameters.
-        time_min (Optional[str]): The start of the time range (inclusive) in RFC3339 format (e.g., '2024-05-12T10:00:00Z' or '2024-05-12'). If omitted, defaults to the current time. Ignored if event_id is provided.
+        time_min (Optional[str]): The start of the time range (inclusive) in RFC3339 format (e.g., '2024-05-12T10:00:00Z' or '2024-05-12'). If omitted, defaults to the current time when single_events=True. It is omitted from unexpanded queries so recurring masters that began in the past but still have future occurrences remain discoverable. Ignored if event_id is provided.
         time_max (Optional[str]): The end of the time range (exclusive) in RFC3339 format. If omitted, events starting from `time_min` onwards are considered (up to `max_results`). Ignored if event_id is provided.
         max_results (int): The maximum number of events to return. Defaults to 25. Ignored if event_id is provided.
         query (Optional[str]): A keyword to search for within event fields (summary, description, location). Ignored if event_id is provided.
@@ -454,13 +454,20 @@ async def get_events(
         formatted_time_min = _correct_time_format_for_api(time_min, "time_min", None)
         if formatted_time_min:
             effective_time_min = formatted_time_min
-        else:
+        elif single_events:
             utc_now = datetime.datetime.now(datetime.timezone.utc)
             effective_time_min = utc_now.isoformat().replace("+00:00", "Z")
+        else:
+            effective_time_min = None
         if time_min is None:
-            logger.info(
-                f"time_min not provided, defaulting to current UTC time: {effective_time_min}"
-            )
+            if single_events:
+                logger.info(
+                    f"time_min not provided, defaulting to current UTC time: {effective_time_min}"
+                )
+            else:
+                logger.info(
+                    "time_min not provided for unexpanded events; omitting it so older recurring masters remain discoverable"
+                )
         else:
             logger.info(
                 f"time_min processing: original='{time_min}', formatted='{formatted_time_min}', effective='{effective_time_min}'"
@@ -479,11 +486,13 @@ async def get_events(
         # Build the request parameters dynamically
         request_params = {
             "calendarId": calendar_id,
-            "timeMin": effective_time_min,
             "timeMax": effective_time_max,
             "maxResults": max_results,
             "singleEvents": single_events,
         }
+
+        if effective_time_min:
+            request_params["timeMin"] = effective_time_min
 
         # The Calendar API only permits start-time ordering when recurring
         # series are expanded. Unexpanded results retain the API's stable

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -414,6 +414,7 @@ async def get_events(
     query: Optional[str] = None,
     detailed: bool = False,
     include_attachments: bool = False,
+    single_events: bool = True,
 ) -> str:
     """
     Retrieves events from a specified Google Calendar. Can retrieve a single event by ID or multiple events within a time range.
@@ -427,14 +428,15 @@ async def get_events(
         time_max (Optional[str]): The end of the time range (exclusive) in RFC3339 format. If omitted, events starting from `time_min` onwards are considered (up to `max_results`). Ignored if event_id is provided.
         max_results (int): The maximum number of events to return. Defaults to 25. Ignored if event_id is provided.
         query (Optional[str]): A keyword to search for within event fields (summary, description, location). Ignored if event_id is provided.
-        detailed (bool): Whether to return detailed event information including description, location, colour (colorId), attendees, and attendee details (response status, organizer, optional flags). Recurring instances also report the parent series ID needed to edit the whole series, and events that are not ordinary confirmed meetings report their event type (outOfOffice, workingLocation, focusTime) and status. Defaults to False.
+        detailed (bool): Whether to return detailed event information including description, location, colour (colorId), attendees, and attendee details (response status, organizer, optional flags). Recurring instances also report the parent series ID needed to edit the whole series; recurring masters report their raw RFC5545 recurrence rules; and events that are not ordinary confirmed meetings report their event type (outOfOffice, workingLocation, focusTime) and status. Defaults to False.
         include_attachments (bool): Whether to include attachment information in detailed event output. When True, shows attachment details (fileId, fileUrl, mimeType, title) for events that have attachments. Only applies when detailed=True. Set this to True when you need to view or access files that have been attached to calendar events, such as meeting documents, presentations, or other shared files. Defaults to False.
+        single_events (bool): Whether to expand recurring series into individual instances. Defaults to True for backwards compatibility. Set to False with detailed=True to retrieve recurring master events and their exact RFC5545 recurrence rules instead of inferring cadence from expanded instances.
 
     Returns:
         str: A formatted list of events (summary, start and end times, link) within the specified range, or detailed information for a single event if event_id is provided.
     """
     logger.info(
-        f"[get_events] Raw parameters - event_id: '{event_id}', time_min: '{time_min}', time_max: '{time_max}', query_len={len(query) if query else 0}, detailed: {detailed}, include_attachments: {include_attachments}"
+        f"[get_events] Raw parameters - event_id: '{event_id}', time_min: '{time_min}', time_max: '{time_max}', query_len={len(query) if query else 0}, detailed: {detailed}, include_attachments: {include_attachments}, single_events: {single_events}"
     )
 
     # Handle single event retrieval
@@ -480,9 +482,14 @@ async def get_events(
             "timeMin": effective_time_min,
             "timeMax": effective_time_max,
             "maxResults": max_results,
-            "singleEvents": True,
-            "orderBy": "startTime",
+            "singleEvents": single_events,
         }
+
+        # The Calendar API only permits start-time ordering when recurring
+        # series are expanded. Unexpanded results retain the API's stable
+        # default ordering and expose the master event's recurrence array.
+        if single_events:
+            request_params["orderBy"] = "startTime"
 
         if query:
             request_params["q"] = query

--- a/tests/gcalendar/test_get_events_detailed_fields.py
+++ b/tests/gcalendar/test_get_events_detailed_fields.py
@@ -40,15 +40,30 @@ def _mock_service(items):
 
 
 async def _ranged_detail(item, *, single_events=True):
-    """Detailed output via the time_min/time_max branch."""
-    return await _unwrap(get_events)(
-        service=_mock_service([item]),
+    """Detailed output via the time_min/time_max branch.
+
+    Also asserts the forwarded request matches what was asked for, so tests
+    using this helper check the actual events.list() call, not just the
+    formatted text it produced.
+    """
+    service = _mock_service([item])
+    result = await _unwrap(get_events)(
+        service=service,
         user_google_email="user@example.com",
         time_min="2026-04-06T00:00:00Z",
         time_max="2026-04-07T00:00:00Z",
         detailed=True,
         single_events=single_events,
     )
+
+    params = service.events().list.call_args.kwargs
+    assert params["singleEvents"] is single_events
+    if single_events:
+        assert params["orderBy"] == "startTime"
+    else:
+        assert "orderBy" not in params
+
+    return result
 
 
 async def _single_detail(item):

--- a/tests/gcalendar/test_get_events_detailed_fields.py
+++ b/tests/gcalendar/test_get_events_detailed_fields.py
@@ -239,6 +239,7 @@ async def test_basic_ranged_output_is_unchanged():
 @pytest.mark.asyncio
 @both_branches
 async def test_detailed_recurring_master_emits_lossless_recurrence(detail):
+    """Detailed output preserves every recurrence line from a series master."""
     result = await detail(RECURRING_SERIES)
 
     assert (
@@ -249,6 +250,7 @@ async def test_detailed_recurring_master_emits_lossless_recurrence(detail):
 
 @pytest.mark.asyncio
 async def test_get_events_can_return_unexpanded_recurring_masters():
+    """Unexpanded requests reach Google without start-time ordering."""
     service = _mock_service([RECURRING_SERIES])
 
     await _unwrap(get_events)(
@@ -266,7 +268,30 @@ async def test_get_events_can_return_unexpanded_recurring_masters():
 
 
 @pytest.mark.asyncio
+async def test_unexpanded_query_without_time_min_keeps_older_masters_discoverable():
+    """Do not filter masters by their first occurrence when no range was requested."""
+    older_series = {
+        **RECURRING_SERIES,
+        "start": {"dateTime": "2020-01-06T09:00:00Z"},
+        "end": {"dateTime": "2020-01-06T09:15:00Z"},
+        "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO"],
+    }
+    service = _mock_service([older_series])
+
+    await _unwrap(get_events)(
+        service=service,
+        user_google_email="user@example.com",
+        detailed=True,
+        single_events=False,
+    )
+
+    params = service.events().list.call_args.kwargs
+    assert "timeMin" not in params
+
+
+@pytest.mark.asyncio
 async def test_get_events_expands_recurring_series_by_default():
+    """The default request remains expanded and chronologically ordered."""
     service = _mock_service([RECURRING_INSTANCE])
 
     await _unwrap(get_events)(

--- a/tests/gcalendar/test_get_events_detailed_fields.py
+++ b/tests/gcalendar/test_get_events_detailed_fields.py
@@ -146,6 +146,16 @@ ORDINARY_MEETING = {
     "status": "confirmed",
 }
 
+CANCELLED_RECURRING_EXCEPTION = {
+    "id": "evt123_20260420T090000Z",
+    "status": "cancelled",
+    "recurringEventId": "evt123",
+    "originalStartTime": {
+        "dateTime": "2026-04-20T11:00:00+02:00",
+        "timeZone": "Europe/Paris",
+    },
+}
+
 
 @pytest.mark.asyncio
 @both_branches
@@ -246,6 +256,37 @@ async def test_detailed_recurring_master_emits_lossless_recurrence(detail):
         'Recurrence: ["RRULE:FREQ=WEEKLY;INTERVAL=4;BYDAY=MO", '
         '"EXDATE:20260504T090000Z"]' in result
     )
+
+
+@pytest.mark.asyncio
+@both_branches
+async def test_cancelled_recurring_exception_uses_original_start_time(detail):
+    """Sparse Google tombstones render as exclusions instead of crashing."""
+    result = await detail(CANCELLED_RECURRING_EXCEPTION)
+
+    assert "Starts: 2026-04-20T11:00:00+02:00" in result
+    assert "Ends: Unavailable" in result
+    assert (
+        'Original Start Time: {"dateTime": "2026-04-20T11:00:00+02:00", '
+        '"timeZone": "Europe/Paris"}' in result
+    )
+    assert "Recurring Event ID: evt123" in result
+    assert "Status: cancelled" in result
+
+
+@pytest.mark.asyncio
+async def test_all_day_cancelled_exception_uses_original_date():
+    """All-day exclusions use originalStartTime.date as their start boundary."""
+    result = await _ranged_detail(
+        {
+            **CANCELLED_RECURRING_EXCEPTION,
+            "originalStartTime": {"date": "2026-04-20"},
+        }
+    )
+
+    assert "Starts: 2026-04-20" in result
+    assert "Ends: Unavailable" in result
+    assert 'Original Start Time: {"date": "2026-04-20"}' in result
 
 
 @pytest.mark.asyncio

--- a/tests/gcalendar/test_get_events_detailed_fields.py
+++ b/tests/gcalendar/test_get_events_detailed_fields.py
@@ -277,9 +277,7 @@ async def test_cancelled_recurring_exception_uses_original_start_time():
 @pytest.mark.asyncio
 async def test_ranged_cancelled_exception_uses_original_start_time():
     """Unexpanded ranges render sparse cancelled exceptions."""
-    result = await _ranged_detail(
-        CANCELLED_RECURRING_EXCEPTION, single_events=False
-    )
+    result = await _ranged_detail(CANCELLED_RECURRING_EXCEPTION, single_events=False)
 
     assert "Starts: 2026-04-20T11:00:00+02:00" in result
     assert "Ends: Unavailable" in result

--- a/tests/gcalendar/test_get_events_detailed_fields.py
+++ b/tests/gcalendar/test_get_events_detailed_fields.py
@@ -102,6 +102,25 @@ RECURRING_INSTANCE = {
     "status": "confirmed",
 }
 
+RECURRING_SERIES = {
+    "id": "evt123",
+    "summary": "Standup",
+    "start": {
+        "dateTime": "2026-04-06T09:00:00Z",
+        "timeZone": "Europe/London",
+    },
+    "end": {
+        "dateTime": "2026-04-06T09:15:00Z",
+        "timeZone": "Europe/London",
+    },
+    "htmlLink": "https://calendar.google.com/event?eid=evt123",
+    "recurrence": [
+        "RRULE:FREQ=WEEKLY;INTERVAL=4;BYDAY=MO",
+        "EXDATE:20260504T090000Z",
+    ],
+    "status": "confirmed",
+}
+
 # Every optional field set to a value that renders, so parity can be asserted
 # on all four at once. RECURRING_INSTANCE deliberately can't do that: its
 # eventType is absent and its status is the suppressed default.
@@ -215,6 +234,51 @@ async def test_basic_ranged_output_is_unchanged():
 
     assert "Color ID" not in result
     assert "Recurring Event ID" not in result
+
+
+@pytest.mark.asyncio
+@both_branches
+async def test_detailed_recurring_master_emits_lossless_recurrence(detail):
+    result = await detail(RECURRING_SERIES)
+
+    assert (
+        'Recurrence: ["RRULE:FREQ=WEEKLY;INTERVAL=4;BYDAY=MO", '
+        '"EXDATE:20260504T090000Z"]' in result
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_events_can_return_unexpanded_recurring_masters():
+    service = _mock_service([RECURRING_SERIES])
+
+    await _unwrap(get_events)(
+        service=service,
+        user_google_email="user@example.com",
+        time_min="2026-04-01T00:00:00Z",
+        time_max="2026-05-01T00:00:00Z",
+        detailed=True,
+        single_events=False,
+    )
+
+    params = service.events().list.call_args.kwargs
+    assert params["singleEvents"] is False
+    assert "orderBy" not in params
+
+
+@pytest.mark.asyncio
+async def test_get_events_expands_recurring_series_by_default():
+    service = _mock_service([RECURRING_INSTANCE])
+
+    await _unwrap(get_events)(
+        service=service,
+        user_google_email="user@example.com",
+        time_min="2026-04-01T00:00:00Z",
+        time_max="2026-05-01T00:00:00Z",
+    )
+
+    params = service.events().list.call_args.kwargs
+    assert params["singleEvents"] is True
+    assert params["orderBy"] == "startTime"
 
 
 @pytest.mark.asyncio

--- a/tests/gcalendar/test_get_events_detailed_fields.py
+++ b/tests/gcalendar/test_get_events_detailed_fields.py
@@ -39,7 +39,7 @@ def _mock_service(items):
     return mock_service
 
 
-async def _ranged_detail(item):
+async def _ranged_detail(item, *, single_events=True):
     """Detailed output via the time_min/time_max branch."""
     return await _unwrap(get_events)(
         service=_mock_service([item]),
@@ -47,6 +47,7 @@ async def _ranged_detail(item):
         time_min="2026-04-06T00:00:00Z",
         time_max="2026-04-07T00:00:00Z",
         detailed=True,
+        single_events=single_events,
     )
 
 
@@ -259,10 +260,26 @@ async def test_detailed_recurring_master_emits_lossless_recurrence(detail):
 
 
 @pytest.mark.asyncio
-@both_branches
-async def test_cancelled_recurring_exception_uses_original_start_time(detail):
+async def test_cancelled_recurring_exception_uses_original_start_time():
     """Sparse Google tombstones render as exclusions instead of crashing."""
-    result = await detail(CANCELLED_RECURRING_EXCEPTION)
+    result = await _single_detail(CANCELLED_RECURRING_EXCEPTION)
+
+    assert "Starts: 2026-04-20T11:00:00+02:00" in result
+    assert "Ends: Unavailable" in result
+    assert (
+        'Original Start Time: {"dateTime": "2026-04-20T11:00:00+02:00", '
+        '"timeZone": "Europe/Paris"}' in result
+    )
+    assert "Recurring Event ID: evt123" in result
+    assert "Status: cancelled" in result
+
+
+@pytest.mark.asyncio
+async def test_ranged_cancelled_exception_uses_original_start_time():
+    """Unexpanded ranges render sparse cancelled exceptions."""
+    result = await _ranged_detail(
+        CANCELLED_RECURRING_EXCEPTION, single_events=False
+    )
 
     assert "Starts: 2026-04-20T11:00:00+02:00" in result
     assert "Ends: Unavailable" in result
@@ -281,7 +298,8 @@ async def test_all_day_cancelled_exception_uses_original_date():
         {
             **CANCELLED_RECURRING_EXCEPTION,
             "originalStartTime": {"date": "2026-04-20"},
-        }
+        },
+        single_events=False,
     )
 
     assert "Starts: 2026-04-20" in result


### PR DESCRIPTION
Spun off from #1064 

[guidupuy](https://github.com/guidupuy)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to view recurring calendar events as series or individual occurrences.
  * Recurring events that began in the past can now be discovered when viewing series.
  * Event details preserve recurrence information and original start times for exceptions.

* **Bug Fixes**
  * Improved handling of cancelled recurring-event instances.
  * Malformed or missing event times now display as “Unavailable.”

* **Tests**
  * Expanded coverage for recurring events, exclusions, cancellations, and all-day events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->