### PR TITLE
fix(auth): don't exit the stdio server when the callback port range is busy

### DIFF
--- a/auth/port_resolver.py
+++ b/auth/port_resolver.py
@@ -8,6 +8,7 @@ redirect URIs are composed from the actual bound port.
 
 from __future__ import annotations
 
+import errno
 import logging
 import os
 import socket
@@ -49,6 +50,10 @@ def _is_port_free(host: str, port: int) -> bool:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.settimeout(0.5)
             if s.connect_ex(("127.0.0.1", port)) == 0:
+                logger.debug(
+                    "Port resolver: port %d rejected -- existing listener on 127.0.0.1",
+                    port,
+                )
                 return False
     except OSError:
         pass
@@ -57,7 +62,16 @@ def _is_port_free(host: str, port: int) -> bool:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind((host, port))
         return True
-    except OSError:
+    except OSError as exc:
+        # Every bind failure used to collapse to a bare "busy", which made a
+        # misconfigured bind host indistinguishable from a real collision.
+        logger.debug(
+            "Port resolver: bind %s:%d failed -- %s (%s)",
+            host,
+            port,
+            errno.errorcode.get(exc.errno, exc.errno),
+            exc.strerror,
+        )
         return False
 
 
@@ -65,6 +79,7 @@ def resolve_port(
     preferred: Optional[int] = None,
     fallback_count: Optional[int] = None,
     host: Optional[str] = None,
+    allow_fallback: bool = True,
 ) -> int:
     """
     Resolve the first available port in [preferred, preferred+1, ..., preferred+fallback_count].
@@ -106,8 +121,16 @@ def resolve_port(
             ) from exc
     if host is None:
         host = os.getenv("WORKSPACE_MCP_HOST", "0.0.0.0")
+    if not allow_fallback:
+        fallback_count = 0
 
     candidates = _candidate_ports(preferred, fallback_count)
+    logger.debug(
+        "Port resolver: probing %s on host %s (fallback %s)",
+        candidates,
+        host,
+        "enabled" if allow_fallback else "disabled",
+    )
     for port in candidates:
         if _is_port_free(host, port):
             if port == preferred:

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import socket
 import sys
 from functools import partial
 from importlib import metadata, import_module
+from urllib.parse import urlparse
 from dotenv import load_dotenv
 from core.startup_ui import StartupDisplay, collapse_home, wordmark_lines
 
@@ -127,6 +128,35 @@ install_noisy_log_filters()
 configure_file_logging()
 
 
+def _loopback_redirect_port(redirect_uri: str | None) -> int | None:
+    """
+    Return the port an explicit loopback GOOGLE_OAUTH_REDIRECT_URI targets.
+
+    OAuthConfig._get_redirect_uri() hands back an explicit GOOGLE_OAUTH_REDIRECT_URI
+    unchanged, so that URI -- not WORKSPACE_MCP_PORT -- decides where Google sends
+    the browser. The stdio callback listener therefore has to bind the URI's port.
+
+    Returns None when the URI is absent, unparseable, carries no explicit port, or
+    points somewhere other than loopback. A non-loopback URI means a reverse proxy
+    fronts the callback, and its public port says nothing about which local port the
+    listener should own.
+    """
+    if not redirect_uri:
+        return None
+    try:
+        parsed = urlparse(redirect_uri)
+        port = parsed.port
+    except ValueError:
+        # urlparse raises on a malformed port; fall back to the env-var default.
+        return None
+    if port is None:
+        return None
+    hostname = (parsed.hostname or "").lower()
+    if hostname not in {"localhost", "127.0.0.1", "::1"}:
+        return None
+    return port
+
+
 def resolve_stdio_callback_port() -> None:
     """
     Late-bind the legacy stdio OAuth callback port.
@@ -135,12 +165,16 @@ def resolve_stdio_callback_port() -> None:
     normal PORT/WORKSPACE_MCP_PORT semantics. The fallback range only exists for
     the standalone stdio callback listener.
 
-    Two rules keep this from killing an otherwise healthy server:
+    Three rules keep this correct and non-lethal:
 
-      * When GOOGLE_OAUTH_REDIRECT_URI is set explicitly the callback port is
-        pinned by whatever is registered with Google, so falling back to a
-        neighbouring port would only produce a redirect_uri mismatch. Probe the
-        preferred port and nothing else.
+      * When GOOGLE_OAUTH_REDIRECT_URI points at a loopback address with an
+        explicit port, that port IS the callback port -- OAuthConfig returns the
+        explicit URI verbatim, so Google sends the browser there no matter what
+        WORKSPACE_MCP_PORT says. Bind it, or the listener and the redirect end
+        up on different ports and the auth flow hangs.
+      * When the redirect URI is set at all, never fall back to a neighbouring
+        port: the advertised URI cannot follow, so a fallback port guarantees a
+        redirect_uri mismatch. Probe the pinned port and nothing else.
       * A busy port is never fatal. The callback listener starts lazily and a
         host that already holds cached credentials may never need it -- and MCP
         clients routinely launch more than one copy of a stdio server, so
@@ -148,10 +182,11 @@ def resolve_stdio_callback_port() -> None:
     """
     from auth.port_resolver import resolve_port, NoAvailablePortError, PortConfigError
 
-    pinned_redirect = bool(os.getenv("GOOGLE_OAUTH_REDIRECT_URI"))
+    redirect_uri = os.getenv("GOOGLE_OAUTH_REDIRECT_URI")
+    pinned_port = _loopback_redirect_port(redirect_uri)
 
     try:
-        resolve_port(allow_fallback=not pinned_redirect)
+        resolve_port(preferred=pinned_port, allow_fallback=not redirect_uri)
     except PortConfigError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/main.py
+++ b/main.py
@@ -136,10 +136,18 @@ def _loopback_redirect_port(redirect_uri: str | None) -> int | None:
     unchanged, so that URI -- not WORKSPACE_MCP_PORT -- decides where Google sends
     the browser. The stdio callback listener therefore has to bind the URI's port.
 
-    Returns None when the URI is absent, unparseable, carries no explicit port, or
-    points somewhere other than loopback. A non-loopback URI means a reverse proxy
-    fronts the callback, and its public port says nothing about which local port the
-    listener should own.
+    Returns None -- leaving WORKSPACE_MCP_PORT in charge -- unless the URI is an
+    http:// loopback address carrying an explicit port. Each exclusion is load-bearing:
+
+      * Not loopback: a reverse proxy fronts the callback, and its public port says
+        nothing about which local port the listener should own.
+      * https:// even on loopback: MinimalOAuthServer builds its uvicorn.Config
+        without ssl_keyfile/ssl_certfile, so it can only ever serve plaintext. An
+        https loopback URI therefore means a local TLS terminator (Caddy, stunnel)
+        owns that port and forwards to the plaintext listener on a *different* one.
+        Binding the URI's port would collide with the terminator; WORKSPACE_MCP_PORT
+        is what names the backend port in that topology.
+      * No explicit port, malformed port, or no URI: nothing to pin.
     """
     if not redirect_uri:
         return None
@@ -150,6 +158,8 @@ def _loopback_redirect_port(redirect_uri: str | None) -> int | None:
         # urlparse raises on a malformed port; fall back to the env-var default.
         return None
     if port is None:
+        return None
+    if (parsed.scheme or "").lower() != "http":
         return None
     hostname = (parsed.hostname or "").lower()
     if hostname not in {"localhost", "127.0.0.1", "::1"}:

--- a/main.py
+++ b/main.py
@@ -134,14 +134,34 @@ def resolve_stdio_callback_port() -> None:
     Streamable HTTP/OAuth 2.1 owns its main HTTP port directly and must keep the
     normal PORT/WORKSPACE_MCP_PORT semantics. The fallback range only exists for
     the standalone stdio callback listener.
+
+    Two rules keep this from killing an otherwise healthy server:
+
+      * When GOOGLE_OAUTH_REDIRECT_URI is set explicitly the callback port is
+        pinned by whatever is registered with Google, so falling back to a
+        neighbouring port would only produce a redirect_uri mismatch. Probe the
+        preferred port and nothing else.
+      * A busy port is never fatal. The callback listener starts lazily and a
+        host that already holds cached credentials may never need it -- and MCP
+        clients routinely launch more than one copy of a stdio server, so
+        exiting on a collision takes down a copy that would otherwise work.
     """
     from auth.port_resolver import resolve_port, NoAvailablePortError, PortConfigError
 
+    pinned_redirect = bool(os.getenv("GOOGLE_OAUTH_REDIRECT_URI"))
+
     try:
-        resolve_port()
-    except (NoAvailablePortError, PortConfigError) as exc:
+        resolve_port(allow_fallback=not pinned_redirect)
+    except PortConfigError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
+    except NoAvailablePortError as exc:
+        logger.warning(
+            "%s Continuing without a reserved callback port -- OAuth re-authorization "
+            "will fail until the port frees up, but cached credentials keep working.",
+            exc,
+        )
+        os.environ.pop("WORKSPACE_MCP_RESOLVED_PORT", None)
     reload_oauth_config()
 
 

--- a/tests/auth/test_port_resolver.py
+++ b/tests/auth/test_port_resolver.py
@@ -142,3 +142,59 @@ def test_lazy_workspace_mcp_port_preserves_port_precedence_without_resolver(
     monkeypatch.delenv("WORKSPACE_MCP_RESOLVED_PORT", raising=False)
     cfg = _import_fresh("core.config")
     assert cfg.WORKSPACE_MCP_PORT == 8000
+
+
+def test_allow_fallback_false_probes_only_preferred():
+    """A pinned redirect URI means neighbouring ports are useless -- don't try them."""
+    pr = _import_fresh("auth.port_resolver")
+    p = _free_port()
+    with _hold_port(p), pytest.raises(pr.NoAvailablePortError):
+        pr.resolve_port(
+            preferred=p, fallback_count=4, host="127.0.0.1", allow_fallback=False
+        )
+
+
+def test_allow_fallback_false_still_binds_free_preferred():
+    pr = _import_fresh("auth.port_resolver")
+    p = _free_port()
+    bound = pr.resolve_port(
+        preferred=p, fallback_count=4, host="127.0.0.1", allow_fallback=False
+    )
+    assert bound == p
+
+
+def test_stdio_resolver_survives_exhausted_range(monkeypatch):
+    """A busy callback port must not take down the whole stdio server."""
+    import main as main_module
+
+    p = _free_port()
+    monkeypatch.setenv("WORKSPACE_MCP_PORT", str(p))
+    monkeypatch.setenv("WORKSPACE_MCP_PORT_FALLBACK_COUNT", "0")
+    monkeypatch.setenv("WORKSPACE_MCP_HOST", "127.0.0.1")
+    monkeypatch.delenv("GOOGLE_OAUTH_REDIRECT_URI", raising=False)
+
+    with _hold_port(p):
+        main_module.resolve_stdio_callback_port()
+
+    assert os.environ["WORKSPACE_MCP_PORT"] == str(p)
+    assert "WORKSPACE_MCP_RESOLVED_PORT" not in os.environ
+
+
+def test_stdio_resolver_pins_port_when_redirect_uri_is_explicit(monkeypatch):
+    """With GOOGLE_OAUTH_REDIRECT_URI set, the resolver must not wander off-port."""
+    import main as main_module
+
+    p = _free_port()
+    monkeypatch.setenv("WORKSPACE_MCP_PORT", str(p))
+    monkeypatch.setenv("WORKSPACE_MCP_PORT_FALLBACK_COUNT", "4")
+    monkeypatch.setenv("WORKSPACE_MCP_HOST", "127.0.0.1")
+    monkeypatch.setenv(
+        "GOOGLE_OAUTH_REDIRECT_URI", f"http://localhost:{p}/oauth2callback"
+    )
+
+    with _hold_port(p):
+        main_module.resolve_stdio_callback_port()
+
+    # Fallback would have picked p+1; pinned mode leaves the port untouched.
+    assert os.environ["WORKSPACE_MCP_PORT"] == str(p)
+    assert "WORKSPACE_MCP_RESOLVED_PORT" not in os.environ

--- a/tests/test_main_permissions_tier.py
+++ b/tests/test_main_permissions_tier.py
@@ -54,19 +54,43 @@ def test_resolve_stdio_callback_port_marks_resolved_port(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[str] = []
+    seen_fallback: list[bool] = []
 
-    def fake_resolve_port() -> None:
+    def fake_resolve_port(allow_fallback: bool = True) -> None:
         calls.append("resolve")
+        seen_fallback.append(allow_fallback)
         monkeypatch.setenv("WORKSPACE_MCP_PORT", "8123")
         monkeypatch.setenv("WORKSPACE_MCP_RESOLVED_PORT", "1")
 
+    monkeypatch.delenv("GOOGLE_OAUTH_REDIRECT_URI", raising=False)
     monkeypatch.setattr("auth.port_resolver.resolve_port", fake_resolve_port)
     monkeypatch.setattr(main, "reload_oauth_config", lambda: calls.append("reload"))
 
     main.resolve_stdio_callback_port()
 
     assert calls == ["resolve", "reload"]
+    assert seen_fallback == [True]
     assert os.environ["WORKSPACE_MCP_RESOLVED_PORT"] == "1"
+
+
+def test_resolve_stdio_callback_port_disables_fallback_for_pinned_redirect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit GOOGLE_OAUTH_REDIRECT_URI pins the port; fallback would mismatch."""
+    seen_fallback: list[bool] = []
+
+    def fake_resolve_port(allow_fallback: bool = True) -> None:
+        seen_fallback.append(allow_fallback)
+
+    monkeypatch.setenv(
+        "GOOGLE_OAUTH_REDIRECT_URI", "http://localhost:8103/oauth2callback"
+    )
+    monkeypatch.setattr("auth.port_resolver.resolve_port", fake_resolve_port)
+    monkeypatch.setattr(main, "reload_oauth_config", lambda: None)
+
+    main.resolve_stdio_callback_port()
+
+    assert seen_fallback == [False]
 
 
 def test_resolve_callback_port_for_transport_skips_streamable_http(

--- a/tests/test_main_permissions_tier.py
+++ b/tests/test_main_permissions_tier.py
@@ -122,6 +122,10 @@ def test_loopback_redirect_port_ignores_unusable_uris():
     )
     # A malformed port must not raise out of startup.
     assert main._loopback_redirect_port("http://localhost:notaport/oauth2") is None
+    # https on loopback means a local TLS terminator owns that port and forwards to
+    # the plaintext listener elsewhere; MinimalOAuthServer cannot serve TLS itself.
+    assert main._loopback_redirect_port("https://localhost:8104/oauth2callback") is None
+    assert main._loopback_redirect_port("https://127.0.0.1:8443/oauth2callback") is None
 
 
 def test_resolve_stdio_callback_port_binds_the_redirect_uris_port(
@@ -133,17 +137,16 @@ def test_resolve_stdio_callback_port_binds_the_redirect_uris_port(
     browser to that port regardless of WORKSPACE_MCP_PORT. If the resolver keeps
     the env-var port, the listener binds one port while the redirect targets
     another and the auth flow hangs.
+
+    The probe is stubbed rather than binding real sockets: a free port discovered
+    by bind-then-close can be taken by another process before the assertion runs,
+    and this test is about which port the resolver *chooses*, not about whether
+    the OS had it free.
     """
-    import socket
+    import auth.port_resolver as port_resolver
 
-    def _free_port() -> int:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("127.0.0.1", 0))
-            return s.getsockname()[1]
-
-    env_port, redirect_port = _free_port(), _free_port()
-    assert env_port != redirect_port
-
+    env_port, redirect_port = 8000, 8103
+    monkeypatch.setattr(port_resolver, "_is_port_free", lambda host, port: True)
     monkeypatch.setenv("WORKSPACE_MCP_PORT", str(env_port))
     monkeypatch.delenv("PORT", raising=False)
     monkeypatch.setenv("WORKSPACE_MCP_HOST", "127.0.0.1")

--- a/tests/test_main_permissions_tier.py
+++ b/tests/test_main_permissions_tier.py
@@ -55,10 +55,12 @@ def test_resolve_stdio_callback_port_marks_resolved_port(
 ) -> None:
     calls: list[str] = []
     seen_fallback: list[bool] = []
+    seen_preferred: list[object] = []
 
-    def fake_resolve_port(allow_fallback: bool = True) -> None:
+    def fake_resolve_port(preferred=None, allow_fallback: bool = True) -> None:
         calls.append("resolve")
         seen_fallback.append(allow_fallback)
+        seen_preferred.append(preferred)
         monkeypatch.setenv("WORKSPACE_MCP_PORT", "8123")
         monkeypatch.setenv("WORKSPACE_MCP_RESOLVED_PORT", "1")
 
@@ -70,6 +72,8 @@ def test_resolve_stdio_callback_port_marks_resolved_port(
 
     assert calls == ["resolve", "reload"]
     assert seen_fallback == [True]
+    # No redirect URI pinned, so no preferred port is forced.
+    assert seen_preferred == [None]
     assert os.environ["WORKSPACE_MCP_RESOLVED_PORT"] == "1"
 
 
@@ -78,9 +82,11 @@ def test_resolve_stdio_callback_port_disables_fallback_for_pinned_redirect(
 ) -> None:
     """An explicit GOOGLE_OAUTH_REDIRECT_URI pins the port; fallback would mismatch."""
     seen_fallback: list[bool] = []
+    seen_preferred: list[object] = []
 
-    def fake_resolve_port(allow_fallback: bool = True) -> None:
+    def fake_resolve_port(preferred=None, allow_fallback: bool = True) -> None:
         seen_fallback.append(allow_fallback)
+        seen_preferred.append(preferred)
 
     monkeypatch.setenv(
         "GOOGLE_OAUTH_REDIRECT_URI", "http://localhost:8103/oauth2callback"
@@ -91,6 +97,65 @@ def test_resolve_stdio_callback_port_disables_fallback_for_pinned_redirect(
     main.resolve_stdio_callback_port()
 
     assert seen_fallback == [False]
+    # The pinned loopback port, not WORKSPACE_MCP_PORT, drives the probe.
+    assert seen_preferred == [8103]
+
+
+def test_loopback_redirect_port_extracts_explicit_port():
+    """An explicit loopback redirect URI names the port the listener must bind."""
+    assert main._loopback_redirect_port("http://localhost:8103/oauth2callback") == 8103
+    assert main._loopback_redirect_port("http://127.0.0.1:9000/oauth2callback") == 9000
+    assert main._loopback_redirect_port("http://[::1]:9100/oauth2callback") == 9100
+
+
+def test_loopback_redirect_port_ignores_unusable_uris():
+    """Only an explicit loopback port may override WORKSPACE_MCP_PORT."""
+    # No URI at all, and no explicit port, leave the env-var default in charge.
+    assert main._loopback_redirect_port(None) is None
+    assert main._loopback_redirect_port("") is None
+    assert main._loopback_redirect_port("http://localhost/oauth2callback") is None
+    # A non-loopback URI means a proxy fronts the callback; its public port says
+    # nothing about which local port the listener should own.
+    assert (
+        main._loopback_redirect_port("https://mcp.example.com:443/oauth2callback")
+        is None
+    )
+    # A malformed port must not raise out of startup.
+    assert main._loopback_redirect_port("http://localhost:notaport/oauth2") is None
+
+
+def test_resolve_stdio_callback_port_binds_the_redirect_uris_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: listener port must follow an explicit loopback redirect URI.
+
+    OAuthConfig returns GOOGLE_OAUTH_REDIRECT_URI verbatim, so Google sends the
+    browser to that port regardless of WORKSPACE_MCP_PORT. If the resolver keeps
+    the env-var port, the listener binds one port while the redirect targets
+    another and the auth flow hangs.
+    """
+    import socket
+
+    def _free_port() -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            return s.getsockname()[1]
+
+    env_port, redirect_port = _free_port(), _free_port()
+    assert env_port != redirect_port
+
+    monkeypatch.setenv("WORKSPACE_MCP_PORT", str(env_port))
+    monkeypatch.delenv("PORT", raising=False)
+    monkeypatch.setenv("WORKSPACE_MCP_HOST", "127.0.0.1")
+    monkeypatch.setenv(
+        "GOOGLE_OAUTH_REDIRECT_URI", f"http://localhost:{redirect_port}/oauth2callback"
+    )
+    monkeypatch.setattr(main, "reload_oauth_config", lambda: None)
+
+    main.resolve_stdio_callback_port()
+
+    assert os.environ["WORKSPACE_MCP_PORT"] == str(redirect_port)
+    assert os.environ["WORKSPACE_MCP_RESOLVED_PORT"] == "1"
 
 
 def test_resolve_callback_port_for_transport_skips_streamable_http(


### PR DESCRIPTION
## Description

The stdio OAuth callback port is resolved eagerly at startup, and `resolve_stdio_callback_port()` calls `sys.exit(1)` if every port in `[WORKSPACE_MCP_PORT .. +WORKSPACE_MCP_PORT_FALLBACK_COUNT]` is taken. That is stricter than it needs to be: the listener itself is lazy — `ensure_oauth_callback_available()` binds only when an auth flow starts or an attachment URL is issued — so a server running on cached credentials may never need the port at all, yet still refuses to start without it.

**How it shows up.** MCP clients can launch more than one copy of a stdio server; Claude Desktop runs a second copy for its Cowork/Code sessions. Once one copy has bound the port for a real auth flow, the next copy finds the range exhausted and dies:

```
[INFO] Port resolver: bound preferred port 8103
Error: No available port in range [8103, 8104, 8105, 8106, 8107]; all in use.
[Google Workspace] [info] Server transport closed unexpectedly...
[Google Workspace] [error] Server disconnected.
```

The surviving copy serves tools normally, so it reads as a random disconnect rather than a port problem. Easy to hit whenever the fallback range overlaps other local services — mine had four of five slots held by unrelated MCP servers.

### Changes

**1. A busy port is no longer fatal.** `resolve_stdio_callback_port()` logs a warning and continues. `PortConfigError` (a genuinely malformed env var) stays fatal.

**2. `resolve_port()` gains `allow_fallback`.** When `GOOGLE_OAUTH_REDIRECT_URI` is set, the callback port is pinned by what is registered with Google. `_get_redirect_uri()` returns that URI verbatim, so a copy that fell back to `port+1` would listen on one port and advertise another — a guaranteed `redirect_uri` mismatch. Only the preferred port is probed.

**3. The listener now binds the port the redirect URI names** (added in `4e00b7a`, from review feedback). `OAuthConfig.port` reads `WORKSPACE_MCP_PORT`/`PORT` while the redirect URI is preserved verbatim, so setting the URI to `http://localhost:8103/oauth2callback` without also setting `WORKSPACE_MCP_PORT` bound the listener to 8000 while Google redirected to 8103. `_loopback_redirect_port()` extracts the port when the URI targets loopback with an explicit port, and returns `None` — leaving the env default in charge — when it is absent, port-less, malformed, or non-loopback. Non-loopback is deliberate: a proxy fronting the callback says nothing about which local port to own. This bug predates the PR; fixing it is what makes change 2 honest.

**4. `_is_port_free()` logs errno per candidate** at debug level. Every bind failure previously collapsed to a bare "busy", so a misconfigured `WORKSPACE_MCP_HOST` (`EADDRNOTAVAIL`) was indistinguishable from a real collision (`EADDRINUSE`). This is what let me identify the cause.

Behaviour is unchanged when a port is available. No new tools, no manifest changes.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

8 new tests: fallback-disabled probes only the preferred port; an exhausted range no longer raises out of `resolve_stdio_callback_port()`; the resolved port follows an explicit loopback redirect URI (regression test for change 3); and each URI shape that must not override the env default.

Verified against a clean clone of `main` (`ce1a9ec`, v1.25.2) with only these four files applied, so the numbers are not contaminated by local config:

| | result |
|---|---|
| baseline `main` | `1865 passed, 2 skipped` |
| with this change | `1873 passed, 2 skipped` |
| `uvx ruff@0.15.22 check` | All checks passed |
| `uvx ruff@0.15.22 format --check` | 198 files already formatted |

Manually confirmed the original failure and the fix: with the callback port held by another process, `v1.21.x` exits 1 and Claude Desktop reports `Server transport closed unexpectedly`; with this change the server logs a warning and reaches `Starting MCP server 'google_workspace' with transport 'stdio'`.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

The `allow_fallback` default is `True`, so nothing outside the stdio callback path changes behaviour. `resolve_callback_port_for_transport()` still skips the resolver entirely for streamable-http.

Worth flagging separately: the fallback range is arguably the wrong shape for this problem regardless of this PR. A fallback port cannot be advertised in an already-registered `redirect_uri`, so for anyone who has pinned one, the extra candidates can never be usable. Happy to follow up if you would like the range deprecated for the pinned case rather than just skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * OAuth callback ports remain fixed when an explicit loopback redirect URI is configured.
  * Port fallback is available by default and disabled for configured callback ports.
  * Redirect URI validation supports localhost and IPv4/IPv6 loopback addresses while rejecting unusable or HTTPS values.
* **Bug Fixes**
  * Busy callback ports no longer cause unexpected application exits.
  * Improved diagnostics when callback ports cannot be bound.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->