### PR TITLE
fix(gmail): keep a label's visibility when updating it

### DIFF
--- a/gmail/gmail_helpers.py
+++ b/gmail/gmail_helpers.py
@@ -206,6 +206,24 @@ def build_label_color(
     }
 
 
+def build_label_visibility(
+    requested: Optional[str],
+    stored: Optional[str],
+    fallback: str,
+) -> str:
+    """Resolve one visibility field for a label update.
+
+    `users.labels.update` is a PUT, so the body it receives replaces the label
+    outright: any field taken from a parameter default overwrites what Gmail
+    has stored. Visibility is therefore carried over from the fetched label
+    whenever the caller did not ask to change it, which is what `name` and
+    `color` already do in the same request body.
+    """
+    if requested is not None:
+        return requested
+    return stored if stored is not None else fallback
+
+
 def _normalize_email(address: str) -> str:
     """Lowercase an email address and strip plus-addressing so that
     e.g. 'Alex <alex+foo@scopestack.io>' normalizes to 'alex@scopestack.io'.

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -77,6 +77,7 @@ from gmail.gmail_helpers import (
     _retryable_result_ids,
     _signature_html_to_text,
     build_label_color,
+    build_label_visibility,
     html_to_text_preserving_breaks,
 )
 
@@ -3745,8 +3746,8 @@ async def manage_gmail_label(
     action: Literal["create", "update", "delete"],
     name: Optional[str] = None,
     label_id: Optional[str] = None,
-    label_list_visibility: Literal["labelShow", "labelHide"] = "labelShow",
-    message_list_visibility: Literal["show", "hide"] = "show",
+    label_list_visibility: Optional[Literal["labelShow", "labelHide"]] = None,
+    message_list_visibility: Optional[Literal["show", "hide"]] = None,
     background_color: Optional[str] = None,
     text_color: Optional[str] = None,
     clear_color: bool = False,
@@ -3759,8 +3760,8 @@ async def manage_gmail_label(
         action (Literal["create", "update", "delete"]): Action to perform on the label.
         name (Optional[str]): Label name. Required for create, optional for update.
         label_id (Optional[str]): Label ID. Required for update and delete operations.
-        label_list_visibility (Literal["labelShow", "labelHide"]): Whether the label is shown in the label list.
-        message_list_visibility (Literal["show", "hide"]): Whether the label is shown in the message list.
+        label_list_visibility (Optional[Literal["labelShow", "labelHide"]]): Whether the label is shown in the label list. Defaults to "labelShow" on create. On update, omitting it keeps the label's current setting.
+        message_list_visibility (Optional[Literal["show", "hide"]]): Whether the label's messages are shown in the message list. Defaults to "show" on create. On update, omitting it keeps the label's current setting.
         background_color (Optional[str]): Label background color as a hex string, e.g. "#fb4c2f". Set together with text_color; Gmail requires both. Gmail accepts only its own palette, and an unsupported value is rejected before the request. Colors apply to user labels, not system labels.
         text_color (Optional[str]): Label text color as a hex string, e.g. "#ffffff". Set together with background_color. Same palette. On update, omitting both keeps the label's current color.
         clear_color (bool): On update, remove the label's current color. Cannot be combined with background_color or text_color.
@@ -3796,8 +3797,8 @@ async def manage_gmail_label(
     if action == "create":
         label_object = {
             "name": name,
-            "labelListVisibility": label_list_visibility,
-            "messageListVisibility": message_list_visibility,
+            "labelListVisibility": label_list_visibility or "labelShow",
+            "messageListVisibility": message_list_visibility or "show",
         }
         if color:
             label_object["color"] = color
@@ -3814,8 +3815,16 @@ async def manage_gmail_label(
         label_object = {
             "id": label_id,
             "name": name if name is not None else current_label["name"],
-            "labelListVisibility": label_list_visibility,
-            "messageListVisibility": message_list_visibility,
+            "labelListVisibility": build_label_visibility(
+                label_list_visibility,
+                current_label.get("labelListVisibility"),
+                "labelShow",
+            ),
+            "messageListVisibility": build_label_visibility(
+                message_list_visibility,
+                current_label.get("messageListVisibility"),
+                "show",
+            ),
         }
         label_color = None if clear_color else color or current_label.get("color")
         if label_color:

--- a/tests/gmail/test_manage_gmail_label_color.py
+++ b/tests/gmail/test_manage_gmail_label_color.py
@@ -299,7 +299,7 @@ async def test_update_still_applies_visibility_when_asked():
 
 @pytest.mark.asyncio
 async def test_update_falls_back_when_gmail_reports_no_visibility():
-    """Gmail omits these fields on some labels; the previous behaviour applies."""
+    """Gmail omits these fields on some labels; the previous behavior applies."""
     service = _build_mock_service({"id": "Label_1", "name": "Urgent"})
 
     await _update(service, name="Renamed")

--- a/tests/gmail/test_manage_gmail_label_color.py
+++ b/tests/gmail/test_manage_gmail_label_color.py
@@ -254,3 +254,67 @@ def test_palette_exactly_matches_the_discovery_document_snapshot():
         fingerprint
         == "3a734f759085172c6803b4aeef05b8dd92df341f56d66a5cf86b658f36c8a948"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stored",
+    [
+        {"labelListVisibility": "labelHide", "messageListVisibility": "hide"},
+        {"labelListVisibility": "labelHide", "messageListVisibility": "show"},
+        {"labelListVisibility": "labelShow", "messageListVisibility": "hide"},
+    ],
+)
+async def test_update_without_visibility_keeps_the_stored_visibility(stored):
+    """users.labels.update is a PUT, so a parameter default overwrites what
+    Gmail has stored. Renaming a hidden label used to make it visible."""
+    service = _build_mock_service({"id": "Label_1", "name": "Urgent", **stored})
+
+    await _update(service, name="Renamed")
+
+    body = _sent_body(service, "update")
+    assert body["labelListVisibility"] == stored["labelListVisibility"]
+    assert body["messageListVisibility"] == stored["messageListVisibility"]
+
+
+@pytest.mark.asyncio
+async def test_update_still_applies_visibility_when_asked():
+    service = _build_mock_service(
+        {
+            "id": "Label_1",
+            "name": "Urgent",
+            "labelListVisibility": "labelHide",
+            "messageListVisibility": "hide",
+        }
+    )
+
+    await _update(
+        service, label_list_visibility="labelShow", message_list_visibility="show"
+    )
+
+    body = _sent_body(service, "update")
+    assert body["labelListVisibility"] == "labelShow"
+    assert body["messageListVisibility"] == "show"
+
+
+@pytest.mark.asyncio
+async def test_update_falls_back_when_gmail_reports_no_visibility():
+    """Gmail omits these fields on some labels; the previous behaviour applies."""
+    service = _build_mock_service({"id": "Label_1", "name": "Urgent"})
+
+    await _update(service, name="Renamed")
+
+    body = _sent_body(service, "update")
+    assert body["labelListVisibility"] == "labelShow"
+    assert body["messageListVisibility"] == "show"
+
+
+@pytest.mark.asyncio
+async def test_create_sends_the_same_defaults_as_before():
+    service = _build_mock_service()
+
+    await _create(service)
+
+    body = _sent_body(service, "create")
+    assert body["labelListVisibility"] == "labelShow"
+    assert body["messageListVisibility"] == "show"


### PR DESCRIPTION
Closes #1094

`users.labels.update` is a PUT, so the body replaces the label outright. Both visibility fields were typed with defaults, so any update that did not mention them wrote those defaults over what Gmail had stored:

```
stored:   labelListVisibility=labelHide, messageListVisibility=hide
call:     manage_gmail_label(action="update", label_id="Label_1", name="Receipts 2026")
PUT body: {'id': 'Label_1', 'name': 'Receipts 2026',
           'labelListVisibility': 'labelShow', 'messageListVisibility': 'show'}
```

The label returns to the sidebar and its messages return to the message list. The receipt reports the rename and says nothing about the visibility change.

`name` and `color` in that same request body already fall back to the fetched label. Visibility now does too.

### Why not `users.labels.patch`

It exists and would avoid the problem generally, but `clear_color` depends on PUT semantics — omitting `color` is what removes it. Switching would break that, so the fix is in how the body is built.

### Changes

- `build_label_visibility` in `gmail_helpers.py`, beside `build_label_color`.
- Both parameters become `Optional[...] = None`, so "not specified" is distinguishable from "labelShow".
- Create is unchanged and still sends `labelShow`/`show`.
- Docstrings match the wording already used for `text_color`.

### Tests

In `tests/gmail/test_manage_gmail_label_color.py`:

- three stored-visibility combinations preserved across a rename — these fail with the source change reverted
- an explicit visibility change still applies
- a label Gmail returns without visibility fields keeps the previous behaviour
- create sends the same body as before

280 passed in `tests/gmail`. `ruff check` and `ruff format --check` clean on 0.15.22.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updating a Gmail label without specifying visibility settings now preserves its existing visibility.
  - Explicit visibility changes continue to apply correctly.
  - Visibility uses standard defaults when no stored values are available.
  - Creating labels retains the existing default visibility behavior.

- **Documentation**
  - Clarified that visibility defaults apply during label creation, while omitted settings during updates preserve current values.

- **Tests**
  - Added coverage for preserving, overriding, and defaulting label visibility settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->