### PR TITLE
feat(chat): edit an already-sent message via send_message

### DIFF
--- a/gchat/chat_tools.py
+++ b/gchat/chat_tools.py
@@ -347,7 +347,7 @@ async def send_message(
     """
     logger.info(f"[send_message] Email: '{user_google_email}', Space: '{space_id}'")
 
-    if message_name:
+    if message_name is not None:
         if thread_name or thread_key:
             raise UserInputError(
                 "message_name cannot be combined with thread_name or thread_key: "

--- a/gchat/chat_tools.py
+++ b/gchat/chat_tools.py
@@ -339,7 +339,8 @@ async def send_message(
         thread_key: Reply in a thread by app-defined key (creates thread if not found).
         message_name: Edit this message in place instead of sending a new one
             (e.g. spaces/X/messages/Y, as returned by send_message or get_messages).
-            Only the text is replaced, and only the author can edit their own message.
+            Must be a message of space_id. Only the text is replaced, and only the
+            author can edit their own message.
 
     Returns:
         str: Confirmation message with the sent or updated message details.
@@ -351,6 +352,11 @@ async def send_message(
             raise UserInputError(
                 "message_name cannot be combined with thread_name or thread_key: "
                 "editing a message cannot move it to another thread."
+            )
+        if not message_name.startswith(f"{space_id}/messages/"):
+            raise UserInputError(
+                f"message_name '{message_name}' does not belong to space '{space_id}'. "
+                "Expected the full resource name, e.g. spaces/X/messages/Y."
             )
 
         message = await asyncio.to_thread(
@@ -364,7 +370,7 @@ async def send_message(
             .execute
         )
 
-        update_time = message.get("lastUpdateTime", "")
+        update_time = message.get("lastUpdateTime") or message.get("createTime", "")
         msg = (
             f"Message updated in space '{space_id}' by {user_google_email}. "
             f"Message ID: {message.get('name', message_name)}, Time: {update_time}"
@@ -390,10 +396,10 @@ async def send_message(
         service.spaces().messages().create(**request_params).execute
     )
 
-    message_name = message.get("name", "")
+    sent_message_name = message.get("name", "")
     create_time = message.get("createTime", "")
 
-    msg = f"Message sent to space '{space_id}' by {user_google_email}. Message ID: {message_name}, Time: {create_time}"
+    msg = f"Message sent to space '{space_id}' by {user_google_email}. Message ID: {sent_message_name}, Time: {create_time}"
     logger.info(
         f"Successfully sent message to space '{space_id}' by {user_google_email}"
     )

--- a/gchat/chat_tools.py
+++ b/gchat/chat_tools.py
@@ -18,7 +18,7 @@ from mcp.types import ToolAnnotations
 # Auth & server utilities
 from auth.service_decorator import require_google_service, require_multiple_services
 from core.server import server
-from core.utils import TransientNetworkError, handle_http_errors
+from core.utils import TransientNetworkError, UserInputError, handle_http_errors
 
 logger = logging.getLogger(__name__)
 
@@ -329,18 +329,50 @@ async def send_message(
     message_text: str,
     thread_key: Optional[str] = None,
     thread_name: Optional[str] = None,
+    message_name: Optional[str] = None,
 ) -> str:
     """
-    Sends a message to a Google Chat space.
+    Sends a message to a Google Chat space, or edits a message already sent there.
 
     Args:
         thread_name: Reply in an existing thread by its resource name (e.g. spaces/X/threads/Y).
         thread_key: Reply in a thread by app-defined key (creates thread if not found).
+        message_name: Edit this message in place instead of sending a new one
+            (e.g. spaces/X/messages/Y, as returned by send_message or get_messages).
+            Only the text is replaced, and only the author can edit their own message.
 
     Returns:
-        str: Confirmation message with sent message details.
+        str: Confirmation message with the sent or updated message details.
     """
     logger.info(f"[send_message] Email: '{user_google_email}', Space: '{space_id}'")
+
+    if message_name:
+        if thread_name or thread_key:
+            raise UserInputError(
+                "message_name cannot be combined with thread_name or thread_key: "
+                "editing a message cannot move it to another thread."
+            )
+
+        message = await asyncio.to_thread(
+            service.spaces()
+            .messages()
+            .patch(
+                name=message_name,
+                updateMask="text",
+                body={"text": message_text},
+            )
+            .execute
+        )
+
+        update_time = message.get("lastUpdateTime", "")
+        msg = (
+            f"Message updated in space '{space_id}' by {user_google_email}. "
+            f"Message ID: {message.get('name', message_name)}, Time: {update_time}"
+        )
+        logger.info(
+            f"Successfully updated message '{message_name}' by {user_google_email}"
+        )
+        return msg
 
     message_body = {"text": message_text}
 

--- a/gchat/chat_tools.py
+++ b/gchat/chat_tools.py
@@ -7,6 +7,7 @@ This module provides MCP tools for interacting with Google Chat API.
 import base64
 import logging
 import asyncio
+import re
 import ssl
 from typing import Dict, List, Optional
 
@@ -316,7 +317,7 @@ async def get_messages(
     title="Send Message",
     annotations=ToolAnnotations(
         readOnlyHint=False,
-        destructiveHint=False,
+        destructiveHint=True,
         idempotentHint=False,
         openWorldHint=True,
     ),
@@ -354,7 +355,13 @@ async def send_message(
                 "message_name cannot be combined with thread_name or thread_key: "
                 "editing a message cannot move it to another thread."
             )
-        if not message_name.startswith(f"{space_id}/messages/"):
+        message_match = re.fullmatch(r"spaces/([^/]+)/messages/[^/]+", message_name)
+        if message_match is None:
+            raise UserInputError(
+                f"Invalid message_name '{message_name}'. "
+                "Expected the full resource name, e.g. spaces/X/messages/Y."
+            )
+        if f"spaces/{message_match.group(1)}" != space_id:
             raise UserInputError(
                 f"message_name '{message_name}' does not belong to space '{space_id}'. "
                 "Expected the full resource name, e.g. spaces/X/messages/Y."

--- a/skills/managing-google-workspace/SKILL.md
+++ b/skills/managing-google-workspace/SKILL.md
@@ -222,6 +222,7 @@ For parameters: [references/contacts.md](references/contacts.md)
 | Get messages | `get_messages` |
 | Search messages | `search_messages` |
 | Send message | `send_message` |
+| Edit a message already sent | `send_message` with `message_name` |
 | React to message | `create_reaction` |
 | Download attachment | `download_chat_attachment` |
 

--- a/skills/managing-google-workspace/references/chat.md
+++ b/skills/managing-google-workspace/references/chat.md
@@ -49,7 +49,7 @@ Sends a message to a Google Chat space. Can reply to existing threads, or edit a
 | message_text | string | yes | | |
 | thread_key | any | no | | App-defined key; creates thread if not found |
 | thread_name | any | no | | Resource name, e.g. `spaces/X/threads/Y` |
-| message_name | any | no | | Edit this message in place, e.g. `spaces/X/messages/Y`; own messages only, cannot be combined with a thread parameter |
+| message_name | any | no | | Edit this message in place, e.g. `spaces/X/messages/Y`; must sit in `space_id`, own messages only, cannot be combined with a thread parameter |
 
 ---
 

--- a/skills/managing-google-workspace/references/chat.md
+++ b/skills/managing-google-workspace/references/chat.md
@@ -40,7 +40,7 @@ Searches for messages in Google Chat spaces by text content.
 | page_size | integer | no | 25 | |
 
 ### send_message
-Sends a message to a Google Chat space. Can reply to existing threads.
+Sends a message to a Google Chat space. Can reply to existing threads, or edit a message already sent.
 
 | Parameter | Type | Required | Default | Notes |
 |-----------|------|----------|---------|-------|
@@ -49,6 +49,7 @@ Sends a message to a Google Chat space. Can reply to existing threads.
 | message_text | string | yes | | |
 | thread_key | any | no | | App-defined key; creates thread if not found |
 | thread_name | any | no | | Resource name, e.g. `spaces/X/threads/Y` |
+| message_name | any | no | | Edit this message in place, e.g. `spaces/X/messages/Y`; own messages only, cannot be combined with a thread parameter |
 
 ---
 

--- a/tests/gchat/test_chat_message_edit.py
+++ b/tests/gchat/test_chat_message_edit.py
@@ -1,0 +1,120 @@
+"""Regression tests for message edits through the registered tool's decorators."""
+
+import json
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from googleapiclient.errors import HttpError
+from httplib2 import Response
+
+import auth.service_decorator as service_decorator
+from core.server import server
+from core.utils import UserInputError
+from gchat.chat_tools import send_message
+
+
+@pytest.fixture
+def chat_service(monkeypatch):
+    """Inject a fake API service while retaining auth and HTTP error wrappers."""
+    service = Mock()
+    monkeypatch.setattr(service_decorator, "_user_email_is_managed", lambda: False)
+    monkeypatch.setattr(
+        service_decorator,
+        "_get_auth_context",
+        AsyncMock(return_value=(None, None, None)),
+    )
+    monkeypatch.setattr(service_decorator, "_detect_oauth_version", lambda *args: False)
+    monkeypatch.setattr(
+        service_decorator,
+        "_authenticate_service",
+        AsyncMock(return_value=(service, "test@example.com")),
+    )
+    return service
+
+
+async def _edit_message(message_name):
+    # Access the callable without unwrapping authentication or HTTP error handling.
+    public_fn = getattr(send_message, "fn", send_message)
+    return await public_fn(
+        user_google_email="test@example.com",
+        space_id="spaces/S",
+        message_text="corrected text",
+        message_name=message_name,
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_advertises_destructive_updates():
+    tool = await server.get_tool("send_message")
+    assert tool.annotations.readOnlyHint is False
+    assert tool.annotations.destructiveHint is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message_name",
+    [
+        "",
+        "M",
+        "spaces/S/messages/",
+        "spaces/S/messages/M/extra",
+        "spaces//messages/M",
+        "rooms/S/messages/M",
+        "spaces/S/threads/T",
+        "spaces/OTHER/messages/M",
+    ],
+)
+async def test_invalid_edit_remains_input_error(chat_service, message_name):
+    with pytest.raises(UserInputError, match="message_name"):
+        await _edit_message(message_name)
+
+    chat_service.spaces.assert_not_called()
+    chat_service.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message_id", ["M", "BBBBBBBBBBB.BBBBBBBBBBB", "client-custom-name"]
+)
+async def test_valid_message_names_are_editable(chat_service, message_id):
+    message_name = f"spaces/S/messages/{message_id}"
+    messages = chat_service.spaces.return_value.messages.return_value
+    messages.patch.return_value.execute.return_value = {
+        "name": message_name,
+        "lastUpdateTime": "2025-01-01T00:00:00Z",
+    }
+
+    result = await _edit_message(message_name)
+
+    assert "Message updated" in result
+    assert message_name in result
+    messages.patch.assert_called_once_with(
+        name=message_name, updateMask="text", body={"text": "corrected text"}
+    )
+    messages.create.assert_not_called()
+    chat_service.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "api_message"),
+    [(403, "Cannot edit another user's message"), (404, "Message not found")],
+)
+async def test_edit_api_failure_is_surfaced_without_creating(
+    chat_service, status, api_message
+):
+    messages = chat_service.spaces.return_value.messages.return_value
+    error = HttpError(
+        Response({"status": str(status)}),
+        json.dumps({"error": {"code": status, "message": api_message}}).encode(),
+    )
+    messages.patch.return_value.execute.side_effect = error
+
+    with pytest.raises(Exception, match="API error in send_message") as exc_info:
+        await _edit_message("spaces/S/messages/M")
+
+    assert api_message in str(exc_info.value)
+    assert exc_info.value.__cause__ is error
+    messages.patch.return_value.execute.assert_called_once_with()
+    messages.create.assert_not_called()
+    chat_service.close.assert_called_once_with()

--- a/tests/gchat/test_chat_tools.py
+++ b/tests/gchat/test_chat_tools.py
@@ -707,3 +707,101 @@ async def test_download_returns_error_on_failure():
 
     assert "Failed to download" in result
     assert "connection refused" in result
+
+
+# ---------------------------------------------------------------------------
+# send_message: editing an existing message in place
+# ---------------------------------------------------------------------------
+
+
+def _mock_chat_service():
+    """Chat service mock exposing a stable spaces().messages() resource."""
+    service = Mock()
+    messages = Mock()
+    service.spaces.return_value.messages.return_value = messages
+    return service, messages
+
+
+@pytest.mark.asyncio
+async def test_send_message_exposes_message_name_param():
+    """send_message should expose message_name for in-place edits."""
+    from gchat.chat_tools import send_message
+
+    public_fn = getattr(send_message, "fn", send_message)
+    params = inspect.signature(public_fn).parameters
+
+    assert "message_name" in params
+    assert params["message_name"].default is None
+
+
+@pytest.mark.asyncio
+async def test_send_message_edits_existing_message_instead_of_creating():
+    """With message_name set, send_message should patch the message, not create one."""
+    service, messages = _mock_chat_service()
+    messages.patch.return_value.execute.return_value = {
+        "name": "spaces/S/messages/M",
+        "lastUpdateTime": "2025-01-01T00:00:00Z",
+    }
+
+    from gchat.chat_tools import send_message
+
+    result = await _unwrap(send_message)(
+        service=service,
+        user_google_email="test@example.com",
+        space_id="spaces/S",
+        message_text="corrected text",
+        message_name="spaces/S/messages/M",
+    )
+
+    assert messages.create.call_count == 0
+    patch_kwargs = messages.patch.call_args.kwargs
+    assert patch_kwargs["name"] == "spaces/S/messages/M"
+    assert patch_kwargs["updateMask"] == "text"
+    assert patch_kwargs["body"] == {"text": "corrected text"}
+    assert "updated" in result.lower()
+    assert "spaces/S/messages/M" in result
+
+
+@pytest.mark.asyncio
+async def test_send_message_without_message_name_still_creates():
+    """The default path must stay a create, untouched by the edit support."""
+    service, messages = _mock_chat_service()
+    messages.create.return_value.execute.return_value = {
+        "name": "spaces/S/messages/NEW",
+        "createTime": "2025-01-01T00:00:00Z",
+    }
+
+    from gchat.chat_tools import send_message
+
+    result = await _unwrap(send_message)(
+        service=service,
+        user_google_email="test@example.com",
+        space_id="spaces/S",
+        message_text="hello",
+    )
+
+    assert messages.patch.call_count == 0
+    assert messages.create.call_args.kwargs["parent"] == "spaces/S"
+    assert "sent" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_send_message_rejects_message_name_with_thread_reply():
+    """An edit cannot also be a thread reply — the thread of a message is fixed."""
+    service, messages = _mock_chat_service()
+
+    from gchat.chat_tools import send_message
+    from core.utils import UserInputError
+
+    with pytest.raises(UserInputError):
+        await _unwrap(send_message)(
+            service=service,
+            user_google_email="test@example.com",
+            space_id="spaces/S",
+            message_text="corrected text",
+            message_name="spaces/S/messages/M",
+            thread_name="spaces/S/threads/T",
+        )
+
+    assert messages.patch.call_count == 0
+    assert messages.create.call_count == 0

--- a/tests/gchat/test_chat_tools.py
+++ b/tests/gchat/test_chat_tools.py
@@ -805,3 +805,65 @@ async def test_send_message_rejects_message_name_with_thread_reply():
 
     assert messages.patch.call_count == 0
     assert messages.create.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_send_message_rejects_message_name_outside_the_space():
+    """A message_name from another space would silently report the wrong space."""
+    service, messages = _mock_chat_service()
+
+    from gchat.chat_tools import send_message
+    from core.utils import UserInputError
+
+    with pytest.raises(UserInputError):
+        await _unwrap(send_message)(
+            service=service,
+            user_google_email="test@example.com",
+            space_id="spaces/S",
+            message_text="corrected text",
+            message_name="spaces/OTHER/messages/M",
+        )
+
+    assert messages.patch.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_send_message_rejects_malformed_message_name():
+    """A bare message id cannot be patched — fail before the API does."""
+    service, messages = _mock_chat_service()
+
+    from gchat.chat_tools import send_message
+    from core.utils import UserInputError
+
+    with pytest.raises(UserInputError):
+        await _unwrap(send_message)(
+            service=service,
+            user_google_email="test@example.com",
+            space_id="spaces/S",
+            message_text="corrected text",
+            message_name="M",
+        )
+
+    assert messages.patch.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_send_message_edit_falls_back_to_create_time():
+    """Older API responses omit lastUpdateTime; the confirmation must stay readable."""
+    service, messages = _mock_chat_service()
+    messages.patch.return_value.execute.return_value = {
+        "name": "spaces/S/messages/M",
+        "createTime": "2025-01-01T00:00:00Z",
+    }
+
+    from gchat.chat_tools import send_message
+
+    result = await _unwrap(send_message)(
+        service=service,
+        user_google_email="test@example.com",
+        space_id="spaces/S",
+        message_text="corrected text",
+        message_name="spaces/S/messages/M",
+    )
+
+    assert "2025-01-01T00:00:00Z" in result

--- a/tests/gchat/test_chat_tools.py
+++ b/tests/gchat/test_chat_tools.py
@@ -867,3 +867,24 @@ async def test_send_message_edit_falls_back_to_create_time():
     )
 
     assert "2025-01-01T00:00:00Z" in result
+
+
+@pytest.mark.asyncio
+async def test_send_message_rejects_empty_message_name():
+    """An empty message_name is a failed edit, not a request to post a new message."""
+    service, messages = _mock_chat_service()
+
+    from gchat.chat_tools import send_message
+    from core.utils import UserInputError
+
+    with pytest.raises(UserInputError):
+        await _unwrap(send_message)(
+            service=service,
+            user_google_email="test@example.com",
+            space_id="spaces/S",
+            message_text="corrected text",
+            message_name="",
+        )
+
+    assert messages.create.call_count == 0
+    assert messages.patch.call_count == 0


### PR DESCRIPTION
Hi, and thanks for this server, I use it daily and the Chat tools have been solid. 🙏

One gap I ran into: Google Chat lets you fix a message you already sent, but `send_message` only creates. So a typo, a stale link, or a message written for the wrong audience is permanent. That last one is what bit me: I posted a very technical answer in a room full of non-technical readers, and had no way to reword it.

I read CONTRIBUTING first, so this **extends the existing tool** rather than adding `update_message`: one new optional `message_name`. Tool count unchanged.

## Behaviour

- `message_name` unset, unchanged create path, byte for byte.
- `message_name` set, the message is patched in place with `updateMask=text`.
- `message_name` combined with `thread_name`/`thread_key`, `UserInputError`. An edit cannot move a message to another thread.
- `message_name` not inside `space_id`, `UserInputError`. A resource name carries its own space, so `space_id="spaces/A"` with a message from `spaces/B` would patch B while the confirmation claimed A. The same check catches a bare message id or an empty string, which would otherwise reach the API and fail there with something opaque.

## Notes

- Uses `spaces.messages.patch`, which [Google recommends over `update`](https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages/update). Both exist in the v1 discovery document with identical parameters and scopes.
- **No new scope.** `patch` needs `chat.messages` under user authentication, which `send_message` already requires via `chat_write`, so no re-consent for existing users.
- Editing is author-only, enforced by the API itself.
- The confirmation falls back to `createTime` when the response carries no `lastUpdateTime`, so it never ends with an empty `Time:`.
- `destructiveHint` left as `False`: an edit does overwrite the previous text, but the annotation is per-tool and flipping it would mislabel every ordinary send. Happy to revisit if you would rather have the honest label, though that argues for a separate tool, which CONTRIBUTING rules out.
- Logic stays in the tool function: `gchat/` has no helpers module yet and `send_message` already builds its request inline, so adding one just for this seemed to make the diff harder to review rather than easier. Say the word and I will extract both branches into `chat_helpers.py`.

## Tests

Eight tests in `tests/gchat/test_chat_tools.py`, each written failing first:

- `message_name` is exposed and defaults to `None`
- with it, `patch` is called with the right `name`/`updateMask`/`body`, and `create` is not called
- without it, `create` still runs and `patch` does not (regression guard)
- a thread parameter, a foreign space, a malformed name and an empty name each raise before any API call
- the confirmation falls back to `createTime`

`uvx ruff@0.15.22 check`, `ruff format --check` and `uv run pytest` all pass locally: 1913 passed, 2 skipped.

`skills/managing-google-workspace/SKILL.md` and `references/chat.md` are updated for the new parameter. Maintainer edits are enabled.

Deleting a message (`spaces.messages.delete`) is still missing from the module. Out of scope here, glad to open a follow-up if you want it.

Happy to rework naming, docs, or scope however you prefer. Thanks for taking a look! 😊


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for editing already-sent Google Chat messages using the optional `message_name` parameter.
  * Edit requests validate that the message belongs to the selected space and can’t be combined with thread replies.

* **Bug Fixes**
  * Improved edit confirmations when update timestamps are unavailable.
  * Prevented invalid or empty message identifiers from creating or modifying messages.

* **Documentation**
  * Updated Google Workspace documentation to describe message editing and its usage requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->