### PR TITLE
fix(utils): distinguish an unreadable Office file from an empty one

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -47,6 +47,20 @@ _OFFICE_RELATIONSHIP_BASES = {
     "https://schemas.openxmlformats.org/officeDocument/2006/relationships",
     "http://purl.oclc.org/ooxml/officeDocument/relationships",
 }
+# The MIME types this extractor understands. Anything else is not an Office
+# document, so its bytes failing to open as a ZIP says nothing about damage.
+#
+# Do not remove this set and let every payload reach the ZIP open below: callers
+# distinguish "raised" from "returned None" to pick a branch, and their fallback
+# decoding lives in the branch an exception skips. Raising for a readable .txt
+# therefore does not merely mislabel it — it discards the content.
+_OFFICE_XML_MIME_TYPES = frozenset(
+    {
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    }
+)
 _WORD_TEXT_RELATIONSHIP_KINDS = {"header", "footer", "footnotes", "endnotes"}
 _WORD_TEXT_RELATIONSHIP_TYPES = {
     f"{base}/{kind}": kind
@@ -560,6 +574,13 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
             a caller, and conflating them reports a corrupt document as an
             unsupported or empty one.
     """
+    # Only a file that CLAIMS to be an Office document can be a damaged one.
+    # For any other MIME type, returning None hands the caller back to its own
+    # decoding, which is what read a .txt or .csv correctly before this
+    # extractor learned to raise.
+    if mime_type not in _OFFICE_XML_MIME_TYPES:
+        return None
+
     shared_strings: List[str] = []
     ns_excel_main = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -323,6 +323,15 @@ def check_credentials_directory_permissions(credentials_dir: str = None) -> None
     )
 
 
+class OfficeXmlExtractionError(Exception):
+    """Raised when an Office file cannot be READ.
+
+    Distinct from a valid file that simply contains no text. Callers that cannot
+    tell those apart end up reporting a damaged document as an empty or
+    unsupported one, which sends the reader looking in the wrong place.
+    """
+
+
 def _xml_name(tag: str) -> tuple[Optional[str], str]:
     """Return an ElementTree tag's namespace URI and local name."""
     if tag.startswith("{") and "}" in tag:
@@ -400,8 +409,18 @@ def _word_related_text_targets(zf: zipfile.ZipFile, document_root: Any) -> list[
     """Return active Word text parts using OPC relationships, not filenames."""
     try:
         relationships_root = ET.fromstring(zf.read("word/_rels/document.xml.rels"))
-    except (KeyError, ET.ParseError, DefusedXmlException):
+    except KeyError:
+        # ABSENT is not DAMAGED: a .docx with no relationship part simply has no
+        # headers, footers or notes to find. Do NOT merge this into the handler
+        # below, which raises.
         return []
+    except (ET.ParseError, DefusedXmlException) as e:
+        # Every header, footer, footnote and endnote is reached through this
+        # part. Returning [] on a MALFORMED one silently drops all of them and
+        # reports the remaining body text as the whole document.
+        raise OfficeXmlExtractionError(
+            f"member 'word/_rels/document.xml.rels' is not parseable XML: {e}"
+        ) from e
 
     relationships: list[tuple[str, str, str]] = []
     relationships_by_id: dict[str, tuple[str, str]] = {}
@@ -529,8 +548,17 @@ def _alternate_content_skip_set(
 def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
     """
     Very light-weight XML scraper for Word, Excel, PowerPoint files.
-    Returns plain-text if something readable is found, else None.
     Uses zipfile + defusedxml.ElementTree.
+
+    Returns:
+        The extracted text, or None if the file is readable but holds no text.
+
+    Raises:
+        OfficeXmlExtractionError: the file could not be read at all — not a ZIP,
+            or its XML will not parse. This is deliberately NOT folded into the
+            None return: "damaged" and "empty" call for different responses from
+            a caller, and conflating them reports a corrupt document as an
+            unsupported or empty one.
     """
     shared_strings: List[str] = []
     ns_excel_main = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
@@ -552,9 +580,19 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
                     # missing main part.
                     pass
                 else:
-                    document_root, choice_namespaces = (
-                        _parse_xml_with_choice_namespaces(document_content)
-                    )
+                    try:
+                        document_root, choice_namespaces = (
+                            _parse_xml_with_choice_namespaces(document_content)
+                        )
+                    except (ET.ParseError, DefusedXmlException) as e:
+                        # Parsed here rather than in the member loop below, so the
+                        # loop's member-level handler never sees this failure. Name
+                        # the member anyway: a report that says only "the XML would
+                        # not parse" does not say which part is damaged.
+                        raise OfficeXmlExtractionError(
+                            f"member 'word/document.xml' is not parseable XML "
+                            f"(mime_type: {mime_type}): {e}"
+                        ) from e
                     parsed_members["word/document.xml"] = (
                         document_root,
                         choice_namespaces,
@@ -592,7 +630,15 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
                         "No sharedStrings.xml found in Excel file (this is optional)."
                     )
                 except ET.ParseError as e:
+                    # Absent sharedStrings is optional (KeyError above). MALFORMED
+                    # is not: every t="s" cell resolves through it, so continuing
+                    # would silently produce wrong cell text.
                     logger.error(f"Error parsing sharedStrings.xml: {e}")
+                    raise OfficeXmlExtractionError(
+                        f"sharedStrings.xml is not parseable XML: {e}"
+                    ) from e
+                except OfficeXmlExtractionError:
+                    raise
                 except (
                     Exception
                 ) as e:  # Catch any other unexpected error during sharedStrings parsing
@@ -600,6 +646,9 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
                         f"Unexpected error processing sharedStrings.xml: {e}",
                         exc_info=True,
                     )
+                    raise OfficeXmlExtractionError(
+                        f"could not read sharedStrings.xml: {e}"
+                    ) from e
             else:
                 return None
 
@@ -751,15 +800,41 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
                         pieces.append(sep.join(member_texts))
 
                 except ET.ParseError as e:
+                    # A member that will not parse means we cannot report this
+                    # file's text. Swallowing it here and returning None below
+                    # would present a damaged document as an empty one.
                     logger.warning(
                         f"Could not parse XML in member '{member}' for {mime_type} file: {e}"
                     )
+                    raise OfficeXmlExtractionError(
+                        f"member '{member}' is not parseable XML "
+                        f"(mime_type: {mime_type}): {e}"
+                    ) from e
+                except OfficeXmlExtractionError:
+                    raise
+                except KeyError:
+                    # ABSENT is not DAMAGED, and the difference is the contract:
+                    # this function returns None for a readable file with no
+                    # extractable text, and raises only when the file cannot be
+                    # read. A member that is simply not in the archive is the
+                    # former.
+                    #
+                    # Do NOT merge this into the generic handler below. That one
+                    # raises, so folding these together would report every archive
+                    # lacking an optional member as corrupt.
+                    logger.info(
+                        f"Member '{member}' not present in {mime_type} file; skipping."
+                    )
+                    continue
                 except Exception as e:
                     logger.error(
                         f"Error processing member '{member}' for {mime_type}: {e}",
                         exc_info=True,
                     )
-                    # continue processing other members
+                    raise OfficeXmlExtractionError(
+                        f"could not read member '{member}' "
+                        f"(mime_type: {mime_type}): {e}"
+                    ) from e
 
             if not pieces:  # If no text was extracted at all
                 return None
@@ -768,19 +843,30 @@ def extract_office_xml_text(file_bytes: bytes, mime_type: str) -> Optional[str]:
             text = "\n\n".join(pieces).strip(" ")
             return text or None  # Ensure None is returned if text is empty after strip
 
-    except zipfile.BadZipFile:
+    except zipfile.BadZipFile as e:
         logger.warning(f"File is not a valid ZIP archive (mime_type: {mime_type}).")
-        return None
+        raise OfficeXmlExtractionError(
+            f"not a valid Office file (mime_type: {mime_type}): {e}"
+        ) from e
     except (
         ET.ParseError
     ) as e:  # Catch parsing errors at the top level if zipfile itself is XML-like
         logger.error(f"XML parsing error at a high level for {mime_type}: {e}")
-        return None
+        raise OfficeXmlExtractionError(
+            f"Office file XML could not be parsed (mime_type: {mime_type}): {e}"
+        ) from e
+    except OfficeXmlExtractionError:
+        raise
     except Exception as e:
+        # An unexpected failure is still a failure to READ the file, not evidence
+        # that it holds no text. Surface it rather than letting it masquerade as
+        # an empty document.
         logger.error(
             f"Failed to extract office XML text for {mime_type}: {e}", exc_info=True
         )
-        return None
+        raise OfficeXmlExtractionError(
+            f"could not extract text from Office file (mime_type: {mime_type}): {e}"
+        ) from e
 
 
 IMAGE_MIME_TYPES = {

--- a/gdocs/docs_tools.py
+++ b/gdocs/docs_tools.py
@@ -27,6 +27,7 @@ from core.file_limits import (
 )
 from core.utils import (
     GOOGLE_API_WRITE_RETRIES,
+    OfficeXmlExtractionError,
     extract_office_xml_text,
     handle_http_errors,
     UserInputError,
@@ -344,9 +345,20 @@ async def get_doc_content(
         except FileTooLargeError as e:
             return str(e)
 
-        office_text = extract_office_xml_text(file_content_bytes, mime_type)
+        office_text = None
+        unreadable = None
+        try:
+            office_text = extract_office_xml_text(file_content_bytes, mime_type)
+        except OfficeXmlExtractionError as e:
+            # A damaged file must not be reported as an unsupported encoding.
+            unreadable = (
+                f"[Could not read '{mime_type}' file - it appears damaged or is "
+                f"not a valid Office document: {e}]"
+            )
         if office_text:
             body_text = office_text
+        elif unreadable:
+            body_text = unreadable
         else:
             try:
                 body_text = file_content_bytes.decode("utf-8")

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -33,6 +33,7 @@ from core.utils import (
     GOOGLE_API_WRITE_RETRIES,
     IMAGE_MIME_TYPES,
     encode_image_content,
+    OfficeXmlExtractionError,
     extract_office_xml_text,
     extract_pdf_text,
     handle_http_errors,
@@ -409,11 +410,24 @@ async def get_drive_file_content(
 
     if mime_type in office_mime_types:
         # Offload Office XML extraction to a thread to avoid blocking the event loop
-        office_text = await asyncio.to_thread(
-            extract_office_xml_text, file_content_bytes, mime_type
-        )
+        office_text = None
+        unreadable = None
+        try:
+            office_text = await asyncio.to_thread(
+                extract_office_xml_text, file_content_bytes, mime_type
+            )
+        except OfficeXmlExtractionError as e:
+            # Say the file is damaged. Falling through to the binary branch would
+            # report a corrupt document as "unsupported text encoding", sending
+            # the reader after the wrong problem.
+            unreadable = (
+                f"[Could not read '{mime_type}' file - it appears damaged or is "
+                f"not a valid Office document: {e}]"
+            )
         if office_text:
             body_text = office_text
+        elif unreadable:
+            body_text = unreadable
         else:
             # Fallback: try UTF-8; otherwise flag binary
             try:

--- a/tests/core/test_non_office_mime_passthrough.py
+++ b/tests/core/test_non_office_mime_passthrough.py
@@ -1,0 +1,81 @@
+"""Office extraction must not claim a non-Office file is damaged.
+
+`extract_office_xml_text` opens the payload as a ZIP before it dispatches on
+MIME type, so before this fix it raised `OfficeXmlExtractionError` for every
+non-Office input -- text/plain, CSV, JSON, PDF. That matters because
+`get_doc_content` uses the raised/None distinction to choose a branch:
+
+    try:
+        office_text = extract_office_xml_text(file_content_bytes, mime_type)
+    except OfficeXmlExtractionError as e:
+        unreadable = "[Could not read ... it appears damaged ...]"
+    if office_text:      ...
+    elif unreadable:     ...        <- taken for a perfectly readable .txt
+    else:                body_text = file_content_bytes.decode("utf-8")
+
+A readable text file therefore reported itself as damaged and its content was
+never decoded, because the UTF-8 fallback sits in the branch the exception
+skipped.
+
+The regression was introduced by the change that made damaged Office files
+raise instead of returning None -- the fix for one conflation created another,
+in the opposite direction. Reported by an automated reviewer on PR #1101 and
+confirmed by running it.
+
+These tests pin BOTH directions, so a future change cannot restore one
+conflation while removing the other.
+"""
+
+import zipfile
+import io
+
+import pytest
+
+from core.utils import OfficeXmlExtractionError, extract_office_xml_text
+
+DOCX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+PPTX = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+
+
+@pytest.mark.parametrize(
+    "mime_type, payload",
+    [
+        ("text/plain", b"hello world, plain text\n"),
+        ("text/csv", b"a,b,c\n1,2,3\n"),
+        ("text/markdown", b"# heading\n\nbody\n"),
+        ("application/json", b'{"key": "value"}'),
+        ("application/pdf", b"%PDF-1.4 this is not a zip"),
+        ("application/octet-stream", b"\x00\x01\x02\x03"),
+        ("", b"no mime type at all"),
+    ],
+)
+def test_non_office_mime_returns_none_rather_than_raising(mime_type, payload):
+    """None is the caller's signal to fall through to its own decoding.
+
+    Raising here is not a harmless over-report: the caller's UTF-8 fallback
+    lives in the branch an exception skips, so a raise does not merely mislabel
+    the file, it discards the content entirely.
+    """
+    assert extract_office_xml_text(payload, mime_type) is None
+
+
+@pytest.mark.parametrize("mime_type", [DOCX, XLSX, PPTX])
+def test_damaged_office_file_still_raises(mime_type):
+    """The property the original change existed for, still holding.
+
+    Without this, a fix aimed at the regression above could simply stop raising
+    altogether and every test in the non-Office set would still pass.
+    """
+    with pytest.raises(OfficeXmlExtractionError):
+        extract_office_xml_text(b"this is definitely not a zip archive", mime_type)
+
+
+@pytest.mark.parametrize("mime_type", [DOCX, XLSX, PPTX])
+def test_readable_office_file_with_no_text_still_returns_none(mime_type):
+    """The other half of the original distinction: readable but empty."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("docProps/app.xml", "<Properties/>")
+
+    assert extract_office_xml_text(buffer.getvalue(), mime_type) is None

--- a/tests/core/test_office_extraction_errors.py
+++ b/tests/core/test_office_extraction_errors.py
@@ -1,0 +1,211 @@
+"""Tests that extract_office_xml_text distinguishes UNREADABLE from EMPTY.
+
+Both used to return None, so a caller could not tell "this file is damaged"
+from "this file contains no text". The two call for different responses, and
+conflating them reports a corrupt document as an unsupported or empty one —
+which sends the reader after the wrong problem.
+"""
+
+import io
+import zipfile
+
+import pytest
+
+from core.utils import OfficeXmlExtractionError, extract_office_xml_text
+
+W_NS = (
+    'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" '
+    'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+)
+REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+REL_BASE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+EXCEL_NS = 'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+
+
+def _docx(document_xml: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("word/document.xml", document_xml)
+    return buf.getvalue()
+
+
+def _valid(body: str) -> bytes:
+    return _docx(
+        f'<?xml version="1.0"?><w:document {W_NS}><w:body>{body}</w:body></w:document>'
+    )
+
+
+class TestUnreadableRaises:
+    def test_not_a_zip_raises(self):
+        with pytest.raises(OfficeXmlExtractionError):
+            extract_office_xml_text(b"this is not a zip at all", DOCX_MIME)
+
+    def test_truncated_zip_raises(self):
+        good = _valid("<w:p><w:r><w:t>hello</w:t></w:r></w:p>")
+        with pytest.raises(OfficeXmlExtractionError):
+            extract_office_xml_text(good[: len(good) // 2], DOCX_MIME)
+
+    def test_empty_bytes_raises(self):
+        with pytest.raises(OfficeXmlExtractionError):
+            extract_office_xml_text(b"", DOCX_MIME)
+
+    def test_message_names_the_mime_type(self):
+        """The report should say what it failed to read."""
+        with pytest.raises(OfficeXmlExtractionError) as excinfo:
+            extract_office_xml_text(b"not a zip", DOCX_MIME)
+        assert DOCX_MIME in str(excinfo.value)
+
+    def test_original_cause_is_chained(self):
+        """`raise ... from e` keeps the underlying error for debugging."""
+        with pytest.raises(OfficeXmlExtractionError) as excinfo:
+            extract_office_xml_text(b"not a zip", DOCX_MIME)
+        assert excinfo.value.__cause__ is not None
+
+
+class TestMemberLevelFailuresAlsoRaise:
+    """A per-member failure is still a failure to READ the file.
+
+    Suppressing it and falling through to "no pieces -> None" presents a damaged
+    document as an empty one, which is the exact conflation this change removes.
+    """
+
+    def test_malformed_document_xml_raises(self):
+        blob = _docx('<?xml version="1.0"?><w:document><unclosed>')
+        with pytest.raises(OfficeXmlExtractionError):
+            extract_office_xml_text(blob, DOCX_MIME)
+
+    def test_malformed_member_names_the_member(self):
+        blob = _docx('<?xml version="1.0"?><w:document><unclosed>')
+        with pytest.raises(OfficeXmlExtractionError) as excinfo:
+            extract_office_xml_text(blob, DOCX_MIME)
+        assert "word/document.xml" in str(excinfo.value)
+
+    def test_malformed_header_part_raises(self):
+        """A damaged header is a damaged file, not a document without a header."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(
+                "word/document.xml",
+                f'<?xml version="1.0"?><w:document {W_NS}><w:body><w:p><w:r>'
+                "<w:t>body</w:t></w:r></w:p>"
+                '<w:sectPr><w:headerReference w:type="default" r:id="rId1"/>'
+                "</w:sectPr></w:body></w:document>",
+            )
+            zf.writestr(
+                "word/_rels/document.xml.rels",
+                f'<?xml version="1.0"?><Relationships xmlns="{REL_NS}">'
+                f'<Relationship Id="rId1" Type="{REL_BASE}/header" '
+                'Target="header1.xml"/></Relationships>',
+            )
+            zf.writestr("word/header1.xml", '<?xml version="1.0"?><w:hdr><unclosed>')
+        with pytest.raises(OfficeXmlExtractionError) as excinfo:
+            extract_office_xml_text(buf.getvalue(), DOCX_MIME)
+        assert "word/header1.xml" in str(excinfo.value)
+
+    def test_malformed_relationships_part_raises(self):
+        """Headers, footers and notes are ALL reached through this part.
+
+        Returning no targets on a malformed one silently drops every one of them
+        and reports the body alone as the whole document.
+        """
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(
+                "word/document.xml",
+                f'<?xml version="1.0"?><w:document {W_NS}><w:body><w:p><w:r>'
+                "<w:t>body</w:t></w:r></w:p></w:body></w:document>",
+            )
+            zf.writestr(
+                "word/_rels/document.xml.rels",
+                '<?xml version="1.0"?><Relationships><unclosed>',
+            )
+        with pytest.raises(OfficeXmlExtractionError) as excinfo:
+            extract_office_xml_text(buf.getvalue(), DOCX_MIME)
+        assert "word/_rels/document.xml.rels" in str(excinfo.value)
+
+    def test_absent_relationships_part_is_not_an_error(self):
+        """A .docx with no relationship part simply has no headers or notes."""
+        blob = _valid("<w:p><w:r><w:t>body</w:t></w:r></w:p>")
+        assert extract_office_xml_text(blob, DOCX_MIME) == "body"
+
+    def test_malformed_shared_strings_raises(self):
+        """Absent sharedStrings is optional; MALFORMED is not -- every t="s"
+        cell resolves through it, so continuing yields wrong cell text."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(
+                "xl/worksheets/sheet1.xml",
+                f'<?xml version="1.0"?><worksheet {EXCEL_NS}><sheetData></sheetData>'
+                "</worksheet>",
+            )
+            zf.writestr("xl/sharedStrings.xml", '<?xml version="1.0"?><sst><unclosed>')
+        with pytest.raises(OfficeXmlExtractionError):
+            extract_office_xml_text(buf.getvalue(), XLSX_MIME)
+
+    def test_absent_shared_strings_is_not_an_error(self):
+        """The optional-member path must stay optional."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(
+                "xl/worksheets/sheet1.xml",
+                f'<?xml version="1.0"?><worksheet {EXCEL_NS}><sheetData><row>'
+                '<c r="A1" t="str"><v>alpha</v></c>'
+                "</row></sheetData></worksheet>",
+            )
+        assert extract_office_xml_text(buf.getvalue(), XLSX_MIME) == "alpha"
+
+    def test_malformed_worksheet_raises(self):
+        """The .xlsx sibling of the malformed-document.xml case."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(
+                "xl/worksheets/sheet1.xml",
+                '<?xml version="1.0"?><worksheet><unclosed>',
+            )
+        with pytest.raises(OfficeXmlExtractionError) as excinfo:
+            extract_office_xml_text(buf.getvalue(), XLSX_MIME)
+        assert "xl/worksheets/sheet1.xml" in str(excinfo.value)
+
+    def test_malformed_slide_raises(self):
+        """The .pptx sibling of the malformed-document.xml case."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("ppt/slides/slide1.xml", '<?xml version="1.0"?><sld><unclosed>')
+        pptx = (
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        )
+        with pytest.raises(OfficeXmlExtractionError) as excinfo:
+            extract_office_xml_text(buf.getvalue(), pptx)
+        assert "ppt/slides/slide1.xml" in str(excinfo.value)
+
+
+class TestReadableButEmptyStillReturnsNone:
+    def test_document_with_no_text_returns_none(self):
+        """A valid file holding no text is NOT an error — the old contract."""
+        assert extract_office_xml_text(_valid("<w:p/>"), DOCX_MIME) is None
+
+    def test_whitespace_only_text_returns_none(self):
+        body = '<w:p><w:r><w:t xml:space="preserve">   </w:t></w:r></w:p>'
+        assert extract_office_xml_text(_valid(body), DOCX_MIME) is None
+
+    def test_zip_without_the_expected_member_returns_none(self):
+        """Readable ZIP, nothing to extract from — still empty, not damaged."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("unrelated.txt", "hello")
+        assert extract_office_xml_text(buf.getvalue(), DOCX_MIME) is None
+
+    def test_unsupported_mime_type_returns_none(self):
+        """Not an Office type at all is an absence, not a damaged file."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("whatever.txt", "hello")
+        assert extract_office_xml_text(buf.getvalue(), "application/zip") is None
+
+
+class TestSuccessPathUnchanged:
+    def test_normal_document_still_extracts(self):
+        blob = _valid("<w:p><w:r><w:t>hello world</w:t></w:r></w:p>")
+        assert extract_office_xml_text(blob, DOCX_MIME) == "hello world"


### PR DESCRIPTION
Replaces #1060, which had drifted 114 commits behind `main` and could no longer be merged. Same change, rebuilt on current `main` (v1.26.0). **Please close #1060 in favour of this.**

## The problem

`extract_office_xml_text` returns `None` for two different things: a file that is genuinely empty, and a file that could not be read at all. Callers cannot tell them apart, so `get_drive_file_content` reports a damaged `.docx` as `[Binary or unsupported text encoding]` — which sends the reader looking at encoding rather than at a corrupt file.

Measured on `main` before the change:

| input | result |
|---|---|
| not a zip at all | `None` |
| truncated zip | `None` |
| malformed `word/document.xml` | `None` |
| readable, genuinely no text | `None` |

Four different situations, one answer.

## The change

A new `OfficeXmlExtractionError`. Damaged input **raises**; readable-but-empty still returns `None`. Same four inputs after:

```
not a zip at all          -> RAISED  not a valid Office file
truncated zip             -> RAISED  not a valid Office file
malformed document.xml    -> RAISED  member 'word/document.xml' is not parseable XML
READABLE but no text      -> returned None
```

The two call sites (`gdocs/docs_tools.py`, `gdrive/drive_tools.py`) catch it and report `[Could not read '<mime>' file - it appears damaged…]`.

Deliberately preserved: a file that is readable and simply has no extractable text keeps returning `None`, and a *missing* optional part stays a non-error. Only "present and unreadable" raises. Distinguishing those is the whole point — a change that raised for both would trade one conflation for another.

## What differs from #1060

Beyond the rebase, this covers two paths that version missed, both found by re-deriving against current `main` rather than replaying the old diff:

- `word/document.xml` is now parsed **ahead of** the member loop, so its failure never reached the member-level handler.
- `_word_related_text_targets` returned `[]` on a **malformed** relationships part, silently dropping every header, footer and note — a different door onto the same defect.

## Testing

`2133 passed, 2 skipped` on this branch. `ruff check .` and `ruff format --check .` both clean. 19 new tests in `tests/core/test_office_extraction_errors.py`, covering all three states.

**Negative control:** with all 9 raise sites neutered, **12 of 19 fail** with `DID NOT RAISE`. The 7 that still pass are the readable-but-empty and success-path tests, which must pass either way — so the suite distinguishes "guard works" from "guard absent" rather than merely being green.

## Note on #1059

#1059's work is already on `main` — it landed via #1071. The comment I left on both PRs saying they were not independent and could not merge in either order **is now stale**; it was written when both were open, and there is nothing left to order. This PR stands alone against current `main`.

Scoped to Office/OOXML only. The equivalent PDF conflation is real but is a separate change and not included here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of damaged or invalid Office documents during text extraction.
  - Users now receive a clear message when an Office file cannot be read, instead of an inaccurate unsupported-encoding message.
  - Readable Office files containing no text continue to be handled as empty.
  - Non-Office files, including text, CSV, Markdown, JSON, and PDF files, continue through their normal fallback handling.
  - Existing extraction behavior for valid documents and UTF-8 files remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->