### PR TITLE
fix(gdocs): keep get_doc_content output aligned with document indices

### DIFF
--- a/gdocs/docs_helpers.py
+++ b/gdocs/docs_helpers.py
@@ -1955,3 +1955,88 @@ def validate_operation(operation: Dict[str, Any]) -> tuple[bool, str]:
             )
 
     return True, ""
+
+
+# Unicode OBJECT REPLACEMENT CHARACTER. Stands in for a non-text paragraph
+# element (inline image, page break, footnote reference, ...) so that the
+# extracted text keeps the same length as the document range it came from.
+OBJECT_REPLACEMENT_CHAR = "￼"
+
+# Paragraph elements that are not textRun but still occupy index positions.
+NON_TEXT_PARAGRAPH_ELEMENTS = (
+    "inlineObjectElement",
+    "pageBreak",
+    "columnBreak",
+    "horizontalRule",
+    "footnoteReference",
+    "person",
+    "richLink",
+    "equation",
+    "autoText",
+)
+
+TAB_HEADER_FORMAT = "\n--- TAB: {tab_name} (ID: {tab_id}) ---\n"
+
+
+def _paragraph_element_text(element: Dict[str, Any]) -> str:
+    """Return the text a single paragraph element contributes.
+
+    A textRun contributes its content verbatim. Any other element type
+    contributes OBJECT_REPLACEMENT_CHAR repeated to match the element's own
+    index span, so offsets computed from the result stay aligned with the
+    document. Falls back to a single character when the API omits the span.
+    """
+    text_run = element.get("textRun", {})
+    if text_run and "content" in text_run:
+        return text_run["content"]
+
+    if any(key in element for key in NON_TEXT_PARAGRAPH_ELEMENTS):
+        start = element.get("startIndex")
+        end = element.get("endIndex")
+        if isinstance(start, int) and isinstance(end, int) and end > start:
+            return OBJECT_REPLACEMENT_CHAR * (end - start)
+        return OBJECT_REPLACEMENT_CHAR
+
+    return ""
+
+
+def extract_text_from_elements(
+    elements: List[Dict[str, Any]],
+    tab_name: Optional[str] = None,
+    tab_id: Optional[str] = None,
+    depth: int = 0,
+) -> str:
+    """Extract text from Google Docs structural elements.
+
+    Empty paragraphs are preserved: a paragraph whose only content is a
+    newline still occupies an index in the document, so dropping it shifts
+    every subsequent offset. Non-textRun paragraph elements are represented
+    by OBJECT_REPLACEMENT_CHAR for the same reason.
+
+    Table cell text is included but is not index-aligned; the table and row
+    structure itself occupies indices that are not represented here.
+    """
+    if depth > 5:
+        return ""
+
+    text_lines = []
+    if tab_name:
+        text_lines.append(TAB_HEADER_FORMAT.format(tab_name=tab_name, tab_id=tab_id))
+
+    for element in elements:
+        if "paragraph" in element:
+            para_elements = element.get("paragraph", {}).get("elements", [])
+            text_lines.append(
+                "".join(_paragraph_element_text(pe) for pe in para_elements)
+            )
+        elif "table" in element:
+            table_rows = element.get("table", {}).get("tableRows", [])
+            for row in table_rows:
+                for cell in row.get("tableCells", []):
+                    cell_text = extract_text_from_elements(
+                        cell.get("content", []), depth=depth + 1
+                    )
+                    if cell_text:
+                        text_lines.append(cell_text)
+
+    return "".join(text_lines)

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -44,6 +44,7 @@ from gdocs.docs_helpers import (
     create_delete_doc_tab_request,
     validate_suggestions_view_mode,
     create_update_paragraph_style_request,
+    extract_text_from_elements,
 )
 
 # Import document structure and table utilities
@@ -207,43 +208,6 @@ async def get_doc_content(
             )
             .execute
         )
-        TAB_HEADER_FORMAT = "\n--- TAB: {tab_name} (ID: {tab_id}) ---\n"
-
-        def extract_text_from_elements(elements, tab_name=None, tab_id=None, depth=0):
-            """Extract text from document elements (paragraphs, tables, etc.)"""
-            if depth > 5:
-                return ""
-            text_lines = []
-            if tab_name:
-                text_lines.append(
-                    TAB_HEADER_FORMAT.format(tab_name=tab_name, tab_id=tab_id)
-                )
-
-            for element in elements:
-                if "paragraph" in element:
-                    paragraph = element.get("paragraph", {})
-                    para_elements = paragraph.get("elements", [])
-                    current_line_text = ""
-                    for pe in para_elements:
-                        text_run = pe.get("textRun", {})
-                        if text_run and "content" in text_run:
-                            current_line_text += text_run["content"]
-                    if current_line_text.strip():
-                        text_lines.append(current_line_text)
-                elif "table" in element:
-                    # Handle table content
-                    table = element.get("table", {})
-                    table_rows = table.get("tableRows", [])
-                    for row in table_rows:
-                        row_cells = row.get("tableCells", [])
-                        for cell in row_cells:
-                            cell_content = cell.get("content", [])
-                            cell_text = extract_text_from_elements(
-                                cell_content, depth=depth + 1
-                            )
-                            if cell_text.strip():
-                                text_lines.append(cell_text)
-            return "".join(text_lines)
 
         def process_tab_hierarchy(tab, level=0):
             """Process a tab and its nested child tabs recursively"""
@@ -268,13 +232,13 @@ async def get_doc_content(
 
         body_elements = doc_data.get("body", {}).get("content", [])
         main_content = extract_text_from_elements(body_elements)
-        if main_content.strip():
+        if main_content:
             processed_text_lines.append(main_content)
 
         tabs = doc_data.get("tabs", [])
         for tab in tabs:
             tab_content = process_tab_hierarchy(tab)
-            if tab_content.strip():
+            if tab_content:
                 processed_text_lines.append(tab_content)
 
         body_text = "".join(processed_text_lines)

--- a/tests/gdocs/test_doc_content_index_alignment.py
+++ b/tests/gdocs/test_doc_content_index_alignment.py
@@ -1,0 +1,111 @@
+"""Tests that extracted document text stays aligned with document indices.
+
+An empty paragraph occupies an index in the document. Dropping it from the
+extracted text shifts every subsequent offset, so any index computed by
+searching that text lands in the wrong place. Same for paragraph elements
+that are not textRun.
+"""
+
+from gdocs.docs_helpers import (
+    OBJECT_REPLACEMENT_CHAR,
+    extract_text_from_elements,
+)
+
+
+def _para(*elements):
+    return {"paragraph": {"elements": list(elements)}}
+
+
+def _run(content, start=None, end=None):
+    element = {"textRun": {"content": content}}
+    if start is not None:
+        element["startIndex"] = start
+        element["endIndex"] = end
+    return element
+
+
+# Body is "Alpha", empty paragraph, "Bravo", empty paragraph — indices 1..15.
+ALPHA_BRAVO_BODY = [
+    _para(_run("Alpha\n")),
+    _para(_run("\n")),
+    _para(_run("Bravo\n")),
+    _para(_run("\n")),
+]
+
+
+def test_empty_paragraphs_are_preserved():
+    assert extract_text_from_elements(ALPHA_BRAVO_BODY) == "Alpha\n\nBravo\n\n"
+
+
+def test_extracted_length_matches_document_span():
+    """Body spans indices 1-15, i.e. 14 characters."""
+    assert len(extract_text_from_elements(ALPHA_BRAVO_BODY)) == 15 - 1
+
+
+def test_offset_of_later_text_matches_document_index():
+    """'Bravo' starts at index 8; searching the extracted text must agree.
+
+    The extracted text is 0-based while document indices start the body at 1,
+    so the document index is the offset plus one.
+    """
+    text = extract_text_from_elements(ALPHA_BRAVO_BODY)
+    assert text.index("Bravo") + 1 == 8
+
+
+def test_paragraph_with_no_elements_still_contributes_nothing_but_is_not_dropped():
+    body = [_para(_run("A\n")), {"paragraph": {}}, _para(_run("B\n"))]
+    assert extract_text_from_elements(body) == "A\nB\n"
+
+
+def test_page_break_occupies_its_index_span():
+    body = [
+        _para(_run("Alpha\n")),
+        _para({"pageBreak": {}, "startIndex": 7, "endIndex": 8}, _run("\n")),
+    ]
+    text = extract_text_from_elements(body)
+    assert text == "Alpha\n" + OBJECT_REPLACEMENT_CHAR + "\n"
+    assert len(text) == 8
+
+
+def test_inline_object_occupies_one_index():
+    body = [
+        _para(
+            _run("a"),
+            {"inlineObjectElement": {"inlineObjectId": "kix.1"}},
+            _run("b\n"),
+        )
+    ]
+    assert extract_text_from_elements(body) == "a" + OBJECT_REPLACEMENT_CHAR + "b\n"
+
+
+def test_non_text_element_without_span_falls_back_to_one_char():
+    body = [_para({"footnoteReference": {"footnoteId": "kix.f1"}}, _run("\n"))]
+    assert extract_text_from_elements(body) == OBJECT_REPLACEMENT_CHAR + "\n"
+
+
+def test_unknown_element_types_contribute_nothing():
+    body = [_para(_run("a\n"), {"someFutureElement": {}})]
+    assert extract_text_from_elements(body) == "a\n"
+
+
+def test_tab_header_is_emitted_when_named():
+    text = extract_text_from_elements(ALPHA_BRAVO_BODY, "My Tab", "t.abc")
+    assert text.startswith("\n--- TAB: My Tab (ID: t.abc) ---\n")
+    assert text.endswith("Alpha\n\nBravo\n\n")
+
+
+def test_table_cell_text_is_included():
+    body = [
+        {
+            "table": {
+                "tableRows": [
+                    {"tableCells": [{"content": [_para(_run("cell\n"))]}]},
+                ]
+            }
+        }
+    ]
+    assert extract_text_from_elements(body) == "cell\n"
+
+
+def test_recursion_is_bounded():
+    assert extract_text_from_elements([_para(_run("x\n"))], depth=6) == ""


### PR DESCRIPTION
## Description

Fixes #1085.

`get_doc_content` dropped any paragraph that was empty after `.strip()`, and accumulated only `textRun` content. An empty paragraph is `"\n"` and still occupies an index in the document, as do `inlineObjectElement`, `pageBreak`, `columnBreak`, `horizontalRule`, `footnoteReference`, `person` and `richLink`. Offsets computed by searching the returned text therefore drifted from the document's real indices — silently, and cumulatively — so a subsequent `format_text` / `delete_text` / `replace_text` landed on the wrong range.

This preserves empty paragraphs and represents non-`textRun` elements with U+FFFC (OBJECT REPLACEMENT CHARACTER), sized from each element's own `startIndex`/`endIndex` span so the extracted text keeps the same length as the range it came from.

The extraction also moves out of the nested closure inside `get_doc_content` into `docs_helpers.extract_text_from_elements`, so it is unit-testable and the tool file stays thin per CONTRIBUTING.

**Known limitation, called out in the docstring:** table cell text is included but is not index-aligned — the table and row structure occupies indices that are not represented here. Fixing that is a larger change and I left it out deliberately rather than half-doing it. Happy to follow up if you want it.

**Behaviour change worth flagging for review:** callers that treated the output as prose will now see blank lines that were previously swallowed, and U+FFFC where an inline object sits. That is the point of the fix, but it is a visible difference.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

`tests/gdocs/test_doc_content_index_alignment.py` — 11 tests. The core one asserts the extracted length equals the document's own span, and that `text.index("Bravo") + 1` equals the index `inspect_doc_structure` reports (8) for the repro in #1085.

Local run with the CI-pinned toolchain:

```
uvx ruff@0.15.22 check          -> All checks passed!
uvx ruff@0.15.22 format --check -> 201 files already formatted
uv run pytest                   -> 1897 passed, 2 skipped
```

Manually verified against a real ~10k-character document tab: extracted length now matches the API's reported span exactly, where it was previously short by the count of empty paragraphs.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

Two related issues are open and I am happy to take either: #1084 (`inspect_doc_structure` truncates `text_preview` at 100 chars, so sub-paragraph offsets cannot be located even once this fix lands) and #1086 (read tools cannot target a tab). Both are parameter additions to existing tools rather than new tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved document text extraction to preserve character positions accurately, including page breaks, inline objects, and other non-text elements.
  * Preserved empty paragraphs and whitespace during content extraction.
  * Added support for extracting text from tables and document tabs, including tab identification.
  * Added safeguards for deeply nested table content.
* **Tests**
  * Expanded coverage for extraction alignment, special elements, tables, tabs, and nested content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->