### PR TITLE
docs(gdocs): clarify the body-final range note in inspect_doc_structure

### DIFF
--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -1476,7 +1476,8 @@ async def inspect_doc_structure(
     Ranges can include required empty paragraphs. Before cleanup, use detailed=true
     to check adjacent elements, formatting, and object anchors. Preserve the final
     newline and newlines before tables, tables of contents, or section breaks.
-    The final range has end == total_length and may be omitted by truncation.
+    If the body ends with an empty paragraph, that paragraph's range has
+    end == total_length; truncation may omit that range.
 
     WORKFLOW FOR TABLE INSERTION:
     Step 1: Call this function


### PR DESCRIPTION
## Description

Follow-up to #1080 — thanks for the quick review and release, the layout stats are exactly what our agents needed. One small wording issue survived the merge; CodeRabbit flagged it in its post-merge pass and I agree with it.

The `inspect_doc_structure` docstring says:

> The final range has end == total_length and may be omitted by truncation.

`empty_paragraph_ranges` contains only empty paragraphs, so when a non-empty paragraph follows the last empty one, the last returned range ends before `total_length` and there is no body-final range at all. Read literally, the sentence invites a caller to treat `empty_paragraph_ranges[-1]` as the body-final paragraph and apply the body-final deletion rule to a paragraph in the middle of the document.

This PR states the condition explicitly (only a body-final *empty* paragraph has `end == total_length`; truncation may omit that range), as suggested by CodeRabbit in its post-merge review of #1080. Docstring only, no behaviour change.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually

`uvx ruff@0.15.22 check` and `format --check` clean; `uv run --frozen pytest tests/gdocs/test_structure_statistics.py` — 22 passed (same as `main`). Wording verified against `summarize_paragraph_layout` in `gdocs/docs_structure.py`, which sets `end` to the paragraph's `end_index` and caps the list at `EMPTY_PARAGRAPH_RANGE_LIMIT`.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

## Additional Notes

Two-line docstring change. The skill reference (`skills/managing-google-workspace/references/docs.md`) already ties `end == total_length` to the final newline rather than to a position in the list, so only the tool docstring needed aligning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified documentation for inspecting document structure, including how trailing empty paragraphs may be represented.
  - No functional behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->