### PR TITLE
fix(auth): infer sole account in single-user mode

### DIFF
--- a/auth/account_identity.py
+++ b/auth/account_identity.py
@@ -1,0 +1,88 @@
+"""Resolve caller-visible Google account identity for legacy auth modes.
+
+Credential lookup remains strict in ``auth.google_auth``. This module only
+provides the server/decorator layer with an account identity that it can safely
+advertise or inject before a tool call reaches credential lookup.
+"""
+
+from dataclasses import dataclass
+import logging
+import os
+from typing import Optional
+
+from auth.credential_store import get_credential_store
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LegacyAccountIdentity:
+    """Account identity visible to legacy OAuth 2.0 tool calls."""
+
+    single_user: bool
+    configured_email: Optional[str]
+    stored_users: tuple[str, ...]
+
+    @property
+    def sole_stored_email(self) -> Optional[str]:
+        if self.single_user and len(self.stored_users) == 1:
+            return self.stored_users[0]
+        return None
+
+    @property
+    def default_email(self) -> Optional[str]:
+        """Return an explicit configured account, or the sole stored account."""
+        if self.configured_email:
+            return self.configured_email
+        return self.sole_stored_email
+
+    @property
+    def default_is_sole_stored(self) -> bool:
+        """True when the default was inferred rather than explicitly configured."""
+        return bool(self.sole_stored_email and not self.configured_email)
+
+    def canonical_stored_email(self, requested_email: str) -> Optional[str]:
+        """Return the stored spelling for a case-insensitive account match."""
+        requested = requested_email.strip().casefold()
+        matches = [user for user in self.stored_users if user.casefold() == requested]
+        return matches[0] if len(matches) == 1 else None
+
+
+def _normalize_email(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def get_legacy_account_identity() -> LegacyAccountIdentity:
+    """Resolve configured and locally stored identity for legacy auth.
+
+    Stored accounts are enumerated only in ``--single-user`` mode. The local
+    credential-store backend supports this operation; unsupported or unhealthy
+    stores fail soft here so tool discovery remains available and the existing
+    authentication path can report the underlying problem when invoked.
+    """
+    single_user = os.getenv("MCP_SINGLE_USER_MODE") == "1"
+    configured_email = _normalize_email(os.getenv("USER_GOOGLE_EMAIL"))
+    stored_users: tuple[str, ...] = ()
+
+    if single_user:
+        try:
+            stored_users = tuple(get_credential_store().list_users())
+        except Exception as exc:
+            logger.warning(
+                "Unable to enumerate single-user credential accounts: %s", exc
+            )
+
+    if configured_email:
+        requested = configured_email.casefold()
+        matches = [user for user in stored_users if user.casefold() == requested]
+        if len(matches) == 1:
+            configured_email = matches[0]
+
+    return LegacyAccountIdentity(
+        single_user=single_user,
+        configured_email=configured_email,
+        stored_users=stored_users,
+    )

--- a/auth/account_identity.py
+++ b/auth/account_identity.py
@@ -25,6 +25,7 @@ class LegacyAccountIdentity:
 
     @property
     def sole_stored_email(self) -> Optional[str]:
+        """Return the sole stored account when single-user mode makes it unambiguous."""
         if self.single_user and len(self.stored_users) == 1:
             return self.stored_users[0]
         return None
@@ -49,6 +50,7 @@ class LegacyAccountIdentity:
 
 
 def _normalize_email(value: Optional[str]) -> Optional[str]:
+    """Trim an optional email value and collapse blank strings to ``None``."""
     if value is None:
         return None
     normalized = value.strip()

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -13,6 +13,7 @@ from google.auth.exceptions import RefreshError
 from google.oauth2 import service_account as google_service_account
 from googleapiclient.discovery import build
 from fastmcp.server.dependencies import get_access_token, get_context
+from auth.account_identity import get_legacy_account_identity
 from auth.google_auth import get_authenticated_google_service, GoogleAuthenticationError
 from auth.gateway_identity import require_gateway_principal
 from auth.request_identity import get_request_identity
@@ -80,8 +81,9 @@ def _release_google_service_cycles() -> None:
 
 
 def _get_configured_user_google_email() -> Optional[str]:
-    """Return the configured default user email, preferring the live environment."""
-    return os.getenv("USER_GOOGLE_EMAIL") or _ENV_USER_EMAIL
+    """Return the configured or safely inferred default user email."""
+    identity_email = get_legacy_account_identity().default_email
+    return identity_email or os.getenv("USER_GOOGLE_EMAIL") or _ENV_USER_EMAIL
 
 
 # Authentication helper functions

--- a/auth/service_decorator.py
+++ b/auth/service_decorator.py
@@ -80,10 +80,15 @@ def _release_google_service_cycles() -> None:
     gc.collect()
 
 
+def _get_explicit_user_google_email() -> Optional[str]:
+    """Return only an explicitly configured default user email."""
+    return os.getenv("USER_GOOGLE_EMAIL") or _ENV_USER_EMAIL
+
+
 def _get_configured_user_google_email() -> Optional[str]:
-    """Return the configured or safely inferred default user email."""
+    """Return the explicit or safely inferred legacy OAuth default email."""
     identity_email = get_legacy_account_identity().default_email
-    return identity_email or os.getenv("USER_GOOGLE_EMAIL") or _ENV_USER_EMAIL
+    return identity_email or _get_explicit_user_google_email()
 
 
 # Authentication helper functions
@@ -304,7 +309,7 @@ async def _authenticate_service(
         Tuple of (service, actual_user_email)
     """
     if is_service_account_enabled():
-        canonical_email = _get_configured_user_google_email()
+        canonical_email = _get_explicit_user_google_email()
         if not canonical_email:
             raise GoogleAuthenticationError(
                 "Service account mode requires USER_GOOGLE_EMAIL to be configured."

--- a/core/server.py
+++ b/core/server.py
@@ -12,6 +12,7 @@ from core.warning_filters import install_startup_warning_filters
 
 install_startup_warning_filters()
 
+from auth.account_identity import get_legacy_account_identity
 from auth.auth_info_middleware import AuthInfoMiddleware
 from core.camel_case_middleware import CamelCaseArgumentsMiddleware
 from auth.google_auth import handle_auth_callback, start_auth_flow, check_client_secrets
@@ -38,6 +39,7 @@ from core.config import (
 )
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 from fastmcp.server.auth.providers.google import GoogleProvider
 from mcp.types import ToolAnnotations, Icon
 from starlette.applications import Starlette
@@ -266,13 +268,13 @@ class SecureFastMCP(FastMCP):
         return app
 
     async def list_tools(self, *, run_middleware: bool = True):
-        """Override to mark user_google_email as optional when USER_GOOGLE_EMAIL is set.
+        """Expose a safe default account when legacy auth has one canonical user.
 
-        In single-user / self-hosted mode the env var provides the default email, so
-        callers (agents, MCP adapters) should not be required to supply it.  We patch
-        the JSON schema returned by list_tools to remove 'user_google_email' from the
-        ``required`` array and inject the env-var value as the ``default``.  The
-        runtime still resolves the email correctly via the service decorator.
+        OAuth 2.1 and trusted-gateway modes derive identity from verified request
+        context. Legacy/self-hosted mode may instead have an explicit
+        ``USER_GOOGLE_EMAIL`` or, in ``--single-user`` mode, exactly one stored
+        credential account. In either case callers should not have to guess the
+        account string, so the tool schema advertises it as an optional default.
         """
         tools = list(await super().list_tools(run_middleware=run_middleware))
         if is_trust_gateway_identity():
@@ -292,8 +294,13 @@ class SecureFastMCP(FastMCP):
                 schema.update(required=required, properties=properties)
                 patched.append(tool.model_copy(update={"parameters": schema}))
             return patched
-        if not USER_GOOGLE_EMAIL or is_oauth21_enabled():
+        if is_oauth21_enabled():
             return tools
+
+        default_email = get_legacy_account_identity().default_email
+        if not default_email:
+            return tools
+
         patched = []
         for tool in tools:
             schema = dict(tool.parameters)
@@ -302,7 +309,7 @@ class SecureFastMCP(FastMCP):
                 required = [r for r in required if r != "user_google_email"]
                 props = {k: dict(v) for k, v in schema.get("properties", {}).items()}
                 if "user_google_email" in props:
-                    props["user_google_email"]["default"] = USER_GOOGLE_EMAIL
+                    props["user_google_email"]["default"] = default_email
                 schema = dict(schema, required=required, properties=props)
                 patched.append(tool.model_copy(update={"parameters": schema}))
             else:
@@ -310,13 +317,7 @@ class SecureFastMCP(FastMCP):
         return patched
 
     async def call_tool(self, name: str, arguments: Optional[dict], *args, **kwargs):
-        """Inject user_google_email before pydantic validates the call arguments.
-
-        When USER_GOOGLE_EMAIL is configured and OAuth 2.1 is not active, callers
-        (agents, adapters) are allowed to omit user_google_email.  FastMCP validates
-        arguments against the function signature BEFORE calling the tool, so we must
-        inject the default BEFORE that validation step.
-        """
+        """Resolve legacy account identity before pydantic validates tool arguments."""
         arguments = arguments or {}
         if is_trust_gateway_identity():
             # The verified gateway principal is authoritative for every tool, and the
@@ -328,12 +329,31 @@ class SecureFastMCP(FastMCP):
                 for key, value in arguments.items()
                 if key != "user_google_email"
             }
-        elif (
-            not is_oauth21_enabled()
-            and USER_GOOGLE_EMAIL
-            and "user_google_email" not in arguments
-        ):
-            arguments = {**arguments, "user_google_email": USER_GOOGLE_EMAIL}
+        elif not is_oauth21_enabled():
+            identity = get_legacy_account_identity()
+            requested_email = arguments.get("user_google_email")
+
+            if requested_email and identity.single_user:
+                canonical_email = identity.canonical_stored_email(str(requested_email))
+                if canonical_email:
+                    arguments = {
+                        **arguments,
+                        "user_google_email": canonical_email,
+                    }
+                elif identity.default_is_sole_stored and name != "start_google_auth":
+                    raise ToolError(
+                        "This single-user server has one stored credential account, "
+                        f"'{identity.sole_stored_email}', but the call requested "
+                        f"'{requested_email}'. Retry with the authenticated account, "
+                        "or use start_google_auth to explicitly authenticate a different account."
+                    )
+
+            if "user_google_email" not in arguments and identity.default_email:
+                arguments = {
+                    **arguments,
+                    "user_google_email": identity.default_email,
+                }
+
         return await super().call_tool(name, arguments, *args, **kwargs)
 
 

--- a/skills/managing-google-workspace/references/server-options.md
+++ b/skills/managing-google-workspace/references/server-options.md
@@ -15,7 +15,7 @@ These mirror the MCP server's own flags. **Default setup**: use stdio transport 
 
 | Mode | Flag / Env | Use case |
 |------|-----------|----------|
-| Single-user | `--single-user` | One user, cached credentials, CLI or local MCP. Cannot combine with OAuth 2.1. Note: `user_google_email` is still required by the tool schema -- this flag only affects credential lookup |
+| Single-user | `--single-user` | One user, cached credentials, CLI or local MCP. Cannot combine with OAuth 2.1. When exactly one credential account is stored, it becomes the safe default and callers may omit `user_google_email`; with zero or multiple stored accounts and no `USER_GOOGLE_EMAIL`, callers must still identify the account explicitly |
 | OAuth 2.0 (default) | _(no flag)_ | Multi-user with browser OAuth flow per session |
 | OAuth 2.1 | `MCP_ENABLE_OAUTH21=true` | Multi-user HTTP deployment, per-session tokens |
 | External OAuth | `EXTERNAL_OAUTH21_PROVIDER=true` | External OAuth flow with bearer tokens. Requires OAuth 2.1 |

--- a/tests/auth/test_account_identity.py
+++ b/tests/auth/test_account_identity.py
@@ -1,0 +1,88 @@
+import auth.account_identity as account_identity
+
+
+class _CredentialStore:
+    def __init__(self, users):
+        self.users = list(users)
+        self.list_calls = 0
+
+    def list_users(self):
+        self.list_calls += 1
+        return self.users
+
+
+def test_single_user_uses_sole_stored_account_as_default(monkeypatch):
+    store = _CredentialStore(["user@example.com"])
+    monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
+    monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
+    monkeypatch.setattr(account_identity, "get_credential_store", lambda: store)
+
+    identity = account_identity.get_legacy_account_identity()
+
+    assert identity.single_user is True
+    assert identity.stored_users == ("user@example.com",)
+    assert identity.sole_stored_email == "user@example.com"
+    assert identity.default_email == "user@example.com"
+    assert identity.default_is_sole_stored is True
+
+
+def test_configured_account_wins_over_sole_stored_account(monkeypatch):
+    store = _CredentialStore(["stored@example.com"])
+    monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "configured@example.com")
+    monkeypatch.setattr(account_identity, "get_credential_store", lambda: store)
+
+    identity = account_identity.get_legacy_account_identity()
+
+    assert identity.default_email == "configured@example.com"
+    assert identity.default_is_sole_stored is False
+
+
+def test_configured_account_uses_stored_casing_when_it_matches(monkeypatch):
+    store = _CredentialStore(["User@Example.com"])
+    monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "user@example.com")
+    monkeypatch.setattr(account_identity, "get_credential_store", lambda: store)
+
+    identity = account_identity.get_legacy_account_identity()
+
+    assert identity.configured_email == "User@Example.com"
+    assert identity.default_email == "User@Example.com"
+
+
+def test_multiple_stored_accounts_do_not_create_implicit_default(monkeypatch):
+    store = _CredentialStore(["a@example.com", "b@example.com"])
+    monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
+    monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
+    monkeypatch.setattr(account_identity, "get_credential_store", lambda: store)
+
+    identity = account_identity.get_legacy_account_identity()
+
+    assert identity.default_email is None
+    assert identity.sole_stored_email is None
+
+
+def test_non_single_user_mode_does_not_enumerate_credentials(monkeypatch):
+    store = _CredentialStore(["user@example.com"])
+    monkeypatch.delenv("MCP_SINGLE_USER_MODE", raising=False)
+    monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
+    monkeypatch.setattr(account_identity, "get_credential_store", lambda: store)
+
+    identity = account_identity.get_legacy_account_identity()
+
+    assert identity.single_user is False
+    assert identity.stored_users == ()
+    assert identity.default_email is None
+    assert store.list_calls == 0
+
+
+def test_canonical_stored_email_is_case_insensitive(monkeypatch):
+    store = _CredentialStore(["User@Example.com"])
+    monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
+    monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
+    monkeypatch.setattr(account_identity, "get_credential_store", lambda: store)
+
+    identity = account_identity.get_legacy_account_identity()
+
+    assert identity.canonical_stored_email("user@example.com") == "User@Example.com"
+    assert identity.canonical_stored_email("other@example.com") is None

--- a/tests/core/test_user_google_email_defaults.py
+++ b/tests/core/test_user_google_email_defaults.py
@@ -413,6 +413,39 @@ async def test_authenticate_service_account_raises_without_configured_user(
         )
 
 
+@pytest.mark.asyncio
+async def test_service_account_does_not_use_inferred_single_user_identity(monkeypatch):
+    """A sole OAuth credential must not satisfy service-account configuration."""
+    monkeypatch.setattr(service_decorator, "_ENV_USER_EMAIL", None)
+    monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
+    monkeypatch.setenv("MCP_SINGLE_USER_MODE", "1")
+    monkeypatch.setattr(service_decorator, "is_service_account_enabled", lambda: True)
+    monkeypatch.setattr(
+        service_decorator,
+        "get_legacy_account_identity",
+        lambda: LegacyAccountIdentity(
+            single_user=True,
+            configured_email=None,
+            stored_users=("stored@example.com",),
+        ),
+    )
+
+    with pytest.raises(
+        service_decorator.GoogleAuthenticationError,
+        match="Service account mode requires USER_GOOGLE_EMAIL to be configured",
+    ):
+        await service_decorator._authenticate_service(
+            use_oauth21=False,
+            service_name="gmail",
+            service_version="v1",
+            tool_name="sample_tool",
+            user_google_email="caller@example.com",
+            resolved_scopes=["scope-a"],
+            mcp_session_id=None,
+            authenticated_user=None,
+        )
+
+
 # --- DWD per-request impersonation tests ---
 
 

--- a/tests/core/test_user_google_email_defaults.py
+++ b/tests/core/test_user_google_email_defaults.py
@@ -2,8 +2,10 @@ import inspect
 from types import SimpleNamespace
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 import auth.service_decorator as service_decorator
+from auth.account_identity import LegacyAccountIdentity
 import core.server as server_module
 from core.server import SecureFastMCP
 
@@ -33,16 +35,48 @@ def test_extract_oauth20_user_email_falls_back_to_env(monkeypatch):
 
 def test_extract_oauth20_user_email_raises_without_arg_or_env(monkeypatch):
     monkeypatch.setattr(service_decorator, "_ENV_USER_EMAIL", None)
+    monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
+    monkeypatch.setattr(
+        service_decorator,
+        "get_legacy_account_identity",
+        lambda: LegacyAccountIdentity(
+            single_user=False,
+            configured_email=None,
+            stored_users=(),
+        ),
+    )
 
     with pytest.raises(Exception, match="user_google_email"):
         service_decorator._extract_oauth20_user_email((), {}, _sample_sig())
+
+
+def test_extract_oauth20_user_email_falls_back_to_sole_stored_account(monkeypatch):
+    monkeypatch.setattr(service_decorator, "_ENV_USER_EMAIL", None)
+    monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
+    monkeypatch.setattr(
+        service_decorator,
+        "get_legacy_account_identity",
+        lambda: LegacyAccountIdentity(
+            single_user=True,
+            configured_email=None,
+            stored_users=("stored@example.com",),
+        ),
+    )
+    kwargs = {}
+
+    user_google_email = service_decorator._extract_oauth20_user_email(
+        (), kwargs, _sample_sig()
+    )
+
+    assert user_google_email == "stored@example.com"
+    assert kwargs["user_google_email"] == "stored@example.com"
 
 
 @pytest.mark.asyncio
 async def test_list_tools_marks_user_google_email_optional_when_default_configured(
     monkeypatch,
 ):
-    monkeypatch.setattr(server_module, "USER_GOOGLE_EMAIL", "configured@example.com")
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "configured@example.com")
     monkeypatch.setattr(server_module, "is_oauth21_enabled", lambda: False)
     monkeypatch.setattr(server_module, "is_trust_gateway_identity", lambda: False)
 
@@ -68,7 +102,7 @@ async def test_list_tools_marks_user_google_email_optional_when_default_configur
 
 @pytest.mark.asyncio
 async def test_list_tools_leaves_schema_unchanged_without_default(monkeypatch):
-    monkeypatch.setattr(server_module, "USER_GOOGLE_EMAIL", None)
+    monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
     monkeypatch.setattr(server_module, "is_oauth21_enabled", lambda: False)
     monkeypatch.setattr(server_module, "is_trust_gateway_identity", lambda: False)
 
@@ -91,7 +125,7 @@ async def test_list_tools_leaves_schema_unchanged_without_default(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_call_tool_injects_default_email_before_validation(monkeypatch):
-    monkeypatch.setattr(server_module, "USER_GOOGLE_EMAIL", "configured@example.com")
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "configured@example.com")
     monkeypatch.setattr(server_module, "is_oauth21_enabled", lambda: False)
     monkeypatch.setattr(server_module, "is_trust_gateway_identity", lambda: False)
 
@@ -108,10 +142,128 @@ async def test_call_tool_injects_default_email_before_validation(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_single_user_sole_credential_becomes_tool_default(monkeypatch):
+    monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
+    monkeypatch.setattr(server_module, "is_oauth21_enabled", lambda: False)
+    monkeypatch.setattr(server_module, "is_trust_gateway_identity", lambda: False)
+    monkeypatch.setattr(
+        server_module,
+        "get_legacy_account_identity",
+        lambda: LegacyAccountIdentity(
+            single_user=True,
+            configured_email=None,
+            stored_users=("stored@example.com",),
+        ),
+    )
+
+    server = SecureFastMCP(name="test_server")
+
+    def echo_email(user_google_email: str) -> str:
+        return user_google_email
+
+    server.tool()(echo_email)
+
+    tool = next(
+        t
+        for t in await server.list_tools(run_middleware=False)
+        if t.name == "echo_email"
+    )
+    result = await server.call_tool("echo_email", None)
+
+    assert "user_google_email" not in tool.parameters.get("required", [])
+    assert (
+        tool.parameters["properties"]["user_google_email"]["default"]
+        == "stored@example.com"
+    )
+    assert _result_text(result) == "stored@example.com"
+
+
+@pytest.mark.asyncio
+async def test_single_user_sole_credential_rejects_wrong_caller_email(monkeypatch):
+    monkeypatch.setattr(server_module, "is_oauth21_enabled", lambda: False)
+    monkeypatch.setattr(server_module, "is_trust_gateway_identity", lambda: False)
+    monkeypatch.setattr(
+        server_module,
+        "get_legacy_account_identity",
+        lambda: LegacyAccountIdentity(
+            single_user=True,
+            configured_email=None,
+            stored_users=("stored@example.com",),
+        ),
+    )
+
+    server = SecureFastMCP(name="test_server")
+
+    def echo_email(user_google_email: str) -> str:
+        return user_google_email
+
+    server.tool()(echo_email)
+
+    with pytest.raises(ToolError, match="stored@example.com"):
+        await server.call_tool("echo_email", {"user_google_email": "wrong@example.com"})
+
+
+@pytest.mark.asyncio
+async def test_single_user_canonicalizes_case_only_email_mismatch(monkeypatch):
+    monkeypatch.setattr(server_module, "is_oauth21_enabled", lambda: False)
+    monkeypatch.setattr(server_module, "is_trust_gateway_identity", lambda: False)
+    monkeypatch.setattr(
+        server_module,
+        "get_legacy_account_identity",
+        lambda: LegacyAccountIdentity(
+            single_user=True,
+            configured_email=None,
+            stored_users=("Stored@Example.com",),
+        ),
+    )
+
+    server = SecureFastMCP(name="test_server")
+
+    def echo_email(user_google_email: str) -> str:
+        return user_google_email
+
+    server.tool()(echo_email)
+
+    result = await server.call_tool(
+        "echo_email", {"user_google_email": "stored@example.com"}
+    )
+
+    assert _result_text(result) == "Stored@Example.com"
+
+
+@pytest.mark.asyncio
+async def test_start_google_auth_allows_explicit_different_account(monkeypatch):
+    monkeypatch.setattr(server_module, "is_oauth21_enabled", lambda: False)
+    monkeypatch.setattr(server_module, "is_trust_gateway_identity", lambda: False)
+    monkeypatch.setattr(
+        server_module,
+        "get_legacy_account_identity",
+        lambda: LegacyAccountIdentity(
+            single_user=True,
+            configured_email=None,
+            stored_users=("stored@example.com",),
+        ),
+    )
+
+    server = SecureFastMCP(name="test_server")
+
+    def start_google_auth(user_google_email: str) -> str:
+        return user_google_email
+
+    server.tool()(start_google_auth)
+
+    result = await server.call_tool(
+        "start_google_auth", {"user_google_email": "new@example.com"}
+    )
+
+    assert _result_text(result) == "new@example.com"
+
+
+@pytest.mark.asyncio
 async def test_gateway_mode_strips_email_and_ignores_configured_default(monkeypatch):
     """In gateway mode call_tool must drop caller-supplied user_google_email and
     never inject USER_GOOGLE_EMAIL — tool signatures no longer accept the param."""
-    monkeypatch.setattr(server_module, "USER_GOOGLE_EMAIL", "configured@example.com")
+    monkeypatch.setenv("USER_GOOGLE_EMAIL", "configured@example.com")
     monkeypatch.setattr(server_module, "is_oauth21_enabled", lambda: False)
     monkeypatch.setattr(server_module, "is_trust_gateway_identity", lambda: True)
 
@@ -132,7 +284,7 @@ async def test_gateway_mode_strips_email_and_ignores_configured_default(monkeypa
 
 @pytest.mark.asyncio
 async def test_gateway_mode_hides_start_google_auth_email(monkeypatch):
-    monkeypatch.setattr(server_module, "USER_GOOGLE_EMAIL", None)
+    monkeypatch.delenv("USER_GOOGLE_EMAIL", raising=False)
     monkeypatch.setattr(server_module, "is_oauth21_enabled", lambda: False)
     monkeypatch.setattr(server_module, "is_trust_gateway_identity", lambda: True)
 


### PR DESCRIPTION
## Description

Addresses #642 by resolving a safe caller-visible account identity at the existing server/decorator boundary instead of weakening credential lookup.

In `--single-user` mode, when exactly one credential account is stored and `USER_GOOGLE_EMAIL` is not configured, the server now:

- advertises the stored account as the optional `user_google_email` default in tool schemas;
- injects that account before FastMCP argument validation when the caller omits the email;
- canonicalizes case-only mismatches to the stored account spelling;
- rejects a materially different caller-supplied email with a clear error instead of triggering unnecessary OAuth;
- still allows `start_google_auth` to explicitly authenticate a different account.

The strict lookup behavior in `get_credentials()` is intentionally unchanged, preserving the account-isolation protection added in #729. Explicit `USER_GOOGLE_EMAIL`, multi-account single-user setups, OAuth 2.1, trusted-gateway identity, and service-account/DWD paths keep their existing behavior.

This revisits #642 and builds on the investigation and propagation work in #765. The implementation differs by using the server/tool-contract layer introduced in #644 rather than falling back to another credential inside `get_credentials()`.

The original #642 report suggested unconditionally overriding any caller-supplied email with the sole credential-file identity. This PR intentionally does **not** do that for materially different addresses: #718/#729 subsequently established strict wrong-account isolation after silent credential substitution caused operations to run against the wrong Google account. The compatibility goal here is therefore narrower and safer: avoid unnecessary OAuth when identity is omitted or differs only by canonical casing, while failing explicitly on a genuinely different requested account.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

Validation performed against current `main`:

- `uv sync --extra test --frozen`
- `uvx ruff@0.15.22 check`
- `uvx ruff@0.15.22 format --check`
- `uv run pytest` — **1815 passed, 2 skipped**
- `git diff --check upstream/main...HEAD`
- manual single-credential smoke test: schema default discovery and omitted-email invocation both resolved to the stored account without starting OAuth

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

The earlier #765 approach correctly identified the stale/profile-derived caller-email problem and the need to propagate the resolved account downstream. This PR credits that work but keeps credential lookup strict: account inference happens before credential selection, so a guessed email cannot cause credentials for another account to be used or persisted under the wrong identity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic account selection for single-user setups with one stored Google credential.
  * Tool requests support case-insensitive email matching and use the canonical stored address.
  * Requests for unavailable accounts now return a clear error.
  * Authentication can use the sole stored account when no email is specified.
  * Service-account authentication still requires an explicitly configured email.

* **Documentation**
  * Clarified when `user_google_email` must be provided for single-user configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
