### PR TITLE
feat(gmail): reject a send-as alias Gmail would silently discard

### DIFF
--- a/gmail/gmail_helpers.py
+++ b/gmail/gmail_helpers.py
@@ -687,40 +687,68 @@ def _find_send_as_entry(
     )
 
 
-async def _get_send_as_signature_html(service, from_email: Optional[str] = None) -> str:
+def _accepted_send_as_emails(send_as_entries: List[Dict[str, Any]]) -> List[str]:
     """
-    Fetch signature HTML from Gmail send-as settings.
+    Addresses Gmail will actually honour in a From header.
 
-    Returns empty string when the account has no signature configured or when
-    auth/scope errors mean the settings endpoint is unavailable.
+    An entry is usable unless Gmail explicitly reports it as not yet verified.
+    A missing verificationStatus is treated as usable rather than as a failure:
+    the primary address never carries one, and the field is not guaranteed on
+    every entry, so absence means "not reported", not "rejected".
     """
-    send_as_entries = await _get_send_as_entries(service)
-    if not send_as_entries:
-        return ""
+    return [
+        email
+        for entry in send_as_entries
+        if (email := (entry.get("sendAsEmail") or "").strip())
+        and _send_as_entry_is_usable(entry)
+    ]
 
-    if from_email:
-        entry = _find_send_as_entry(send_as_entries, from_email)
-        if entry:
-            return entry.get("signature", "") or ""
 
-    for entry in send_as_entries:
-        if entry.get("isPrimary"):
-            return entry.get("signature", "") or ""
-
-    return send_as_entries[0].get("signature", "") or ""
+def _send_as_entry_is_usable(entry: Dict[str, Any]) -> bool:
+    """True unless Gmail explicitly reports this send-as entry as unverified."""
+    if entry.get("isPrimary"):
+        return True
+    status = entry.get("verificationStatus")
+    return not status or status == "accepted"
 
 
 async def _get_send_as_identity_and_signature(
     service,
     from_email: Optional[str],
     fallback_email: str,
-) -> tuple[str, str]:
-    """Resolve the requested or default Gmail send-as identity and signature."""
+) -> tuple[str, str, str]:
+    """
+    Resolve the send-as identity, refusing an alias Gmail would silently discard.
+
+    Returns (sender_email, display_name, signature_html).
+
+    users.messages.send does NOT reject a From header naming an unconfigured
+    address -- it quietly substitutes the default sender and reports success. A
+    caller asking for one identity and getting another, with no error, is the
+    worst available outcome, so an unusable from_email raises here instead,
+    naming the addresses that would have worked.
+
+    When the send-as list cannot be read at all (no gmail.settings.basic scope --
+    _get_send_as_entries returns [] for that case by design) validation is skipped
+    rather than blocking the send: an unverifiable alias is not a known-bad one.
+    """
     send_as_entries = await _get_send_as_entries(service)
     selected_entry = None
 
     if from_email:
+        if not send_as_entries:
+            # Nothing to validate against; preserve the caller's intent.
+            return from_email, "", ""
         selected_entry = _find_send_as_entry(send_as_entries, from_email)
+        if selected_entry is None or not _send_as_entry_is_usable(selected_entry):
+            accepted = _accepted_send_as_emails(send_as_entries)
+            raise ToolExecutionError(
+                f"'{from_email}' is not an accepted 'Send mail as' address for this "
+                f"mailbox, and Gmail would silently send from the default address "
+                f"instead. Accepted: {', '.join(accepted) or '(none)'}. Add the "
+                f"address under Gmail Settings > Accounts > Send mail as, or omit "
+                f"from_email to use the default sender."
+            )
     else:
         selected_entry = next(
             (entry for entry in send_as_entries if entry.get("isDefault")), None
@@ -733,17 +761,12 @@ async def _get_send_as_identity_and_signature(
             selected_entry = send_as_entries[0]
 
     sender_email = from_email or fallback_email
+    display_name = ""
     signature_html = ""
     if selected_entry:
         if not from_email:
             sender_email = selected_entry.get("sendAsEmail") or fallback_email
+        display_name = (selected_entry.get("displayName") or "").strip()
         signature_html = selected_entry.get("signature", "") or ""
 
-    return sender_email, signature_html
-
-
-async def _get_send_as_signature_html_for_tool(
-    service, from_email: Optional[str] = None
-) -> str:
-    """Fetch signature HTML and convert non-benign failures to tool errors."""
-    return await _get_send_as_signature_html(service, from_email=from_email)
+    return sender_email, display_name, signature_html

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -66,7 +66,6 @@ from gmail.gmail_helpers import (
     _derive_reply_headers,
     _fetch_with_retry,
     _get_send_as_identity_and_signature,
-    _get_send_as_signature_html_for_tool,
     _http_error_status,
     _retryable_result_ids,
     _signature_html_to_text,
@@ -2569,9 +2568,35 @@ async def send_gmail_message(
         f"[send_gmail_message] Invoked. Email: '{user_google_email}', subject_len={len(subject) if subject else 0}, Attachments: {len(attachments) if attachments else 0}"
     )
 
-    # Prepare the email message
-    # Use from_email (Send As alias) if provided, otherwise default to authenticated user
-    sender_email = from_email or user_google_email
+    # Prepare the email message. Where the send-as settings are fetched anyway,
+    # resolving the identity there also validates an explicit from_email: Gmail
+    # silently rewrites an unconfigured From to the default sender rather than
+    # erroring, so an unusable alias must be caught here or the caller gets a
+    # successful send from the wrong address. The explicit-alias-without-signature
+    # branch keeps upstream's fast path -- it exists so a caller holding only
+    # gmail.send, without gmail.settings.basic, can still send.
+    if not include_signature:
+        sender_email, sender_display_name, resolved_signature_html = (
+            from_email or user_google_email,
+            "",
+            "",
+        )
+    else:
+        (
+            sender_email,
+            sender_display_name,
+            resolved_signature_html,
+        ) = await _get_send_as_identity_and_signature(
+            service,
+            from_email=from_email,
+            fallback_email=user_google_email,
+        )
+    # An explicitly requested alias carries its own display name in Gmail's
+    # settings; without it the From header is a bare address, which is rarely
+    # what someone picking an alias wants. Scoped to explicit aliases so the
+    # default-sender path keeps its existing header exactly.
+    if from_email and not from_name:
+        from_name = sender_display_name or None
 
     # A reply's headers, recipients and quoted original are all derivable from the
     # thread, so a caller should not have to assemble them by hand. Mirrors
@@ -2605,11 +2630,7 @@ async def send_gmail_message(
 
     # Optionally append the Gmail signature from send-as settings, mirroring
     # draft_gmail_message so sent mail respects the user's Settings > Signature.
-    signature_html = ""
-    if include_signature:
-        signature_html = await _get_send_as_signature_html_for_tool(
-            service, from_email=sender_email
-        )
+    signature_html = resolved_signature_html if include_signature else ""
 
     if quote_original and target_reply:
         send_body_content = _build_quoted_reply_body(
@@ -2985,16 +3006,19 @@ async def draft_gmail_message(
     # its signature is disabled. Otherwise resolve the identity and signature
     # together so Gmail's default sender and its signature stay aligned.
     if from_email and not include_signature:
-        sender_email, resolved_signature_html = from_email, ""
+        sender_email, sender_display_name, resolved_signature_html = from_email, "", ""
     else:
         (
             sender_email,
+            sender_display_name,
             resolved_signature_html,
         ) = await _get_send_as_identity_and_signature(
             service,
             from_email=from_email,
             fallback_email=user_google_email,
         )
+    if from_email and not from_name:
+        from_name = sender_display_name or None
     draft_body = body
     signature_html = resolved_signature_html if include_signature else ""
 

--- a/tests/gmail/test_send_as_validation.py
+++ b/tests/gmail/test_send_as_validation.py
@@ -1,0 +1,179 @@
+"""
+Tests for send-as identity validation.
+
+users.messages.send does not reject a From header naming an address that is not a
+configured send-as identity -- Gmail silently substitutes the default sender and
+reports success. These cover the resulting contract: an unusable from_email raises
+instead, an alias Gmail has not explicitly rejected is honoured, and the alias's
+own display name fills in when the caller did not supply one.
+"""
+
+import base64
+from email import policy
+from email.parser import BytesParser
+import os
+import sys
+from unittest.mock import Mock
+
+from fastmcp.exceptions import ToolError
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gmail.gmail_tools import draft_gmail_message, send_gmail_message
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _parse_raw_message(raw_message: str):
+    return BytesParser(policy=policy.default).parsebytes(
+        base64.urlsafe_b64decode(raw_message.encode())
+    )
+
+
+def _service_with_send_as(entries):
+    service = Mock()
+    service.users.return_value.settings.return_value.sendAs.return_value.list.return_value.execute.return_value = {
+        "sendAs": entries
+    }
+    service.users.return_value.messages.return_value.send.return_value.execute.return_value = {
+        "id": "msg_1"
+    }
+    service.users.return_value.drafts.return_value.create.return_value.execute.return_value = {
+        "id": "draft_1"
+    }
+    return service
+
+
+PRIMARY = {
+    "sendAsEmail": "primary@example.com",
+    "displayName": "Primary Person",
+    "isPrimary": True,
+    "isDefault": True,
+    "signature": "",
+    "verificationStatus": "accepted",
+}
+ACCEPTED_ALIAS = {
+    "sendAsEmail": "brand@example.com",
+    "displayName": "Brand Team",
+    "isPrimary": False,
+    "isDefault": False,
+    "signature": "",
+    "verificationStatus": "accepted",
+}
+
+
+async def _send(service, **kwargs):
+    return await _unwrap(send_gmail_message)(
+        service=service,
+        user_google_email="primary@example.com",
+        to="recipient@example.com",
+        subject="Subject",
+        body="Body",
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_an_alias_that_is_not_configured():
+    """An unconfigured From would be silently rewritten by Gmail, so refuse it."""
+    service = _service_with_send_as([PRIMARY, ACCEPTED_ALIAS])
+
+    with pytest.raises(ToolError) as exc:
+        await _send(service, from_email="nobody@example.com")
+
+    message = str(exc.value)
+    assert "nobody@example.com" in message
+    # The error must name what would have worked, or the caller is left guessing.
+    assert "primary@example.com" in message
+    assert "brand@example.com" in message
+    # Nothing may be sent once the identity is known to be wrong.
+    service.users.return_value.messages.return_value.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_an_alias_still_pending_verification():
+    pending = dict(ACCEPTED_ALIAS, verificationStatus="pending")
+    service = _service_with_send_as([PRIMARY, pending])
+
+    with pytest.raises(ToolError) as exc:
+        await _send(service, from_email="brand@example.com")
+
+    assert "brand@example.com" in str(exc.value)
+    service.users.return_value.messages.return_value.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_allows_an_alias_with_no_verification_status():
+    """Absence of the field means 'not reported', not 'rejected'."""
+    unreported = {k: v for k, v in ACCEPTED_ALIAS.items() if k != "verificationStatus"}
+    service = _service_with_send_as([PRIMARY, unreported])
+
+    await _send(service, from_email="brand@example.com")
+
+    kwargs = service.users.return_value.messages.return_value.send.call_args.kwargs
+    parsed = _parse_raw_message(kwargs["body"]["raw"])
+    assert "brand@example.com" in parsed["From"]
+
+
+@pytest.mark.asyncio
+async def test_send_skips_validation_when_send_as_settings_are_unreadable():
+    """Without gmail.settings.basic the list comes back empty; do not block the send.
+
+    An unverifiable alias is not the same as a known-bad one, and refusing here
+    would make the tool unusable for callers holding only gmail.send.
+    """
+    service = _service_with_send_as([])
+
+    await _send(service, from_email="whatever@example.com")
+
+    kwargs = service.users.return_value.messages.return_value.send.call_args.kwargs
+    parsed = _parse_raw_message(kwargs["body"]["raw"])
+    assert "whatever@example.com" in parsed["From"]
+
+
+@pytest.mark.asyncio
+async def test_send_fills_the_display_name_from_the_chosen_alias():
+    """Picking an alias should not produce a bare address in the From header."""
+    service = _service_with_send_as([PRIMARY, ACCEPTED_ALIAS])
+
+    await _send(service, from_email="brand@example.com")
+
+    kwargs = service.users.return_value.messages.return_value.send.call_args.kwargs
+    parsed = _parse_raw_message(kwargs["body"]["raw"])
+    assert parsed["From"] == "Brand Team <brand@example.com>"
+
+
+@pytest.mark.asyncio
+async def test_send_prefers_an_explicit_from_name_over_the_alias_display_name():
+    service = _service_with_send_as([PRIMARY, ACCEPTED_ALIAS])
+
+    await _send(service, from_email="brand@example.com", from_name="Someone Else")
+
+    kwargs = service.users.return_value.messages.return_value.send.call_args.kwargs
+    parsed = _parse_raw_message(kwargs["body"]["raw"])
+    assert parsed["From"] == "Someone Else <brand@example.com>"
+
+
+@pytest.mark.asyncio
+async def test_draft_rejects_an_alias_that_is_not_configured():
+    service = _service_with_send_as([PRIMARY, ACCEPTED_ALIAS])
+
+    with pytest.raises(ToolError) as exc:
+        await _unwrap(draft_gmail_message)(
+            service=service,
+            user_google_email="primary@example.com",
+            to="recipient@example.com",
+            subject="Subject",
+            body="Body",
+            from_email="nobody@example.com",
+        )
+
+    assert "brand@example.com" in str(exc.value)
+    service.users.return_value.drafts.return_value.create.assert_not_called()


### PR DESCRIPTION
## Description

`users.messages.send` does not reject a `From` header naming an address that is not a configured send-as identity. Gmail quietly substitutes the default sender and returns success. So a caller that asks to send as one identity gets a delivered message from another, with nothing in the response indicating the swap — for a mailbox fronting several alias domains, that is the worst available outcome. `from_email` is currently passed straight into the header with no check.

`_get_send_as_identity_and_signature()` now validates an explicit `from_email` against the send-as list and raises with the accepted addresses named, so the caller learns both that the alias is unusable and what would have worked:

```
'nobody@example.com' is not an accepted 'Send mail as' address for this mailbox,
and Gmail would silently send from the default address instead.
Accepted: primary@example.com, brand@example.com. Add the address under
Gmail Settings > Accounts > Send mail as, or omit from_email to use the default sender.
```

### Three deliberate limits

**An entry is refused only when Gmail explicitly reports it unverified.** A missing `verificationStatus` is treated as usable — the primary address never carries one, and the field is not guaranteed on every entry, so absence means "not reported", not "rejected". Two of this repo's existing fixtures model aliases without the field, which is what convinced me a stricter rule would be a guess.

**When the send-as list cannot be read at all, validation is skipped rather than blocking.** `_get_send_as_entries()` already returns `[]` for the missing-scope case by design; an unverifiable alias is not the same as a known-bad one.

**The existing "explicit alias, signatures disabled" fast paths are preserved.** `test_draft_gmail_message_explicit_send_as_skips_lookup_without_signature` documents why they exist — *"we must NOT call the settings endpoint at all (avoids requiring the gmail.settings.basic scope)"* — and validating there would force the very call they avoid. Validation rides along wherever the settings are already being fetched, which is the default path (`include_signature` defaults to `True`). Net new API calls: zero.

### Display name

Also fills the `From` display name from the chosen alias when the caller did not supply one, so picking an alias no longer produces a bare address. Scoped to explicit aliases, leaving the default-sender header byte-identical.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

No new tools — this extends `send_gmail_message` and `draft_gmail_message`, per CONTRIBUTING's preference for extending over adding.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

**No existing test was changed.** 7 new tests in `tests/gmail/test_send_as_validation.py`: rejection of an unconfigured alias (and that nothing is sent), rejection of a `pending` alias, acceptance of an alias with no `verificationStatus`, the unreadable-settings path, display-name fill-in, explicit `from_name` winning, and the draft-side rejection.

| | result |
|---|---|
| baseline `main` (`ce1a9ec`) | `1865 passed, 2 skipped` |
| with this change | `1872 passed, 2 skipped` |
| `uvx ruff@0.15.22 check` | All checks passed |
| `uvx ruff@0.15.22 format --check` | 199 files already formatted |

Verified against live Gmail settings on a Workspace account with six alias-domain identities: `users.settings.sendAs.list` returns them all with `verificationStatus: accepted` and `treatAsAlias: true`, which is the shape the accept path keys on.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

Stacked conceptually on #1073 but textually independent — different files, no conflict either way.

One thing I chose not to do: a tool that lists the send-as identities. It would make aliases discoverable to a model that currently has no way to learn which values `from_email` accepts, but CONTRIBUTING is clear that new tools will almost never be merged. Naming the accepted addresses in the error message covers most of the same ground at zero tool-count cost. Happy to revisit if you would rather surface them another way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gmail messages and drafts now validate requested sender addresses before sending.
  * Invalid or unverified addresses display an error with the available sender options instead of silently using the default sender.
  * Configured sender display names are now used automatically when no custom name is provided.
  * Custom sender names continue to take precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->