### PR TITLE
feat(auth): support multiple OAuth clients, one per Cloud project

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -23,7 +23,14 @@ from auth.client_secrets import get_client_secrets_path, load_client_secrets_fil
 from auth.oauth21_session_store import get_oauth21_session_store
 from auth.credential_store import get_credential_store
 from auth.gateway_identity import normalize_principal_email
+from auth.oauth_clients import (
+    SOURCE_LEGACY_ENV,
+    OAuthClient,
+    OAuthClientResolutionError,
+    load_registry_from_env,
+)
 from auth.oauth_config import (
+    get_oauth_config,
     is_oauth21_enabled,
     is_stateless_mode,
     is_trust_gateway_identity,
@@ -200,21 +207,36 @@ def load_credentials_from_session(session_id: str) -> Optional[Credentials]:
     return credentials
 
 
-def load_client_secrets_from_env() -> Optional[Dict[str, Any]]:
+def load_client_secrets_from_env(
+    client: Optional["OAuthClient"] = None,
+) -> Optional[Dict[str, Any]]:
     """
-    Loads the client secrets from environment variables.
+    Loads the client secrets for one registered OAuth client.
 
     Environment variables used:
-        - GOOGLE_OAUTH_CLIENT_ID: OAuth client ID (required)
+        - GOOGLE_OAUTH_CLIENTS_FILE / GOOGLE_OAUTH_CLIENTS: multi-client registry
+        - GOOGLE_OAUTH_CLIENT_ID: OAuth client ID (single-client deployments)
         - GOOGLE_OAUTH_CLIENT_SECRET: OAuth client secret (optional for public clients)
         - GOOGLE_OAUTH_REDIRECT_URI: (optional) OAuth redirect URI
 
+    Args:
+        client: The client to build config for. When omitted, the registry's
+            default client is read from the environment at call time.
+
     Returns:
         Client secrets configuration dict compatible with Google OAuth library,
-        or None if required environment variables are not set.
+        or None if no OAuth client is configured.
     """
-    client_id = os.getenv("GOOGLE_OAUTH_CLIENT_ID")
-    client_secret = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET")
+    if client is None:
+        # Read the environment here rather than via the cached OAuthConfig
+        # singleton: this function's contract is to reflect the environment as
+        # it stands at call time, and the singleton is a snapshot taken at
+        # first access.
+        registry = load_registry_from_env()
+        client = registry.default if registry else None
+
+    client_id = client.client_id if client else None
+    client_secret = client.client_secret if client else None
     redirect_uri = os.getenv("GOOGLE_OAUTH_REDIRECT_URI")
 
     if client_id:
@@ -238,7 +260,10 @@ def load_client_secrets_from_env() -> Optional[Dict[str, Any]]:
         top_level_key = "web" if client_secret else "installed"
         config = {top_level_key: client_config}
 
-        logger.info("Loaded OAuth client credentials from environment variables")
+        logger.info(
+            "Loaded OAuth client credentials for client %s",
+            client.describe() if client else "<default>",
+        )
         return config
 
     logger.debug("OAuth client credentials not found in environment variables")
@@ -248,6 +273,14 @@ def load_client_secrets_from_env() -> Optional[Dict[str, Any]]:
 def load_client_secrets(client_secrets_path: str) -> Dict[str, Any]:
     """
     Loads the client secrets from environment variables (preferred) or from the client secrets file.
+
+    NOT ACCOUNT-AWARE, and currently unused by this package. It reads only the
+    registry's DEFAULT client and silently falls back to the file when there is
+    none, which for a multi-client registry without a default means authorizing
+    an account against whatever client_secret.json happens to be on disk. Use
+    ``create_oauth_flow`` (or ``resolve_oauth_client`` plus
+    ``load_client_secrets_from_env(client)``) for anything that authorizes a
+    specific account; those refuse instead of guessing.
 
     Priority order:
     1. Environment variables (GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET)
@@ -287,19 +320,139 @@ def load_client_secrets(client_secrets_path: str) -> Dict[str, Any]:
 
 def check_client_secrets() -> Optional[str]:
     """
-    Checks for the presence of OAuth client secrets, either as environment
-    variables or as a file.
+    Check that at least one OAuth client is available anywhere.
+
+    This gates ``start_google_auth`` and both OAuth callback handlers, and the
+    question it asks is deliberately PLURAL: is any OAuth client configured at
+    all. It must not ask for the *default* client. A multi-client registry may
+    legitimately have no default — an unmapped account is then refused rather
+    than silently authorized against an arbitrary Cloud project — and asking
+    ``load_client_secrets_from_env()`` with no account reads only that default,
+    so the whole deployment reported "credentials not found", including for
+    accounts the registry maps perfectly well.
+
+    Which client serves a given account is a separate, later decision made by
+    ``resolve_oauth_client``, which refuses rather than guessing.
 
     Returns:
-        An error message string if secrets are not found, otherwise None.
+        An error message string if no OAuth client is configured, otherwise None.
     """
-    env_config = load_client_secrets_from_env()
-    if not env_config and not os.path.exists(CONFIG_CLIENT_SECRETS_PATH):
-        logger.error(
-            f"OAuth client credentials not found. No environment variables set and no file at {CONFIG_CLIENT_SECRETS_PATH}"
+    # load_registry_from_env raises OAuthClientRegistryError for a configured
+    # but malformed registry. That stays fatal: a broken registry is not the
+    # same as an absent one, and treating it as absent would send the operator
+    # after credentials that are already there.
+    if load_registry_from_env() is not None:
+        return None
+
+    if os.path.exists(CONFIG_CLIENT_SECRETS_PATH):
+        return None
+
+    logger.error(
+        "No OAuth client is configured. No registry and no single-client "
+        "environment variables are set, and there is no file at %s",
+        CONFIG_CLIENT_SECRETS_PATH,
+    )
+    # Every source named here can actually take effect, because this branch is
+    # only reachable when none of them is set. Naming only
+    # GOOGLE_OAUTH_CLIENT_ID would have been advice that provably cannot work
+    # whenever a registry variable is present: load_registry_from_env returns
+    # at the first source that hits, and the registry sources are checked
+    # first, so the legacy variables would be ignored.
+    return (
+        "No OAuth client is configured. Set GOOGLE_OAUTH_CLIENTS_FILE (a path "
+        "to a JSON client registry) or GOOGLE_OAUTH_CLIENTS (that same "
+        "document inline) to register one or more OAuth clients; or, for a "
+        "single-client deployment, set GOOGLE_OAUTH_CLIENT_ID and "
+        "GOOGLE_OAUTH_CLIENT_SECRET; or provide a client secrets file at "
+        f"{CONFIG_CLIENT_SECRETS_PATH}."
+    )
+
+
+def resolve_oauth_client(
+    client_key: Optional[str] = None,
+    user_google_email: Optional[str] = None,
+) -> Optional[OAuthClient]:
+    """
+    Resolve which OAuth client to use for a flow.
+
+    ``client_key`` wins when given: the callback must complete the exchange with
+    the same client that issued the authorization URL, so it is looked up
+    exactly and a miss is an error rather than a fallback to the default.
+    Otherwise the account's email selects the client via the registry.
+
+    Returns:
+        The selected client, or None with exactly ONE meaning: no OAuth client
+        registry is configured at all, so the caller's client-secrets-file
+        fallback is the intended single-client path.
+
+        None used to mean two opposite things — "the caller specified nothing"
+        and "the registry refused this account" — and every caller read it as
+        the first, falling through to whatever ``client_secret.json`` was on
+        disk. Refusal is now an exception, which is fail-closed by omission
+        rather than depending on each caller remembering to check.
+
+    Raises:
+        OAuthClientResolutionError: if ``client_key`` names a client that is
+            not registered, or if a registry is configured but can select no
+            client for this request.
+    """
+    config = get_oauth_config()
+
+    if client_key:
+        client = config.get_client_by_key(client_key)
+        if client is None:
+            # Falling back here would exchange the code against a different
+            # Cloud project and fail at Google as 'invalid_client', pointing
+            # investigation at the token exchange rather than at the config
+            # change that actually caused it.
+            raise OAuthClientResolutionError(
+                f"OAuth client {client_key!r} is no longer registered. The "
+                "authorization was started with a client that has since been "
+                "removed or renamed; restart the authentication flow."
+            )
+        return client
+
+    registry = config.client_registry
+    if registry is None:
+        # Nothing configured at all. Not a refusal — the caller's file
+        # fallback is the supported single-client deployment.
+        return None
+
+    if registry.source == SOURCE_LEGACY_ENV:
+        # A registry synthesized from GOOGLE_OAUTH_CLIENT_ID/SECRET holds one
+        # client and no emails/domains map, so it can only ever select the same
+        # credentials the caller would resolve anyway — it carries no routing
+        # information, only a second copy of the answer.
+        #
+        # Returning None hands single-client deployments back to the existing
+        # environment-and-file resolution UNCHANGED. That is not merely tidier:
+        # get_oauth_config() is a process-lifetime singleton, so a client taken
+        # from it reflects the environment as it stood when the config was first
+        # built, whereas the path below reads os.environ at call time. Answering
+        # from the registry here silently converts a call-time read into a
+        # start-up read for deployments that never asked for multi-client at all.
+        return None
+
+    client = config.get_client_for_email(user_google_email)
+    if client is not None:
+        return client
+
+    registered = ", ".join(registry.keys)
+    if user_google_email:
+        raise OAuthClientResolutionError(
+            f"No OAuth client is registered for '{user_google_email}'. The "
+            f"registry defines {registered}, but maps neither that address "
+            "nor its domain to one and declares no default client. Add it to "
+            "'emails' or 'domains', or set 'default'. Refusing rather than "
+            "authorizing this account against an arbitrary Cloud project."
         )
-        return f"OAuth client credentials not found. Please set GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET environment variables or provide a client secrets file at {CONFIG_CLIENT_SECRETS_PATH}."
-    return None
+    raise OAuthClientResolutionError(
+        "No account was supplied and the OAuth client registry "
+        f"({registered}) declares no default client, so no client can be "
+        "selected. Set 'default' in the registry, or start the flow with an "
+        "account the registry maps. Refusing rather than authorizing against "
+        "an arbitrary Cloud project."
+    )
 
 
 def create_oauth_flow(
@@ -308,8 +461,25 @@ def create_oauth_flow(
     state: Optional[str] = None,
     code_verifier: Optional[str] = None,
     autogenerate_code_verifier: bool = True,
+    client_key: Optional[str] = None,
+    user_google_email: Optional[str] = None,
 ) -> Flow:
-    """Creates an OAuth flow using environment variables or client secrets file."""
+    """
+    Creates an OAuth flow using environment variables or client secrets file.
+
+    ``client_key`` / ``user_google_email`` select which registered OAuth client
+    the flow uses. Both may be omitted, which selects the default client and
+    reproduces the single-client behaviour.
+
+    Raises:
+        OAuthClientResolutionError: if a registry is configured but can select
+            no client for this request. The client secrets file is reached
+            only when no registry exists at all.
+        FileNotFoundError: if there is no registry and no client secrets file.
+    """
+    client = resolve_oauth_client(
+        client_key=client_key, user_google_email=user_google_email
+    )
     flow_kwargs = {
         "scopes": scopes,
         "redirect_uri": redirect_uri,
@@ -327,14 +497,29 @@ def create_oauth_flow(
         flow_kwargs["autogenerate_code_verifier"] = autogenerate_code_verifier
 
     # Try environment variables first
-    env_config = load_client_secrets_from_env()
+    env_config = load_client_secrets_from_env(client)
     if env_config:
         # Use client config directly
         flow = Flow.from_client_config(env_config, **flow_kwargs)
         logger.debug("Created OAuth flow from environment variables")
         return flow
 
-    # Fall back to file-based config
+    if client is not None:
+        # Second, independent layer. resolve_oauth_client has already refused
+        # every request it cannot serve, so a resolved client that yields no
+        # usable config is a bug — and still not a reason to authorize this
+        # account against whatever file happens to be on disk. The two checks
+        # are deliberately redundant: this one holds even if resolution is
+        # later relaxed.
+        raise OAuthClientResolutionError(
+            f"OAuth client {client.key!r} was resolved but produced no usable "
+            "client configuration. Refusing to fall back to "
+            f"{CONFIG_CLIENT_SECRETS_PATH}, which belongs to a different "
+            "Cloud project."
+        )
+
+    # No registry configured at all: the client secrets file is the intended
+    # single-client path.
     if not os.path.exists(CONFIG_CLIENT_SECRETS_PATH):
         raise FileNotFoundError(
             f"OAuth client secrets file not found at {CONFIG_CLIENT_SECRETS_PATH} and no environment variables set"
@@ -522,10 +707,28 @@ async def start_auth_flow(
         oauth_state = os.urandom(16).hex()
         current_scopes = get_current_scopes()
 
+        # Pick the OAuth client whose Cloud project may authorize this account,
+        # and remember it on the state so the callback exchanges the code
+        # against the same client.
+        oauth_client = resolve_oauth_client(user_google_email=user_google_email)
+        if oauth_client is None and get_oauth_config().has_multiple_clients():
+            # Second, independent layer: resolve_oauth_client now raises for
+            # this case, so reaching here means resolution returned None while
+            # a multi-client registry exists — a contradiction. Kept rather
+            # than deleted so the fail-closed property does not rest on a
+            # single check.
+            raise OAuthClientResolutionError(
+                f"No OAuth client is configured for '{user_google_email}'. Map its "
+                "address or domain in the OAuth client registry, or set a default "
+                "client."
+            )
+        oauth_client_key = oauth_client.key if oauth_client else None
+
         flow = create_oauth_flow(
             scopes=current_scopes,  # Use scopes for enabled tools only
             redirect_uri=redirect_uri,  # Use passed redirect_uri
             state=oauth_state,
+            client_key=oauth_client_key,
         )
 
         session_id = None
@@ -576,10 +779,12 @@ async def start_auth_flow(
             ),
             enforce_user_email_match=enforce_user_email_match,
             principal_source=principal_source,
+            client_key=oauth_client_key,
         )
 
         logger.info(
             f"Auth flow started for {user_display_name}. State: {oauth_state[:8]}... "
+            f"OAuth client: {oauth_client_key or '<default>'}. "
             f"Browser opened automatically: {browser_opened}"
         )
 
@@ -746,12 +951,25 @@ async def handle_auth_callback(
                     _session_id_log_fingerprint(originating_session_id),
                 )
 
+        # The token exchange must use the same OAuth client that issued the
+        # authorization URL. State entries written before multi-client support
+        # carry no client_key, so resolution falls back to the registry's
+        # default — correct for those, since a pre-upgrade state can only have
+        # been issued by a single-client deployment.
+        #
+        # It does NOT fall through to whatever client_secret.json is on disk.
+        # If the registry has since grown several clients and no default,
+        # create_oauth_flow raises OAuthClientResolutionError rather than
+        # exchanging the code against an arbitrary Cloud project. That is a
+        # legible failure ("restart the flow") instead of a credential issued
+        # by the wrong project.
         flow = create_oauth_flow(
             scopes=scopes,
             redirect_uri=redirect_uri,
             state=state,
             code_verifier=state_info.get("code_verifier"),
             autogenerate_code_verifier=False,
+            client_key=state_info.get("client_key"),
         )
 
         # Exchange the authorization code for credentials

--- a/auth/oauth21_session_store.py
+++ b/auth/oauth21_session_store.py
@@ -13,7 +13,7 @@ import os
 from typing import Dict, Optional, Any, Tuple, Callable, IO
 from threading import RLock
 from datetime import datetime, timedelta, timezone
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 try:
     import fcntl
@@ -108,7 +108,11 @@ class SessionContext:
 
     session_id: Optional[str] = None
     user_id: Optional[str] = None
-    auth_context: Optional[Any] = None
+    # Holds the request's AccessToken, whose own repr renders the bearer token.
+    # Excluded from this dataclass's repr for the same reason as
+    # auth.oauth_clients.OAuthClient.client_secret: a container's repr is how a
+    # credential reaches a log line or a traceback nobody meant to widen.
+    auth_context: Optional[Any] = field(default=None, repr=False)
     request: Optional[Any] = None
     metadata: Dict[str, Any] = None
     issuer: Optional[str] = None
@@ -267,6 +271,11 @@ class OAuth21SessionStore:
             "code_verifier": state_info.get("code_verifier"),
             "expected_user_email": state_info.get("expected_user_email"),
             "principal_source": state_info.get("principal_source"),
+            # Which registered OAuth client issued the authorization URL. The
+            # callback must exchange the code against that same client. Absent
+            # (None) on entries written before multi-client support, which the
+            # callback reads as "the default client".
+            "client_key": state_info.get("client_key"),
             # Retained for compatibility with state files written by the initial
             # trusted-gateway implementation.
             "user_email": state_info.get("user_email"),
@@ -472,12 +481,17 @@ class OAuth21SessionStore:
         expected_user_email: Optional[str] = None,
         enforce_user_email_match: bool = False,
         principal_source: Optional[str] = None,
+        client_key: Optional[str] = None,
     ) -> None:
         """Persist an OAuth state value for later validation.
 
         Enforced identity bindings are explicit so callback security does not depend on
         process-global configuration at callback time. ``user_email`` is retained only
         for compatibility with state entries created by older releases.
+
+        ``client_key`` records which registered OAuth client issued the
+        authorization URL, so the callback can exchange the code against that
+        same client instead of whichever one configuration currently defaults to.
         """
         if not state:
             raise ValueError("OAuth state must be provided")
@@ -497,6 +511,7 @@ class OAuth21SessionStore:
                 "expected_user_email": expected_user_email,
                 "enforce_user_email_match": enforce_user_email_match,
                 "principal_source": principal_source,
+                "client_key": client_key,
             }
             self._oauth_states[state] = state_info
             self._persist_oauth_state_to_shared_store(state, state_info)

--- a/auth/oauth_clients.py
+++ b/auth/oauth_clients.py
@@ -1,0 +1,360 @@
+"""
+Multi-client OAuth registry.
+
+A single Google Cloud project can only issue OAuth credentials that its own
+consent screen permits. A project whose consent screen is configured as
+``Internal`` rejects every account outside its Workspace organization with
+``Error 403: org_internal``. Serving accounts that live in different
+organizations therefore requires more than one OAuth client.
+
+This module maps a Google account to the OAuth client that is allowed to
+authorize it. Resolution is by exact email first, then by domain, then by a
+configured default, so the common single-client deployment needs no
+configuration at all and keeps working unchanged.
+
+Note that only the *initial authorization* consults this registry. Stored
+credentials already embed the ``client_id`` and ``client_secret`` they were
+issued with (see ``auth.credential_store``), so refreshing an existing token
+uses that account's original client without reference to this registry.
+
+Configuration (first match wins):
+
+1. ``GOOGLE_OAUTH_CLIENTS_FILE`` — path to a JSON registry file.
+2. ``GOOGLE_OAUTH_CLIENTS`` — the same JSON document, inline.
+3. ``GOOGLE_OAUTH_CLIENT_ID`` / ``GOOGLE_OAUTH_CLIENT_SECRET`` — the legacy
+   single-client variables, used as a registry of exactly one client.
+
+Registry document shape::
+
+    {
+      "default": "personal",
+      "clients": {
+        "personal": {"client_id": "...", "client_secret": "..."},
+        "work":     {"client_id": "...", "client_secret": "..."}
+      },
+      "domains": {"example.com": "work"},
+      "emails":  {"someone@gmail.com": "personal"}
+    }
+
+``client_secret`` is optional; omitting it declares a public (PKCE) client.
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+# Environment variables read by this module.
+# Provenance of a registry. A registry document declares its clients per Cloud
+# project deliberately, so the single-client client_secret.json fallback has no
+# authority to amend its entries; a registry synthesized from the legacy
+# GOOGLE_OAUTH_CLIENT_ID/SECRET pair describes the same one client that fallback
+# is completing, so there it must.
+SOURCE_REGISTRY_DOCUMENT = "registry-document"
+SOURCE_LEGACY_ENV = "legacy-env"
+
+ENV_CLIENTS_FILE = "GOOGLE_OAUTH_CLIENTS_FILE"
+ENV_CLIENTS_INLINE = "GOOGLE_OAUTH_CLIENTS"
+ENV_LEGACY_CLIENT_ID = "GOOGLE_OAUTH_CLIENT_ID"
+ENV_LEGACY_CLIENT_SECRET = "GOOGLE_OAUTH_CLIENT_SECRET"
+
+# Key assigned to the client synthesized from the legacy single-client env vars.
+LEGACY_CLIENT_KEY = "default"
+
+
+class OAuthClientRegistryError(ValueError):
+    """Raised when the OAuth client registry is malformed."""
+
+
+class OAuthClientResolutionError(ValueError):
+    """Raised when a configured registry can select no client for a request.
+
+    This is deliberately an exception and not a second ``None``. "The registry
+    refused this account" and "no OAuth client is configured at all" are
+    opposite situations that used to share one sentinel, and every caller read
+    it as the second: the refusal fell through to whatever ``client_secret.json``
+    happened to be on disk, authorizing an unmapped account against an
+    arbitrary Cloud project. A sentinel obliges every present and future caller
+    to remember to check; an exception is fail-closed by omission, which is the
+    property that was missing.
+
+    Subclasses ``ValueError`` so existing handlers keep working.
+    """
+
+
+@dataclass(frozen=True)
+class OAuthClient:
+    """One OAuth client, i.e. one Google Cloud project's credentials."""
+
+    key: str
+    client_id: str
+    # repr=False, not merely "call describe() instead": the generated repr is
+    # what "%r" logging, f-strings, container reprs and tracebacks-with-locals
+    # all reach for, and none of those call describe(). The secret is excluded
+    # from the repr so there is no rendering of this object that leaks it.
+    # client_id stays visible — it is not a credential (it is published in
+    # every authorization URL) and it is what makes a log line diagnosable.
+    client_secret: Optional[str] = field(default=None, repr=False)
+
+    @property
+    def is_public(self) -> bool:
+        """True when no secret is configured (a PKCE/desktop client)."""
+        return not self.client_secret
+
+    def describe(self) -> str:
+        """Log-safe description. Never includes the secret."""
+        suffix = "public" if self.is_public else "confidential"
+        return f"{self.key} ({self.client_id[:16]}…, {suffix})"
+
+
+class OAuthClientRegistry:
+    """Resolves a Google account to the OAuth client that may authorize it."""
+
+    def __init__(
+        self,
+        clients: Mapping[str, OAuthClient],
+        default_key: Optional[str] = None,
+        domains: Optional[Mapping[str, str]] = None,
+        emails: Optional[Mapping[str, str]] = None,
+        source: str = SOURCE_REGISTRY_DOCUMENT,
+    ):
+        # Where this registry came from. Recorded rather than re-derived by
+        # callers: whether the single-client secrets-file fallback may amend the
+        # default entry depends on it, and a caller re-reading the environment
+        # to answer that would be a second copy of the precedence rules in
+        # load_registry_from_env(), free to drift out of agreement with it.
+        self.source = source
+        self._clients: Dict[str, OAuthClient] = dict(clients)
+        # Match case-insensitively; Google addresses and domains are not
+        # case-sensitive, and a config typo here fails silently otherwise.
+        self._domains: Dict[str, str] = {
+            k.lower(): v for k, v in (domains or {}).items()
+        }
+        self._emails: Dict[str, str] = {k.lower(): v for k, v in (emails or {}).items()}
+
+        if default_key is not None and default_key not in self._clients:
+            raise OAuthClientRegistryError(
+                f"default client {default_key!r} is not defined in 'clients' "
+                f"(defined: {sorted(self._clients) or 'none'})"
+            )
+        # With exactly one client and no explicit default, that client is the
+        # default. With several, an unset default means "no fallback": an
+        # unmapped account is an error rather than a silent wrong-project auth.
+        if default_key is None and len(self._clients) == 1:
+            default_key = next(iter(self._clients))
+        self._default_key = default_key
+
+        for label, mapping in (("domains", self._domains), ("emails", self._emails)):
+            for source, target in mapping.items():
+                if target not in self._clients:
+                    raise OAuthClientRegistryError(
+                        f"{label} entry {source!r} refers to undefined client "
+                        f"{target!r} (defined: {sorted(self._clients) or 'none'})"
+                    )
+
+    def __len__(self) -> int:
+        return len(self._clients)
+
+    @property
+    def keys(self):
+        return sorted(self._clients)
+
+    @property
+    def default(self) -> Optional[OAuthClient]:
+        if self._default_key is None:
+            return None
+        return self._clients[self._default_key]
+
+    def get(self, key: str) -> Optional[OAuthClient]:
+        """Look up a client by its registry key."""
+        return self._clients.get(key)
+
+    def resolve(self, user_google_email: Optional[str] = None) -> Optional[OAuthClient]:
+        """
+        Resolve the client for an account: exact email, then domain, then default.
+
+        Returns None when nothing matches and no default is configured, which
+        the caller must treat as a configuration error rather than falling back
+        to an arbitrary client.
+        """
+        if user_google_email:
+            email = user_google_email.strip().lower()
+            key = self._emails.get(email)
+            if key:
+                logger.debug("OAuth client %r matched email %s", key, email)
+                return self._clients[key]
+
+            _, _, domain = email.partition("@")
+            if domain:
+                key = self._domains.get(domain)
+                if key:
+                    logger.debug("OAuth client %r matched domain %s", key, domain)
+                    return self._clients[key]
+
+        default = self.default
+        if default is not None and user_google_email:
+            logger.debug(
+                "OAuth client %r used as default for %s",
+                default.key,
+                user_google_email,
+            )
+        return default
+
+
+def _parse_client_entry(key: str, raw: Any) -> OAuthClient:
+    if not isinstance(raw, dict):
+        raise OAuthClientRegistryError(
+            f"client {key!r} must be an object, got {type(raw).__name__}"
+        )
+
+    client_id = raw.get("client_id")
+    if not isinstance(client_id, str) or not client_id.strip():
+        raise OAuthClientRegistryError(
+            f"client {key!r} is missing a non-empty string 'client_id'"
+        )
+
+    client_secret = raw.get("client_secret")
+    if client_secret is not None and not isinstance(client_secret, str):
+        raise OAuthClientRegistryError(
+            f"client {key!r} has a non-string 'client_secret'"
+        )
+    # Treat "" as absent so a blank value in config means "public client"
+    # rather than a confidential client with an empty secret.
+    if isinstance(client_secret, str) and not client_secret.strip():
+        client_secret = None
+
+    return OAuthClient(
+        key=key, client_id=client_id.strip(), client_secret=client_secret
+    )
+
+
+def _parse_str_map(document: Mapping[str, Any], field: str) -> Dict[str, str]:
+    raw = document.get(field)
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise OAuthClientRegistryError(
+            f"'{field}' must be an object, got {type(raw).__name__}"
+        )
+    parsed: Dict[str, str] = {}
+    for source, target in raw.items():
+        if not isinstance(source, str) or not isinstance(target, str):
+            raise OAuthClientRegistryError(
+                f"'{field}' entries must map string to string; "
+                f"got {source!r} -> {target!r}"
+            )
+        parsed[source.strip()] = target.strip()
+    return parsed
+
+
+def parse_registry_document(document: Any) -> OAuthClientRegistry:
+    """Build a registry from an already-decoded JSON document."""
+    if not isinstance(document, dict):
+        raise OAuthClientRegistryError(
+            f"registry must be a JSON object, got {type(document).__name__}"
+        )
+
+    raw_clients = document.get("clients")
+    if not isinstance(raw_clients, dict) or not raw_clients:
+        raise OAuthClientRegistryError(
+            "registry must define a non-empty 'clients' object"
+        )
+
+    clients = {
+        key: _parse_client_entry(key, value) for key, value in raw_clients.items()
+    }
+
+    default_key = document.get("default")
+    if default_key is not None and not isinstance(default_key, str):
+        raise OAuthClientRegistryError(
+            f"'default' must be a string, got {type(default_key).__name__}"
+        )
+
+    return OAuthClientRegistry(
+        clients=clients,
+        default_key=default_key,
+        domains=_parse_str_map(document, "domains"),
+        emails=_parse_str_map(document, "emails"),
+    )
+
+
+def _load_registry_from_file(path: str) -> OAuthClientRegistry:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            document = json.load(handle)
+    except OSError as exc:
+        raise OAuthClientRegistryError(
+            f"could not read {ENV_CLIENTS_FILE} at {path}: {exc}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise OAuthClientRegistryError(
+            f"{ENV_CLIENTS_FILE} at {path} is not valid JSON: {exc}"
+        ) from exc
+    return parse_registry_document(document)
+
+
+def _load_registry_from_inline(raw: str) -> OAuthClientRegistry:
+    try:
+        document = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise OAuthClientRegistryError(
+            f"{ENV_CLIENTS_INLINE} is not valid JSON: {exc}"
+        ) from exc
+    return parse_registry_document(document)
+
+
+def _load_legacy_single_client() -> Optional[OAuthClientRegistry]:
+    client_id = os.getenv(ENV_LEGACY_CLIENT_ID)
+    if not client_id or not client_id.strip():
+        return None
+    secret = os.getenv(ENV_LEGACY_CLIENT_SECRET)
+    client = OAuthClient(
+        key=LEGACY_CLIENT_KEY,
+        client_id=client_id.strip(),
+        client_secret=secret.strip() if secret and secret.strip() else None,
+    )
+    return OAuthClientRegistry(
+        clients={LEGACY_CLIENT_KEY: client},
+        default_key=LEGACY_CLIENT_KEY,
+        source=SOURCE_LEGACY_ENV,
+    )
+
+
+def load_registry_from_env() -> Optional[OAuthClientRegistry]:
+    """
+    Build the registry from the environment.
+
+    Returns None when no OAuth client is configured at all, which callers
+    already handle by falling back to a client secrets file.
+
+    Raises:
+        OAuthClientRegistryError: if a registry is configured but malformed.
+            This is deliberately fatal — silently ignoring a broken registry
+            would authorize accounts against the wrong Cloud project.
+    """
+    path = os.getenv(ENV_CLIENTS_FILE)
+    if path and path.strip():
+        registry = _load_registry_from_file(path.strip())
+        logger.info(
+            "Loaded %d OAuth client(s) from %s: %s",
+            len(registry),
+            ENV_CLIENTS_FILE,
+            ", ".join(registry.keys),
+        )
+        return registry
+
+    inline = os.getenv(ENV_CLIENTS_INLINE)
+    if inline and inline.strip():
+        registry = _load_registry_from_inline(inline.strip())
+        logger.info(
+            "Loaded %d OAuth client(s) from %s: %s",
+            len(registry),
+            ENV_CLIENTS_INLINE,
+            ", ".join(registry.keys),
+        )
+        return registry
+
+    return _load_legacy_single_client()

--- a/auth/oauth_config.py
+++ b/auth/oauth_config.py
@@ -16,6 +16,13 @@ from urllib.parse import urlparse
 from typing import List, Optional, Dict, Any
 
 from auth.client_secrets import get_client_secrets_path, load_client_secrets_file
+from auth.oauth_clients import (
+    LEGACY_CLIENT_KEY,
+    SOURCE_LEGACY_ENV,
+    OAuthClient,
+    OAuthClientRegistry,
+    load_registry_from_env as load_oauth_client_registry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,8 +87,21 @@ class OAuthConfig:
         # OAuth client configuration. Environment variables take precedence;
         # values missing from the environment fall back to the client secrets file
         # (resolved below, once the OAuth 2.1 flag is known).
-        self.client_id = os.getenv("GOOGLE_OAUTH_CLIENT_ID")
-        self.client_secret = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET")
+        #
+        # The registry holds one OAuth client per Cloud project, so accounts in
+        # different Google Workspace organizations can each authorize against the
+        # consent screen that actually permits them. It is loaded from
+        # GOOGLE_OAUTH_CLIENTS_FILE / GOOGLE_OAUTH_CLIENTS when either is set, and
+        # otherwise from GOOGLE_OAUTH_CLIENT_ID/SECRET — in which case it holds
+        # exactly one client and everything below behaves as it did before.
+        # When none of those are set it is None, and the client secrets file
+        # fallback further down resolves credentials exactly as before.
+        self.client_registry: Optional[OAuthClientRegistry] = (
+            load_oauth_client_registry()
+        )
+        default_client = self.client_registry.default if self.client_registry else None
+        self.client_id = default_client.client_id if default_client else None
+        self.client_secret = default_client.client_secret if default_client else None
         self.client_secrets_file: Optional[str] = None
 
         # Branding for the OAuth consent page. FastMCP's OAuth proxy renders the
@@ -120,6 +140,7 @@ class OAuthConfig:
         self._apply_client_secrets_file_fallback(
             required=self.oauth21_enabled and not self.external_oauth21_provider
         )
+        self._reconcile_registry_with_resolved_default()
 
         # Trusted-gateway identity (provider-agnostic).
         # An MCP-aware reverse proxy (e.g. Pomerium, oauth2-proxy, Cloudflare Access,
@@ -263,6 +284,51 @@ class OAuthConfig:
         # Ensure FastMCP's Google provider picks up our existing configuration
         self._apply_fastmcp_google_env()
 
+    def _reconcile_registry_with_resolved_default(self) -> None:
+        """Keep the registry's default client equal to the resolved credentials.
+
+        `_apply_client_secrets_file_fallback` can supply a client_id or a
+        client_secret that the registry never saw — most commonly when only
+        GOOGLE_OAUTH_CLIENT_ID is exported and the secret lives in
+        client_secret.json. Without this, `self.client_secret` and
+        `client_registry.default.client_secret` disagree, and which one a caller
+        gets depends on whether it reads the config or resolves a client. That
+        split is silent: both values are populated and each looks correct alone.
+
+        A registry loaded from a real registry document is left untouched — its
+        entries are declared per Cloud project and the single-client file
+        fallback has no authority over them.
+        """
+        if not self.client_id:
+            return
+
+        if self.client_registry is not None:
+            if self.client_registry.source != SOURCE_LEGACY_ENV:
+                return
+            default_client = self.client_registry.default
+            if (
+                default_client is not None
+                and default_client.client_id == self.client_id
+                and default_client.client_secret == self.client_secret
+            ):
+                return
+
+        # Either credentials came from client_secret.json with no registry at
+        # all, or the file completed the legacy single client. Rebuild rather
+        # than mutate: the registry validates its own invariants in __init__,
+        # and an in-place edit would bypass them.
+        self.client_registry = OAuthClientRegistry(
+            clients={
+                LEGACY_CLIENT_KEY: OAuthClient(
+                    key=LEGACY_CLIENT_KEY,
+                    client_id=self.client_id,
+                    client_secret=self.client_secret,
+                )
+            },
+            default_key=LEGACY_CLIENT_KEY,
+            source=SOURCE_LEGACY_ENV,
+        )
+
     def _apply_client_secrets_file_fallback(self, required: bool) -> None:
         """Fill missing client credentials from the client secrets file.
 
@@ -345,8 +411,58 @@ class OAuthConfig:
             path = uri if uri.startswith("/") else f"/{uri}"
         return path or "/oauth2callback"
 
+    def _warn_if_oauth21_cannot_serve_the_whole_registry(self) -> None:
+        """Warn when OAuth 2.1 cannot honour per-account client selection.
+
+        FastMCP's Google provider is configured through process-global
+        environment variables, so it can only ever be bound to one OAuth
+        client. Per-account selection therefore applies to the tool-level
+        (legacy OAuth 2.0) flow only.
+
+        This must run before ``_apply_fastmcp_google_env``'s ``client_id``
+        check, not after it: ``client_id`` is None exactly when a multi-client
+        registry has no default, which is both the worst case (no
+        protocol-level login can be served at all) and the case where this
+        warning is the only signal an operator gets.
+        """
+        registry = self.client_registry
+        if not self.oauth21_enabled or registry is None or len(registry) <= 1:
+            return
+
+        default = registry.default
+        if default is None:
+            logger.warning(
+                "%d OAuth clients are registered and none is marked 'default', "
+                "but OAuth 2.1 binds FastMCP's Google provider to a single "
+                "client. No protocol-level login can be served at all. Set "
+                "'default' in the OAuth client registry (%s), or run one "
+                "deployment per client. The tool-level start_google_auth flow "
+                "is disabled whenever MCP_ENABLE_OAUTH21=true, so it cannot "
+                "cover the remaining accounts.",
+                len(registry),
+                ", ".join(registry.keys),
+            )
+            return
+
+        others = [key for key in registry.keys if key != default.key]
+        logger.warning(
+            "%d OAuth clients are registered, but OAuth 2.1 binds FastMCP's "
+            "Google provider to a single client (%s). Every protocol-level "
+            "login uses that client; accounts that need %s cannot be "
+            "authorized by this deployment. The tool-level start_google_auth "
+            "flow is disabled whenever MCP_ENABLE_OAUTH21=true, so it is not "
+            "an alternative: run one deployment per OAuth client, or unset "
+            "MCP_ENABLE_OAUTH21 to use the tool-level flow, which does honour "
+            "per-account client selection.",
+            len(registry),
+            default.key,
+            ", ".join(others),
+        )
+
     def _apply_fastmcp_google_env(self) -> None:
         """Mirror legacy GOOGLE_* env vars into FastMCP Google provider settings."""
+        self._warn_if_oauth21_cannot_serve_the_whole_registry()
+
         if not self.client_id:
             return
 
@@ -364,6 +480,10 @@ class OAuthConfig:
                 else None,
             )
 
+        # The multi-client limitation these process-global variables impose is
+        # reported by _warn_if_oauth21_cannot_serve_the_whole_registry above,
+        # which runs before the client_id check so the no-default case is
+        # reachable.
         _set_if_absent("FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_ID", self.client_id)
         if self.client_secret:
             _set_if_absent(
@@ -375,6 +495,34 @@ class OAuthConfig:
     def is_public_client(self) -> bool:
         """Return True when only a client_id is configured (no client_secret)."""
         return bool(self.client_id and not self.client_secret)
+
+    def has_multiple_clients(self) -> bool:
+        """True when more than one OAuth client is registered."""
+        registry = self.client_registry
+        return registry is not None and len(registry) > 1
+
+    def get_client_for_email(
+        self, user_google_email: Optional[str] = None
+    ) -> Optional["OAuthClient"]:
+        """
+        Resolve the OAuth client that may authorize the given account.
+
+        Falls back to the configured default, and returns None only when no
+        client is configured at all or when a multi-client registry has no
+        mapping and no default for this account. Callers must treat None as a
+        configuration error rather than substituting an arbitrary client — an
+        account authorized against the wrong Cloud project fails at Google with
+        ``org_internal`` or ``invalid_client``, well away from the real cause.
+        """
+        if not self.client_registry:
+            return None
+        return self.client_registry.resolve(user_google_email)
+
+    def get_client_by_key(self, client_key: Optional[str]) -> Optional["OAuthClient"]:
+        """Look up a registered client by key; None when absent or unregistered."""
+        if not self.client_registry or not client_key:
+            return None
+        return self.client_registry.get(client_key)
 
     def get_redirect_uris(self) -> List[str]:
         """
@@ -476,6 +624,10 @@ class OAuthConfig:
             "client_configured": bool(self.client_id),
             "client_secret_configured": bool(self.client_secret),
             "public_client": self.is_public_client(),
+            # Keys only — never the ids or secrets themselves.
+            "registered_client_keys": (
+                self.client_registry.keys if self.client_registry else []
+            ),
             "oauth21_enabled": self.oauth21_enabled,
             "external_oauth21_provider": self.external_oauth21_provider,
             "pkce_required": self.pkce_required,

--- a/auth/oauth_types.py
+++ b/auth/oauth_types.py
@@ -5,7 +5,7 @@ This module provides structured types for OAuth-related parameters,
 improving code maintainability and type safety.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
 
 from fastmcp.server.auth import AccessToken
@@ -59,10 +59,15 @@ class OAuthVersionDetectionParams:
     """
 
     client_id: Optional[str] = None
-    client_secret: Optional[str] = None
+    # Same reason as auth.oauth_clients.OAuthClient.client_secret: this object
+    # is built straight from request parameters, so its generated repr renders
+    # a live client secret and a live PKCE verifier into any "%r" log line or
+    # traceback-with-locals. Version detection only ever needs to know whether
+    # each is present, which the remaining fields already make visible.
+    client_secret: Optional[str] = field(default=None, repr=False)
     code_challenge: Optional[str] = None
     code_challenge_method: Optional[str] = None
-    code_verifier: Optional[str] = None
+    code_verifier: Optional[str] = field(default=None, repr=False)
     authenticated_user: Optional[str] = None
     session_id: Optional[str] = None
 

--- a/tests/auth/test_google_auth_pkce.py
+++ b/tests/auth/test_google_auth_pkce.py
@@ -75,6 +75,13 @@ def test_create_oauth_flow_preserves_callback_verifier():
 def test_create_oauth_flow_file_config_still_enables_pkce():
     expected_flow = object()
     with (
+        # State the premise instead of inheriting it from the ambient
+        # environment: the client secrets file is reached only when NO OAuth
+        # client registry is configured, which resolve_oauth_client signals by
+        # returning None. Without this, the test passed or failed depending on
+        # whether the developer's shell happened to export
+        # GOOGLE_OAUTH_CLIENT_ID -- and it does on at least one machine.
+        patch("auth.google_auth.resolve_oauth_client", return_value=None),
         patch("auth.google_auth.load_client_secrets_from_env", return_value=None),
         patch("auth.google_auth.os.path.exists", return_value=True),
         patch(

--- a/tests/auth/test_legacy_env_defers_to_call_time.py
+++ b/tests/auth/test_legacy_env_defers_to_call_time.py
@@ -1,0 +1,111 @@
+"""A legacy single-client registry must not shadow call-time resolution.
+
+`load_registry_from_env` synthesizes a one-client registry from
+GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET when no registry document
+is configured. That registry carries no routing information -- one client, no
+emails or domains map -- so it can only ever name the same credentials the
+existing environment-and-file resolution would reach on its own.
+
+Answering from it anyway would not be merely redundant. `get_oauth_config()` is
+a process-lifetime singleton, so a client taken from it reflects the
+environment as it stood when the config was FIRST built, while the fallback
+path reads `os.environ` at call time. Deployments that never asked for
+multi-client would silently have a call-time read converted into a start-up
+read.
+
+`resolve_oauth_client` therefore returns None for a legacy-env registry, and
+these tests pin that -- separately from the registry-document case, which must
+still be honoured, so that a fix for one cannot quietly disable the other.
+"""
+
+import pytest
+
+from auth.oauth_clients import (
+    SOURCE_LEGACY_ENV,
+    SOURCE_REGISTRY_DOCUMENT,
+    load_registry_from_env,
+)
+from auth.oauth_config import OAuthConfig
+from auth.google_auth import resolve_oauth_client
+
+
+REGISTRY_DOCUMENT = """
+{
+  "clients": {
+    "work": {"client_id": "work-id.apps.googleusercontent.com",
+             "client_secret": "work-secret"}
+  },
+  "emails": {"someone@example.com": "work"},
+  "default": "work"
+}
+"""
+
+
+@pytest.fixture
+def legacy_env(monkeypatch):
+    monkeypatch.delenv("GOOGLE_OAUTH_CLIENTS_FILE", raising=False)
+    monkeypatch.delenv("GOOGLE_OAUTH_CLIENTS", raising=False)
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "legacy-id.apps.googleusercontent.com")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "legacy-secret")
+
+
+def test_legacy_env_registry_is_labelled_as_such(legacy_env):
+    registry = load_registry_from_env()
+
+    assert registry is not None
+    assert registry.source == SOURCE_LEGACY_ENV
+
+
+def test_registry_document_is_labelled_as_such(monkeypatch, tmp_path):
+    path = tmp_path / "clients.json"
+    path.write_text(REGISTRY_DOCUMENT)
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS_FILE", str(path))
+
+    registry = load_registry_from_env()
+
+    assert registry is not None
+    assert registry.source == SOURCE_REGISTRY_DOCUMENT
+
+
+def test_legacy_env_registry_defers_to_call_time_resolution(legacy_env, monkeypatch):
+    """The whole point: a legacy registry must not answer for the flow."""
+    cfg = OAuthConfig()
+    monkeypatch.setattr("auth.google_auth.get_oauth_config", lambda: cfg)
+
+    assert cfg.client_registry is not None
+    assert cfg.client_registry.source == SOURCE_LEGACY_ENV
+    assert resolve_oauth_client(user_google_email="anyone@example.com") is None
+    assert resolve_oauth_client() is None
+
+
+def test_registry_document_is_still_honoured(monkeypatch, tmp_path):
+    """The deferral above must not disable the feature it sits next to."""
+    path = tmp_path / "clients.json"
+    path.write_text(REGISTRY_DOCUMENT)
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS_FILE", str(path))
+    cfg = OAuthConfig()
+    monkeypatch.setattr("auth.google_auth.get_oauth_config", lambda: cfg)
+
+    resolved = resolve_oauth_client(user_google_email="someone@example.com")
+
+    assert resolved is not None
+    assert resolved.key == "work"
+
+
+def test_explicit_client_key_still_works_against_a_legacy_registry(
+    legacy_env, monkeypatch
+):
+    """Deferral is for the unselected case only.
+
+    A caller naming a client key has asked a question the fallback path cannot
+    answer, so the registry must still be consulted even when it came from the
+    legacy environment pair.
+    """
+    cfg = OAuthConfig()
+    monkeypatch.setattr("auth.google_auth.get_oauth_config", lambda: cfg)
+    (key,) = cfg.client_registry.keys
+
+    resolved = resolve_oauth_client(client_key=key)
+
+    assert resolved is not None
+    assert resolved.client_id == "legacy-id.apps.googleusercontent.com"

--- a/tests/auth/test_oauth_clients.py
+++ b/tests/auth/test_oauth_clients.py
@@ -1,0 +1,963 @@
+"""Tests for the multi-client OAuth registry and per-account client selection."""
+
+import json
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import Flow
+
+from auth.google_auth import (
+    check_client_secrets,
+    create_oauth_flow,
+    handle_auth_callback,
+    load_client_secrets_from_env,
+    resolve_oauth_client,
+    start_auth_flow,
+)
+from auth.oauth21_session_store import OAuth21SessionStore, SessionContext
+from auth.oauth_types import OAuthVersionDetectionParams
+from auth.oauth_clients import (
+    OAuthClient,
+    OAuthClientRegistryError,
+    OAuthClientResolutionError,
+    load_registry_from_env,
+    parse_registry_document,
+)
+from auth.oauth_config import OAuthConfig
+
+REGISTRY_ENV_VARS = (
+    "GOOGLE_OAUTH_CLIENTS_FILE",
+    "GOOGLE_OAUTH_CLIENTS",
+    "GOOGLE_OAUTH_CLIENT_ID",
+    "GOOGLE_OAUTH_CLIENT_SECRET",
+)
+
+THREE_CLIENT_DOC = {
+    "default": "personal",
+    "clients": {
+        "personal": {"client_id": "personal-id", "client_secret": "personal-secret"},
+        "work": {"client_id": "work-id", "client_secret": "work-secret"},
+        "contract": {"client_id": "contract-id"},
+    },
+    "domains": {"warnes.net": "personal", "example.com": "work"},
+    "emails": {"someone@example.com": "contract"},
+}
+
+
+# A registry with several clients and NO default. This is the configuration
+# every fail-open bug in this area hides in: there is nothing to fall back to,
+# so any code that treats "could not resolve" as "use the default" ends up
+# using something arbitrary instead of refusing.
+NO_DEFAULT_DOC = {
+    "clients": {
+        "personal": {"client_id": "personal-id", "client_secret": "personal-secret"},
+        "work": {"client_id": "work-id", "client_secret": "work-secret"},
+    },
+    "domains": {"example.com": "work"},
+}
+
+_FASTMCP_ENV_VARS = (
+    "FASTMCP_SERVER_AUTH",
+    "FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_ID",
+    "FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_SECRET",
+    "FASTMCP_SERVER_AUTH_GOOGLE_BASE_URL",
+    "FASTMCP_SERVER_AUTH_GOOGLE_REDIRECT_PATH",
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_registry_env(monkeypatch):
+    """Every test starts from an unconfigured environment."""
+    for name in REGISTRY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def pinned_fastmcp_env(monkeypatch):
+    """Stop OAuthConfig's _set_if_absent from leaking into the rest of the run.
+
+    ``_apply_fastmcp_google_env`` writes FASTMCP_* straight into ``os.environ``
+    when they are absent, and monkeypatch cannot undo a write it did not make.
+    Pre-setting them makes every ``_set_if_absent`` a no-op, and monkeypatch
+    restores these.
+    """
+    for name in _FASTMCP_ENV_VARS:
+        monkeypatch.setenv(name, "pinned-by-test")
+
+
+# --------------------------------------------------------------------------
+# Document parsing and validation
+# --------------------------------------------------------------------------
+
+
+def test_parses_multi_client_document():
+    registry = parse_registry_document(THREE_CLIENT_DOC)
+
+    assert len(registry) == 3
+    assert registry.keys == ["contract", "personal", "work"]
+    assert registry.default.key == "personal"
+    assert registry.get("work").client_secret == "work-secret"
+
+
+def test_client_without_secret_is_public():
+    registry = parse_registry_document(THREE_CLIENT_DOC)
+    contract = registry.get("contract")
+
+    assert contract.client_secret is None
+    assert contract.is_public is True
+
+
+def test_blank_secret_is_treated_as_public_not_empty_secret():
+    # A blank value in config means "no secret", not "a secret that is the
+    # empty string" — the latter would be sent to Google as a real credential.
+    registry = parse_registry_document(
+        {"clients": {"a": {"client_id": "a-id", "client_secret": "   "}}}
+    )
+
+    assert registry.get("a").client_secret is None
+    assert registry.get("a").is_public is True
+
+
+@pytest.mark.parametrize(
+    "document, expected_message",
+    [
+        ({}, "non-empty 'clients'"),
+        ({"clients": {}}, "non-empty 'clients'"),
+        ({"clients": {"a": "not-an-object"}}, "must be an object"),
+        ({"clients": {"a": {}}}, "missing a non-empty string 'client_id'"),
+        ({"clients": {"a": {"client_id": "   "}}}, "missing a non-empty string"),
+        (
+            {"clients": {"a": {"client_id": "x", "client_secret": 42}}},
+            "non-string 'client_secret'",
+        ),
+        (
+            {"clients": {"a": {"client_id": "x"}}, "default": "missing"},
+            "is not defined in 'clients'",
+        ),
+        (
+            {"clients": {"a": {"client_id": "x"}}, "domains": {"d.com": "nope"}},
+            "refers to undefined client",
+        ),
+        (
+            {"clients": {"a": {"client_id": "x"}}, "emails": {"e@d.com": "nope"}},
+            "refers to undefined client",
+        ),
+        ({"clients": {"a": {"client_id": "x"}}, "domains": []}, "must be an object"),
+        ("not-a-dict", "must be a JSON object"),
+    ],
+)
+def test_malformed_documents_are_rejected(document, expected_message):
+    with pytest.raises(OAuthClientRegistryError) as excinfo:
+        parse_registry_document(document)
+    assert expected_message in str(excinfo.value)
+
+
+def test_client_describe_never_leaks_the_secret():
+    client = OAuthClient(key="work", client_id="work-id", client_secret="s3cr3t")
+    description = client.describe()
+
+    assert "s3cr3t" not in description
+    assert "work" in description
+
+
+def test_client_repr_never_leaks_the_secret():
+    # describe() is only reached by code that chose to call it. The dataclass
+    # repr is reached by everything else: "%r" logging, an f-string, a
+    # traceback rendered with locals, or the repr of any container holding the
+    # client. A secret that is safe in one and cleartext in the other is not
+    # protected at all.
+    client = OAuthClient(key="work", client_id="work-id", client_secret="s3cr3t")
+
+    assert "s3cr3t" not in repr(client)
+    assert "s3cr3t" not in str(client)
+    assert "s3cr3t" not in f"{client}"
+    assert "s3cr3t" not in f"{client!r}"
+    # Containers render their members with repr(), so this is the logging path
+    # that matters in practice.
+    assert "s3cr3t" not in repr({"clients": [client]})
+    assert "s3cr3t" not in repr(parse_registry_document(THREE_CLIENT_DOC).get("work"))
+    # Still diagnosable: the key identifies which client without exposing it.
+    assert "work" in repr(client)
+
+
+def test_sibling_credential_dataclasses_keep_secrets_out_of_repr():
+    # Bug-class sweep for the same defect: a dataclass field holding a
+    # credential with the generated repr left live. These two were found by
+    # grepping every @dataclass in the tree for credential-bearing fields.
+    detection = OAuthVersionDetectionParams(
+        client_id="public-client-id",
+        client_secret="detection-secret",
+        code_verifier="pkce-verifier",
+    )
+    rendered = repr(detection)
+    assert "detection-secret" not in rendered
+    assert "pkce-verifier" not in rendered
+    assert "public-client-id" in rendered
+
+    class _FakeAccessToken:
+        def __repr__(self):
+            return "AccessToken(token='bearer-token-value')"
+
+    context = SessionContext(session_id="s1", auth_context=_FakeAccessToken())
+    assert "bearer-token-value" not in repr(context)
+    assert "s1" in repr(context)
+
+
+# --------------------------------------------------------------------------
+# Resolution
+# --------------------------------------------------------------------------
+
+
+def test_exact_email_match_wins_over_domain():
+    registry = parse_registry_document(THREE_CLIENT_DOC)
+
+    # someone@example.com is mapped explicitly to "contract" while the
+    # example.com domain maps to "work"; the more specific rule must win.
+    assert registry.resolve("someone@example.com").key == "contract"
+    assert registry.resolve("other@example.com").key == "work"
+
+
+def test_domain_match():
+    registry = parse_registry_document(THREE_CLIENT_DOC)
+    assert registry.resolve("greg@warnes.net").key == "personal"
+
+
+def test_unmapped_account_falls_back_to_default():
+    registry = parse_registry_document(THREE_CLIENT_DOC)
+    assert registry.resolve("stranger@elsewhere.org").key == "personal"
+
+
+def test_resolution_is_case_insensitive():
+    registry = parse_registry_document(THREE_CLIENT_DOC)
+
+    assert registry.resolve("GREG@WARNES.NET").key == "personal"
+    assert registry.resolve("  SomeOne@Example.COM  ").key == "contract"
+
+
+def test_multi_client_without_default_returns_none_for_unmapped_account():
+    # No default means an unmapped account is a configuration error, not a
+    # silent authorization against an arbitrary project.
+    document = dict(THREE_CLIENT_DOC)
+    document.pop("default")
+    registry = parse_registry_document(document)
+
+    assert registry.default is None
+    assert registry.resolve("stranger@elsewhere.org") is None
+    assert registry.resolve("greg@warnes.net").key == "personal"
+
+
+def test_single_client_is_its_own_default_without_being_named():
+    registry = parse_registry_document({"clients": {"solo": {"client_id": "solo-id"}}})
+
+    assert registry.default.key == "solo"
+    assert registry.resolve("anyone@anywhere.com").key == "solo"
+
+
+# --------------------------------------------------------------------------
+# Environment loading
+# --------------------------------------------------------------------------
+
+
+def test_loads_registry_from_file(tmp_path, monkeypatch):
+    path = tmp_path / "clients.json"
+    path.write_text(json.dumps(THREE_CLIENT_DOC), encoding="utf-8")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS_FILE", str(path))
+
+    registry = load_registry_from_env()
+
+    assert len(registry) == 3
+    assert registry.resolve("greg@warnes.net").key == "personal"
+
+
+def test_loads_registry_from_inline_json(monkeypatch):
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS", json.dumps(THREE_CLIENT_DOC))
+
+    registry = load_registry_from_env()
+
+    assert registry.resolve("other@example.com").key == "work"
+
+
+def test_registry_file_takes_precedence_over_inline(tmp_path, monkeypatch):
+    path = tmp_path / "clients.json"
+    path.write_text(
+        json.dumps({"clients": {"from-file": {"client_id": "file-id"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS_FILE", str(path))
+    monkeypatch.setenv(
+        "GOOGLE_OAUTH_CLIENTS",
+        json.dumps({"clients": {"from-inline": {"client_id": "inline-id"}}}),
+    )
+
+    assert load_registry_from_env().keys == ["from-file"]
+
+
+def test_malformed_registry_file_raises_rather_than_falling_back(tmp_path, monkeypatch):
+    # Silently ignoring a broken registry would authorize accounts against
+    # whichever client happened to remain configured.
+    path = tmp_path / "clients.json"
+    path.write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS_FILE", str(path))
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "legacy-id")
+
+    with pytest.raises(OAuthClientRegistryError) as excinfo:
+        load_registry_from_env()
+    assert "not valid JSON" in str(excinfo.value)
+
+
+def test_missing_registry_file_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "GOOGLE_OAUTH_CLIENTS_FILE", str(tmp_path / "does-not-exist.json")
+    )
+
+    with pytest.raises(OAuthClientRegistryError) as excinfo:
+        load_registry_from_env()
+    assert "could not read" in str(excinfo.value)
+
+
+def test_legacy_single_client_env_still_works(monkeypatch):
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "legacy-id")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "legacy-secret")
+
+    registry = load_registry_from_env()
+
+    assert registry.keys == ["default"]
+    assert registry.default.client_id == "legacy-id"
+    assert registry.default.client_secret == "legacy-secret"
+    assert registry.resolve("anyone@anywhere.com").key == "default"
+
+
+def test_no_configuration_at_all_returns_none():
+    assert load_registry_from_env() is None
+
+
+# --------------------------------------------------------------------------
+# OAuthConfig integration and backward compatibility
+# --------------------------------------------------------------------------
+
+
+def test_legacy_env_still_populates_client_id_and_secret(monkeypatch):
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "legacy-id")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "legacy-secret")
+
+    cfg = OAuthConfig()
+
+    assert cfg.client_id == "legacy-id"
+    assert cfg.client_secret == "legacy-secret"
+    assert cfg.is_configured() is True
+    assert cfg.has_multiple_clients() is False
+
+
+def test_config_exposes_default_client_of_a_registry(monkeypatch):
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS", json.dumps(THREE_CLIENT_DOC))
+
+    cfg = OAuthConfig()
+
+    assert cfg.client_id == "personal-id"
+    assert cfg.has_multiple_clients() is True
+    assert cfg.get_client_for_email("other@example.com").key == "work"
+    assert cfg.get_client_by_key("contract").client_id == "contract-id"
+    assert cfg.get_client_by_key("nonexistent") is None
+
+
+def test_environment_summary_lists_keys_but_no_credentials(monkeypatch):
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS", json.dumps(THREE_CLIENT_DOC))
+
+    summary = OAuthConfig().get_environment_summary()
+
+    assert summary["registered_client_keys"] == ["contract", "personal", "work"]
+    rendered = json.dumps(summary)
+    assert "personal-secret" not in rendered
+    assert "personal-id" not in rendered
+
+
+def test_unconfigured_config_has_no_client(monkeypatch):
+    cfg = OAuthConfig()
+
+    assert cfg.client_id is None
+    assert cfg.client_secret is None
+    assert cfg.get_client_for_email("anyone@anywhere.com") is None
+
+
+# --------------------------------------------------------------------------
+# Flow-level client selection
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registry_config(monkeypatch):
+    """Point auth.google_auth at a freshly built three-client config."""
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS", json.dumps(THREE_CLIENT_DOC))
+    cfg = OAuthConfig()
+    monkeypatch.setattr("auth.google_auth.get_oauth_config", lambda: cfg)
+    return cfg
+
+
+def test_resolve_by_email(registry_config):
+    assert resolve_oauth_client(user_google_email="other@example.com").key == "work"
+
+
+def test_explicit_client_key_wins_over_email(registry_config):
+    # The callback passes the recorded key; it must not be second-guessed by
+    # whatever the email would resolve to now.
+    client = resolve_oauth_client(
+        client_key="contract", user_google_email="greg@warnes.net"
+    )
+    assert client.key == "contract"
+
+
+def test_unknown_client_key_raises_instead_of_falling_back(registry_config):
+    # Falling back to the default would exchange the code against a different
+    # Cloud project and surface as an opaque 'invalid_client' from Google.
+    with pytest.raises(ValueError) as excinfo:
+        resolve_oauth_client(client_key="retired-client")
+
+    assert "no longer registered" in str(excinfo.value)
+
+
+def test_absent_client_key_uses_default(registry_config):
+    assert resolve_oauth_client().key == "personal"
+
+
+def test_client_secrets_shape_is_confidential_for_a_client_with_a_secret():
+    config = load_client_secrets_from_env(
+        OAuthClient(key="work", client_id="work-id", client_secret="work-secret")
+    )
+
+    assert "web" in config
+    assert config["web"]["client_id"] == "work-id"
+    assert config["web"]["client_secret"] == "work-secret"
+
+
+def test_client_secrets_reflect_the_environment_at_call_time(monkeypatch):
+    # Regression: resolving the default client through the cached OAuthConfig
+    # singleton made this function return whatever client the process started
+    # with, ignoring the current environment entirely.
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "first-id")
+    assert load_client_secrets_from_env()["installed"]["client_id"] == "first-id"
+
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "second-id")
+    assert load_client_secrets_from_env()["installed"]["client_id"] == "second-id"
+
+
+def test_client_secrets_are_none_when_environment_has_no_client():
+    assert load_client_secrets_from_env() is None
+
+
+def test_client_secrets_shape_is_installed_for_a_public_client():
+    config = load_client_secrets_from_env(
+        OAuthClient(key="contract", client_id="contract-id")
+    )
+
+    assert "installed" in config
+    assert config["installed"]["client_id"] == "contract-id"
+    assert config["installed"]["client_secret"] == ""
+
+
+# --------------------------------------------------------------------------
+# OAuth state round-trip
+# --------------------------------------------------------------------------
+
+
+def test_client_key_survives_serialization_to_the_state_file(tmp_path):
+    # NARROW ON PURPOSE: this covers the store's serialization only. It was
+    # previously named ..._survives_the_state_round_trip, which read as though
+    # it joined the producer to the consumer; it does not, and both
+    # `client_key=` arguments could be deleted with this test still green. The
+    # seam itself is covered by
+    # test_client_key_travels_from_start_auth_flow_to_the_callback_exchange.
+    #
+    # The callback recovers the client from the persisted state, so the value
+    # has to survive serialization to disk, not merely live in memory.
+    state_file = tmp_path / "oauth_states.json"
+    writer = OAuth21SessionStore(oauth_state_file=str(state_file))
+    writer.store_oauth_state("state-abc", code_verifier="verifier", client_key="work")
+
+    reader = OAuth21SessionStore(oauth_state_file=str(state_file))
+    state_info = reader.validate_and_consume_oauth_state("state-abc")
+
+    assert state_info is not None
+    assert state_info.get("client_key") == "work"
+    assert state_info.get("code_verifier") == "verifier"
+
+
+def test_state_written_without_a_client_key_reads_back_as_none(tmp_path):
+    # State entries created before multi-client support must still complete;
+    # the callback treats a missing key as "the default client".
+    state_file = tmp_path / "oauth_states.json"
+    writer = OAuth21SessionStore(oauth_state_file=str(state_file))
+    writer.store_oauth_state("state-legacy", code_verifier="verifier")
+
+    reader = OAuth21SessionStore(oauth_state_file=str(state_file))
+    state_info = reader.validate_and_consume_oauth_state("state-legacy")
+
+    assert state_info is not None
+    assert state_info.get("client_key") is None
+
+
+# --------------------------------------------------------------------------
+# OAuth 2.1 single-provider warning
+# --------------------------------------------------------------------------
+
+
+def _warnings_from(caplog):
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    ]
+
+
+def _multi_client_warnings(caplog):
+    return [
+        message
+        for message in _warnings_from(caplog)
+        if "OAuth 2.1" in message and "OAuth client" in message
+    ]
+
+
+def test_oauth21_multi_client_warning_fires_when_there_is_no_default(
+    monkeypatch, caplog, pinned_fastmcp_env
+):
+    # The no-default case is the ONE case where this warning is the only
+    # signal an operator gets, and it was exactly the case the warning could
+    # not reach: `if not self.client_id: return` ran first, and client_id is
+    # None precisely when there is no default client.
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS", json.dumps(NO_DEFAULT_DOC))
+    monkeypatch.setenv("MCP_ENABLE_OAUTH21", "true")
+
+    with caplog.at_level(logging.WARNING, logger="auth.oauth_config"):
+        config = OAuthConfig()
+
+    assert config.client_id is None  # the condition that suppressed the warning
+    matched = _multi_client_warnings(caplog)
+    assert matched, (
+        f"no multi-client OAuth 2.1 warning emitted: {_warnings_from(caplog)}"
+    )
+
+    text = " ".join(matched)
+    # The dead `default_key or "<none>"` was the tell that this branch had
+    # never run. A message that still renders "<none>" has not been fixed,
+    # only relocated.
+    assert "<none>" not in text
+    assert "default" in text.lower()
+
+
+def test_oauth21_multi_client_warning_does_not_offer_the_disabled_tool_flow(
+    monkeypatch, caplog, pinned_fastmcp_env
+):
+    # core/server.py's start_google_auth returns "disabled when OAuth 2.1 is
+    # enabled" unconditionally, so directing an operator to the tool-level
+    # flow is advice that provably cannot work.
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS", json.dumps(THREE_CLIENT_DOC))
+    monkeypatch.setenv("MCP_ENABLE_OAUTH21", "true")
+
+    with caplog.at_level(logging.WARNING, logger="auth.oauth_config"):
+        OAuthConfig()
+
+    matched = _multi_client_warnings(caplog)
+    assert matched, (
+        f"no multi-client OAuth 2.1 warning emitted: {_warnings_from(caplog)}"
+    )
+
+    text = " ".join(matched)
+    assert "personal" in text  # the client every login will actually use
+    assert "contract" in text and "work" in text  # the ones that cannot be used
+    # The remedy must be one that exists: turning OAuth 2.1 off, or running a
+    # deployment per client. Naming the switch is what makes it actionable.
+    assert "MCP_ENABLE_OAUTH21" in text
+    assert "disabled" in text
+
+
+def test_no_multi_client_warning_for_a_single_client_under_oauth21(
+    monkeypatch, caplog, pinned_fastmcp_env
+):
+    # The warning describes a limitation that does not exist with one client;
+    # emitting it there would train operators to ignore it.
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "solo-id")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "solo-secret")
+    monkeypatch.setenv("MCP_ENABLE_OAUTH21", "true")
+
+    with caplog.at_level(logging.WARNING, logger="auth.oauth_config"):
+        OAuthConfig()
+
+    assert _multi_client_warnings(caplog) == []
+
+
+# --------------------------------------------------------------------------
+# check_client_secrets: "is ANY client configured", not "is there a default"
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_secrets_file(monkeypatch, tmp_path):
+    """Point CONFIG_CLIENT_SECRETS_PATH at a path that does not exist."""
+    absent = tmp_path / "client_secret.json"
+    monkeypatch.setattr("auth.google_auth.CONFIG_CLIENT_SECRETS_PATH", str(absent))
+    return absent
+
+
+def test_check_client_secrets_accepts_a_registry_without_a_default(
+    monkeypatch, no_secrets_file
+):
+    # This gates start_google_auth (core/server.py) and both callback
+    # handlers. Asking only for the DEFAULT client made it answer "credentials
+    # not found" for every user of a no-default registry -- including accounts
+    # the registry maps perfectly well. The right question at this call site is
+    # plural: is ANY OAuth client configured. Which client serves a given
+    # account is resolve_oauth_client()'s decision, made later.
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS", json.dumps(NO_DEFAULT_DOC))
+
+    assert check_client_secrets() is None
+
+
+def test_check_client_secrets_accepts_a_registry_with_a_default(
+    monkeypatch, no_secrets_file
+):
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS", json.dumps(THREE_CLIENT_DOC))
+
+    assert check_client_secrets() is None
+
+
+def test_check_client_secrets_still_reports_a_wholly_unconfigured_server(
+    no_secrets_file,
+):
+    message = check_client_secrets()
+
+    assert message is not None
+    assert str(no_secrets_file) in message
+
+
+def test_check_client_secrets_remediation_names_every_working_source(no_secrets_file):
+    # The old text advised setting GOOGLE_OAUTH_CLIENT_ID/SECRET. Whenever a
+    # registry variable is set that advice is a guaranteed no-op, because
+    # load_registry_from_env returns at the first source that hits and the
+    # registry sources are checked first. The message must name the sources
+    # that can actually take effect.
+    message = check_client_secrets()
+
+    assert message is not None
+    assert "GOOGLE_OAUTH_CLIENTS_FILE" in message
+    assert "GOOGLE_OAUTH_CLIENTS" in message
+    assert "GOOGLE_OAUTH_CLIENT_ID" in message
+
+
+def test_check_client_secrets_accepts_a_bare_secrets_file(monkeypatch, tmp_path):
+    # No registry at all: the file fallback is the intended single-client path
+    # and must keep working untouched.
+    secrets = tmp_path / "client_secret.json"
+    secrets.write_text(json.dumps({"installed": {"client_id": "on-disk-id"}}))
+    monkeypatch.setattr("auth.google_auth.CONFIG_CLIENT_SECRETS_PATH", str(secrets))
+
+    assert check_client_secrets() is None
+
+
+# --------------------------------------------------------------------------
+# Refusal is fatal: an unresolvable account must never reach the file
+# --------------------------------------------------------------------------
+
+
+ON_DISK_SECRETS = {
+    "installed": {
+        "client_id": "on-disk-id",
+        "client_secret": "on-disk-secret",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+}
+
+
+@pytest.fixture
+def secrets_file_on_disk(monkeypatch, tmp_path):
+    """A perfectly valid client_secret.json sitting where the fallback looks.
+
+    Its presence is the whole point: the fail-open path was silent precisely
+    because the file exists on a real deployment and the flow it produced
+    looked fine right up until Google rejected it.
+    """
+    path = tmp_path / "client_secret.json"
+    path.write_text(json.dumps(ON_DISK_SECRETS))
+    monkeypatch.setattr("auth.google_auth.CONFIG_CLIENT_SECRETS_PATH", str(path))
+    return path
+
+
+@pytest.fixture
+def no_default_registry_config(monkeypatch):
+    """Point auth.google_auth at a multi-client registry with no default."""
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS", json.dumps(NO_DEFAULT_DOC))
+    cfg = OAuthConfig()
+    monkeypatch.setattr("auth.google_auth.get_oauth_config", lambda: cfg)
+    return cfg
+
+
+def test_unresolvable_account_raises_instead_of_returning_none(
+    no_default_registry_config,
+):
+    # "The registry refused this account" and "the caller did not specify one"
+    # shared the None sentinel, and every caller read it as the second.
+    with pytest.raises(OAuthClientResolutionError) as excinfo:
+        resolve_oauth_client(user_google_email="stranger@nowhere.test")
+
+    message = str(excinfo.value)
+    assert "stranger@nowhere.test" in message
+    assert "personal" in message and "work" in message  # what IS registered
+
+
+def test_resolution_with_no_account_and_no_default_raises(no_default_registry_config):
+    # This is the callback's shape: a pre-multi-client state entry carries no
+    # client_key and the callback has no email yet, so nothing selects a client.
+    with pytest.raises(OAuthClientResolutionError):
+        resolve_oauth_client()
+
+
+def test_resolution_still_returns_none_when_nothing_is_configured(monkeypatch):
+    # The surviving None has exactly one meaning: no registry at all, so the
+    # caller's client-secrets-file fallback is the intended path.
+    cfg = OAuthConfig()
+    monkeypatch.setattr("auth.google_auth.get_oauth_config", lambda: cfg)
+
+    assert resolve_oauth_client(user_google_email="anyone@anywhere.test") is None
+
+
+def test_unresolvable_account_never_reaches_the_client_secrets_file(
+    no_default_registry_config, secrets_file_on_disk
+):
+    with pytest.raises(OAuthClientResolutionError) as excinfo:
+        create_oauth_flow(
+            scopes=["https://www.googleapis.com/auth/userinfo.email"],
+            redirect_uri="http://localhost:8000/oauth2callback",
+            user_google_email="stranger@nowhere.test",
+        )
+
+    message = str(excinfo.value)
+    # The error must name the real cause, not a missing file: the file is
+    # right there, and blaming it sends the operator to fix the wrong thing.
+    assert "stranger@nowhere.test" in message
+    assert "not found" not in message
+    assert str(secrets_file_on_disk) not in message
+
+
+def test_callback_shaped_flow_with_no_client_key_never_reaches_the_file(
+    no_default_registry_config, secrets_file_on_disk
+):
+    # The callback path had no guard at all. A state entry written before
+    # multi-client support has client_key=None, so this is exactly the call
+    # handle_auth_callback makes for one.
+    with pytest.raises(OAuthClientResolutionError):
+        create_oauth_flow(
+            scopes=["https://www.googleapis.com/auth/userinfo.email"],
+            redirect_uri="http://localhost:8000/oauth2callback",
+            state="state-abc",
+            code_verifier="verifier",
+            autogenerate_code_verifier=False,
+            client_key=None,
+        )
+
+
+def test_file_fallback_still_works_when_no_registry_is_configured(
+    monkeypatch, secrets_file_on_disk
+):
+    # The fix must not break the single-client, file-only deployment.
+    cfg = OAuthConfig()
+    monkeypatch.setattr("auth.google_auth.get_oauth_config", lambda: cfg)
+
+    flow = create_oauth_flow(
+        scopes=["https://www.googleapis.com/auth/userinfo.email"],
+        redirect_uri="http://localhost:8000/oauth2callback",
+    )
+
+    assert flow.client_config["client_id"] == "on-disk-id"
+
+
+# --------------------------------------------------------------------------
+# The seam: producer (start_auth_flow) joined to consumer (handle_auth_callback)
+# --------------------------------------------------------------------------
+
+
+REDIRECT_URI = "http://localhost:8000/oauth2callback"
+SEAM_SCOPES = ["https://www.googleapis.com/auth/userinfo.email"]
+
+
+class _StubCredentialStore:
+    def __init__(self):
+        self.saved = []
+
+    def get_credential(self, user_email):  # noqa: ARG002
+        return None
+
+    def store_credential(self, user_email, credentials):
+        self.saved.append((user_email, credentials))
+        return True
+
+
+def _auth_url_from(message: str) -> str:
+    for line in message.splitlines():
+        if "Authorization URL:" in line:
+            return line.split("Authorization URL:", 1)[1].strip()
+    raise AssertionError(f"no authorization URL in start_auth_flow output:\n{message}")
+
+
+@pytest.fixture
+def seam_harness(monkeypatch, tmp_path):
+    """Everything except the two halves under test.
+
+    The OAuth client registry, the state store and the Flow construction are
+    all REAL -- mocking any of them would mock the seam itself. Only the
+    Google boundary (fetch_token, userinfo) and the credential persistence are
+    stubbed.
+    """
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS", json.dumps(THREE_CLIENT_DOC))
+    config = OAuthConfig()
+    monkeypatch.setattr("auth.google_auth.get_oauth_config", lambda: config)
+
+    state_file = tmp_path / "oauth_states.json"
+    store = OAuth21SessionStore(oauth_state_file=str(state_file))
+    monkeypatch.setattr("auth.google_auth.get_oauth21_session_store", lambda: store)
+
+    built_client_ids = []
+
+    class _RecordingFlow(Flow):
+        """A real google-auth-oauthlib Flow that records how it was built."""
+
+        @classmethod
+        def from_client_config(cls, client_config, scopes, **kwargs):
+            section = client_config.get("web") or client_config["installed"]
+            built_client_ids.append(section["client_id"])
+            return super().from_client_config(client_config, scopes, **kwargs)
+
+        @classmethod
+        def from_client_secrets_file(cls, client_secrets_file, scopes, **kwargs):
+            raise AssertionError(
+                f"flow fell back to the client secrets file at {client_secrets_file}"
+            )
+
+        def fetch_token(self, **kwargs):  # noqa: ARG002
+            # The Google boundary. No network.
+            return None
+
+        @property
+        def credentials(self):
+            return Credentials(
+                token="access-token",
+                refresh_token="refresh-token",
+                token_uri="https://oauth2.googleapis.com/token",
+                client_id=self.client_config["client_id"],
+                client_secret=self.client_config.get("client_secret") or None,
+                scopes=list(SEAM_SCOPES),
+            )
+
+    monkeypatch.setattr("auth.google_auth.Flow", _RecordingFlow)
+    monkeypatch.setattr(
+        "auth.google_auth.get_current_scopes", lambda: list(SEAM_SCOPES)
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.get_transport_mode", lambda: "streamable-http"
+    )
+    monkeypatch.setattr("auth.google_auth.get_fastmcp_session_id", lambda: None)
+    monkeypatch.setattr(
+        "auth.google_auth._determine_oauth_prompt",
+        AsyncMock(return_value="consent"),
+    )
+    monkeypatch.setattr("auth.google_auth.is_stateless_mode", lambda: False)
+    monkeypatch.setattr(
+        "auth.google_auth.get_credential_store", lambda: _StubCredentialStore()
+    )
+    monkeypatch.setattr(
+        "auth.google_auth.save_credentials_to_session", lambda *args: None
+    )
+
+    return SimpleNamespace(
+        config=config,
+        store=store,
+        state_file=state_file,
+        built_client_ids=built_client_ids,
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_key_travels_from_start_auth_flow_to_the_callback_exchange(
+    monkeypatch, seam_harness
+):
+    """Join the producer of client_key to its consumer.
+
+    The resolver was covered in isolation and the state store was covered in
+    isolation, and nothing joined them: deleting `client_key=oauth_client_key`
+    from the store_oauth_state call, or `client_key=state_info.get("client_key")`
+    from the callback's create_oauth_flow call, each left the FULL suite green.
+    Both mutations fail here.
+
+    analyst@example.com resolves through the 'example.com' domain mapping to
+    the NON-default 'work' client, so a lost key shows up as the default
+    'personal-id' rather than as an error.
+    """
+    monkeypatch.setattr(
+        "auth.google_auth.get_user_info",
+        lambda credentials: {"email": "analyst@example.com"},  # noqa: ARG005
+    )
+
+    message = await start_auth_flow(
+        user_google_email="analyst@example.com",
+        service_name="Gmail",
+        redirect_uri=REDIRECT_URI,
+    )
+
+    # Producer: the authorization URL Google sees carries the work client.
+    query = parse_qs(urlparse(_auth_url_from(message)).query)
+    assert query["client_id"] == ["work-id"]
+    state = query["state"][0]
+
+    # The key is on the PERSISTED state, not just in memory.
+    persisted = json.loads(seam_harness.state_file.read_text())
+    assert persisted[state]["client_key"] == "work"
+
+    # Consumer: the callback rebuilds the flow from that persisted state.
+    user_email, credentials = await handle_auth_callback(
+        scopes=list(SEAM_SCOPES),
+        authorization_response=f"{REDIRECT_URI}?state={state}&code=fake-code",
+        redirect_uri=REDIRECT_URI,
+    )
+
+    assert user_email == "analyst@example.com"
+    # Two flows were built -- one per half -- and BOTH used the work client.
+    # 'personal-id' here would mean the callback silently fell back to the
+    # registry default, which is the failure this test exists to catch.
+    assert seam_harness.built_client_ids == ["work-id", "work-id"]
+    assert credentials.client_id == "work-id"
+
+
+@pytest.mark.asyncio
+async def test_start_auth_flow_refuses_an_account_the_registry_cannot_serve(
+    monkeypatch, seam_harness, secrets_file_on_disk
+):
+    """Fail-closed at the caller, with nothing persisted.
+
+    Nothing asserted that start_auth_flow treats an unresolvable account as an
+    error rather than proceeding. A client_secret.json is deliberately present:
+    the fail-open outcome was a perfectly ordinary-looking authorization URL
+    built from it.
+    """
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENTS", json.dumps(NO_DEFAULT_DOC))
+    config = OAuthConfig()
+    monkeypatch.setattr("auth.google_auth.get_oauth_config", lambda: config)
+
+    with pytest.raises(Exception) as excinfo:
+        await start_auth_flow(
+            user_google_email="stranger@nowhere.test",
+            service_name="Gmail",
+            redirect_uri=REDIRECT_URI,
+        )
+
+    message = str(excinfo.value)
+    # The error must name the unresolvable account, not a missing file.
+    assert "stranger@nowhere.test" in message
+    assert str(secrets_file_on_disk) not in message
+    # No flow was built and no state was persisted for a refused request.
+    assert seam_harness.built_client_ids == []
+    assert (
+        not seam_harness.state_file.exists()
+        or json.loads(seam_harness.state_file.read_text() or "{}") == {}
+    )


### PR DESCRIPTION
## The problem

An account can only be authorized by a Cloud project whose consent screen admits it. A Workspace project with an **Internal** consent screen rejects every address outside its own organization:

```
Error 403: org_internal
```

No scope configuration changes this — it is a property of the consent screen, not of the grant. So a single `GOOGLE_OAUTH_CLIENT_ID` cannot serve accounts in several organizations. Today the server has one client, so a user with a work Workspace account and a personal account has to run two servers.

## The change

An **optional** registry mapping accounts to OAuth clients, via `GOOGLE_OAUTH_CLIENTS_FILE` (a path) or `GOOGLE_OAUTH_CLIENTS` (the same JSON inline):

```json
{
  "clients": {
    "work":     {"client_id": "...", "client_secret": "..."},
    "personal": {"client_id": "...", "client_secret": "..."}
  },
  "domains": {"example.com": "work"},
  "emails":  {"someone@gmail.com": "personal"},
  "default": "work"
}
```

Resolution order is **email → domain → default**. The selected client's key is recorded in the OAuth state, so the callback exchanges the code against the client that *issued* it rather than against whichever client is first.

## Strictly additive

With no registry configured, `resolve_oauth_client()` returns `None` and the existing environment-and-file resolution runs unchanged.

That includes the legacy `GOOGLE_OAUTH_CLIENT_ID`/`SECRET` pair. It does synthesize a one-client registry (so `has_multiple_clients()` and the environment summary have something coherent to read), but that registry is deliberately **not** consulted for flow creation. It carries no routing information — one client, no maps — so it could only ever name the same credentials the fallback reaches anyway, and answering from it has a real cost: `get_oauth_config()` is a process-lifetime singleton, so a client taken from it reflects the environment as it stood when the config was *first built*, while the fallback reads `os.environ` at call time. Consulting it would silently convert a call-time read into a start-up read for deployments that never asked for multi-client.

This was not reasoned out in advance — `test_create_oauth_flow_env_id_alone_does_not_load_file_secret` (yours) caught it, and `tests/auth/test_legacy_env_defers_to_call_time.py` now pins both halves: the legacy registry defers, and a real registry document is still honoured.

## Fail-closed

When a registry **is** configured but selects no client for a request, resolution raises `OAuthClientResolutionError` rather than returning `None`. Returning `None` would fall through to the client secrets file and authorize the account against an arbitrary Cloud project — which then fails at Google as an opaque `invalid_client`, pointing investigation at the token exchange instead of at the config.

`OAuthClient.client_secret` is `field(repr=False)`, so no rendering of the object — `%r` logging, f-strings, container reprs, tracebacks with locals — can leak it. `describe()` is the log-safe form.

## Testing

`2179 passed, 2 skipped` (2114 on `main` + 65 new). `ruff check .` and `ruff format --check .` clean.

**Negative controls** — each mutation was watched failing, so the tests distinguish "guard works" from "guard absent":

| mutation | result |
|---|---|
| empty the email/domain routing maps | **9 fail** |
| neuter all 5 `OAuthClientResolutionError` raise sites | **5 fail** |
| remove the legacy-env deferral | **2 fail** |

## Verified live

Both accounts in different orgs authenticate against their own Cloud project and complete a full create/edit/fetch/search/remove cycle across Docs, Sheets, Slides, Forms, Drive and Gmail — 35/35 on each. That is what motivated the change; the `org_internal` failure above is the error it started from.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for multiple Google OAuth clients, with selection by client key, account email, or domain.
  - Added registry configuration through environment variables and JSON sources.
  - Preserved compatibility with existing single-client configurations.

- **Security**
  - Prevented OAuth secrets, tokens, and PKCE values from appearing in logs or diagnostic output.
  - OAuth callbacks now use the same client that initiated authorization and fail safely when no match exists.

- **Bug Fixes**
  - Improved OAuth state handling to retain the selected client throughout authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->