### PR TITLE
feat(gdocs): add paragraph layout stats to inspect_doc_structure

### DIFF
--- a/gdocs/docs_structure.py
+++ b/gdocs/docs_structure.py
@@ -100,6 +100,12 @@ def _parse_element(element: dict[str, Any]) -> Optional[dict[str, Any]]:
         element_info["text"] = _extract_paragraph_text(paragraph)
         element_info["style"] = paragraph.get("paragraphStyle", {})
         element_info["is_list_item"] = "bullet" in paragraph
+        for api_key, key in (
+            ("positionedObjectIds", "positioned_object_ids"),
+            ("suggestedPositionedObjectIds", "suggested_positioned_object_ids"),
+        ):
+            if paragraph.get(api_key):
+                element_info[key] = paragraph[api_key]
 
     elif "table" in element:
         table = element["table"]
@@ -349,6 +355,15 @@ def get_next_paragraph_index(doc_data: dict[str, Any], after_index: int = 0) -> 
     return structure["total_length"] - 1 if structure["total_length"] > 0 else 1
 
 
+def _is_empty_paragraph(paragraph: dict[str, Any]) -> bool:
+    """A newline-only paragraph with no existing or suggested object anchors."""
+    return (
+        paragraph["end_index"] - paragraph["start_index"] == 1
+        and not paragraph.get("positioned_object_ids")
+        and not paragraph.get("suggested_positioned_object_ids")
+    )
+
+
 def summarize_paragraph_layout(structure: dict[str, Any]) -> dict[str, Any]:
     """
     Summarize the paragraph-level layout signals of a parsed document body.
@@ -359,7 +374,8 @@ def summarize_paragraph_layout(structure: dict[str, Any]) -> dict[str, Any]:
     inherit that list's bullet).
 
     Only top-level body paragraphs are considered; paragraphs nested in table
-    cells are not part of this summary.
+    cells are not part of this summary. Paragraphs anchoring existing or
+    suggested positioned objects are not considered empty.
 
     Args:
         structure: Parsed structure from parse_document_structure
@@ -367,7 +383,10 @@ def summarize_paragraph_layout(structure: dict[str, Any]) -> dict[str, Any]:
     The ranges are paragraph extents, not ready-made delete ranges: the
     body-final paragraph ends at the segment-terminating newline, which Google
     Docs refuses to delete. At most EMPTY_PARAGRAPH_RANGE_LIMIT ranges are
-    returned; the count is always exact.
+    returned; the count is always exact. Truncation can omit the body-final
+    paragraph: identify it by end == structure["total_length"], not list position.
+    Newlines immediately before tables, tables of contents, and section breaks
+    are also protected, even when their paragraphs are empty.
 
     Returns:
         Dictionary with empty_paragraphs, empty_paragraph_ranges,
@@ -379,7 +398,7 @@ def summarize_paragraph_layout(structure: dict[str, Any]) -> dict[str, Any]:
     empty_ranges = [
         {"start": p["start_index"], "end": p["end_index"]}
         for p in paragraphs
-        if p["end_index"] - p["start_index"] == 1
+        if _is_empty_paragraph(p)
     ]
 
     last_paragraph = None
@@ -387,7 +406,7 @@ def summarize_paragraph_layout(structure: dict[str, Any]) -> dict[str, Any]:
         last = paragraphs[-1]
         last_paragraph = {
             "is_list_item": bool(last.get("is_list_item")),
-            "is_empty": last["end_index"] - last["start_index"] == 1,
+            "is_empty": _is_empty_paragraph(last),
         }
 
     return {

--- a/gdocs/docs_structure.py
+++ b/gdocs/docs_structure.py
@@ -10,6 +10,11 @@ from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
+# Cap on the number of empty-paragraph ranges reported by
+# summarize_paragraph_layout, so the basic inspection stays small even on a
+# badly rendered document. The count itself is never capped.
+EMPTY_PARAGRAPH_RANGE_LIMIT = 100
+
 
 def parse_document_structure(doc_data: dict[str, Any]) -> dict[str, Any]:
     """
@@ -94,6 +99,7 @@ def _parse_element(element: dict[str, Any]) -> Optional[dict[str, Any]]:
         element_info["type"] = "paragraph"
         element_info["text"] = _extract_paragraph_text(paragraph)
         element_info["style"] = paragraph.get("paragraphStyle", {})
+        element_info["is_list_item"] = "bullet" in paragraph
 
     elif "table" in element:
         table = element["table"]
@@ -343,6 +349,56 @@ def get_next_paragraph_index(doc_data: dict[str, Any], after_index: int = 0) -> 
     return structure["total_length"] - 1 if structure["total_length"] > 0 else 1
 
 
+def summarize_paragraph_layout(structure: dict[str, Any]) -> dict[str, Any]:
+    """
+    Summarize the paragraph-level layout signals of a parsed document body.
+
+    These answer the two questions that follow a markdown render without
+    requiring the full element listing: how many literal empty paragraphs the
+    body carries, and whether it ends inside a list (the next insertion would
+    inherit that list's bullet).
+
+    Only top-level body paragraphs are considered; paragraphs nested in table
+    cells are not part of this summary.
+
+    Args:
+        structure: Parsed structure from parse_document_structure
+
+    The ranges are paragraph extents, not ready-made delete ranges: the
+    body-final paragraph ends at the segment-terminating newline, which Google
+    Docs refuses to delete. At most EMPTY_PARAGRAPH_RANGE_LIMIT ranges are
+    returned; the count is always exact.
+
+    Returns:
+        Dictionary with empty_paragraphs, empty_paragraph_ranges,
+        empty_paragraph_ranges_truncated and last_paragraph (None when the body
+        holds no paragraph at all)
+    """
+    paragraphs = [e for e in structure["body"] if e.get("type") == "paragraph"]
+
+    empty_ranges = [
+        {"start": p["start_index"], "end": p["end_index"]}
+        for p in paragraphs
+        if p["end_index"] - p["start_index"] == 1
+    ]
+
+    last_paragraph = None
+    if paragraphs:
+        last = paragraphs[-1]
+        last_paragraph = {
+            "is_list_item": bool(last.get("is_list_item")),
+            "is_empty": last["end_index"] - last["start_index"] == 1,
+        }
+
+    return {
+        "empty_paragraphs": len(empty_ranges),
+        "empty_paragraph_ranges": empty_ranges[:EMPTY_PARAGRAPH_RANGE_LIMIT],
+        "empty_paragraph_ranges_truncated": len(empty_ranges)
+        > EMPTY_PARAGRAPH_RANGE_LIMIT,
+        "last_paragraph": last_paragraph,
+    }
+
+
 def analyze_document_complexity(doc_data: dict[str, Any]) -> dict[str, Any]:
     """
     Analyze document complexity and provide statistics.
@@ -365,6 +421,7 @@ def analyze_document_complexity(doc_data: dict[str, Any]) -> dict[str, Any]:
         "total_length": structure["total_length"],
         "has_headers": bool(structure["headers"]),
         "has_footers": bool(structure["footers"]),
+        **summarize_paragraph_layout(structure),
     }
 
     # Add table statistics

--- a/gdocs/docs_structure.py
+++ b/gdocs/docs_structure.py
@@ -10,9 +10,7 @@ from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
-# Cap on the number of empty-paragraph ranges reported by
-# summarize_paragraph_layout, so the basic inspection stays small even on a
-# badly rendered document. The count itself is never capped.
+# Limit returned ranges; the count remains exact.
 EMPTY_PARAGRAPH_RANGE_LIMIT = 100
 
 
@@ -365,33 +363,11 @@ def _is_empty_paragraph(paragraph: dict[str, Any]) -> bool:
 
 
 def summarize_paragraph_layout(structure: dict[str, Any]) -> dict[str, Any]:
-    """
-    Summarize the paragraph-level layout signals of a parsed document body.
+    """Count empty body paragraphs and report the last paragraph's state.
 
-    These answer the two questions that follow a markdown render without
-    requiring the full element listing: how many literal empty paragraphs the
-    body carries, and whether it ends inside a list (the next insertion would
-    inherit that list's bullet).
-
-    Only top-level body paragraphs are considered; paragraphs nested in table
-    cells are not part of this summary. Paragraphs anchoring existing or
-    suggested positioned objects are not considered empty.
-
-    Args:
-        structure: Parsed structure from parse_document_structure
-
-    The ranges are paragraph extents, not ready-made delete ranges: the
-    body-final paragraph ends at the segment-terminating newline, which Google
-    Docs refuses to delete. At most EMPTY_PARAGRAPH_RANGE_LIMIT ranges are
-    returned; the count is always exact. Truncation can omit the body-final
-    paragraph: identify it by end == structure["total_length"], not list position.
-    Newlines immediately before tables, tables of contents, and section breaks
-    are also protected, even when their paragraphs are empty.
-
-    Returns:
-        Dictionary with empty_paragraphs, empty_paragraph_ranges,
-        empty_paragraph_ranges_truncated and last_paragraph (None when the body
-        holds no paragraph at all)
+    Only top-level paragraphs are included; object anchors do not count as empty.
+    Ranges are capped extents, including protected newlines. last_paragraph is
+    None if absent.
     """
     paragraphs = [e for e in structure["body"] if e.get("type") == "paragraph"]
 

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -1400,37 +1400,17 @@ async def inspect_doc_structure(
     - table_details: Position and dimensions of each table
     - headers / footers: Real segment IDs and previews for header/footer editing
     - tabs: List of available tabs in the document (if no tab_id specified)
-    - empty_paragraphs: count of newline-only body paragraphs without existing
-      or suggested positioned-object anchors
-    - empty_paragraph_ranges: their start/end ranges, capped at 100 entries
-    - empty_paragraph_ranges_truncated: whether further ranges were omitted
-    - last_paragraph: whether the body ends in a list item, and whether it is empty
+    - empty_paragraphs: newline-only count, excluding existing/suggested object anchors
+    - empty_paragraph_ranges: start/end extents, capped at 100
+    - empty_paragraph_ranges_truncated: whether ranges were omitted
+    - last_paragraph: is_list_item and is_empty, or null if no body paragraphs
 
-    VERIFYING A RENDERED DOCUMENT:
-    The paragraph layout fields are reported in both modes - at the top level
-    when detailed=false, and under "statistics" when detailed=true - so checking
-    whether a render left stray empty paragraphs behind, or ended inside a list
-    (where the next insertion would inherit that bullet), does not require the
-    full element listing. Use detailed=true when you need per-element indices.
-
-    Before deleting by these ranges:
-    - These are paragraph extents, not ready-made delete ranges. Use
-      detailed=true to check adjacent elements and positioned_object_ids /
-      suggested_positioned_object_ids before deleting paragraph boundaries;
-      merging paragraphs can affect styles, lists, and anchored objects.
-    - Identify a body-final range by end == total_length, not its position in
-      the returned list. When ranges are truncated, the body-final paragraph
-      may be omitted even when last_paragraph.is_empty is true.
-    - Docs refuses to delete the body-final newline; start to end - 1 is also
-      invalid for an empty paragraph. Only when another paragraph immediately
-      precedes it, consider deleting start - 1 to end - 1 to merge them after
-      checking that paragraph's formatting and anchors. A body holding only
-      one paragraph cannot be emptied further.
-    - Docs also refuses to delete the newline immediately before a table,
-      table of contents, or section break unless that element is deleted too.
-      Keep these structural separators when cleaning up empty paragraphs.
-    - Docs requires a paragraph after a table. When that trailing paragraph is
-      empty it is still counted, so cleanup need not make empty_paragraphs zero.
+    Paragraph statistics cover top-level body paragraphs and appear at the top
+    level in basic mode or under "statistics" in detailed mode.
+    Ranges can include required empty paragraphs. Before cleanup, use detailed=true
+    to check adjacent elements, formatting, and object anchors. Preserve the final
+    newline and newlines before tables, tables of contents, or section breaks.
+    The final range has end == total_length and may be omitted by truncation.
 
     WORKFLOW FOR TABLE INSERTION:
     Step 1: Call this function

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -51,6 +51,7 @@ from gdocs.docs_structure import (
     parse_document_structure,
     find_tables,
     analyze_document_complexity,
+    summarize_paragraph_layout,
 )
 from gdocs.docs_tables import extract_table_as_data
 from gdocs.docs_markdown import (
@@ -1381,6 +1382,28 @@ async def inspect_doc_structure(
     - table_details: Position and dimensions of each table
     - headers / footers: Real segment IDs and previews for header/footer editing
     - tabs: List of available tabs in the document (if no tab_id specified)
+    - empty_paragraphs: count of literal empty paragraphs in the body
+    - empty_paragraph_ranges: their start/end ranges, capped at 100 entries
+    - empty_paragraph_ranges_truncated: whether that cap was reached
+    - last_paragraph: whether the body ends in a list item, and whether it is empty
+
+    VERIFYING A RENDERED DOCUMENT:
+    The paragraph layout fields are reported in both modes - at the top level
+    when detailed=false, and under "statistics" when detailed=true - so checking
+    whether a render left stray empty paragraphs behind, or ended inside a list
+    (where the next insertion would inherit that bullet), does not require the
+    full element listing. Use detailed=true when you need per-element indices.
+
+    Two things to know before deleting by these ranges:
+    - They are paragraph extents, not ready-made delete ranges. When
+      last_paragraph.is_empty is true, the final range is the body-final
+      paragraph, whose end is the segment-terminating newline that Docs refuses
+      to delete; deleting from start to end - 1 is an empty range and is
+      rejected as well. Remove that paragraph by deleting from start - 1 to
+      end - 1 instead, which is the preceding paragraph's newline.
+    - A body ending in a table always carries one trailing empty paragraph,
+      because Docs requires a paragraph after a table, so empty_paragraphs does
+      not reach zero on such a document.
 
     WORKFLOW FOR TABLE INSERTION:
     Step 1: Call this function
@@ -1493,6 +1516,7 @@ async def inspect_doc_structure(
                 "named_ranges": len(structure["named_ranges"]),
                 "has_headers": bool(structure["headers"]),
                 "has_footers": bool(structure["footers"]),
+                **summarize_paragraph_layout(structure),
             },
             "elements": [],
         }
@@ -1511,6 +1535,7 @@ async def inspect_doc_structure(
                 elem_summary["cell_count"] = len(element.get("cells", []))
             elif element["type"] == "paragraph":
                 elem_summary["text_preview"] = element.get("text", "")[:100]
+                elem_summary["is_list_item"] = bool(element.get("is_list_item"))
 
             result["elements"].append(elem_summary)
 

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -1400,7 +1400,8 @@ async def inspect_doc_structure(
     - table_details: Position and dimensions of each table
     - headers / footers: Real segment IDs and previews for header/footer editing
     - tabs: List of available tabs in the document (if no tab_id specified)
-    - empty_paragraphs: count of literal empty paragraphs in the body
+    - empty_paragraphs: count of newline-only body paragraphs without existing
+      or suggested positioned-object anchors
     - empty_paragraph_ranges: their start/end ranges, capped at 100 entries
     - empty_paragraph_ranges_truncated: whether further ranges were omitted
     - last_paragraph: whether the body ends in a list item, and whether it is empty
@@ -1412,18 +1413,24 @@ async def inspect_doc_structure(
     (where the next insertion would inherit that bullet), does not require the
     full element listing. Use detailed=true when you need per-element indices.
 
-    Two things to know before deleting by these ranges:
-    - They are paragraph extents, not ready-made delete ranges. When
-      last_paragraph.is_empty is true, the final range is the body-final
-      paragraph, whose end is the segment-terminating newline that Docs refuses
-      to delete; deleting from start to end - 1 is an empty range and is
-      rejected as well. When a paragraph precedes it, remove it by deleting from
-      start - 1 to end - 1 instead, which is that paragraph's newline. A body
-      holding nothing else cannot be emptied further: index 0 is the leading
-      section break, and the body always keeps one paragraph.
-    - A body ending in a table always carries one trailing empty paragraph,
-      because Docs requires a paragraph after a table, so empty_paragraphs does
-      not reach zero on such a document.
+    Before deleting by these ranges:
+    - These are paragraph extents, not ready-made delete ranges. Use
+      detailed=true to check adjacent elements and positioned_object_ids /
+      suggested_positioned_object_ids before deleting paragraph boundaries;
+      merging paragraphs can affect styles, lists, and anchored objects.
+    - Identify a body-final range by end == total_length, not its position in
+      the returned list. When ranges are truncated, the body-final paragraph
+      may be omitted even when last_paragraph.is_empty is true.
+    - Docs refuses to delete the body-final newline; start to end - 1 is also
+      invalid for an empty paragraph. Only when another paragraph immediately
+      precedes it, consider deleting start - 1 to end - 1 to merge them after
+      checking that paragraph's formatting and anchors. A body holding only
+      one paragraph cannot be emptied further.
+    - Docs also refuses to delete the newline immediately before a table,
+      table of contents, or section break unless that element is deleted too.
+      Keep these structural separators when cleaning up empty paragraphs.
+    - Docs requires a paragraph after a table. When that trailing paragraph is
+      empty it is still counted, so cleanup need not make empty_paragraphs zero.
 
     WORKFLOW FOR TABLE INSERTION:
     Step 1: Call this function
@@ -1556,6 +1563,9 @@ async def inspect_doc_structure(
             elif element["type"] == "paragraph":
                 elem_summary["text_preview"] = element.get("text", "")[:100]
                 elem_summary["is_list_item"] = bool(element.get("is_list_item"))
+                for key in ("positioned_object_ids", "suggested_positioned_object_ids"):
+                    if key in element:
+                        elem_summary[key] = element[key]
 
             result["elements"].append(elem_summary)
 

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -1384,7 +1384,7 @@ async def inspect_doc_structure(
     - tabs: List of available tabs in the document (if no tab_id specified)
     - empty_paragraphs: count of literal empty paragraphs in the body
     - empty_paragraph_ranges: their start/end ranges, capped at 100 entries
-    - empty_paragraph_ranges_truncated: whether that cap was reached
+    - empty_paragraph_ranges_truncated: whether further ranges were omitted
     - last_paragraph: whether the body ends in a list item, and whether it is empty
 
     VERIFYING A RENDERED DOCUMENT:
@@ -1399,8 +1399,10 @@ async def inspect_doc_structure(
       last_paragraph.is_empty is true, the final range is the body-final
       paragraph, whose end is the segment-terminating newline that Docs refuses
       to delete; deleting from start to end - 1 is an empty range and is
-      rejected as well. Remove that paragraph by deleting from start - 1 to
-      end - 1 instead, which is the preceding paragraph's newline.
+      rejected as well. When a paragraph precedes it, remove it by deleting from
+      start - 1 to end - 1 instead, which is that paragraph's newline. A body
+      holding nothing else cannot be emptied further: index 0 is the leading
+      section break, and the body always keeps one paragraph.
     - A body ending in a table always carries one trailing empty paragraph,
       because Docs requires a paragraph after a table, so empty_paragraphs does
       not reach zero on such a document.

--- a/skills/managing-google-workspace/references/docs-layout-workflow.md
+++ b/skills/managing-google-workspace/references/docs-layout-workflow.md
@@ -130,15 +130,9 @@ Then download and read the PDF to check:
 - Heading hierarchy is correct (H1 > H2 > H3)
 - No stray empty paragraphs or list items
 
-The last point is cheaper to check first: `inspect_doc_structure` reports
-`empty_paragraphs` and `last_paragraph.is_list_item` in its basic mode, so potential
-stray empty paragraphs and a body left inside a list can be found before a PDF
-is rendered. Paragraphs anchoring existing or suggested positioned objects are
-excluded from the empty count. Before deleting, inspect adjacent elements with
-`detailed=true`: empty paragraphs can be required structural separators. The
-body-final newline and newlines directly before tables, tables of contents, or
-section breaks must be preserved. Capped ranges may omit the final paragraph;
-identify it by `end == total_length`. The PDF pass verifies the visual layout.
+Before exporting, check `empty_paragraphs` and `last_paragraph.is_list_item` with
+`inspect_doc_structure`. Some empty paragraphs are required; see the
+[cleanup constraints](docs.md#inspect_doc_structure) before deleting them.
 
 ---
 

--- a/skills/managing-google-workspace/references/docs-layout-workflow.md
+++ b/skills/managing-google-workspace/references/docs-layout-workflow.md
@@ -130,6 +130,11 @@ Then download and read the PDF to check:
 - Heading hierarchy is correct (H1 > H2 > H3)
 - No stray empty paragraphs or list items
 
+The last point is cheaper to check first: `inspect_doc_structure` reports
+`empty_paragraphs` and `last_paragraph.is_list_item` in its basic mode, so stray
+empty paragraphs and a body left inside a list can be found and fixed before a
+PDF is rendered. The PDF pass remains the way to verify everything else.
+
 ---
 
 ## Common Pitfalls & Fixes

--- a/skills/managing-google-workspace/references/docs-layout-workflow.md
+++ b/skills/managing-google-workspace/references/docs-layout-workflow.md
@@ -131,9 +131,14 @@ Then download and read the PDF to check:
 - No stray empty paragraphs or list items
 
 The last point is cheaper to check first: `inspect_doc_structure` reports
-`empty_paragraphs` and `last_paragraph.is_list_item` in its basic mode, so stray
-empty paragraphs and a body left inside a list can be found and fixed before a
-PDF is rendered. The PDF pass remains the way to verify everything else.
+`empty_paragraphs` and `last_paragraph.is_list_item` in its basic mode, so potential
+stray empty paragraphs and a body left inside a list can be found before a PDF
+is rendered. Paragraphs anchoring existing or suggested positioned objects are
+excluded from the empty count. Before deleting, inspect adjacent elements with
+`detailed=true`: empty paragraphs can be required structural separators. The
+body-final newline and newlines directly before tables, tables of contents, or
+section breaks must be preserved. Capped ranges may omit the final paragraph;
+identify it by `end == total_length`. The PDF pass verifies the visual layout.
 
 ---
 

--- a/skills/managing-google-workspace/references/docs.md
+++ b/skills/managing-google-workspace/references/docs.md
@@ -280,18 +280,15 @@ Key output fields:
 - `tables` -- count of existing tables
 - `table_details` -- position and dimensions per table
 - `tabs` -- list of tabs with IDs (when no tab_id specified)
-- `empty_paragraphs` / `empty_paragraph_ranges` -- newline-only body paragraphs without existing or suggested positioned-object anchors (ranges are capped, with a truncation flag)
-- `last_paragraph` -- whether the body ends in a list item, and whether it is empty
+- `empty_paragraphs` -- newline-only body paragraph count, excluding existing or suggested object anchors
+- `empty_paragraph_ranges` / `empty_paragraph_ranges_truncated` -- first 100 start/end extents and whether more exist
+- `last_paragraph` -- `is_list_item` and `is_empty`, or null if no body paragraphs
 
-The last two are reported in both modes, so checking a rendered document does not
-need `detailed=true`.
-
-Ranges are paragraph extents, not deletion instructions. A body-final range has
-`end == total_length`; truncation may omit it. Before cleanup, use `detailed=true`
-to check adjacent elements and any `positioned_object_ids` or
-`suggested_positioned_object_ids`. Keep the terminal newline and newlines directly
-before tables, tables of contents, or section breaks. Merging paragraphs can
-change formatting, list membership, and anchored objects.
+Paragraph statistics exclude nested paragraphs and appear at the top level in basic
+mode, under `statistics` in detailed mode. Before cleanup, use `detailed=true` to
+check adjacent elements, formatting, and object anchors. Preserve the final newline
+(`end == total_length`, possibly omitted by truncation) and newlines before tables,
+tables of contents, or section breaks. Required empty paragraphs are still counted.
 
 ### debug_table_structure
 Detailed view of a single table's layout: dimensions, cell positions, current content, and insertion indices per cell. Use after creating or populating a table to verify results.

--- a/skills/managing-google-workspace/references/docs.md
+++ b/skills/managing-google-workspace/references/docs.md
@@ -280,11 +280,18 @@ Key output fields:
 - `tables` -- count of existing tables
 - `table_details` -- position and dimensions per table
 - `tabs` -- list of tabs with IDs (when no tab_id specified)
-- `empty_paragraphs` / `empty_paragraph_ranges` -- literal empty paragraphs left in the body (ranges are capped, with a truncation flag)
+- `empty_paragraphs` / `empty_paragraph_ranges` -- newline-only body paragraphs without existing or suggested positioned-object anchors (ranges are capped, with a truncation flag)
 - `last_paragraph` -- whether the body ends in a list item, and whether it is empty
 
 The last two are reported in both modes, so checking a rendered document does not
 need `detailed=true`.
+
+Ranges are paragraph extents, not deletion instructions. A body-final range has
+`end == total_length`; truncation may omit it. Before cleanup, use `detailed=true`
+to check adjacent elements and any `positioned_object_ids` or
+`suggested_positioned_object_ids`. Keep the terminal newline and newlines directly
+before tables, tables of contents, or section breaks. Merging paragraphs can
+change formatting, list membership, and anchored objects.
 
 ### debug_table_structure
 Detailed view of a single table's layout: dimensions, cell positions, current content, and insertion indices per cell. Use after creating or populating a table to verify results.

--- a/skills/managing-google-workspace/references/docs.md
+++ b/skills/managing-google-workspace/references/docs.md
@@ -280,6 +280,11 @@ Key output fields:
 - `tables` -- count of existing tables
 - `table_details` -- position and dimensions per table
 - `tabs` -- list of tabs with IDs (when no tab_id specified)
+- `empty_paragraphs` / `empty_paragraph_ranges` -- literal empty paragraphs left in the body (ranges are capped, with a truncation flag)
+- `last_paragraph` -- whether the body ends in a list item, and whether it is empty
+
+The last two are reported in both modes, so checking a rendered document does not
+need `detailed=true`.
 
 ### debug_table_structure
 Detailed view of a single table's layout: dimensions, cell positions, current content, and insertion indices per cell. Use after creating or populating a table to verify results.

--- a/tests/gdocs/test_structure_statistics.py
+++ b/tests/gdocs/test_structure_statistics.py
@@ -1,0 +1,242 @@
+"""Tests for empty-paragraph and trailing-paragraph statistics in structure analysis."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from gdocs import docs_tools
+from gdocs.docs_structure import (
+    EMPTY_PARAGRAPH_RANGE_LIMIT,
+    analyze_document_complexity,
+)
+
+
+def _unwrap(tool):
+    """Unwrap a FunctionTool + decorator chain to the original function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _paragraph(start, end, text, bullet=False):
+    """Build a minimal Docs API paragraph element."""
+    paragraph = {"elements": [{"textRun": {"content": text}}]}
+    if bullet:
+        paragraph["bullet"] = {"listId": "kix.list1", "nestingLevel": 0}
+    return {"startIndex": start, "endIndex": end, "paragraph": paragraph}
+
+
+def _section_break(start, end):
+    return {"startIndex": start, "endIndex": end, "sectionBreak": {"sectionStyle": {}}}
+
+
+def _doc(*elements):
+    return {"body": {"content": list(elements)}}
+
+
+def _extract_json(result):
+    """Pull the JSON payload out of the tool's human-readable response."""
+    payload = result.split("\n\n", 1)[1].rsplit("\n\nLink:", 1)[0]
+    return json.loads(payload)
+
+
+class TestEmptyParagraphStatistics:
+    def test_document_without_empty_paragraphs(self):
+        stats = analyze_document_complexity(
+            _doc(
+                _paragraph(1, 7, "Hello\n"),
+                _paragraph(7, 13, "World\n"),
+            )
+        )
+
+        assert stats["empty_paragraphs"] == 0
+        assert stats["empty_paragraph_ranges"] == []
+
+    def test_empty_paragraphs_are_counted_and_located(self):
+        stats = analyze_document_complexity(
+            _doc(
+                _paragraph(1, 7, "Hello\n"),
+                _paragraph(7, 8, "\n"),
+                _paragraph(8, 14, "World\n"),
+                _paragraph(14, 15, "\n"),
+            )
+        )
+
+        assert stats["empty_paragraphs"] == 2
+        assert stats["empty_paragraph_ranges"] == [
+            {"start": 7, "end": 8},
+            {"start": 14, "end": 15},
+        ]
+
+    def test_section_breaks_are_not_empty_paragraphs(self):
+        stats = analyze_document_complexity(
+            _doc(
+                _section_break(0, 1),
+                _paragraph(1, 7, "Hello\n"),
+            )
+        )
+
+        assert stats["empty_paragraphs"] == 0
+        assert stats["empty_paragraph_ranges"] == []
+
+
+class TestEmptyParagraphRangeLimit:
+    @staticmethod
+    def _doc_with_empty_paragraphs(count):
+        elements, index = [], 1
+        for _ in range(count):
+            elements.append(_paragraph(index, index + 1, "\n"))
+            index += 1
+        return _doc(*elements)
+
+    def test_ranges_are_capped_but_count_is_not(self):
+        over_limit = EMPTY_PARAGRAPH_RANGE_LIMIT + 50
+        stats = analyze_document_complexity(self._doc_with_empty_paragraphs(over_limit))
+
+        assert stats["empty_paragraphs"] == over_limit
+        assert len(stats["empty_paragraph_ranges"]) == EMPTY_PARAGRAPH_RANGE_LIMIT
+        assert stats["empty_paragraph_ranges_truncated"] is True
+
+    def test_ranges_at_the_limit_are_not_flagged(self):
+        stats = analyze_document_complexity(
+            self._doc_with_empty_paragraphs(EMPTY_PARAGRAPH_RANGE_LIMIT)
+        )
+
+        assert len(stats["empty_paragraph_ranges"]) == EMPTY_PARAGRAPH_RANGE_LIMIT
+        assert stats["empty_paragraph_ranges_truncated"] is False
+
+
+class TestLastParagraphStatistics:
+    def test_reports_trailing_list_item(self):
+        stats = analyze_document_complexity(
+            _doc(
+                _paragraph(1, 7, "Hello\n"),
+                _paragraph(7, 13, "Item\n", bullet=True),
+            )
+        )
+
+        assert stats["last_paragraph"] == {"is_list_item": True, "is_empty": False}
+
+    def test_reports_trailing_plain_paragraph(self):
+        stats = analyze_document_complexity(
+            _doc(
+                _paragraph(1, 7, "Item\n", bullet=True),
+                _paragraph(7, 13, "Hello\n"),
+            )
+        )
+
+        assert stats["last_paragraph"] == {"is_list_item": False, "is_empty": False}
+
+    def test_reports_trailing_empty_paragraph(self):
+        stats = analyze_document_complexity(
+            _doc(
+                _paragraph(1, 7, "Hello\n"),
+                _paragraph(7, 8, "\n"),
+            )
+        )
+
+        assert stats["last_paragraph"] == {"is_list_item": False, "is_empty": True}
+
+    def test_ignores_trailing_non_paragraph_elements(self):
+        stats = analyze_document_complexity(
+            _doc(
+                _paragraph(1, 7, "Item\n", bullet=True),
+                _section_break(7, 8),
+            )
+        )
+
+        assert stats["last_paragraph"] == {"is_list_item": True, "is_empty": False}
+
+    def test_document_without_paragraphs(self):
+        stats = analyze_document_complexity(_doc(_section_break(0, 1)))
+
+        assert stats["empty_paragraphs"] == 0
+        assert stats["empty_paragraph_ranges"] == []
+        assert stats["last_paragraph"] is None
+
+
+class TestInspectDocStructureReportsStatistics:
+    @staticmethod
+    def _service(doc):
+        service = Mock()
+        service.documents.return_value.get.return_value.execute = Mock(return_value=doc)
+        return service
+
+    @pytest.mark.asyncio
+    async def test_basic_and_detailed_modes_agree(self):
+        doc = _doc(
+            _paragraph(1, 7, "Hello\n"),
+            _paragraph(7, 8, "\n"),
+            _paragraph(8, 14, "Item\n", bullet=True),
+        )
+
+        basic = _extract_json(
+            await _unwrap(docs_tools.inspect_doc_structure)(
+                service=self._service(doc),
+                user_google_email="user@example.com",
+                document_id="doc123",
+            )
+        )
+        detailed = _extract_json(
+            await _unwrap(docs_tools.inspect_doc_structure)(
+                service=self._service(doc),
+                user_google_email="user@example.com",
+                document_id="doc123",
+                detailed=True,
+            )
+        )
+
+        expected = {
+            "empty_paragraphs": 1,
+            "empty_paragraph_ranges": [{"start": 7, "end": 8}],
+            "empty_paragraph_ranges_truncated": False,
+            "last_paragraph": {"is_list_item": True, "is_empty": False},
+        }
+
+        for key, value in expected.items():
+            assert basic[key] == value
+            assert detailed["statistics"][key] == value
+
+    @pytest.mark.asyncio
+    async def test_existing_statistics_keys_are_preserved(self):
+        doc = _doc(_paragraph(1, 7, "Hello\n"))
+
+        basic = _extract_json(
+            await _unwrap(docs_tools.inspect_doc_structure)(
+                service=self._service(doc),
+                user_google_email="user@example.com",
+                document_id="doc123",
+            )
+        )
+
+        for key in (
+            "total_elements",
+            "tables",
+            "paragraphs",
+            "section_breaks",
+            "total_length",
+            "has_headers",
+            "has_footers",
+        ):
+            assert key in basic
+
+    @pytest.mark.asyncio
+    async def test_detailed_elements_expose_list_membership(self):
+        doc = _doc(
+            _paragraph(1, 7, "Hello\n"),
+            _paragraph(7, 13, "Item\n", bullet=True),
+        )
+
+        detailed = _extract_json(
+            await _unwrap(docs_tools.inspect_doc_structure)(
+                service=self._service(doc),
+                user_google_email="user@example.com",
+                document_id="doc123",
+                detailed=True,
+            )
+        )
+
+        paragraphs = [e for e in detailed["elements"] if e["type"] == "paragraph"]
+        assert [p["is_list_item"] for p in paragraphs] == [False, True]

--- a/tests/gdocs/test_structure_statistics.py
+++ b/tests/gdocs/test_structure_statistics.py
@@ -165,6 +165,137 @@ class TestInspectDocStructureReportsStatistics:
         return service
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("detailed", [False, True])
+    @pytest.mark.parametrize(
+        "api_key, output_key, anchors",
+        [
+            ("positionedObjectIds", "positioned_object_ids", ["image1"]),
+            (
+                "suggestedPositionedObjectIds",
+                "suggested_positioned_object_ids",
+                {"suggestion1": {"objectIds": ["image1"]}},
+            ),
+        ],
+    )
+    async def test_object_anchors_are_not_empty(
+        self, detailed, api_key, output_key, anchors
+    ):
+        anchored = _paragraph(2, 3, "\n")
+        anchored["paragraph"][api_key] = anchors
+        result = _extract_json(
+            await _unwrap(docs_tools.inspect_doc_structure)(
+                service=self._service(_doc(_paragraph(1, 2, "\n"), anchored)),
+                user_google_email="user@example.com",
+                document_id="doc123",
+                detailed=detailed,
+            )
+        )
+
+        stats = result["statistics"] if detailed else result
+        assert stats["empty_paragraphs"] == 1
+        assert stats["empty_paragraph_ranges"] == [{"start": 1, "end": 2}]
+        assert stats["last_paragraph"]["is_empty"] is False
+        if detailed:
+            assert result["elements"][-1][output_key] == anchors
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("detailed", [False, True])
+    async def test_truncated_ranges_do_not_identify_the_terminal_paragraph(
+        self, detailed
+    ):
+        # Put text between the last returned blank and the actual terminal blank.
+        count = EMPTY_PARAGRAPH_RANGE_LIMIT
+        doc = _doc(
+            *[_paragraph(i, i + 1, "\n") for i in range(1, count + 1)],
+            _paragraph(count + 1, count + 7, "Hello\n"),
+            _paragraph(count + 7, count + 8, "\n"),
+        )
+        result = _extract_json(
+            await _unwrap(docs_tools.inspect_doc_structure)(
+                service=self._service(doc),
+                user_google_email="user@example.com",
+                document_id="doc123",
+                detailed=detailed,
+            )
+        )
+
+        stats = result["statistics"] if detailed else result
+        assert stats["empty_paragraphs"] == count + 1
+        assert len(stats["empty_paragraph_ranges"]) == count
+        assert stats["empty_paragraph_ranges_truncated"] is True
+        assert stats["last_paragraph"]["is_empty"] is True
+        assert stats["empty_paragraph_ranges"][-1]["end"] < result["total_length"]
+        assert result["total_length"] == count + 8
+        if detailed:
+            assert result["elements"][-1]["end_index"] == result["total_length"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "structural_element, element_type",
+        [
+            (
+                {
+                    "startIndex": 2,
+                    "endIndex": 7,
+                    "table": {
+                        "tableRows": [
+                            {
+                                "tableCells": [
+                                    {
+                                        "startIndex": 4,
+                                        "endIndex": 6,
+                                        "content": [_paragraph(5, 6, "\n")],
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                },
+                "table",
+            ),
+            (
+                {
+                    "startIndex": 2,
+                    "endIndex": 4,
+                    "tableOfContents": {"content": [_paragraph(3, 4, "\n")]},
+                },
+                "table_of_contents",
+            ),
+            (_section_break(2, 3), "section_break"),
+        ],
+    )
+    async def test_protected_empty_paragraphs_keep_adjacency_in_detailed_output(
+        self, structural_element, element_type
+    ):
+        end = structural_element["endIndex"]
+        result = _extract_json(
+            await _unwrap(docs_tools.inspect_doc_structure)(
+                service=self._service(
+                    _doc(
+                        _paragraph(1, 2, "\n"),
+                        structural_element,
+                        _paragraph(end, end + 1, "\n"),
+                    )
+                ),
+                user_google_email="user@example.com",
+                document_id="doc123",
+                detailed=True,
+            )
+        )
+
+        # The summary counts literal blanks, including protected separators,
+        # but never the empty paragraph nested inside a table or TOC.
+        assert result["statistics"]["empty_paragraphs"] == 2
+        assert result["statistics"]["empty_paragraph_ranges"] == [
+            {"start": 1, "end": 2},
+            {"start": end, "end": end + 1},
+        ]
+        preceding, protected, terminal = result["elements"]
+        assert preceding["end_index"] == protected["start_index"]
+        assert protected["type"] == element_type
+        assert terminal["end_index"] == result["total_length"]
+
+    @pytest.mark.asyncio
     async def test_basic_and_detailed_modes_agree(self):
         doc = _doc(
             _paragraph(1, 7, "Hello\n"),

--- a/tests/gdocs/test_structure_statistics.py
+++ b/tests/gdocs/test_structure_statistics.py
@@ -1,4 +1,4 @@
-"""Tests for empty-paragraph and trailing-paragraph statistics in structure analysis."""
+"""Paragraph layout statistics."""
 
 import json
 from unittest.mock import Mock
@@ -21,7 +21,6 @@ def _unwrap(tool):
 
 
 def _paragraph(start, end, text, bullet=False):
-    """Build a minimal Docs API paragraph element."""
     paragraph = {"elements": [{"textRun": {"content": text}}]}
     if bullet:
         paragraph["bullet"] = {"listId": "kix.list1", "nestingLevel": 0}
@@ -203,7 +202,6 @@ class TestInspectDocStructureReportsStatistics:
     async def test_truncated_ranges_do_not_identify_the_terminal_paragraph(
         self, detailed
     ):
-        # Put text between the last returned blank and the actual terminal blank.
         count = EMPTY_PARAGRAPH_RANGE_LIMIT
         doc = _doc(
             *[_paragraph(i, i + 1, "\n") for i in range(1, count + 1)],
@@ -283,8 +281,7 @@ class TestInspectDocStructureReportsStatistics:
             )
         )
 
-        # The summary counts literal blanks, including protected separators,
-        # but never the empty paragraph nested inside a table or TOC.
+        # Count protected separators, excluding nested paragraphs.
         assert result["statistics"]["empty_paragraphs"] == 2
         assert result["statistics"]["empty_paragraph_ranges"] == [
             {"start": 1, "end": 2},


### PR DESCRIPTION
Adds empty-paragraph counts, up to 100 paragraph ranges with a truncation flag, and the last paragraph's list/empty status to `inspect_doc_structure` in both modes. Detailed output also includes list membership and object anchors.

Statistics cover top-level body paragraphs; existing or suggested object anchors do not count as empty. Ranges can include protected newlines, so the docs explain cleanup constraints.

Validation: 22 focused tests pass; Ruff 0.15.22 lint and formatting checks pass for the affected Python files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced document structure inspection with paragraph statistics, including empty-paragraph counts, ranges, truncation status, final-paragraph details, and list-item status.
  - Added visibility into positioned-object anchors associated with paragraphs.
  - Excludes anchored and nested protected paragraphs from relevant top-level empty-paragraph statistics while preserving required empty-paragraph information.

- **Documentation**
  - Updated cleanup and export guidance to recommend reviewing paragraph statistics before making changes.
  - Clarified range limits, truncation behavior, protected content, and preservation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->