### PR TITLE
fix(comments): comment tools emit literal \n instead of newlines

### DIFF
--- a/core/comments.py
+++ b/core/comments.py
@@ -262,7 +262,7 @@ async def _read_comments_impl(
     if not comments:
         return f"No comments found in {app_name} {file_id}"
 
-    output = [f"Found {len(comments)} comments in {app_name} {file_id}:\\n"]
+    output = [f"Found {len(comments)} comments in {app_name} {file_id}:\n"]
 
     for comment in comments:
         author = comment.get("author", {}).get("displayName", "Unknown")
@@ -296,7 +296,7 @@ async def _read_comments_impl(
 
         output.append("")  # Empty line between comments
 
-    return "\\n".join(output)
+    return "\n".join(output)
 
 
 async def _create_comment_impl(
@@ -326,7 +326,7 @@ async def _create_comment_impl(
     author = comment.get("author", {}).get("displayName", "Unknown")
     created = comment.get("createdTime", "")
 
-    return f"Comment created successfully!\\nComment ID: {comment_id}\\nAuthor: {author}\\nCreated: {created}\\nContent: {comment_content}"
+    return f"Comment created successfully!\nComment ID: {comment_id}\nAuthor: {author}\nCreated: {created}\nContent: {comment_content}"
 
 
 async def _reply_to_comment_impl(
@@ -354,7 +354,7 @@ async def _reply_to_comment_impl(
     author = reply.get("author", {}).get("displayName", "Unknown")
     created = reply.get("createdTime", "")
 
-    return f"Reply posted successfully!\\nReply ID: {reply_id}\\nAuthor: {author}\\nCreated: {created}\\nContent: {reply_content}"
+    return f"Reply posted successfully!\nReply ID: {reply_id}\nAuthor: {author}\nCreated: {created}\nContent: {reply_content}"
 
 
 async def _resolve_comment_impl(
@@ -382,4 +382,4 @@ async def _resolve_comment_impl(
     author = reply.get("author", {}).get("displayName", "Unknown")
     created = reply.get("createdTime", "")
 
-    return f"Comment {comment_id} has been resolved successfully.\\nResolve reply ID: {reply_id}\\nAuthor: {author}\\nCreated: {created}"
+    return f"Comment {comment_id} has been resolved successfully.\nResolve reply ID: {reply_id}\nAuthor: {author}\nCreated: {created}"

--- a/tests/core/test_comments.py
+++ b/tests/core/test_comments.py
@@ -63,7 +63,7 @@ async def test_read_comments_includes_quoted_text():
     assert "Quoted text: the specific text that was highlighted" in result
     assert "Needs a citation here." in result
 
-    parts = result.split("\\n")
+    parts = result.splitlines()
     bob_section_started = False
     for part in parts:
         if "Author: Bob" in part:

--- a/tests/core/test_comments_line_breaks.py
+++ b/tests/core/test_comments_line_breaks.py
@@ -1,0 +1,74 @@
+"""Comment tool output must use real line breaks, not the two-character `\\n`.
+
+Every return in `core/comments.py` was built with `"\\\\n"` in the source, which
+is a backslash followed by `n` — not a newline. The tools therefore returned one
+physical line containing literal `\\n` text, so a reader (human or model) saw the
+escape sequence rather than a formatted record list.
+
+The assertions are written against `splitlines()` rather than against the absence
+of a particular character, so they pin the PROPERTY (this output is multi-line)
+rather than one spelling of the bug.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.comments import (
+    _create_comment_impl,
+    _read_comments_impl,
+    _reply_to_comment_impl,
+    _resolve_comment_impl,
+)
+
+LITERAL_ESCAPE = "\\" + "n"  # the two characters, never a newline
+
+
+def _service(payload):
+    service = MagicMock()
+    service.comments.return_value.list.return_value.execute.return_value = payload
+    service.comments.return_value.create.return_value.execute.return_value = payload
+    service.replies.return_value.create.return_value.execute.return_value = payload
+    return service
+
+
+COMMENT = {
+    "id": "c1",
+    "author": {"displayName": "Alice"},
+    "content": "First note",
+    "createdTime": "2026-01-01",
+    "resolved": False,
+    "replies": [],
+}
+
+
+@pytest.mark.asyncio
+async def test_read_comments_returns_real_lines():
+    out = await _read_comments_impl(_service({"comments": [COMMENT]}), "docs", "f1")
+
+    assert LITERAL_ESCAPE not in out
+    # One record spans several lines: header, blank, then the fields.
+    assert len(out.splitlines()) > 1
+    assert "Comment ID: c1" in out.splitlines()
+
+
+@pytest.mark.parametrize(
+    "impl, args",
+    [
+        (_create_comment_impl, ("docs", "f1", "hello")),
+        (_reply_to_comment_impl, ("docs", "f1", "c1", "a reply")),
+        (_resolve_comment_impl, ("docs", "f1", "c1")),
+    ],
+)
+@pytest.mark.asyncio
+async def test_write_confirmations_return_real_lines(impl, args):
+    """The three write paths built their confirmations the same way.
+
+    They are covered explicitly because a fix aimed only at the `.join` in the
+    read path leaves these behind — they are f-strings, not joins, so a grep for
+    the join shape does not reach them.
+    """
+    out = await impl(_service(COMMENT), *args)
+
+    assert LITERAL_ESCAPE not in out
+    assert len(out.splitlines()) > 1


### PR DESCRIPTION
## The problem

Every return in `core/comments.py` is assembled with `"\\n"` in the source — a backslash followed by the letter `n`, not a newline. The comment tools return **one physical line** with the escape sequence in it.

Observed on current `main` (v1.26.0), `read_doc_comments` with a single comment:

```
Found 1 comments in Google Docs 1abc:\n\nComment ID: c1\nAuthor: Alice\nContent: First note\n...
```

`len(result.splitlines()) == 1`. Whatever renders that output shows the reader `\n` rather than a line break.

## The change

Five sites, not one. Grepping for the `"\\n".join` shape finds only the read path — the three write confirmations and the list header are **f-strings**, so that search does not reach them:

| line | site |
|---|---|
| 265 | read: list header |
| 299 | read: body `.join` |
| 329 | `_create_comment_impl` confirmation |
| 357 | `_reply_to_comment_impl` confirmation |
| 385 | `_resolve_comment_impl` confirmation |

After: the same call returns 6 real lines, 0 literal escapes.

## Testing

`2118 passed, 2 skipped`. `ruff check .` and `ruff format --check .` clean.

`tests/core/test_comments.py:66` split on the literal escape to reach the fields — that only worked *because* the output was one line. It now uses `splitlines()`, which reads the same either way.

New `tests/core/test_comments_line_breaks.py` covers all four entry points. The assertions pin the **property** (`len(out.splitlines()) > 1`) rather than the absence of one spelling of the bug, so they do not need rewriting if the format changes again.

**Negative control:** with the literals restored, **5 of 21 fail**; with the fix, 21 pass. The tests were watched failing before being trusted.

## Note on scope

This is display formatting only — no API call, argument or return type changes. Any caller that was string-matching on the literal `\n` in these outputs would be matching on the defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Comment tool output now uses actual line breaks instead of displaying literal `\n` sequences.
  - Improved formatting for reading, creating, replying to, and resolving comments.

- **Tests**
  - Added coverage to verify multi-line comment output is rendered correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->