### PR TITLE
Fix/comments real newline

### DIFF
--- a/core/comments.py
+++ b/core/comments.py
@@ -262,7 +262,7 @@ async def _read_comments_impl(
     if not comments:
         return f"No comments found in {app_name} {file_id}"
 
-    output = [f"Found {len(comments)} comments in {app_name} {file_id}:\\n"]
+    output = [f"Found {len(comments)} comments in {app_name} {file_id}:\n"]
 
     for comment in comments:
         author = comment.get("author", {}).get("displayName", "Unknown")
@@ -296,7 +296,7 @@ async def _read_comments_impl(
 
         output.append("")  # Empty line between comments
 
-    return "\\n".join(output)
+    return "\n".join(output)
 
 
 async def _create_comment_impl(
@@ -326,7 +326,7 @@ async def _create_comment_impl(
     author = comment.get("author", {}).get("displayName", "Unknown")
     created = comment.get("createdTime", "")
 
-    return f"Comment created successfully!\\nComment ID: {comment_id}\\nAuthor: {author}\\nCreated: {created}\\nContent: {comment_content}"
+    return f"Comment created successfully!\nComment ID: {comment_id}\nAuthor: {author}\nCreated: {created}\nContent: {comment_content}"
 
 
 async def _reply_to_comment_impl(
@@ -354,7 +354,7 @@ async def _reply_to_comment_impl(
     author = reply.get("author", {}).get("displayName", "Unknown")
     created = reply.get("createdTime", "")
 
-    return f"Reply posted successfully!\\nReply ID: {reply_id}\\nAuthor: {author}\\nCreated: {created}\\nContent: {reply_content}"
+    return f"Reply posted successfully!\nReply ID: {reply_id}\nAuthor: {author}\nCreated: {created}\nContent: {reply_content}"
 
 
 async def _resolve_comment_impl(
@@ -382,4 +382,4 @@ async def _resolve_comment_impl(
     author = reply.get("author", {}).get("displayName", "Unknown")
     created = reply.get("createdTime", "")
 
-    return f"Comment {comment_id} has been resolved successfully.\\nResolve reply ID: {reply_id}\\nAuthor: {author}\\nCreated: {created}"
+    return f"Comment {comment_id} has been resolved successfully.\nResolve reply ID: {reply_id}\nAuthor: {author}\nCreated: {created}"

--- a/tests/core/test_comments.py
+++ b/tests/core/test_comments.py
@@ -63,7 +63,7 @@ async def test_read_comments_includes_quoted_text():
     assert "Quoted text: the specific text that was highlighted" in result
     assert "Needs a citation here." in result
 
-    parts = result.split("\\n")
+    parts = result.splitlines()
     bob_section_started = False
     for part in parts:
         if "Author: Bob" in part:

--- a/tests/core/test_comments_line_breaks.py
+++ b/tests/core/test_comments_line_breaks.py
@@ -1,0 +1,74 @@
+"""Comment tool output must use real line breaks, not the two-character `\\n`.
+
+Every return in `core/comments.py` was built with `"\\\\n"` in the source, which
+is a backslash followed by `n` — not a newline. The tools therefore returned one
+physical line containing literal `\\n` text, so a reader (human or model) saw the
+escape sequence rather than a formatted record list.
+
+The assertions are written against `splitlines()` rather than against the absence
+of a particular character, so they pin the PROPERTY (this output is multi-line)
+rather than one spelling of the bug.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.comments import (
+    _create_comment_impl,
+    _read_comments_impl,
+    _reply_to_comment_impl,
+    _resolve_comment_impl,
+)
+
+LITERAL_ESCAPE = "\\" + "n"  # the two characters, never a newline
+
+
+def _service(payload):
+    service = MagicMock()
+    service.comments.return_value.list.return_value.execute.return_value = payload
+    service.comments.return_value.create.return_value.execute.return_value = payload
+    service.replies.return_value.create.return_value.execute.return_value = payload
+    return service
+
+
+COMMENT = {
+    "id": "c1",
+    "author": {"displayName": "Alice"},
+    "content": "First note",
+    "createdTime": "2026-01-01",
+    "resolved": False,
+    "replies": [],
+}
+
+
+@pytest.mark.asyncio
+async def test_read_comments_returns_real_lines():
+    out = await _read_comments_impl(_service({"comments": [COMMENT]}), "docs", "f1")
+
+    assert LITERAL_ESCAPE not in out
+    # One record spans several lines: header, blank, then the fields.
+    assert len(out.splitlines()) > 1
+    assert "Comment ID: c1" in out.splitlines()
+
+
+@pytest.mark.parametrize(
+    "impl, args",
+    [
+        (_create_comment_impl, ("docs", "f1", "hello")),
+        (_reply_to_comment_impl, ("docs", "f1", "c1", "a reply")),
+        (_resolve_comment_impl, ("docs", "f1", "c1")),
+    ],
+)
+@pytest.mark.asyncio
+async def test_write_confirmations_return_real_lines(impl, args):
+    """The three write paths built their confirmations the same way.
+
+    They are covered explicitly because a fix aimed only at the `.join` in the
+    read path leaves these behind — they are f-strings, not joins, so a grep for
+    the join shape does not reach them.
+    """
+    out = await impl(_service(COMMENT), *args)
+
+    assert LITERAL_ESCAPE not in out
+    assert len(out.splitlines()) > 1


### PR DESCRIPTION
#1102 lacks editor permissions 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment, reply, and resolution output formatting.
  * Multiline comment and reply content is now clearly separated and indented for easier reading.
  * Corrected line breaks in comment-related responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->