### PR TITLE
fix(contacts): keep the rest of a name when updating one part

### DIFF
--- a/gcontacts/contacts_helpers.py
+++ b/gcontacts/contacts_helpers.py
@@ -385,12 +385,6 @@ def _merge_organizations(
     return result
 
 
-# displayName and displayNameLastFirst are output-only on people.Name.
-_NAME_OUTPUT_ONLY_FIELDS = frozenset(
-    {"displayName", "displayNameLastFirst", "metadata"}
-)
-
-
 def _merge_name(
     existing: Dict[str, Any],
     new_name: Dict[str, Any],
@@ -409,7 +403,7 @@ def _merge_name(
     merged = {
         key: value
         for key, value in existing.items()
-        if key not in _NAME_OUTPUT_ONLY_FIELDS
+        if key not in ("displayName", "displayNameLastFirst", "metadata")
     }
     merged.update({key: value for key, value in new_name.items() if value})
     return merged

--- a/gcontacts/contacts_helpers.py
+++ b/gcontacts/contacts_helpers.py
@@ -385,6 +385,34 @@ def _merge_organizations(
     return result
 
 
+# displayName and displayNameLastFirst are output-only on people.Name.
+_NAME_OUTPUT_ONLY_FIELDS = frozenset({"displayName", "displayNameLastFirst", "metadata"})
+
+
+def _merge_name(
+    existing: Dict[str, Any],
+    new_name: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Merge one name object over the stored one, field by field.
+
+    people.updateContact replaces `names` outright, so a body carrying only
+    givenName drops the surname, middle name and any honorific the contact
+    had. Every other multi-value field on this request is merged against the
+    fetched contact; this does the same for the single name object.
+
+    displayName and displayNameLastFirst are output-only and are dropped, so
+    the merged object can be sent straight back.
+    """
+    merged = {
+        key: value
+        for key, value in existing.items()
+        if key not in _NAME_OUTPUT_ONLY_FIELDS
+    }
+    merged.update({key: value for key, value in new_name.items() if value})
+    return merged
+
+
 def _merge_nicknames(
     existing: List[Dict[str, Any]],
     new_nicknames: List[Dict[str, Any]],

--- a/gcontacts/contacts_helpers.py
+++ b/gcontacts/contacts_helpers.py
@@ -386,7 +386,9 @@ def _merge_organizations(
 
 
 # displayName and displayNameLastFirst are output-only on people.Name.
-_NAME_OUTPUT_ONLY_FIELDS = frozenset({"displayName", "displayNameLastFirst", "metadata"})
+_NAME_OUTPUT_ONLY_FIELDS = frozenset(
+    {"displayName", "displayNameLastFirst", "metadata"}
+)
 
 
 def _merge_name(

--- a/gcontacts/contacts_tools.py
+++ b/gcontacts/contacts_tools.py
@@ -21,6 +21,7 @@ from core.utils import UserInputError, handle_http_errors, StringList
 from gcontacts.contacts_helpers import (
     _format_contact,
     _merge_emails,
+    _merge_name,
     _merge_nicknames,
     _merge_organizations,
     _merge_phones,
@@ -1002,6 +1003,14 @@ async def manage_contact(
                     new_body["relations"],
                     relations_mode,
                 )
+
+            # people.updateContact replaces `names` outright, so a body carrying
+            # only givenName drops the surname and any middle name or honorific.
+            if "names" in new_body:
+                existing_names = current.get("names") or [{}]
+                merged_body["names"] = [
+                    _merge_name(existing_names[0], new_body["names"][0])
+                ]
 
             merged_body["etag"] = etag
 

--- a/tests/gcontacts/test_contacts_tools_v3.py
+++ b/tests/gcontacts/test_contacts_tools_v3.py
@@ -34,6 +34,7 @@ from gcontacts.contacts_tools import (  # noqa: E402
 )
 from gcontacts.contacts_helpers import (  # noqa: E402
     _format_contact,
+    _merge_name,
     _merge_nicknames,
     _merge_relations,
     _merge_urls,
@@ -654,3 +655,50 @@ class TestNotesClearBugFix:
         """notes=None means no opinion, do not add the biographies key at all."""
         body = _build_person_body(given_name="Test")
         assert "biographies" not in body
+
+
+# ---------------------------------------------------------------------------
+# _merge_name
+# ---------------------------------------------------------------------------
+class TestMergeName:
+    """people.updateContact replaces `names` outright, so a body carrying only
+    givenName used to drop the surname and every other name part."""
+
+    STORED = {
+        "givenName": "Bob",
+        "familyName": "Smith",
+        "middleName": "Q",
+        "honorificSuffix": "Jr.",
+        "displayName": "Bob Q Smith Jr.",
+        "displayNameLastFirst": "Smith, Bob Q",
+        "metadata": {"primary": True},
+    }
+
+    def test_changing_the_given_name_keeps_the_rest(self):
+        result = _merge_name(self.STORED, {"givenName": "Robert", "familyName": ""})
+        assert result["givenName"] == "Robert"
+        assert result["familyName"] == "Smith"
+        assert result["middleName"] == "Q"
+        assert result["honorificSuffix"] == "Jr."
+
+    def test_changing_the_family_name_keeps_the_rest(self):
+        result = _merge_name(self.STORED, {"givenName": "", "familyName": "Jones"})
+        assert result["givenName"] == "Bob"
+        assert result["familyName"] == "Jones"
+        assert result["middleName"] == "Q"
+
+    def test_both_names_given_replaces_both(self):
+        result = _merge_name(self.STORED, {"givenName": "Ann", "familyName": "Lee"})
+        assert result["givenName"] == "Ann"
+        assert result["familyName"] == "Lee"
+
+    def test_output_only_fields_are_dropped(self):
+        """displayName and displayNameLastFirst cannot be written back."""
+        result = _merge_name(self.STORED, {"givenName": "Robert", "familyName": ""})
+        assert "displayName" not in result
+        assert "displayNameLastFirst" not in result
+        assert "metadata" not in result
+
+    def test_a_contact_with_no_stored_name_takes_the_new_one(self):
+        result = _merge_name({}, {"givenName": "Ann", "familyName": "Lee"})
+        assert result == {"givenName": "Ann", "familyName": "Lee"}

--- a/tests/gcontacts/test_contacts_tools_v3.py
+++ b/tests/gcontacts/test_contacts_tools_v3.py
@@ -657,12 +657,13 @@ class TestNotesClearBugFix:
         assert "biographies" not in body
 
 
-# ---------------------------------------------------------------------------
+# =============================================================================
 # _merge_name
-# ---------------------------------------------------------------------------
+# =============================================================================
+
+
 class TestMergeName:
-    """people.updateContact replaces `names` outright, so a body carrying only
-    givenName used to drop the surname and every other name part."""
+    """people.updateContact replaces `names`, so unspecified parts must survive."""
 
     STORED = {
         "givenName": "Bob",


### PR DESCRIPTION
Closes #1096

`people.updateContact` replaces `names` outright, so an update carrying only `given_name` sent `familyName: ""` and dropped everything else:

```
stored: givenName=Bob, familyName=Smith, middleName=Q, honorificSuffix=Jr.
call:   manage_contact(action="update", resource_name="people/c1", given_name="Robert")
body:   [{'givenName': 'Robert', 'familyName': ''}]
```

Seven multi-value fields on that same request already merge against the fetched contact. `names` did not.

### Changes

`_merge_name` in `contacts_helpers.py`, beside the seven `_merge_*` helpers, merging field by field so unspecified parts survive. `displayName` and `displayNameLastFirst` are output-only on `people.Name`, so they are dropped and the merged object can go straight back.

Only the `names` path changes; nothing else in the request body is touched.

### Tests

Five in `test_contacts_tools_v3.py`: changing the given name keeps the rest, changing the family name keeps the rest, giving both replaces both, output-only fields are dropped, and a contact with no stored name takes the new one.

Verified by mutation — restoring the old `return new_name` fails the first two while the others stay green. 238 passed in `tests/gcontacts`; `ruff check` and `format --check` clean on 0.15.22.

### Scope

`names` only. `addresses` has the same shape at `contacts_tools.py:504` and I'm looking at that next, as its own issue and PR — being a list it needs an `addresses_mode` to match its siblings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a contact’s given or family name now preserves existing middle names, honorifics, honorific suffixes, and other unchanged name details.
  * Contact name updates no longer retain service-generated display or metadata fields.

* **New Features**
  * Added support for writing nicknames, URLs, custom user-defined fields, and relationships to contacts.

* **Tests**
  * Added coverage for contact field updates and name-merging behavior, including preserving existing details and removing output-only fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
