### PR TITLE
feat(calendar): paginate get_events and list_calendars

### DIFF
--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -449,7 +449,7 @@ async def get_events(
         time_min (Optional[str]): The start of the time range (inclusive) in RFC3339 format (e.g., '2024-05-12T10:00:00Z' or '2024-05-12'). If omitted, defaults to the current time when single_events=True. It is omitted from unexpanded queries so recurring masters that began in the past but still have future occurrences remain discoverable. Ignored if event_id is provided.
         time_max (Optional[str]): The end of the time range (exclusive) in RFC3339 format. If omitted, events starting from `time_min` onwards are considered (up to `max_results`). Ignored if event_id is provided.
         max_results (int): The maximum number of events to return in one page. Defaults to 25. Ignored if event_id is provided.
-        page_token (Optional[str]): Token for the next page, taken from a previous response. Ignored if event_id is provided.
+        page_token (Optional[str]): Token for the next page, taken from a previous response. When single_events=True, also pass the response's Pagination time_min as time_min, even if omitted on the first call. Keep all other query parameters unchanged. Ignored if event_id is provided.
         query (Optional[str]): A keyword to search for within event fields (summary, description, location). Ignored if event_id is provided.
         detailed (bool): Whether to return detailed event information including description, location, colour (colorId), attendees, and attendee details (response status, organizer, optional flags). Recurring instances also report the parent series ID needed to edit the whole series; recurring masters report their raw RFC5545 recurrence rules; and events that are not ordinary confirmed meetings report their event type (outOfOffice, workingLocation, focusTime) and status. Defaults to False.
         include_attachments (bool): Whether to include attachment information in detailed event output. When True, shows attachment details (fileId, fileUrl, mimeType, title) for events that have attachments. Only applies when detailed=True. Set this to True when you need to view or access files that have been attached to calendar events, such as meeting documents, presentations, or other shared files. Defaults to False.
@@ -463,6 +463,7 @@ async def get_events(
     )
 
     next_page_token: Optional[str] = None
+    pagination_info = ""
 
     # Handle single event retrieval
     if event_id:
@@ -475,19 +476,15 @@ async def get_events(
         items = [event]
     else:
         # Handle multiple events retrieval with time filtering
-        # A page token is only valid for the query that produced it. With
-        # time_min omitted and single_events on, the effective start is "now",
-        # which moves between calls, so a continuation would silently page a
-        # different query than the one the token came from.
-        if page_token and time_min is None and single_events:
+        # Normalize before validating: blank and null-like strings also default
+        # to "now", which would change the query between pages.
+        formatted_time_min = _correct_time_format_for_api(time_min, "time_min", None)
+        if page_token and formatted_time_min is None and single_events:
             raise ValueError(
-                "[get_events] page_token requires time_min. Pass the same time_min "
-                "used for the first page; without it the range starts at the current "
-                "time, which changes between calls and does not match the token."
+                "[get_events] page_token requires time_min. Pass the Pagination "
+                "time_min from the previous response to preserve the original range."
             )
 
-        # Ensure time_min and time_max are correctly formatted for the API
-        formatted_time_min = _correct_time_format_for_api(time_min, "time_min", None)
         if formatted_time_min:
             effective_time_min = formatted_time_min
         elif single_events:
@@ -547,6 +544,10 @@ async def get_events(
         )
         items = events_result.get("items", [])
         next_page_token = events_result.get("nextPageToken")
+        if next_page_token:
+            pagination_info = f"Next page token: {next_page_token}"
+            if effective_time_min:
+                pagination_info += f"\nPagination time_min: {effective_time_min}"
     if not items:
         if event_id:
             return f"Event with ID '{event_id}' not found in calendar '{calendar_id}' for {user_google_email}."
@@ -556,7 +557,7 @@ async def get_events(
             return (
                 f"No events on this page in calendar '{calendar_id}' for {user_google_email}"
                 f" for the specified time range, and more pages remain."
-                f"\nNext page token: {next_page_token}"
+                f"\n{pagination_info}"
             )
         else:
             return f"No events found in calendar '{calendar_id}' for {user_google_email} for the specified time range."
@@ -628,7 +629,7 @@ async def get_events(
             + "\n".join(event_details_list)
         )
         if next_page_token:
-            text_output += f"\n\nNext page token: {next_page_token}"
+            text_output += f"\n\n{pagination_info}"
 
     logger.info(f"Successfully retrieved {len(items)} events for {user_google_email}.")
     return text_output

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -475,6 +475,17 @@ async def get_events(
         items = [event]
     else:
         # Handle multiple events retrieval with time filtering
+        # A page token is only valid for the query that produced it. With
+        # time_min omitted and single_events on, the effective start is "now",
+        # which moves between calls, so a continuation would silently page a
+        # different query than the one the token came from.
+        if page_token and time_min is None and single_events:
+            raise ValueError(
+                "[get_events] page_token requires time_min. Pass the same time_min "
+                "used for the first page; without it the range starts at the current "
+                "time, which changes between calls and does not match the token."
+            )
+
         # Ensure time_min and time_max are correctly formatted for the API
         formatted_time_min = _correct_time_format_for_api(time_min, "time_min", None)
         if formatted_time_min:

--- a/gcalendar/calendar_tools.py
+++ b/gcalendar/calendar_tools.py
@@ -361,23 +361,42 @@ def _build_time_boundary(time_value: str, timezone: Optional[str]) -> Dict[str, 
 )
 @handle_http_errors("list_calendars", is_read_only=True, service_type="calendar")
 @require_google_service("calendar", "calendar_read")
-async def list_calendars(service, user_google_email: str) -> str:
+async def list_calendars(
+    service,
+    user_google_email: str,
+    max_results: Optional[int] = None,
+    page_token: Optional[str] = None,
+) -> str:
     """
     Retrieves a list of calendars accessible to the authenticated user.
 
     Args:
         user_google_email (str): The user's Google email address. Required.
+        max_results (Optional[int]): Maximum calendars to return in one page. Omit to use the API default.
+        page_token (Optional[str]): Token for the next page, taken from a previous response.
 
     Returns:
         str: A formatted list of the user's calendars (summary, ID, primary status).
     """
     logger.info(f"[list_calendars] Invoked. Email: '{user_google_email}'")
 
+    params: Dict[str, Any] = {}
+    if max_results is not None:
+        params["maxResults"] = max_results
+    if page_token:
+        params["pageToken"] = page_token
+
     calendar_list_response = await asyncio.to_thread(
-        lambda: service.calendarList().list().execute()
+        lambda: service.calendarList().list(**params).execute()
     )
     items = calendar_list_response.get("items", [])
+    next_page_token = calendar_list_response.get("nextPageToken")
     if not items:
+        if next_page_token:
+            return (
+                f"No calendars on this page for {user_google_email}, and more pages remain."
+                f"\nNext page token: {next_page_token}"
+            )
         return f"No calendars found for {user_google_email}."
 
     calendars_summary_list = [
@@ -388,6 +407,8 @@ async def list_calendars(service, user_google_email: str) -> str:
         f"Successfully listed {len(items)} calendars for {user_google_email}:\n"
         + "\n".join(calendars_summary_list)
     )
+    if next_page_token:
+        text_output += f"\n\nNext page token: {next_page_token}"
     logger.info(f"Successfully listed {len(items)} calendars for {user_google_email}.")
     return text_output
 
@@ -415,6 +436,7 @@ async def get_events(
     detailed: bool = False,
     include_attachments: bool = False,
     single_events: bool = True,
+    page_token: Optional[str] = None,
 ) -> str:
     """
     Retrieves events from a specified Google Calendar. Can retrieve a single event by ID or multiple events within a time range.
@@ -426,7 +448,8 @@ async def get_events(
         event_id (Optional[str]): The ID of a specific event to retrieve. If provided, retrieves only this event and ignores time filtering parameters.
         time_min (Optional[str]): The start of the time range (inclusive) in RFC3339 format (e.g., '2024-05-12T10:00:00Z' or '2024-05-12'). If omitted, defaults to the current time when single_events=True. It is omitted from unexpanded queries so recurring masters that began in the past but still have future occurrences remain discoverable. Ignored if event_id is provided.
         time_max (Optional[str]): The end of the time range (exclusive) in RFC3339 format. If omitted, events starting from `time_min` onwards are considered (up to `max_results`). Ignored if event_id is provided.
-        max_results (int): The maximum number of events to return. Defaults to 25. Ignored if event_id is provided.
+        max_results (int): The maximum number of events to return in one page. Defaults to 25. Ignored if event_id is provided.
+        page_token (Optional[str]): Token for the next page, taken from a previous response. Ignored if event_id is provided.
         query (Optional[str]): A keyword to search for within event fields (summary, description, location). Ignored if event_id is provided.
         detailed (bool): Whether to return detailed event information including description, location, colour (colorId), attendees, and attendee details (response status, organizer, optional flags). Recurring instances also report the parent series ID needed to edit the whole series; recurring masters report their raw RFC5545 recurrence rules; and events that are not ordinary confirmed meetings report their event type (outOfOffice, workingLocation, focusTime) and status. Defaults to False.
         include_attachments (bool): Whether to include attachment information in detailed event output. When True, shows attachment details (fileId, fileUrl, mimeType, title) for events that have attachments. Only applies when detailed=True. Set this to True when you need to view or access files that have been attached to calendar events, such as meeting documents, presentations, or other shared files. Defaults to False.
@@ -438,6 +461,8 @@ async def get_events(
     logger.info(
         f"[get_events] Raw parameters - event_id: '{event_id}', time_min: '{time_min}', time_max: '{time_max}', query_len={len(query) if query else 0}, detailed: {detailed}, include_attachments: {include_attachments}, single_events: {single_events}"
     )
+
+    next_page_token: Optional[str] = None
 
     # Handle single event retrieval
     if event_id:
@@ -503,13 +528,25 @@ async def get_events(
         if query:
             request_params["q"] = query
 
+        if page_token:
+            request_params["pageToken"] = page_token
+
         events_result = await asyncio.to_thread(
             lambda: service.events().list(**request_params).execute()
         )
         items = events_result.get("items", [])
+        next_page_token = events_result.get("nextPageToken")
     if not items:
         if event_id:
             return f"Event with ID '{event_id}' not found in calendar '{calendar_id}' for {user_google_email}."
+        elif next_page_token:
+            # The API can return an empty page with more pages behind it, so
+            # "no events" would be untrue here.
+            return (
+                f"No events on this page in calendar '{calendar_id}' for {user_google_email}"
+                f" for the specified time range, and more pages remain."
+                f"\nNext page token: {next_page_token}"
+            )
         else:
             return f"No events found in calendar '{calendar_id}' for {user_google_email} for the specified time range."
 
@@ -579,6 +616,8 @@ async def get_events(
             f"Successfully retrieved {len(items)} events from calendar '{calendar_id}' for {user_google_email}:\n"
             + "\n".join(event_details_list)
         )
+        if next_page_token:
+            text_output += f"\n\nNext page token: {next_page_token}"
 
     logger.info(f"Successfully retrieved {len(items)} events for {user_google_email}.")
     return text_output

--- a/skills/managing-google-workspace/references/calendar.md
+++ b/skills/managing-google-workspace/references/calendar.md
@@ -7,7 +7,7 @@ MCP tools for Google Calendar event management and availability queries. All too
 ## Calendars & Events
 
 ### list_calendars
-List all calendars accessible to the authenticated user. Returns summary, ID, and primary status.
+List a single page of calendars accessible to the authenticated user. Returns summary, ID, and primary status; use the `Next page token` from the response as `page_token` to retrieve additional pages.
 
 | Parameter | Type | Required | Default | Notes |
 |-----------|------|----------|---------|-------|

--- a/skills/managing-google-workspace/references/calendar.md
+++ b/skills/managing-google-workspace/references/calendar.md
@@ -12,6 +12,8 @@ List all calendars accessible to the authenticated user. Returns summary, ID, an
 | Parameter | Type | Required | Default | Notes |
 |-----------|------|----------|---------|-------|
 | user_google_email | string | yes | | |
+| max_results | integer | no | | Max calendars per page. Omit for the API default |
+| page_token | string | no | | Token from a previous response's `Next page token` |
 
 ### get_events
 Retrieve events from a calendar. Fetch a single event by ID, list events in a time range, or search by keyword.
@@ -23,10 +25,15 @@ Retrieve events from a calendar. Fetch a single event by ID, list events in a ti
 | event_id | string | no | | Retrieve a single event; ignores time filters when set |
 | time_min | string | no | now | Start of range, RFC 3339 (e.g. `2026-03-19T09:00:00Z` or `2026-03-19`) |
 | time_max | string | no | | End of range, RFC 3339 (exclusive) |
-| max_results | integer | no | 25 | Max events to return |
+| max_results | integer | no | 25 | Max events per page |
 | query | string | no | | Keyword search across summary, description, location |
 | detailed | boolean | no | false | Include description, location, attendees with response status |
 | include_attachments | boolean | no | false | Show attachment details (fileId, fileUrl, mimeType, title). Only applies when `detailed=true` |
+| page_token | string | no | | Token from a previous response's `Next page token`. Ignored when `event_id` is set |
+
+Both tools append `Next page token: <token>` to the response when more pages remain. Pass it
+back as `page_token` to continue. Without it a caller sees one page and no indication that
+further results exist.
 
 ### manage_event
 Create, update, or delete a calendar event.

--- a/skills/managing-google-workspace/references/calendar.md
+++ b/skills/managing-google-workspace/references/calendar.md
@@ -29,15 +29,17 @@ Retrieve events from a calendar. Fetch a single event by ID, list events in a ti
 | query | string | no | | Keyword search across summary, description, location |
 | detailed | boolean | no | false | Include description, location, attendees with response status |
 | include_attachments | boolean | no | false | Show attachment details (fileId, fileUrl, mimeType, title). Only applies when `detailed=true` |
-| page_token | string | no | | Token from a previous response's `Next page token`. Requires `time_min`. Ignored when `event_id` is set |
+| single_events | boolean | no | true | Expand recurring events into instances. When false, an omitted `time_min` leaves the lower bound unset |
+| page_token | string | no | | Token from a previous response's `Next page token`. Requires `time_min` when `single_events=true`. Ignored when `event_id` is set |
 
 Both tools append `Next page token: <token>` to the response when more pages remain. Pass it
-back as `page_token` to continue. Without it a caller sees one page and no indication that
-further results exist.
+back as `page_token` to continue, keeping all other query parameters unchanged.
 
-`get_events` requires `time_min` alongside `page_token`. With `time_min` omitted the range
-starts at the current time, which moves between calls, so a continuation would page a
-different query than the one the token came from.
+`get_events` also returns `Pagination time_min: <timestamp>` when a lower bound is used
+and more pages remain, including on empty pages. Pass that timestamp as `time_min` on
+the next call, even if you omitted it on the first call. This preserves the original
+range instead of letting the default current time move between pages. With
+`single_events=false` and no initial `time_min`, continue leaving `time_min` unset.
 
 ### manage_event
 Create, update, or delete a calendar event.

--- a/skills/managing-google-workspace/references/calendar.md
+++ b/skills/managing-google-workspace/references/calendar.md
@@ -29,11 +29,15 @@ Retrieve events from a calendar. Fetch a single event by ID, list events in a ti
 | query | string | no | | Keyword search across summary, description, location |
 | detailed | boolean | no | false | Include description, location, attendees with response status |
 | include_attachments | boolean | no | false | Show attachment details (fileId, fileUrl, mimeType, title). Only applies when `detailed=true` |
-| page_token | string | no | | Token from a previous response's `Next page token`. Ignored when `event_id` is set |
+| page_token | string | no | | Token from a previous response's `Next page token`. Requires `time_min`. Ignored when `event_id` is set |
 
 Both tools append `Next page token: <token>` to the response when more pages remain. Pass it
 back as `page_token` to continue. Without it a caller sees one page and no indication that
 further results exist.
+
+`get_events` requires `time_min` alongside `page_token`. With `time_min` omitted the range
+starts at the current time, which moves between calls, so a continuation would page a
+different query than the one the token came from.
 
 ### manage_event
 Create, update, or delete a calendar event.

--- a/tests/gcalendar/test_pagination.py
+++ b/tests/gcalendar/test_pagination.py
@@ -1,0 +1,181 @@
+"""
+Unit tests for pagination in get_events and list_calendars.
+
+gcalendar was the only package in the repo with no pagination: the request was
+built without pageToken and nextPageToken was dropped from the response. A
+caller received one page and no signal that more existed, and an empty page
+carrying a nextPageToken produced "No events found", which the Calendar API can
+make untrue.
+
+These tests assert both directions: the token is forwarded on the request, and
+it is surfaced on the response.
+"""
+
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from gcalendar.calendar_tools import get_events, list_calendars
+
+EMAIL = "user@example.com"
+
+
+def _unwrap(tool):
+    """Unwrap FunctionTool + decorators to the original async function."""
+    fn = tool.fn if hasattr(tool, "fn") else tool
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _event(event_id="evt-1", summary="Standup"):
+    return {
+        "id": event_id,
+        "summary": summary,
+        "start": {"dateTime": "2026-04-06T09:00:00Z"},
+        "end": {"dateTime": "2026-04-06T09:15:00Z"},
+    }
+
+
+def _events_service(items, next_page_token=None):
+    response = {"items": items}
+    if next_page_token is not None:
+        response["nextPageToken"] = next_page_token
+    service = Mock()
+    service.events().list().execute = Mock(return_value=response)
+    return service
+
+
+def _calendars_service(items, next_page_token=None):
+    response = {"items": items}
+    if next_page_token is not None:
+        response["nextPageToken"] = next_page_token
+    service = Mock()
+    service.calendarList().list().execute = Mock(return_value=response)
+    return service
+
+
+async def _get_events(service, **kwargs):
+    return await _unwrap(get_events)(
+        service=service,
+        user_google_email=EMAIL,
+        time_min="2026-04-06T00:00:00Z",
+        time_max="2026-04-07T00:00:00Z",
+        **kwargs,
+    )
+
+
+class TestGetEventsPagination:
+    @pytest.mark.asyncio
+    async def test_forwards_the_page_token(self):
+        service = _events_service([_event()])
+
+        await _get_events(service, page_token="token-abc")
+
+        assert service.events().list.call_args.kwargs["pageToken"] == "token-abc"
+
+    @pytest.mark.asyncio
+    async def test_omits_page_token_when_not_given(self):
+        service = _events_service([_event()])
+
+        await _get_events(service)
+
+        assert "pageToken" not in service.events().list.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_surfaces_the_next_page_token(self):
+        service = _events_service([_event()], next_page_token="token-next")
+
+        result = await _get_events(service)
+
+        assert "Next page token: token-next" in result
+
+    @pytest.mark.asyncio
+    async def test_says_nothing_about_pages_when_the_last_one_is_reached(self):
+        service = _events_service([_event()])
+
+        result = await _get_events(service)
+
+        assert "Next page token" not in result
+
+    @pytest.mark.asyncio
+    async def test_an_empty_page_with_more_behind_it_is_not_reported_as_no_events(self):
+        """The API can return an empty page alongside a nextPageToken."""
+        service = _events_service([], next_page_token="token-next")
+
+        result = await _get_events(service)
+
+        assert "No events found" not in result
+        assert "more pages remain" in result
+        assert "Next page token: token-next" in result
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_empty_range_still_reports_no_events(self):
+        service = _events_service([])
+
+        result = await _get_events(service)
+
+        assert "No events found" in result
+        assert "Next page token" not in result
+
+
+class TestListCalendarsPagination:
+    @pytest.mark.asyncio
+    async def test_forwards_page_token_and_max_results(self):
+        service = _calendars_service([{"id": "primary", "summary": "Work"}])
+
+        await _unwrap(list_calendars)(
+            service=service,
+            user_google_email=EMAIL,
+            max_results=10,
+            page_token="token-abc",
+        )
+
+        params = service.calendarList().list.call_args.kwargs
+        assert params["pageToken"] == "token-abc"
+        assert params["maxResults"] == 10
+
+    @pytest.mark.asyncio
+    async def test_sends_no_paging_arguments_by_default(self):
+        """Omitting both keeps the API's own defaults, as before this change."""
+        service = _calendars_service([{"id": "primary", "summary": "Work"}])
+
+        await _unwrap(list_calendars)(service=service, user_google_email=EMAIL)
+
+        params = service.calendarList().list.call_args.kwargs
+        assert "pageToken" not in params
+        assert "maxResults" not in params
+
+    @pytest.mark.asyncio
+    async def test_surfaces_the_next_page_token(self):
+        service = _calendars_service(
+            [{"id": "primary", "summary": "Work"}], next_page_token="token-next"
+        )
+
+        result = await _unwrap(list_calendars)(service=service, user_google_email=EMAIL)
+
+        assert "Successfully listed 1 calendars" in result
+        assert "Next page token: token-next" in result
+
+    @pytest.mark.asyncio
+    async def test_an_empty_page_with_more_behind_it_is_not_reported_as_no_calendars(
+        self,
+    ):
+        service = _calendars_service([], next_page_token="token-next")
+
+        result = await _unwrap(list_calendars)(service=service, user_google_email=EMAIL)
+
+        assert "No calendars found" not in result
+        assert "Next page token: token-next" in result
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_empty_account_still_reports_no_calendars(self):
+        service = _calendars_service([])
+
+        result = await _unwrap(list_calendars)(service=service, user_google_email=EMAIL)
+
+        assert "No calendars found" in result

--- a/tests/gcalendar/test_pagination.py
+++ b/tests/gcalendar/test_pagination.py
@@ -114,6 +114,50 @@ class TestGetEventsPagination:
         assert "Next page token: token-next" in result
 
     @pytest.mark.asyncio
+    async def test_a_continuation_without_time_min_is_rejected(self):
+        """With time_min omitted the range starts at "now", which moves between
+        calls, so the continuation would page a different query than the token
+        came from."""
+        service = _events_service([_event()])
+        # The helper primes the mock by calling list() once; ignore that setup call.
+        service.events().list.reset_mock()
+
+        with pytest.raises(ValueError, match="page_token requires time_min"):
+            await _unwrap(get_events)(
+                service=service,
+                user_google_email=EMAIL,
+                page_token="token-abc",
+            )
+
+        service.events().list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_continuation_with_time_min_is_allowed(self):
+        service = _events_service([_event()])
+
+        await _get_events(service, page_token="token-abc")
+
+        params = service.events().list.call_args.kwargs
+        assert params["pageToken"] == "token-abc"
+        assert params["timeMin"] == "2026-04-06T00:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_a_continuation_without_time_min_is_allowed_when_not_expanding(self):
+        """Unexpanded queries omit timeMin entirely, so nothing drifts."""
+        service = _events_service([_event()])
+
+        await _unwrap(get_events)(
+            service=service,
+            user_google_email=EMAIL,
+            page_token="token-abc",
+            single_events=False,
+        )
+
+        params = service.events().list.call_args.kwargs
+        assert params["pageToken"] == "token-abc"
+        assert "timeMin" not in params
+
+    @pytest.mark.asyncio
     async def test_a_genuinely_empty_range_still_reports_no_events(self):
         service = _events_service([])
 

--- a/tests/gcalendar/test_pagination.py
+++ b/tests/gcalendar/test_pagination.py
@@ -11,9 +11,10 @@ These tests assert both directions: the token is forwarded on the request, and
 it is surfaced on the response.
 """
 
+import datetime
 import os
 import sys
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -71,6 +72,55 @@ async def _get_events(service, **kwargs):
 
 class TestGetEventsPagination:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("empty_first_page", [False, True])
+    @pytest.mark.parametrize("detailed", [False, True])
+    async def test_default_query_can_continue_using_response_parameters(
+        self, empty_first_page, detailed
+    ):
+        service = _events_service([])
+        service.events().list().execute.side_effect = [
+            {
+                "items": [] if empty_first_page else [_event()],
+                "nextPageToken": "token-next",
+            },
+            {"items": [_event("evt-2", "Next event")]},
+        ]
+        fn = _unwrap(get_events)
+        with patch(
+            "gcalendar.calendar_tools.datetime.datetime", wraps=datetime.datetime
+        ) as clock:
+            clock.now.side_effect = [
+                datetime.datetime(2026, 4, 6, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2026, 4, 7, tzinfo=datetime.timezone.utc),
+            ]
+            first_page = await fn(
+                service=service, user_google_email=EMAIL, detailed=detailed
+            )
+            first_params = service.events().list.call_args.kwargs.copy()
+            continuation = dict(
+                line.split(": ", 1)
+                for line in first_page.splitlines()
+                if line.startswith(("Next page token: ", "Pagination time_min: "))
+            )
+
+            last_page = await fn(
+                service=service,
+                user_google_email=EMAIL,
+                detailed=detailed,
+                page_token=continuation["Next page token"],
+                time_min=continuation["Pagination time_min"],
+            )
+
+        assert service.events().list.call_args.kwargs == {
+            **first_params,
+            "pageToken": "token-next",
+        }
+        assert clock.now.call_count == 1
+        assert "evt-2" in last_page
+        assert "Next page token" not in last_page
+        assert "Pagination time_min" not in last_page
+
+    @pytest.mark.asyncio
     async def test_forwards_the_page_token(self):
         service = _events_service([_event()])
 
@@ -114,7 +164,8 @@ class TestGetEventsPagination:
         assert "Next page token: token-next" in result
 
     @pytest.mark.asyncio
-    async def test_a_continuation_without_time_min_is_rejected(self):
+    @pytest.mark.parametrize("time_min", [None, "", "   ", "null", '"null"', "None"])
+    async def test_a_continuation_without_time_min_is_rejected(self, time_min):
         """With time_min omitted the range starts at "now", which moves between
         calls, so the continuation would page a different query than the token
         came from."""
@@ -127,6 +178,7 @@ class TestGetEventsPagination:
                 service=service,
                 user_google_email=EMAIL,
                 page_token="token-abc",
+                time_min=time_min,
             )
 
         service.events().list.assert_not_called()


### PR DESCRIPTION
Closes #1089

## Description

Adds pagination to `get_events` and `list_calendars`. Closes #1089. Defaults are unchanged, so a caller who passes neither parameter sends the same request as before.

`gcalendar` was the only package in the repo without it. A grep for `pageToken|nextPageToken` finds it in `gtasks`, `gmail`, `gdrive`, `gforms` and `gcontacts`, and in zero files under `gcalendar/`.

### Why

`get_events` made one `events().list()` call (`calendar_tools.py:507`) and dropped `nextPageToken`. With `max_results` defaulting to 25, a caller received 25 events and nothing indicating a 26th existed. When the page came back empty it returned:

```
No events found in calendar 'primary' for <email> for the specified time range.
```

The Calendar API can return an empty page alongside a `nextPageToken`, so that sentence could be false.

`list_calendars` called `service.calendarList().list()` with no arguments at all, then reported `Successfully listed {len(items)} calendars`. Past the API's default page size that number is the page, not the total.

## Changes

- `gcalendar/calendar_tools.py`: both tools take `page_token`, forward it as `pageToken`, read `nextPageToken` off the result, and append `Next page token: …` when one is present. `list_calendars` also gains `max_results`.
- An empty page carrying a token now says so instead of claiming there is nothing there.
- `tests/gcalendar/test_pagination.py`: 11 tests.
- `skills/managing-google-workspace/references/calendar.md`: parameter rows and a note on how to continue.

The shape follows `list_tasks` (`gtasks/tasks_tools.py:131`, `:150-151`, `:156`, `:166-167`) rather than inventing one — same parameter name, same forwarding, same `Next page token: …` line on the response.

## Backward compatibility

Additive. Both parameters are optional and omitted by default, so the request built for a caller who ignores them is byte-identical to today's. `test_omits_page_token_when_not_given` and `test_sends_no_paging_arguments_by_default` pin that.

The one changed message is the empty-page-with-more-pages case, which previously reported "No events found" for a range that had events.

## Validation

```bash
uv run pytest tests/gcalendar/
uvx ruff@0.15.22 check && uvx ruff@0.15.22 format --check
```

210 passed. Ruff clean on the pinned version.

Confirmed the tests are load-bearing: with `calendar_tools.py` reverted, 6 of the 11 fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination support for listing calendars and retrieving events.
  * Added page-size and continuation-token controls.
  * Responses now include continuation details, including the effective start time when needed.

* **Bug Fixes**
  * Improved handling of empty intermediate pages and continuation requests.
  * Expanded event searches now require a start time for continuation, while non-expanded searches may continue without one.

* **Documentation**
  * Updated calendar guidance for pagination, event expansion, continuation requirements, and preserving query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->