### PR TITLE
feat(gmail): add permanent draft deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This project is [MIT licensed](LICENSE) — not "open core," not "source availab
 <tr>
 <td align="center" width="25%">
 <h3>📧</h3><a href="https://workspacemcp.com/gmail?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=services-gmail"><b>Gmail</b></a><br>
-<sub>15 tools - search, send, draft,<br>labels, filters, attachments</sub>
+<sub>16 tools - search, send, drafts,<br>labels, filters, attachments</sub>
 </td>
 <td align="center" width="25%">
 <h3>📁</h3><a href="https://workspacemcp.com/google-drive?utm_source=github.com&utm_medium=referral&utm_campaign=readme&utm_content=services-google-drive"><b>Drive</b></a><br>

--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -12,6 +12,7 @@ gmail:
     - list_gmail_labels
     - manage_gmail_label
     - draft_gmail_message
+    - delete_gmail_draft
     - list_gmail_filters
     - manage_gmail_filter
 

--- a/gmail/gmail_helpers.py
+++ b/gmail/gmail_helpers.py
@@ -16,6 +16,8 @@ from typing import Any, Callable, Dict, Iterable, List, Literal, Mapping, Option
 from fastmcp.exceptions import ToolError as ToolExecutionError
 from googleapiclient.errors import HttpError
 
+from core.utils import GOOGLE_API_WRITE_RETRIES, UserInputError
+
 logger = logging.getLogger(__name__)
 
 RAW_BODY_TRUNCATE_LIMIT = 20000
@@ -43,6 +45,56 @@ GMAIL_METADATA_HEADERS = [
     "Precedence",
     "List-Id",
 ]
+
+
+async def _delete_gmail_draft_by_identifier(service: Any, draft_identifier: str) -> str:
+    """Resolve and permanently delete exactly one Gmail draft.
+
+    ``draft_identifier`` may be either a Draft resource ID or the contained
+    Gmail Message ID. All draft pages are scanned so identifiers from older
+    search results remain usable. Resolution refuses ambiguous identifiers
+    rather than risking deletion of the wrong draft.
+    """
+    matching_draft_ids = set()
+    page_token = None
+
+    while True:
+        request_params = {"userId": "me", "maxResults": 500}
+        if page_token:
+            request_params["pageToken"] = page_token
+        response = await asyncio.to_thread(
+            service.users().drafts().list(**request_params).execute
+        )
+        matching_draft_ids.update(
+            draft.get("id")
+            for draft in response.get("drafts") or []
+            if isinstance(draft, dict)
+            and draft.get("id")
+            and (
+                draft.get("id") == draft_identifier
+                or (draft.get("message") or {}).get("id") == draft_identifier
+            )
+        )
+        page_token = response.get("nextPageToken")
+        if not page_token:
+            break
+
+    if not matching_draft_ids:
+        raise UserInputError(
+            f"No Gmail draft found for identifier '{draft_identifier}'."
+        )
+    if len(matching_draft_ids) > 1:
+        raise UserInputError(
+            f"Identifier '{draft_identifier}' matches multiple Gmail drafts; "
+            "no draft was deleted."
+        )
+
+    draft_id = matching_draft_ids.pop()
+    await asyncio.to_thread(
+        service.users().drafts().delete(userId="me", id=draft_id).execute,
+        num_retries=GOOGLE_API_WRITE_RETRIES,
+    )
+    return f"Draft permanently deleted! Draft ID: {draft_id}"
 
 
 def _normalize_email(address: str) -> str:

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -61,6 +61,7 @@ from gmail.gmail_helpers import (
     RAW_BODY_TRUNCATE_LIMIT,
     _analyze_thread_ownership_impl,
     _build_forward_content,
+    _delete_gmail_draft_by_identifier,
     _derive_reply_all_recipients,
     _derive_reply_headers,
     _fetch_with_retry,
@@ -3081,6 +3082,53 @@ async def draft_gmail_message(
         attached_count, requested_attachment_count
     )
     return f"Draft created{attachment_info}! Draft ID: {draft_id}"
+
+
+@server.tool(
+    title="Delete Gmail Draft",
+    annotations=ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors("delete_gmail_draft", service_type="gmail")
+@require_google_service("gmail", GMAIL_COMPOSE_SCOPE)
+async def delete_gmail_draft(
+    service,
+    user_google_email: str,
+    draft_identifier: Annotated[
+        str,
+        Field(
+            description="Draft ID returned by draft_gmail_message, or the contained Gmail Message ID returned by search_gmail_messages for a draft. The matching draft is permanently deleted."
+        ),
+    ],
+) -> str:
+    """Permanently delete one Gmail draft without sending it.
+
+    The identifier may be either the Draft resource ID returned when the draft
+    was created or the contained Gmail Message ID found with an ``in:drafts``
+    message search. The server resolves either form across all draft pages and
+    deletes only when exactly one draft matches. Gmail draft deletion is
+    immediate and does not move the draft to Trash.
+
+    Args:
+        user_google_email: The user's Google email address for authentication.
+        draft_identifier: A Gmail Draft ID or contained draft Message ID.
+
+    Returns:
+        Confirmation containing the canonical Draft ID that was deleted.
+
+    Raises:
+        UserInputError: If no draft or more than one draft matches the identifier.
+    """
+    logger.info(
+        "[delete_gmail_draft] Invoked. Email: '%s', identifier: '%s'",
+        user_google_email,
+        draft_identifier,
+    )
+    return await _delete_gmail_draft_by_identifier(service, draft_identifier)
 
 
 def _format_thread_content(

--- a/skills/managing-google-workspace/SKILL.md
+++ b/skills/managing-google-workspace/SKILL.md
@@ -75,6 +75,7 @@ For server options, transport, auth modes, tool filtering, and deployment: [refe
 | Read multiple threads | `get_gmail_threads_content_batch` |
 | Send email (new or reply) | `send_gmail_message` |
 | Create draft | `draft_gmail_message` |
+| Permanently delete draft | `delete_gmail_draft` |
 | Download attachment | `get_gmail_attachment_content` |
 | Add/remove labels (one) | `modify_gmail_message_labels` |
 | Add/remove labels (batch) | `batch_modify_gmail_message_labels` |

--- a/skills/managing-google-workspace/references/gmail.md
+++ b/skills/managing-google-workspace/references/gmail.md
@@ -4,7 +4,7 @@ MCP tools for Gmail message search, sending, drafting, labels, and filters. All 
 
 ## Contents
 - Search & Read: search_gmail_messages, get_gmail_message_content, get_gmail_messages_content_batch, get_gmail_thread_content, get_gmail_threads_content_batch, get_gmail_attachment_content
-- Send & Draft: send_gmail_message, draft_gmail_message
+- Send & Draft: send_gmail_message, draft_gmail_message, delete_gmail_draft
 - Label Management: list_gmail_labels, manage_gmail_label, modify_gmail_message_labels, batch_modify_gmail_message_labels
 - Filter Management: list_gmail_filters, manage_gmail_filter
 - Tips
@@ -115,6 +115,16 @@ Create a draft. Same capabilities as send but with additional signature/quoting 
 
 Operational Gmail settings errors such as rate limits abort draft creation instead of silently falling back to a potentially unintended sender.
 
+### delete_gmail_draft
+Immediately and permanently delete one draft without sending it. This does not move the draft to Trash.
+
+| Parameter | Type | Required | Default | Notes |
+|-----------|------|----------|---------|-------|
+| user_google_email | string | yes | | |
+| draft_identifier | string | yes | | Either the Draft ID returned by `draft_gmail_message` or the contained Message ID returned by an `in:drafts` search |
+
+The tool scans all draft pages, resolves either identifier form, and deletes only when exactly one draft matches. If multiple drafts share a thread, use each draft's unique Draft ID or contained Message ID rather than the shared Thread ID.
+
 ---
 
 ## Label Management
@@ -218,6 +228,7 @@ Create or delete a filter.
 
 ### Drafts vs Send
 - Use `draft_gmail_message` when you want the user to review before sending. It supports `include_signature` (auto-appends Gmail signature) and `quote_original` (includes quoted reply text).
+- Use `delete_gmail_draft` to permanently remove a draft. For a safe revision workflow, create the replacement successfully before deleting the previous draft.
 - Use `send_gmail_message` for immediate delivery.
 
 ### Attachments

--- a/tests/core/test_tool_tier_loader.py
+++ b/tests/core/test_tool_tier_loader.py
@@ -1,0 +1,10 @@
+"""Tests for tool-tier behavior loaded from the shipped YAML configuration."""
+
+from core.tool_tier_loader import ToolTierLoader
+
+
+def test_gmail_extended_tier_exposes_delete_gmail_draft():
+    """Removing tier registration must make the new tool undiscoverable."""
+    tools = ToolTierLoader().get_tools_for_tier("extended", services=["gmail"])
+
+    assert "delete_gmail_draft" in tools

--- a/tests/gmail/test_delete_gmail_draft.py
+++ b/tests/gmail/test_delete_gmail_draft.py
@@ -1,0 +1,249 @@
+"""Tests for deleting Gmail drafts by either draft or contained message ID."""
+
+from unittest.mock import AsyncMock, Mock, call
+
+import pytest
+
+from auth.scopes import GMAIL_COMPOSE_SCOPE
+from core.server import server
+from core.utils import GOOGLE_API_WRITE_RETRIES, UserInputError
+from gmail.gmail_helpers import _delete_gmail_draft_by_identifier
+import gmail.gmail_tools as gmail_tools
+
+
+def _unwrap(tool):
+    """Unwrap FastMCP and service decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _request(response):
+    request = Mock()
+    request.execute.return_value = response
+    return request
+
+
+def _build_service(*draft_pages):
+    service = Mock()
+    service.users().drafts().list.side_effect = [_request(page) for page in draft_pages]
+    service.users().drafts().delete.return_value = _request({})
+    return service
+
+
+@pytest.mark.asyncio
+async def test_delete_gmail_draft_accepts_draft_id():
+    """Removing draft-ID resolution or the delete call must fail this test."""
+    service = _build_service(
+        {
+            "drafts": [
+                {
+                    "id": "draft-123",
+                    "message": {"id": "message-123", "threadId": "thread-1"},
+                }
+            ]
+        }
+    )
+    result = await _delete_gmail_draft_by_identifier(service, "draft-123")
+
+    service.users().drafts().delete.assert_called_once_with(userId="me", id="draft-123")
+    service.users().drafts().delete.return_value.execute.assert_called_once_with(
+        num_retries=GOOGLE_API_WRITE_RETRIES
+    )
+    assert result == "Draft permanently deleted! Draft ID: draft-123"
+
+
+@pytest.mark.asyncio
+async def test_delete_gmail_draft_accepts_contained_message_id():
+    """Removing contained-message-ID resolution must fail this test."""
+    service = _build_service(
+        {
+            "drafts": [
+                {
+                    "id": "draft-456",
+                    "message": {"id": "message-456", "threadId": "thread-1"},
+                }
+            ]
+        }
+    )
+
+    result = await _delete_gmail_draft_by_identifier(service, "message-456")
+
+    service.users().drafts().delete.assert_called_once_with(userId="me", id="draft-456")
+    assert result == "Draft permanently deleted! Draft ID: draft-456"
+
+
+@pytest.mark.asyncio
+async def test_delete_gmail_draft_follows_draft_pagination():
+    """Removing page-token traversal must fail this test."""
+    service = _build_service(
+        {
+            "drafts": [
+                {
+                    "id": "draft-first-page",
+                    "message": {"id": "message-first-page", "threadId": "thread-1"},
+                }
+            ],
+            "nextPageToken": "page-2",
+        },
+        {
+            "drafts": [
+                {
+                    "id": "draft-second-page",
+                    "message": {"id": "message-second-page", "threadId": "thread-2"},
+                }
+            ]
+        },
+    )
+
+    result = await _delete_gmail_draft_by_identifier(service, "message-second-page")
+
+    assert service.users().drafts().list.call_args_list == [
+        call(userId="me", maxResults=500),
+        call(userId="me", maxResults=500, pageToken="page-2"),
+    ]
+    service.users().drafts().delete.assert_called_once_with(
+        userId="me", id="draft-second-page"
+    )
+    assert result == "Draft permanently deleted! Draft ID: draft-second-page"
+
+
+@pytest.mark.asyncio
+async def test_delete_gmail_draft_refuses_ambiguous_identifier():
+    """Removing ambiguity protection must fail this destructive-operation test."""
+    service = _build_service(
+        {
+            "drafts": [
+                {
+                    "id": "shared-identifier",
+                    "message": {"id": "message-one", "threadId": "thread-1"},
+                },
+                {
+                    "id": "draft-two",
+                    "message": {
+                        "id": "shared-identifier",
+                        "threadId": "thread-2",
+                    },
+                },
+            ]
+        }
+    )
+
+    with pytest.raises(UserInputError, match="matches multiple Gmail drafts"):
+        await _delete_gmail_draft_by_identifier(service, "shared-identifier")
+
+    service.users().drafts().delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_gmail_draft_scans_later_pages_for_ambiguity():
+    """A first-page match must not bypass a collision on a later page."""
+    service = _build_service(
+        {
+            "drafts": [
+                {
+                    "id": "shared-identifier",
+                    "message": {"id": "message-one", "threadId": "thread-1"},
+                }
+            ],
+            "nextPageToken": "page-2",
+        },
+        {
+            "drafts": [
+                {
+                    "id": "draft-two",
+                    "message": {
+                        "id": "shared-identifier",
+                        "threadId": "thread-2",
+                    },
+                }
+            ]
+        },
+    )
+
+    with pytest.raises(UserInputError, match="matches multiple Gmail drafts"):
+        await _delete_gmail_draft_by_identifier(service, "shared-identifier")
+
+    assert service.users().drafts().list.call_args_list == [
+        call(userId="me", maxResults=500),
+        call(userId="me", maxResults=500, pageToken="page-2"),
+    ]
+    service.users().drafts().delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_gmail_draft_selects_one_of_multiple_drafts_in_same_thread():
+    """Choosing by thread instead of the contained Message ID must fail this test."""
+    service = _build_service(
+        {
+            "drafts": [
+                {
+                    "id": "draft-old",
+                    "message": {"id": "message-old", "threadId": "shared-thread"},
+                },
+                {
+                    "id": "draft-new",
+                    "message": {"id": "message-new", "threadId": "shared-thread"},
+                },
+            ]
+        }
+    )
+
+    result = await _delete_gmail_draft_by_identifier(service, "message-old")
+
+    service.users().drafts().delete.assert_called_once_with(userId="me", id="draft-old")
+    assert "draft-old" in result
+
+
+@pytest.mark.asyncio
+async def test_delete_gmail_draft_rejects_unknown_identifier_without_deleting():
+    """Deleting an arbitrary draft when resolution misses must fail this test."""
+    service = _build_service(
+        {
+            "drafts": [
+                {
+                    "id": "draft-existing",
+                    "message": {
+                        "id": "message-existing",
+                        "threadId": "thread-1",
+                    },
+                }
+            ]
+        }
+    )
+
+    with pytest.raises(UserInputError, match="No Gmail draft found"):
+        await _delete_gmail_draft_by_identifier(service, "not-a-draft")
+
+    service.users().drafts().delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_gmail_draft_tool_delegates_response_formatting(monkeypatch):
+    service = Mock()
+    helper = AsyncMock(return_value="helper-formatted response")
+    monkeypatch.setattr(gmail_tools, "_delete_gmail_draft_by_identifier", helper)
+
+    result = await _unwrap(gmail_tools.delete_gmail_draft)(
+        service=service,
+        user_google_email="user@example.com",
+        draft_identifier="draft-123",
+    )
+
+    helper.assert_awaited_once_with(service, "draft-123")
+    assert result == "helper-formatted response"
+
+
+@pytest.mark.asyncio
+async def test_delete_gmail_draft_declares_scope_and_destructive_annotations():
+    registered_tools = {tool.name: tool for tool in await server.list_tools()}
+    annotations = registered_tools["delete_gmail_draft"].annotations
+
+    assert gmail_tools.delete_gmail_draft._required_google_scopes == [
+        GMAIL_COMPOSE_SCOPE
+    ]
+    assert annotations.readOnlyHint is False
+    assert annotations.destructiveHint is True
+    assert annotations.idempotentHint is False
+    assert annotations.openWorldHint is True


### PR DESCRIPTION
## Description

Adds `delete_gmail_draft`, an extended-tier Gmail tool that permanently deletes exactly one draft.

Taylor can create drafts but currently has no tool to remove them. Gmail requires a Draft ID for deletion, but callers may instead have the draft's contained Message ID from search results. The tool accepts either identifier, resolves it to exactly one Draft ID, and refuses to delete when the identifier is unknown or ambiguous.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation update

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

Automated verification:

- Full test suite: 1,814 passed, 2 skipped
- Ruff lint: passed
- Ruff formatting check: passed
- Git diff check: passed

Manual Gmail validation covered:

- A standalone draft
- A reply draft automatically targeting the latest eligible message in a thread
- Two simultaneous drafts targeting different messages in the same thread
- Two simultaneous drafts both targeting the latest message in the same thread
- Deletion using a Draft ID
- Deletion using a contained Gmail Message ID
- Deletion isolation: removing one draft left its sibling intact
- Correct `threadId` and RFC `In-Reply-To` values for every threaded draft
- Complete cleanup of all disposable test drafts

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

- Uses the existing `gmail.compose` OAuth scope already required by draft creation
- Declares the operation as destructive in its MCP annotations
- Registers the tool only in the Gmail `extended` tier
- Leaves `search_gmail_messages` and its response format unchanged
- Distinguishes drafts in the same thread using their unique Draft or contained Message IDs, never their shared Thread ID


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Gmail tool to permanently delete drafts using either a Draft ID or contained Message ID.
  * Safely handles pagination and prevents deletion when identifiers are missing or ambiguous.
  * Added the tool to the extended Gmail tool tier.

* **Documentation**
  * Updated Gmail service counts, tool references, and draft-management guidance.

* **Tests**
  * Added coverage for deletion scenarios, pagination, ambiguity protection, permissions, and tool behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->