### PR TITLE
feat(auth): expose the OAuth proxy consent mode as an env var

### DIFF
--- a/auth/oauth_proxy_config.py
+++ b/auth/oauth_proxy_config.py
@@ -11,8 +11,24 @@ OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV = (
     "WORKSPACE_MCP_OAUTH_PROXY_TOKEN_EXPIRY_THRESHOLD_SECONDS"
 )
 OAUTH_ACCESS_TOKEN_EXPIRY_ENV = "WORKSPACE_MCP_OAUTH_PROXY_ACCESS_TOKEN_EXPIRY_SECONDS"
+OAUTH_REQUIRE_CONSENT_ENV = "WORKSPACE_MCP_OAUTH_PROXY_REQUIRE_CONSENT"
 MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS = 5 * 60
 MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS = 30 * 24 * 60 * 60
+
+_CONSENT_MODES: dict[str, bool | str] = {
+    "always": True,
+    "true": True,
+    "1": True,
+    "yes": True,
+    "on": True,
+    "remember": "remember",
+    "external": "external",
+    "never": False,
+    "false": False,
+    "0": False,
+    "no": False,
+    "off": False,
+}
 
 
 def _parse_expiry_seconds_env(
@@ -72,3 +88,34 @@ def get_oauth_proxy_expiry_kwargs() -> dict[str, int]:
             fastmcp_access_token_expiry_seconds
         )
     return expiry_kwargs
+
+
+def get_oauth_proxy_consent_kwargs() -> dict[str, bool | str]:
+    """Return the configured consent-screen keyword argument for GoogleProvider.
+
+    Unset or unrecognised values are omitted so FastMCP retains ownership of its
+    default, which prompts on every authorization.
+    """
+    raw = os.getenv(OAUTH_REQUIRE_CONSENT_ENV, "").strip().lower()
+    if not raw:
+        return {}
+    if raw not in _CONSENT_MODES:
+        logger.warning(
+            "Ignoring %s: %r is not one of %s",
+            OAUTH_REQUIRE_CONSENT_ENV,
+            raw,
+            ", ".join(sorted(_CONSENT_MODES)),
+        )
+        return {}
+
+    mode = _CONSENT_MODES[raw]
+    if mode is False:
+        logger.warning(
+            "OAuth 2.1: consent screen disabled via %s; this drops the "
+            "authorization-server-in-the-middle mitigation and is intended for "
+            "local development only",
+            OAUTH_REQUIRE_CONSENT_ENV,
+        )
+    else:
+        logger.info("OAuth 2.1: consent screen mode set to %r", mode)
+    return {"require_authorization_consent": mode}

--- a/core/server.py
+++ b/core/server.py
@@ -24,7 +24,10 @@ from auth.oauth_config import (
     get_oauth_config,
     is_trust_gateway_identity,
 )
-from auth.oauth_proxy_config import get_oauth_proxy_expiry_kwargs
+from auth.oauth_proxy_config import (
+    get_oauth_proxy_consent_kwargs,
+    get_oauth_proxy_expiry_kwargs,
+)
 from auth.oauth_responses import (
     create_error_response,
     create_success_response,
@@ -740,6 +743,7 @@ def configure_server_for_http():
                     jwt_signing_key=jwt_signing_key,
                     allowed_client_redirect_uris=allowed_client_redirect_uris,
                     **expiry_kwargs,
+                    **get_oauth_proxy_consent_kwargs(),
                 )
                 if provider.client_registration_options is not None:
                     # Keep protocol-level auth limited to base identity scopes, but

--- a/tests/auth/test_oauth_proxy_config.py
+++ b/tests/auth/test_oauth_proxy_config.py
@@ -4,7 +4,9 @@ from auth.oauth_proxy_config import (
     MAX_OAUTH_ACCESS_TOKEN_EXPIRY_SECONDS,
     MAX_OAUTH_TOKEN_EXPIRY_THRESHOLD_SECONDS,
     OAUTH_ACCESS_TOKEN_EXPIRY_ENV,
+    OAUTH_REQUIRE_CONSENT_ENV,
     OAUTH_TOKEN_EXPIRY_THRESHOLD_ENV,
+    get_oauth_proxy_consent_kwargs,
     get_oauth_proxy_expiry_kwargs,
 )
 
@@ -68,3 +70,36 @@ def test_token_expiry_env_accepts_safe_limit_boundaries(monkeypatch):
         "token_expiry_threshold_seconds": 300,
         "fastmcp_access_token_expiry_seconds": 2_592_000,
     }
+
+
+def test_consent_env_default_leaves_fastmcp_behaviour_unchanged(monkeypatch):
+    monkeypatch.delenv(OAUTH_REQUIRE_CONSENT_ENV, raising=False)
+
+    assert get_oauth_proxy_consent_kwargs() == {}
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("always", True),
+        ("TRUE", True),
+        ("on", True),
+        ("remember", "remember"),
+        ("External", "external"),
+        ("never", False),
+        ("0", False),
+    ],
+)
+def test_consent_env_maps_to_the_provider_kwarg(monkeypatch, value, expected):
+    monkeypatch.setenv(OAUTH_REQUIRE_CONSENT_ENV, value)
+
+    assert get_oauth_proxy_consent_kwargs() == {
+        "require_authorization_consent": expected
+    }
+
+
+@pytest.mark.parametrize("value", ["maybe", "  ", "rememberr"])
+def test_consent_env_ignores_unusable_values(monkeypatch, value):
+    monkeypatch.setenv(OAUTH_REQUIRE_CONSENT_ENV, value)
+
+    assert get_oauth_proxy_consent_kwargs() == {}

--- a/tests/core/test_http_oauth_scope_config.py
+++ b/tests/core/test_http_oauth_scope_config.py
@@ -373,3 +373,44 @@ def test_configure_server_for_http_passes_expiry_config_to_external_provider(
 
     assert captured["token_expiry_threshold_seconds"] == 120
     assert captured["fastmcp_access_token_expiry_seconds"] == 86400
+
+
+def test_configure_server_for_http_passes_consent_mode_to_google_provider(monkeypatch):
+    captured = {}
+
+    class FakeGoogleProvider:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.client_registration_options = SimpleNamespace(default_scopes=None)
+            self._default_scope_str = ""
+            self._cimd_manager = SimpleNamespace(default_scope="")
+
+    monkeypatch.setenv("WORKSPACE_MCP_OAUTH_PROXY_REQUIRE_CONSENT", "remember")
+    monkeypatch.setattr(server_module, "get_transport_mode", lambda: "streamable-http")
+    monkeypatch.setattr(server_module, "GoogleProvider", FakeGoogleProvider)
+    monkeypatch.setattr(server_module, "set_auth_provider", lambda provider: None)
+    monkeypatch.setattr(server_module, "get_oauth_proxy_expiry_kwargs", lambda: {})
+    monkeypatch.setattr(
+        server_module,
+        "get_current_scopes",
+        lambda: ["https://www.googleapis.com/auth/userinfo.email", "openid"],
+    )
+    monkeypatch.setattr(server_module, "_auth_provider", server_module._auth_provider)
+    monkeypatch.setattr(server_module.server, "auth", server_module.server.auth)
+    monkeypatch.setattr(
+        "auth.oauth_config.get_oauth_config",
+        lambda: SimpleNamespace(
+            is_oauth21_enabled=lambda: True,
+            is_configured=lambda: True,
+            is_public_client=lambda: False,
+            is_external_oauth21_provider=lambda: False,
+            client_id="client-id",
+            client_secret="client-secret",
+            get_oauth_base_url=lambda: "https://workspace-mcp.example.test",
+            redirect_path="/oauth2callback",
+        ),
+    )
+
+    server_module.configure_server_for_http()
+
+    assert captured["require_authorization_consent"] == "remember"


### PR DESCRIPTION
## What

- Adds `WORKSPACE_MCP_OAUTH_PROXY_REQUIRE_CONSENT`, forwarded to `GoogleProvider(require_authorization_consent=...)`.
- Accepts `always` / `remember` / `external` / `never`, plus the boolean spellings already used elsewhere in the repo. Unset or unrecognised values are omitted so FastMCP keeps ownership of its default.
- Selecting `never` logs a warning, since it drops the AS-in-the-middle mitigation.

## Why

- FastMCP supports the knob, but the provider is constructed without it, so every deployment is pinned to prompting on every authorization.
- Operators running this for a fleet of MCP clients want `remember`: prompt once per browser, then approve the same `client_id` + `redirect_uri` silently. Clients that re-run the authorization flow often — anything that spawns more than one proxy process per launch — currently show a consent screen each time.
- The external-provider branch is deliberately untouched: it advertises Google's authorization server and never serves a consent screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration for controlling OAuth authorization consent behavior through an environment variable.
  - Supports consent modes including always require, remember, external-only, and never require.
  - Applies the selected consent mode when configuring Google OAuth authentication.

- **Tests**
  - Added coverage for supported, unset, invalid, and disabled consent settings.
  - Verified that configured consent modes are passed to Google OAuth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->