### PR TITLE
feat(drive): expose file revision history

### DIFF
--- a/core/tool_tiers.yaml
+++ b/core/tool_tiers.yaml
@@ -33,6 +33,7 @@ drive:
     - get_drive_shareable_link
   extended:
     - list_drive_items
+    - list_drive_file_revisions
     - copy_drive_file
     - update_drive_file
     - manage_drive_access

--- a/gdrive/drive_helpers.py
+++ b/gdrive/drive_helpers.py
@@ -15,19 +15,19 @@ import re
 import zipfile
 import zlib
 from pathlib import Path
-from tempfile import SpooledTemporaryFile
+from tempfile import NamedTemporaryFile, SpooledTemporaryFile
 from typing import List, Dict, Any, Awaitable, BinaryIO, Callable, Optional, Tuple
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
 import httpx
-from googleapiclient.http import MediaIoBaseUpload
+from googleapiclient.http import HttpRequest, MediaIoBaseDownload, MediaIoBaseUpload
 
 from core.http_utils import (
     redact_url as _redact_url,
     ssrf_safe_stream as _ssrf_safe_stream,
 )
-from core.utils import validate_file_path
+from core.utils import UserInputError, validate_file_path
 
 logger = logging.getLogger(__name__)
 
@@ -475,6 +475,223 @@ async def resolve_drive_item(
                 f"Shortcut resolution exceeded {max_depth} hops starting from '{file_id}'."
             )
         current_id = target_id
+
+
+async def list_drive_file_revisions_data(
+    service,
+    file_id: str,
+    *,
+    page_size: int = 100,
+    page_token: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Return one Drive-visible page of revision history for a file.
+
+    Drive may compact or omit older revisions, especially for frequently edited
+    Google Workspace documents, so callers must not treat this as a complete
+    immutable audit log.
+    """
+    if not 1 <= page_size <= 1000:
+        raise UserInputError("page_size must be between 1 and 1000.")
+
+    resolved_file_id, metadata = await resolve_drive_item(
+        service,
+        file_id,
+        extra_fields="name, mimeType, headRevisionId",
+    )
+    mime_type = metadata.get("mimeType", "")
+    head_revision_id = metadata.get("headRevisionId")
+
+    response = await asyncio.to_thread(
+        service.revisions()
+        .list(
+            fileId=resolved_file_id,
+            pageSize=page_size,
+            pageToken=page_token,
+            fields=(
+                "nextPageToken, revisions(id,modifiedTime,"
+                "lastModifyingUser(displayName,emailAddress),mimeType,size,"
+                "keepForever,originalFilename)"
+            ),
+        )
+        .execute
+    )
+
+    revisions = []
+    native_file = mime_type.startswith(GOOGLE_APPS_MIME_PREFIX)
+    for revision in response.get("revisions", []):
+        revision_id = revision.get("id")
+        editor = revision.get("lastModifyingUser") or {}
+        can_download = native_file or bool(
+            revision.get("keepForever") or revision_id == head_revision_id
+        )
+        revisions.append(
+            {
+                "id": revision_id,
+                "modified_time": revision.get("modifiedTime"),
+                "last_modifying_user": {
+                    "display_name": editor.get("displayName"),
+                    "email_address": editor.get("emailAddress"),
+                },
+                "mime_type": revision.get("mimeType"),
+                "size": revision.get("size"),
+                "original_filename": revision.get("originalFilename"),
+                "keep_forever": revision.get("keepForever"),
+                "is_head": revision_id == head_revision_id
+                if head_revision_id
+                else None,
+                "download_available": can_download,
+            }
+        )
+
+    return {
+        "file": {
+            "id": resolved_file_id,
+            "name": metadata.get("name", "Unknown File"),
+            "mime_type": mime_type,
+            "head_revision_id": head_revision_id,
+        },
+        "revisions": revisions,
+        "next_page_token": response.get("nextPageToken"),
+        "history_scope": (
+            "Drive-visible revision history only. Google Drive can compact or omit "
+            "older revisions, so this is not guaranteed to be a complete audit log."
+        ),
+    }
+
+
+def _revision_export_target(
+    mime_type: str, export_format: Optional[str]
+) -> Tuple[str, str]:
+    """Resolve and validate the export MIME type and extension for a native revision."""
+    options = {
+        GOOGLE_DOCS_MIME_TYPE: {
+            "pdf": "application/pdf",
+            "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        },
+        GOOGLE_SHEETS_MIME_TYPE: {
+            "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "pdf": "application/pdf",
+            "csv": "text/csv",
+        },
+        GOOGLE_SLIDES_MIME_TYPE: {
+            "pdf": "application/pdf",
+            "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        },
+    }
+    defaults = {
+        GOOGLE_DOCS_MIME_TYPE: "pdf",
+        GOOGLE_SHEETS_MIME_TYPE: "xlsx",
+        GOOGLE_SLIDES_MIME_TYPE: "pdf",
+    }
+    if mime_type not in options:
+        raise UserInputError(
+            f"Historical export is not supported for MIME type '{mime_type}'."
+        )
+
+    selected = export_format.lower() if export_format else defaults[mime_type]
+    if selected not in options[mime_type]:
+        allowed = ", ".join(sorted(options[mime_type]))
+        raise UserInputError(
+            f"Unsupported export_format '{export_format}' for this file. Use one of: {allowed}."
+        )
+    return options[mime_type][selected], selected
+
+
+async def _download_http_request_to_temp(request) -> Path:
+    """Stream an authenticated Google API media request to a temporary file."""
+    tmp_file = NamedTemporaryFile(prefix="wsmcp_revision_", delete=False)
+    tmp_path = Path(tmp_file.name)
+    loop = asyncio.get_event_loop()
+    try:
+        with tmp_file:
+            downloader = MediaIoBaseDownload(
+                tmp_file, request, chunksize=8 * 1024 * 1024
+            )
+            done = False
+            while not done:
+                _status, done = await loop.run_in_executor(None, downloader.next_chunk)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    return tmp_path
+
+
+async def download_drive_revision_to_temp(
+    service,
+    file_id: str,
+    revision_id: str,
+    *,
+    export_format: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Stream a historical Drive revision to disk and return its metadata."""
+    resolved_file_id, metadata = await resolve_drive_item(
+        service,
+        file_id,
+        extra_fields="name, mimeType, headRevisionId",
+    )
+    file_name = metadata.get("name", "Unknown File")
+    current_mime_type = metadata.get("mimeType", "")
+    head_revision_id = metadata.get("headRevisionId")
+
+    revision = await asyncio.to_thread(
+        service.revisions()
+        .get(
+            fileId=resolved_file_id,
+            revisionId=revision_id,
+            fields=(
+                "id,modifiedTime,mimeType,exportLinks,keepForever,size,originalFilename"
+            ),
+        )
+        .execute
+    )
+    revision_mime_type = revision.get("mimeType") or current_mime_type
+
+    if current_mime_type.startswith(GOOGLE_APPS_MIME_PREFIX):
+        target_mime, extension = _revision_export_target(
+            current_mime_type, export_format
+        )
+        export_links = revision.get("exportLinks") or {}
+        export_url = export_links.get(target_mime)
+        if not export_url:
+            available = ", ".join(sorted(export_links)) or "none"
+            raise UserInputError(
+                f"Revision {revision_id} cannot be exported as {extension}. "
+                f"Drive reported these MIME types: {available}."
+            )
+        request = HttpRequest(
+            service._http,
+            lambda response, content: content,
+            export_url,
+            method="GET",
+        )
+        tmp_path = await _download_http_request_to_temp(request)
+        output_mime_type = target_mime
+        output_filename = f"{Path(file_name).stem}_rev{revision_id}.{extension}"
+    else:
+        if revision_id != head_revision_id and not revision.get("keepForever"):
+            raise UserInputError(
+                f"Blob revision {revision_id} is not downloadable because it is not "
+                "the current head revision and was not pinned with keepForever."
+            )
+        request = service.revisions().get_media(
+            fileId=resolved_file_id,
+            revisionId=revision_id,
+        )
+        tmp_path = await _download_http_request_to_temp(request)
+        output_mime_type = revision_mime_type
+        original_name = revision.get("originalFilename") or file_name
+        path = Path(original_name)
+        output_filename = f"{path.stem}_rev{revision_id}{path.suffix}"
+
+    return {
+        "path": tmp_path,
+        "file_id": resolved_file_id,
+        "file_name": file_name,
+        "revision_id": revision_id,
+        "revision_modified_time": revision.get("modifiedTime"),
+        "output_filename": output_filename,
+        "output_mime_type": output_mime_type,
+    }
 
 
 async def resolve_folder_id(

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -54,7 +54,9 @@ from gdrive.drive_helpers import (
     build_drive_list_params,
     check_public_link_permission,
     list_all_permissions,
+    list_drive_file_revisions_data,
     derive_shared_state,
+    download_drive_revision_to_temp,
     format_permission_info,
     get_drive_image_url,
     has_explicit_trashed_clause,
@@ -342,6 +344,7 @@ async def get_drive_file_content(
     service,
     user_google_email: str,
     file_id: str,
+    revision_id: Optional[str] = None,
 ) -> str:
     """
     Retrieves the content of a specific Google Drive file by ID, supporting files in shared drives.
@@ -353,15 +356,19 @@ async def get_drive_file_content(
       fall back to a download hint.
     • Images → returned as base64 with MIME metadata for multimodal clients.
     • Any other file → downloaded; tries UTF-8 decode, else notes binary.
+    • Historical revisions → pass revision_id from list_drive_file_revisions.
 
     Args:
         user_google_email: The user’s Google email address.
         file_id: Drive file ID.
+        revision_id: Optional historical revision ID to read instead of the current file.
 
     Returns:
         str: The file content as plain text with metadata header.
     """
-    logger.info(f"[get_drive_file_content] Invoked. File ID: '{file_id}'")
+    logger.info(
+        f"[get_drive_file_content] Invoked. File ID: '{file_id}', Revision: {revision_id}"
+    )
 
     resolved_file_id, file_metadata = await resolve_drive_item(
         service,
@@ -371,13 +378,37 @@ async def get_drive_file_content(
     file_id = resolved_file_id
     mime_type = file_metadata.get("mimeType", "")
     file_name = file_metadata.get("name", "Unknown File")
-    export_mime_type = {
-        "application/vnd.google-apps.document": "text/plain",
-        "application/vnd.google-apps.spreadsheet": "text/csv",
-        "application/vnd.google-apps.presentation": "text/plain",
-    }.get(mime_type)
+    revision_modified_time = None
 
-    file_content_bytes = await _download_file_bytes(service, file_id, export_mime_type)
+    if revision_id:
+        revision_export_format = {
+            "application/vnd.google-apps.document": "docx",
+            "application/vnd.google-apps.spreadsheet": "xlsx",
+            "application/vnd.google-apps.presentation": "pptx",
+        }.get(mime_type)
+        revision_download = await download_drive_revision_to_temp(
+            service,
+            file_id,
+            revision_id,
+            export_format=revision_export_format,
+        )
+        revision_path = revision_download["path"]
+        try:
+            file_content_bytes = await asyncio.to_thread(revision_path.read_bytes)
+        finally:
+            revision_path.unlink(missing_ok=True)
+        parse_mime_type = revision_download["output_mime_type"]
+        revision_modified_time = revision_download["revision_modified_time"]
+    else:
+        export_mime_type = {
+            "application/vnd.google-apps.document": "text/plain",
+            "application/vnd.google-apps.spreadsheet": "text/csv",
+            "application/vnd.google-apps.presentation": "text/plain",
+        }.get(mime_type)
+        file_content_bytes = await _download_file_bytes(
+            service, file_id, export_mime_type
+        )
+        parse_mime_type = mime_type
 
     # Attempt Office XML extraction only for actual Office XML files
     office_mime_types = {
@@ -386,10 +417,10 @@ async def get_drive_file_content(
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     }
 
-    if mime_type in office_mime_types:
+    if parse_mime_type in office_mime_types:
         # Offload Office XML extraction to a thread to avoid blocking the event loop
         office_text = await asyncio.to_thread(
-            extract_office_xml_text, file_content_bytes, mime_type
+            extract_office_xml_text, file_content_bytes, parse_mime_type
         )
         if office_text:
             body_text = office_text
@@ -399,10 +430,10 @@ async def get_drive_file_content(
                 body_text = file_content_bytes.decode("utf-8")
             except UnicodeDecodeError:
                 body_text = (
-                    f"[Binary or unsupported text encoding for mimeType '{mime_type}' - "
+                    f"[Binary or unsupported text encoding for mimeType '{parse_mime_type}' - "
                     f"{len(file_content_bytes)} bytes]"
                 )
-    elif mime_type == "application/pdf":
+    elif parse_mime_type == "application/pdf":
         # Offload PDF text extraction to a thread to avoid blocking the event loop
         pdf_text = await asyncio.to_thread(extract_pdf_text, file_content_bytes)
         if pdf_text:
@@ -413,24 +444,77 @@ async def get_drive_file_content(
                 f"- the file may be scanned/image-only. "
                 f"Use get_drive_file_download_url to get a direct download link instead.]"
             )
-    elif mime_type in IMAGE_MIME_TYPES:
-        body_text = encode_image_content(file_content_bytes, mime_type)
+    elif parse_mime_type in IMAGE_MIME_TYPES:
+        body_text = encode_image_content(file_content_bytes, parse_mime_type)
     else:
         # For non-Office files (including Google native files), try UTF-8 decode directly
         try:
             body_text = file_content_bytes.decode("utf-8")
         except UnicodeDecodeError:
             body_text = (
-                f"[Binary or unsupported text encoding for mimeType '{mime_type}' - "
+                f"[Binary or unsupported text encoding for mimeType '{parse_mime_type}' - "
                 f"{len(file_content_bytes)} bytes]"
             )
 
     # Assemble response
+    revision_line = (
+        f"Revision: {revision_id} ({revision_modified_time or 'modified time unavailable'})\n"
+        if revision_id
+        else ""
+    )
     header = (
         f'File: "{file_name}" (ID: {file_id}, Type: {mime_type})\n'
+        f"{revision_line}"
         f"Link: {file_metadata.get('webViewLink', '#')}\n\n--- CONTENT ---\n"
     )
     return header + body_text
+
+
+@server.tool(
+    title="List Drive File Revisions",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+@handle_http_errors(
+    "list_drive_file_revisions", is_read_only=True, service_type="drive"
+)
+@require_google_service("drive", "drive_read")
+async def list_drive_file_revisions(
+    service,
+    user_google_email: str,
+    file_id: str,
+    page_size: int = 100,
+    page_token: Optional[str] = None,
+) -> Dict[str, Any]:
+    """List one page of Drive-visible revision history for a file.
+
+    The response includes revision IDs, timestamps, editors, MIME/size metadata,
+    pagination, and whether Drive can retrieve each revision's content. Drive can
+    compact or omit older revisions, so the result is not guaranteed to be a
+    complete audit log.
+
+    Args:
+        user_google_email: The user's Google email address. Required.
+        file_id: Drive file ID or shortcut target. Required.
+        page_size: Revisions to return, 1-1000. Defaults to 100.
+        page_token: Token from a previous response for the next page.
+
+    Returns:
+        dict: File metadata, revision entries, pagination token, and history caveat.
+    """
+    logger.info(
+        f"[list_drive_file_revisions] Invoked. File ID: '{file_id}', page_size={page_size}"
+    )
+    return await list_drive_file_revisions_data(
+        service,
+        file_id,
+        page_size=page_size,
+        page_token=page_token,
+    )
 
 
 @server.tool(
@@ -451,6 +535,7 @@ async def get_drive_file_download_url(
     user_google_email: str,
     file_id: str,
     export_format: Optional[str] = None,
+    revision_id: Optional[str] = None,
 ) -> str:
     """
     Downloads a Google Drive file and saves it to local disk.
@@ -463,7 +548,10 @@ async def get_drive_file_download_url(
     - Google Sheets -> XLSX (default), PDF if export_format='pdf', or CSV if export_format='csv'
     - Google Slides -> PDF (default) or PPTX if export_format='pptx'
 
-    For other files, downloads the original file format.
+    For other files, downloads the original file format. Pass revision_id to
+    download a Drive-visible historical revision. Native Google files are exported
+    in the same formats as current files; historical blob revisions must still be
+    downloadable by Drive (normally the head revision or one pinned keepForever).
 
     Args:
         user_google_email: The user's Google email address. Required.
@@ -472,81 +560,94 @@ async def get_drive_file_download_url(
                       Options: 'pdf', 'docx', 'xlsx', 'csv', 'pptx'.
                       If not specified, uses sensible defaults (PDF for Docs/Slides, XLSX for Sheets).
                       For Sheets: supports 'csv', 'pdf', or 'xlsx' (default).
+        revision_id: Optional revision ID from list_drive_file_revisions. When set,
+                     downloads that historical revision instead of the current file.
 
     Returns:
         str: File metadata with either a local file path or download URL.
     """
     logger.info(
-        f"[get_drive_file_download_url] Invoked. File ID: '{file_id}', Export format: {export_format}"
+        f"[get_drive_file_download_url] Invoked. File ID: '{file_id}', "
+        f"Export format: {export_format}, Revision: {revision_id}"
     )
 
-    # Resolve shortcuts and get file metadata
-    resolved_file_id, file_metadata = await resolve_drive_item(
-        service,
-        file_id,
-        extra_fields="name, webViewLink, mimeType",
-    )
-    file_id = resolved_file_id
-    mime_type = file_metadata.get("mimeType", "")
-    file_name = file_metadata.get("name", "Unknown File")
-
-    # Determine export format for Google native files
     export_mime_type = None
-    output_filename = file_name
-    output_mime_type = mime_type
+    revision_modified_time = None
 
-    if mime_type == "application/vnd.google-apps.document":
-        # Google Docs
-        if export_format == "docx":
-            export_mime_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            output_mime_type = export_mime_type
-            if not output_filename.endswith(".docx"):
-                output_filename = f"{Path(output_filename).stem}.docx"
-        else:
-            # Default to PDF
-            export_mime_type = "application/pdf"
-            output_mime_type = export_mime_type
-            if not output_filename.endswith(".pdf"):
-                output_filename = f"{Path(output_filename).stem}.pdf"
+    if revision_id:
+        revision_download = await download_drive_revision_to_temp(
+            service,
+            file_id,
+            revision_id,
+            export_format=export_format,
+        )
+        file_id = revision_download["file_id"]
+        file_name = revision_download["file_name"]
+        output_filename = revision_download["output_filename"]
+        output_mime_type = revision_download["output_mime_type"]
+        revision_modified_time = revision_download["revision_modified_time"]
+        tmp_path = revision_download["path"]
+    else:
+        # Resolve shortcuts and get file metadata
+        resolved_file_id, file_metadata = await resolve_drive_item(
+            service,
+            file_id,
+            extra_fields="name, webViewLink, mimeType",
+        )
+        file_id = resolved_file_id
+        mime_type = file_metadata.get("mimeType", "")
+        file_name = file_metadata.get("name", "Unknown File")
 
-    elif mime_type == "application/vnd.google-apps.spreadsheet":
-        # Google Sheets
-        if export_format == "csv":
-            export_mime_type = "text/csv"
-            output_mime_type = export_mime_type
-            if not output_filename.endswith(".csv"):
-                output_filename = f"{Path(output_filename).stem}.csv"
-        elif export_format == "pdf":
-            export_mime_type = "application/pdf"
-            output_mime_type = export_mime_type
-            if not output_filename.endswith(".pdf"):
-                output_filename = f"{Path(output_filename).stem}.pdf"
-        else:
-            # Default to XLSX
-            export_mime_type = (
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            )
-            output_mime_type = export_mime_type
-            if not output_filename.endswith(".xlsx"):
-                output_filename = f"{Path(output_filename).stem}.xlsx"
+        # Determine export format for Google native files
+        output_filename = file_name
+        output_mime_type = mime_type
 
-    elif mime_type == "application/vnd.google-apps.presentation":
-        # Google Slides
-        if export_format == "pptx":
-            export_mime_type = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-            output_mime_type = export_mime_type
-            if not output_filename.endswith(".pptx"):
-                output_filename = f"{Path(output_filename).stem}.pptx"
-        else:
-            # Default to PDF
-            export_mime_type = "application/pdf"
-            output_mime_type = export_mime_type
-            if not output_filename.endswith(".pdf"):
-                output_filename = f"{Path(output_filename).stem}.pdf"
+        if mime_type == "application/vnd.google-apps.document":
+            if export_format == "docx":
+                export_mime_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                output_mime_type = export_mime_type
+                if not output_filename.endswith(".docx"):
+                    output_filename = f"{Path(output_filename).stem}.docx"
+            else:
+                export_mime_type = "application/pdf"
+                output_mime_type = export_mime_type
+                if not output_filename.endswith(".pdf"):
+                    output_filename = f"{Path(output_filename).stem}.pdf"
 
-    # Stream the download straight to disk. The payload is never held in memory
-    # as a whole, so file size no longer bounds how much RAM this tool needs.
-    tmp_path = await _download_file_to_temp(service, file_id, export_mime_type)
+        elif mime_type == "application/vnd.google-apps.spreadsheet":
+            if export_format == "csv":
+                export_mime_type = "text/csv"
+                output_mime_type = export_mime_type
+                if not output_filename.endswith(".csv"):
+                    output_filename = f"{Path(output_filename).stem}.csv"
+            elif export_format == "pdf":
+                export_mime_type = "application/pdf"
+                output_mime_type = export_mime_type
+                if not output_filename.endswith(".pdf"):
+                    output_filename = f"{Path(output_filename).stem}.pdf"
+            else:
+                export_mime_type = (
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                )
+                output_mime_type = export_mime_type
+                if not output_filename.endswith(".xlsx"):
+                    output_filename = f"{Path(output_filename).stem}.xlsx"
+
+        elif mime_type == "application/vnd.google-apps.presentation":
+            if export_format == "pptx":
+                export_mime_type = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+                output_mime_type = export_mime_type
+                if not output_filename.endswith(".pptx"):
+                    output_filename = f"{Path(output_filename).stem}.pptx"
+            else:
+                export_mime_type = "application/pdf"
+                output_mime_type = export_mime_type
+                if not output_filename.endswith(".pdf"):
+                    output_filename = f"{Path(output_filename).stem}.pdf"
+
+        # Stream the download straight to disk. The payload is never held in memory
+        # as a whole, so file size no longer bounds how much RAM this tool needs.
+        tmp_path = await _download_file_to_temp(service, file_id, export_mime_type)
     size_bytes = tmp_path.stat().st_size
     size_kb = size_bytes / 1024 if size_bytes else 0
 
@@ -567,6 +668,11 @@ async def get_drive_file_download_url(
             "\nBase64-encoded content (first 100 characters shown):",
             f"{base64.b64encode(preview_bytes).decode('utf-8')}...",
         ]
+        if revision_id:
+            result_lines.insert(
+                3,
+                f"Revision: {revision_id} ({revision_modified_time or 'modified time unavailable'})",
+            )
         logger.info(
             f"[get_drive_file_download_url] Successfully downloaded {size_kb:.1f} KB file (stateless mode)"
         )
@@ -592,6 +698,12 @@ async def get_drive_file_download_url(
             f"Size: {size_kb:.1f} KB ({size_bytes} bytes)",
             f"MIME Type: {output_mime_type}",
         ]
+
+        if revision_id:
+            result_lines.insert(
+                3,
+                f"Revision: {revision_id} ({revision_modified_time or 'modified time unavailable'})",
+            )
 
         if get_transport_mode() == "stdio":
             result_lines.append(f"\n📎 Saved to: {result.path}")

--- a/skills/managing-google-workspace/SKILL.md
+++ b/skills/managing-google-workspace/SKILL.md
@@ -91,8 +91,9 @@ For parameters: [references/gmail.md](references/gmail.md)
 |------|------|
 | Search files/folders | `search_drive_files` |
 | List items in folder | `list_drive_items` |
+| List file revisions | `list_drive_file_revisions` |
 | Read file content | `get_drive_file_content` |
-| Download file | `get_drive_file_download_url` |
+| Download current or historical file | `get_drive_file_download_url` |
 | Create file | `create_drive_file` |
 | Create folder | `create_drive_folder` |
 | Copy file | `copy_drive_file` |

--- a/skills/managing-google-workspace/references/drive.md
+++ b/skills/managing-google-workspace/references/drive.md
@@ -3,7 +3,7 @@
 MCP tools for Google Drive file management, search, content retrieval, and permission control. All tools require `user_google_email` (string, required).
 
 ## Contents
-- Search & Browse: search_drive_files, list_drive_items
+- Search & Browse: search_drive_files, list_drive_items, list_drive_file_revisions
 - Content & Download: get_drive_file_content, get_drive_file_download_url
 - Create & Modify: create_drive_file, create_drive_folder, copy_drive_file, update_drive_file
 - Permissions & Sharing: set_drive_file_permissions, manage_drive_access, get_drive_file_permissions, get_drive_shareable_link, check_drive_file_public_access
@@ -47,6 +47,18 @@ List files and folders in a specific folder.
 | detailed | boolean | no | true | Include size, modified time, and link |
 | order_by | string | no | | Sort order (see Sort Order below) |
 
+### list_drive_file_revisions
+List one page of the Drive-visible revision history for a file. Drive can compact or omit older revisions, especially for frequently edited Google Workspace files, so this is not guaranteed to be a complete audit log.
+
+| Parameter | Type | Required | Default | Notes |
+|-----------|------|----------|---------|-------|
+| user_google_email | string | yes | | |
+| file_id | string | yes | | Drive file ID or shortcut |
+| page_size | integer | no | 100 | 1-1000 revisions |
+| page_token | string | no | | Token from the previous page |
+
+Each revision includes its ID, modified time, last modifying user, MIME/size metadata, keep-forever status where applicable, and a `download_available` flag. Use the returned revision ID with `get_drive_file_download_url(revision_id=...)` to retrieve historical content.
+
 ---
 
 ## Content & Download
@@ -58,6 +70,7 @@ Retrieve file content as text.
 |-----------|------|----------|---------|-------|
 | user_google_email | string | yes | | |
 | file_id | string | yes | | Drive file ID |
+| revision_id | string | no | | Historical revision ID returned by `list_drive_file_revisions` |
 
 Content handling:
 - Google Docs/Sheets/Slides: exported as text/CSV
@@ -72,11 +85,14 @@ Download a file to local disk (stdio mode) or get a temporary URL (HTTP mode, va
 | user_google_email | string | yes | | |
 | file_id | string | yes | | Drive file ID |
 | export_format | string | no | | `pdf`, `docx`, `xlsx`, `csv`, `pptx` |
+| revision_id | string | no | | Historical revision ID returned by `list_drive_file_revisions` |
 
 Default export formats for Google native files:
 - Docs: PDF (or `docx`)
 - Sheets: XLSX (or `pdf`, `csv`)
 - Slides: PDF (or `pptx`)
+
+When `revision_id` is set, the tool retrieves that historical Drive revision. Native Google revisions are exported in the requested format. For uploaded/blob files, older content is only downloadable when Drive still retains it, normally because the revision is the current head or has `keepForever=true`.
 
 ---
 

--- a/tests/gdrive/test_drive_revisions.py
+++ b/tests/gdrive/test_drive_revisions.py
@@ -1,0 +1,379 @@
+"""Tests for Drive revision history and historical downloads."""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from core.utils import UserInputError
+from gdrive.drive_helpers import (
+    download_drive_revision_to_temp,
+    list_drive_file_revisions_data,
+)
+from gdrive.drive_tools import (
+    get_drive_file_content,
+    get_drive_file_download_url,
+    list_drive_file_revisions,
+)
+
+
+def _unwrap(tool):
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _mock_revision_service(list_response=None, get_response=None):
+    service = Mock()
+    revisions = Mock()
+    service.revisions.return_value = revisions
+    if list_response is not None:
+        list_request = Mock()
+        list_request.execute.return_value = list_response
+        revisions.list.return_value = list_request
+    if get_response is not None:
+        get_request = Mock()
+        get_request.execute.return_value = get_response
+        revisions.get.return_value = get_request
+    return service
+
+
+@pytest.mark.asyncio
+async def test_list_revisions_returns_paginated_drive_visible_metadata():
+    service = _mock_revision_service(
+        list_response={
+            "nextPageToken": "next-token",
+            "revisions": [
+                {
+                    "id": "10",
+                    "modifiedTime": "2026-08-28T12:00:00Z",
+                    "lastModifyingUser": {
+                        "displayName": "Coworker",
+                        "emailAddress": "coworker@example.com",
+                    },
+                    "mimeType": "application/vnd.google-apps.document",
+                }
+            ],
+        }
+    )
+
+    with patch(
+        "gdrive.drive_helpers.resolve_drive_item",
+        return_value=(
+            "doc123",
+            {
+                "name": "Policy",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+        ),
+    ):
+        result = await list_drive_file_revisions_data(
+            service, "shortcut-or-id", page_size=25, page_token="page-1"
+        )
+
+    assert result["file"]["id"] == "doc123"
+    assert result["next_page_token"] == "next-token"
+    assert result["revisions"][0]["id"] == "10"
+    assert result["revisions"][0]["last_modifying_user"]["display_name"] == "Coworker"
+    assert result["revisions"][0]["download_available"] is True
+    assert "not guaranteed" in result["history_scope"]
+    service.revisions().list.assert_called_once_with(
+        fileId="doc123",
+        pageSize=25,
+        pageToken="page-1",
+        fields=(
+            "nextPageToken, revisions(id,modifiedTime,"
+            "lastModifyingUser(displayName,emailAddress),mimeType,size,"
+            "keepForever,originalFilename)"
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_revisions_marks_only_head_or_pinned_blob_downloadable():
+    service = _mock_revision_service(
+        list_response={
+            "revisions": [
+                {"id": "1", "keepForever": False},
+                {"id": "2", "keepForever": True},
+                {"id": "3", "keepForever": False},
+            ]
+        }
+    )
+
+    with patch(
+        "gdrive.drive_helpers.resolve_drive_item",
+        return_value=(
+            "file123",
+            {
+                "name": "report.pdf",
+                "mimeType": "application/pdf",
+                "headRevisionId": "3",
+            },
+        ),
+    ):
+        result = await list_drive_file_revisions_data(service, "file123")
+
+    assert [r["download_available"] for r in result["revisions"]] == [False, True, True]
+    assert [r["is_head"] for r in result["revisions"]] == [False, False, True]
+
+
+@pytest.mark.asyncio
+async def test_list_revisions_tool_is_thin_wrapper():
+    expected = {"file": {"id": "x"}, "revisions": []}
+    service = Mock()
+    with patch(
+        "gdrive.drive_tools.list_drive_file_revisions_data",
+        return_value=expected,
+    ) as helper:
+        result = await _unwrap(list_drive_file_revisions)(
+            service=service,
+            user_google_email="user@example.com",
+            file_id="x",
+            page_size=10,
+            page_token="p",
+        )
+
+    assert result == expected
+    helper.assert_awaited_once_with(service, "x", page_size=10, page_token="p")
+
+
+@pytest.mark.asyncio
+async def test_native_revision_download_uses_revision_export_link(tmp_path):
+    service = _mock_revision_service(
+        get_response={
+            "id": "12",
+            "modifiedTime": "2026-08-28T13:00:00Z",
+            "mimeType": "application/vnd.google-apps.document",
+            "exportLinks": {"application/pdf": "https://example.invalid/revision.pdf"},
+        }
+    )
+    service._http = Mock()
+    temp = tmp_path / "revision.pdf"
+    temp.write_bytes(b"pdf")
+
+    with (
+        patch(
+            "gdrive.drive_helpers.resolve_drive_item",
+            return_value=(
+                "doc123",
+                {
+                    "name": "Policy",
+                    "mimeType": "application/vnd.google-apps.document",
+                },
+            ),
+        ),
+        patch(
+            "gdrive.drive_helpers._download_http_request_to_temp",
+            return_value=temp,
+        ) as downloader,
+    ):
+        result = await download_drive_revision_to_temp(
+            service, "doc123", "12", export_format="pdf"
+        )
+
+    request = downloader.call_args.args[0]
+    assert request.uri == "https://example.invalid/revision.pdf"
+    assert result["path"] == temp
+    assert result["output_filename"] == "Policy_rev12.pdf"
+    assert result["output_mime_type"] == "application/pdf"
+
+
+@pytest.mark.asyncio
+async def test_native_revision_download_rejects_bad_export_format():
+    service = _mock_revision_service(
+        get_response={
+            "id": "12",
+            "mimeType": "application/vnd.google-apps.document",
+            "exportLinks": {"application/pdf": "https://example.invalid/revision.pdf"},
+        }
+    )
+
+    with (
+        patch(
+            "gdrive.drive_helpers.resolve_drive_item",
+            return_value=(
+                "doc123",
+                {
+                    "name": "Policy",
+                    "mimeType": "application/vnd.google-apps.document",
+                },
+            ),
+        ),
+        pytest.raises(UserInputError, match="Unsupported export_format"),
+    ):
+        await download_drive_revision_to_temp(
+            service, "doc123", "12", export_format="pdfx"
+        )
+
+
+@pytest.mark.asyncio
+async def test_blob_revision_download_rejects_unpinned_old_revision():
+    service = _mock_revision_service(
+        get_response={
+            "id": "old",
+            "mimeType": "application/pdf",
+            "keepForever": False,
+            "originalFilename": "old-name.pdf",
+        }
+    )
+
+    with (
+        patch(
+            "gdrive.drive_helpers.resolve_drive_item",
+            return_value=(
+                "file123",
+                {
+                    "name": "new-name.pdf",
+                    "mimeType": "application/pdf",
+                    "headRevisionId": "head",
+                },
+            ),
+        ),
+        pytest.raises(UserInputError, match="not downloadable"),
+    ):
+        await download_drive_revision_to_temp(service, "file123", "old")
+
+    service.revisions().get_media.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_blob_revision_uses_revision_filename_and_mime(tmp_path):
+    service = _mock_revision_service(
+        get_response={
+            "id": "old",
+            "modifiedTime": "2026-08-28T14:00:00Z",
+            "mimeType": "application/octet-stream",
+            "keepForever": True,
+            "originalFilename": "historic.bin",
+        }
+    )
+    temp = tmp_path / "historic"
+    temp.write_bytes(b"old")
+
+    with (
+        patch(
+            "gdrive.drive_helpers.resolve_drive_item",
+            return_value=(
+                "file123",
+                {
+                    "name": "current.dat",
+                    "mimeType": "application/octet-stream",
+                    "headRevisionId": "head",
+                },
+            ),
+        ),
+        patch(
+            "gdrive.drive_helpers._download_http_request_to_temp",
+            return_value=temp,
+        ),
+    ):
+        result = await download_drive_revision_to_temp(service, "file123", "old")
+
+    service.revisions().get_media.assert_called_once_with(
+        fileId="file123", revisionId="old"
+    )
+    assert result["output_filename"] == "historic_revold.bin"
+    assert result["output_mime_type"] == "application/octet-stream"
+
+
+@pytest.mark.asyncio
+async def test_existing_download_tool_accepts_revision_id(tmp_path):
+    temp = tmp_path / "revision.pdf"
+    temp.write_bytes(b"history")
+    download_result = {
+        "path": temp,
+        "file_id": "doc123",
+        "file_name": "Policy",
+        "revision_id": "12",
+        "revision_modified_time": "2026-08-28T13:00:00Z",
+        "output_filename": "Policy_rev12.pdf",
+        "output_mime_type": "application/pdf",
+    }
+
+    class _Storage:
+        def save_attachment_from_path(self, src_path, filename, mime_type):
+            result = Mock()
+            result.path = Path(src_path)
+            result.file_id = "attachment"
+            return result
+
+    with (
+        patch(
+            "gdrive.drive_tools.download_drive_revision_to_temp",
+            return_value=download_result,
+        ) as helper,
+        patch("gdrive.drive_tools.is_stateless_mode", return_value=False),
+        patch("gdrive.drive_tools.get_transport_mode", return_value="stdio"),
+        patch("gdrive.drive_tools.get_attachment_storage", return_value=_Storage()),
+    ):
+        result = await _unwrap(get_drive_file_download_url)(
+            service=Mock(),
+            user_google_email="user@example.com",
+            file_id="doc123",
+            export_format="pdf",
+            revision_id="12",
+        )
+
+    helper.assert_awaited_once()
+    assert "Revision: 12 (2026-08-28T13:00:00Z)" in result
+    assert "Policy_rev12.pdf" not in result  # path remains transport-specific
+
+
+@pytest.mark.asyncio
+async def test_existing_content_tool_reads_historical_revision(tmp_path):
+    temp = tmp_path / "revision.docx"
+    temp.write_bytes(b"office-archive")
+    service = Mock()
+    download_result = {
+        "path": temp,
+        "file_id": "doc123",
+        "file_name": "Policy",
+        "revision_id": "12",
+        "revision_modified_time": "2026-08-28T13:00:00Z",
+        "output_filename": "Policy_rev12.docx",
+        "output_mime_type": (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ),
+    }
+
+    with (
+        patch(
+            "gdrive.drive_tools.resolve_drive_item",
+            return_value=(
+                "doc123",
+                {
+                    "name": "Policy",
+                    "mimeType": "application/vnd.google-apps.document",
+                    "webViewLink": "https://docs.google.com/document/d/doc123/edit",
+                },
+            ),
+        ),
+        patch(
+            "gdrive.drive_tools.download_drive_revision_to_temp",
+            return_value=download_result,
+        ) as helper,
+        patch(
+            "gdrive.drive_tools.extract_office_xml_text",
+            return_value="Historical text",
+        ),
+        patch("gdrive.drive_tools._download_file_bytes") as current_download,
+    ):
+        result = await _unwrap(get_drive_file_content)(
+            service=service,
+            user_google_email="user@example.com",
+            file_id="doc123",
+            revision_id="12",
+        )
+
+    helper.assert_awaited_once_with(
+        service,
+        "doc123",
+        "12",
+        export_format="docx",
+    )
+    current_download.assert_not_awaited()
+    assert not temp.exists()
+    assert "Revision: 12 (2026-08-28T13:00:00Z)" in result
+    assert "Historical text" in result


### PR DESCRIPTION
## Description
Adds first-class Google Drive revision-history support while minimizing new tool count:

- adds paginated `list_drive_file_revisions`
- extends `get_drive_file_content` with `revision_id` so historical content can be inspected directly
- extends `get_drive_file_download_url` with `revision_id` for historical download/export
- supports Google Docs, Sheets, and Slides historical exports via revision `exportLinks`
- supports retained blob revisions, with explicit `headRevisionId` / `keepForever` availability checks
- returns revision metadata including timestamp, last modifying user, MIME type, size, head/pinned state, and download availability
- documents Drive's important limitation that API-visible revision history is not guaranteed to be a complete audit log

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

Validation performed:
- `uv run pytest -q` -> 1874 passed, 2 skipped
- `uvx ruff@0.15.22 check` -> pass
- `uvx ruff@0.15.22 format --check` -> pass
- 9 new revision-specific tests covering pagination, editor metadata, blob retention rules, native exports, direct historical content reads, and historical downloads

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes
This is a focused successor to the Drive revision-history portion of #936 by @Carlo-SR. That PR established the useful list-then-export direction. This implementation is rebuilt on current `main`, keeps the spreadsheet audit/diff work separate, follows the current thin-tool/helper split, and addresses the revision download/retention concerns raised in review there.

Current contribution guidance strongly prefers extending existing tools because of tool-count pressure. This therefore adds one new listing tool and extends the two existing Drive content/download tools rather than introducing a separate revision-export tool.

Historical native Workspace revisions are streamed from revision-specific `exportLinks`. Uploaded/blob revisions use `revisions.get_media` only when Drive indicates the content is still retrievable, normally the head revision or a revision pinned with `keepForever`.
