### PR TITLE
docs: point contributors at the same ruff CI runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,11 @@ Thanks for your interest in contributing! This guide covers what you need to kno
 uv sync --extra test
 
 # Run the linter and formatter
-uvx ruff check
-uvx ruff format
+# `uv run` uses the pinned ruff from pyproject.toml, which is the version CI
+# runs. A bare `uvx ruff` floats to the latest release instead, and ruff 0.16
+# expands the default rule set -- you would see thousands of errors CI does not.
+uv run ruff check
+uv run ruff format
 
 # Run tests
 uv run pytest
@@ -28,7 +31,7 @@ Every PR must pass these automated checks before review:
 - **Pytest** - the full test suite must pass
 - **Maintainer edits enabled** - fork PRs must have "Allow edits from maintainers" checked
 
-Run `uvx ruff check && uvx ruff format --check && uv run pytest` locally before pushing. If CI fails, your PR will not be reviewed.
+Run `uv run ruff check && uv run ruff format --check && uv run pytest` locally before pushing. If CI fails, your PR will not be reviewed.
 
 ## Code Organization
 


### PR DESCRIPTION
### The symptom

A contributor who follows `CONTRIBUTING.md` verbatim is told their branch has thousands of lint errors that CI never sees.

`CONTRIBUTING.md` says to run a bare `uvx ruff`, which resolves to the newest ruff release. The Ruff workflow pins `RUFF_VERSION: '0.15.22'`. As of today those are different versions, and 0.16 expands the default rule set — which is exactly what the workflow's own comment warns about:

> Pinned deliberately: ruff 0.16 expands the default rule set and changes formatter behaviour, which would rewrite the entire codebase.

Measured on `main` (`54b1c56`), same tree, both commands run back to back:

```
$ uvx ruff --version          # what CONTRIBUTING.md tells you to run
ruff 0.16.7
$ uvx ruff@0.16.7 check .
Found 2651 errors.
$ uvx ruff@0.16.7 format --check .
1 file would be reformatted, 236 files already formatted

$ uv run ruff --version       # what this PR tells you to run
ruff 0.15.22
$ uv run ruff check ; echo $?
0
$ uv run ruff format --check .
217 files already formatted
```

### The change

The three `uvx ruff` sites become `uv run ruff`, plus a short comment saying why.

### Why `uv run` rather than pinning `uvx ruff@0.15.22` in the doc

`uv run` resolves ruff from `pyproject.toml`'s existing `ruff>=0.15.22,<0.16` bound. Writing `0.15.22` into `CONTRIBUTING.md` instead would create a fourth place the version has to be bumped in lockstep with `ruff.yml`, `pyproject.toml`'s two dependency lists — and the doc is the copy least likely to get bumped, which is how this drifted in the first place. `uv run` cannot drift, because it reads the bound rather than restating it.

It also matches the `uv run pytest` already sitting on the same line in the CI Requirements section.

The trade-off, stated plainly: `uvx` runs ruff in an isolated environment, while `uv run` requires the project environment — so the reader must have done the `uv sync --extra test` that the Development Setup block directly above already tells them to do. I verified that sequence works from a clean checkout of `main`; that is where the `uv run` figures above come from.

### How to verify

```bash
git checkout main && uv sync --extra test
uv run ruff --version        # 0.15.22, matching RUFF_VERSION in .github/workflows/ruff.yml
uv run ruff check && uv run ruff format --check .
```

Docs-only change; no code or workflow files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the contribution guide to use the repository-pinned Ruff tooling.
  - Clarified differences in Ruff versions and rule sets.
  - Updated the documented local CI command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->