### PR TITLE
fix(auth): stop exporting the OAuth client secret into os.environ

### DIFF
--- a/auth/oauth_config.py
+++ b/auth/oauth_config.py
@@ -365,10 +365,18 @@ class OAuthConfig:
             )
 
         _set_if_absent("FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_ID", self.client_id)
-        if self.client_secret:
-            _set_if_absent(
-                "FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_SECRET", self.client_secret
-            )
+        # The client SECRET is deliberately not mirrored here. Nothing reads
+        # FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_SECRET -- not this package, and not
+        # FastMCP, which resolves the Google provider from explicit keyword
+        # arguments in core/server.py rather than from the environment. Writing
+        # it only widened where the credential rests: os.environ is inherited by
+        # every child process, and this method runs from __init__, so importing
+        # a module that builds the config was enough to export it even in stdio
+        # mode with OAuth 2.1 off.
+        #
+        # Do not "restore for symmetry" with the client_id above. The id is
+        # published in every authorization URL; the secret is not, and the two
+        # do not belong in the same place merely because they arrive together.
         _set_if_absent("FASTMCP_SERVER_AUTH_GOOGLE_BASE_URL", self.get_oauth_base_url())
         _set_if_absent("FASTMCP_SERVER_AUTH_GOOGLE_REDIRECT_PATH", self.redirect_path)
 

--- a/tests/auth/test_fastmcp_secret_not_exported.py
+++ b/tests/auth/test_fastmcp_secret_not_exported.py
@@ -1,0 +1,71 @@
+"""The OAuth client secret must not be written into the process environment.
+
+`OAuthConfig._apply_fastmcp_google_env` mirrored the configured client secret
+into `FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_SECRET`. Nothing reads that variable --
+not this repository, not the pinned FastMCP -- so the write placed a live
+credential in `os.environ` for no consumer, where every child process inherits
+it.
+
+Two properties are pinned separately, because a change that satisfied only one
+would still be wrong:
+
+  * the secret is not exported (this is the fix), and
+  * a value the operator set themselves is left alone (this is what the fix
+    must not break -- `_set_if_absent` never overwrote an existing value, and
+    an operator configuring FastMCP directly must stay in control).
+"""
+
+import os
+
+import pytest
+
+from auth.oauth_config import OAuthConfig
+
+SECRET_VAR = "FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_SECRET"
+CLIENT_ID_VAR = "FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_ID"
+
+
+@pytest.fixture
+def configured_env(monkeypatch):
+    """A client id AND secret, which is what makes the write path run at all."""
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "probe.apps.googleusercontent.com")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "probe-client-secret")
+    monkeypatch.delenv(SECRET_VAR, raising=False)
+    monkeypatch.delenv(CLIENT_ID_VAR, raising=False)
+
+
+def test_client_secret_is_not_written_into_the_environment(configured_env):
+    config = OAuthConfig()
+
+    # Assert on a boolean rather than on the value: a bare
+    # `assert os.environ.get(SECRET_VAR) is None` renders the real secret into
+    # pytest output at exactly the moment this guard stops working, which is
+    # also the moment someone pastes that output into an issue.
+    exported = SECRET_VAR in os.environ
+    assert not exported, f"{SECRET_VAR} was exported (value withheld)"
+
+    # The config itself must still hold the secret -- this is about where it is
+    # NOT put, not about failing to read it.
+    assert config.client_secret == "probe-client-secret"
+
+
+def test_an_operator_supplied_value_is_still_left_alone(monkeypatch):
+    """Removing the write must not start clobbering a value someone else set."""
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "probe.apps.googleusercontent.com")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "probe-client-secret")
+    monkeypatch.setenv(SECRET_VAR, "operator-supplied")
+
+    OAuthConfig()
+
+    assert os.environ[SECRET_VAR] == "operator-supplied"
+
+
+def test_the_non_secret_mirror_is_unchanged(configured_env):
+    """Scope check: this change removes the SECRET write and nothing else.
+
+    Without this, the fix could quietly delete the whole mirror and every other
+    assertion here would still pass.
+    """
+    OAuthConfig()
+
+    assert os.environ.get(CLIENT_ID_VAR) == "probe.apps.googleusercontent.com"


### PR DESCRIPTION
## The problem

`OAuthConfig._apply_fastmcp_google_env` mirrors the configured client secret into `FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_SECRET`. **Nothing reads that variable.**

Verified against `main` (v1.26.0) rather than assumed:

| searched | result |
|---|---|
| this repo, `*.py` outside `tests/` | the write at `auth/oauth_config.py:370` is the only occurrence |
| `core/server.py` | every `FASTMCP_SERVER_AUTH*` hit is `..._JWT_SIGNING_KEY` — a different variable this method never writes |
| installed `fastmcp` 3.4.7 | **no file mentions `FASTMCP_SERVER_AUTH` at all** |
| `*.md`, compose, Dockerfiles, `pyproject.toml` | no mention |

FastMCP's Google provider is constructed from explicit keyword arguments in `core/server.py`, not from the environment, so the mirror has no consumer to serve.

## Why it is worth removing rather than leaving

The write bought nothing and widened where the credential rests.

`os.environ` is inherited by every child process. And because this runs from `OAuthConfig.__init__`, which `core/config.py:44` reaches at **module import**, merely importing the package was enough to export the secret — including under stdio with OAuth 2.1 disabled, where the FastMCP Google provider is definitively not in play:

```
$ GOOGLE_OAUTH_CLIENT_ID=… GOOGLE_OAUTH_CLIENT_SECRET=… \
  python -c "import auth.google_auth; import os; print(...)"

before: ['BASE_URL', 'CLIENT_ID', 'CLIENT_SECRET', 'REDIRECT_PATH']
after:  ['BASE_URL', 'CLIENT_ID', 'REDIRECT_PATH']
```

A secret supplied only through a `0600` `client_secret.json` became a process-environment value, which is a weaker resting place than the one the operator chose.

## Scope

Deliberately minimal: **only the secret write is removed.** The client id, base URL and redirect path are still mirrored — the id is published in every authorization URL and is not a credential.

`_set_if_absent` never overwrote an existing value, and that behaviour is preserved: an operator who sets `FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_SECRET` themselves keeps control of it. There is a test for exactly that, so the fix cannot regress into clobbering operator configuration.

## Testing

`2117 passed, 2 skipped` (2114 on `main` plus the 3 added). `ruff check .` and `ruff format --check .` clean.

The new tests were watched failing before being trusted, and each guard was mutated separately because a single mutation cannot distinguish them:

| mutation | result |
|---|---|
| restore the secret write (the defect) | `test_client_secret_is_not_written_into_the_environment` fails |
| delete the whole mirror (the over-broad "fix") | `test_the_non_secret_mirror_is_unchanged` fails |

The assertions compare a boolean rather than the value, so a future failure of this guard cannot print the secret into pytest output — which would otherwise publish the credential at precisely the moment the protection stopped working.

## Note

I found this while chasing test-suite environment bleed, and the import-time construction at `core/config.py:44` is the reason it reaches so far. That is a separate concern and is **not** touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google OAuth client secrets are no longer written to the application environment.
  * Existing operator-provided secret values remain unchanged.
  * Google OAuth client ID configuration continues to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->